### PR TITLE
[GenAI] Test fix for com.google.protobuf:protobuf-java-util:3.23.3 using gpt-5.5

### DIFF
--- a/metadata/com.google.protobuf/protobuf-java-util/3.23.3/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/3.23.3/reachability-metadata.json
@@ -1,0 +1,1235 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.Any",
+      "methods" : [
+        {
+          "name" : "getTypeUrl",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Any",
+      "methods" : [
+        {
+          "name" : "getTypeUrl",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.Any$Builder",
+      "methods" : [
+        {
+          "name" : "setTypeUrl",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.BoolValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.BoolValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.BoolValue$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.BoolValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.BytesValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.BytesValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.BytesValue$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.BytesValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.DoubleValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.DoubleValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.DoubleValue$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.DoubleValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Duration",
+      "methods" : [
+        {
+          "name" : "getNanos",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSeconds",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Duration$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.DurationsTest"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.FieldMask",
+      "methods" : [
+        {
+          "name" : "getPathsList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.FieldMask$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.FloatValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.FloatValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.FloatValue$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.FloatValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.Int32Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Int32Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.Int32Value$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Int32Value$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.Int64Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Int64Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.Int64Value$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Int64Value$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.ListValue",
+      "methods" : [
+        {
+          "name" : "getValuesList",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.ListValue",
+      "methods" : [
+        {
+          "name" : "getValuesList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.ListValue$Builder",
+      "methods" : [
+        {
+          "name" : "addValues",
+          "parameterTypes" : [
+            "com.google.protobuf.Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.ListValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.NullValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.StringValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.StringValue",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.StringValue$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.StringValue$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Struct",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Timestamp",
+      "methods" : [
+        {
+          "name" : "getNanos",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSeconds",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Timestamp$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.UInt32Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.UInt32Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.UInt32Value$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.UInt32Value$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.UInt64Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.UInt64Value",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.UInt64Value$Builder",
+      "methods" : [
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.UInt64Value$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.Value",
+      "methods" : [
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl"
+      },
+      "type" : "com.google.protobuf.Value",
+      "methods" : [
+        {
+          "name" : "getKindCase",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getNullValueValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getNumberValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl$7"
+      },
+      "type" : "com.google.protobuf.Value"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Value",
+      "methods" : [
+        {
+          "name" : "getKindCase",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getListValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getNullValueValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getNumberValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getStringValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getStructValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com.google.protobuf.Value$Builder",
+      "methods" : [
+        {
+          "name" : "setNumberValue",
+          "parameterTypes" : [
+            "double"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com.google.protobuf.Value$Builder",
+      "methods" : [
+        {
+          "name" : "setListValue",
+          "parameterTypes" : [
+            "com.google.protobuf.ListValue"
+          ]
+        },
+        {
+          "name" : "setStringValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setStructValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Struct"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type" : "java.lang.reflect.AccessibleObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type" : "java.sql.Date"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.Timestamps"
+      },
+      "type" : "java.time.Instant",
+      "methods" : [
+        {
+          "name" : "getEpochSecond",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getNano",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "now",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "org.robolectric.Robolectric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$ForeignEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$ForeignMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+      "methods" : [
+        {
+          "name" : "getChild",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasChild",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type" : "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasPayload",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+      "methods" : [
+        {
+          "name" : "clearPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getChild",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setChild",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+          ]
+        },
+        {
+          "name" : "setPayload",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$TestAllTypes"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type" : "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+      "methods" : [
+        {
+          "name" : "getPayload",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setPayload",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$TestAllTypes"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes",
+      "methods" : [
+        {
+          "name" : "getOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedInt32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedNestedMessageList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalString",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalString",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$Builder",
+      "methods" : [
+        {
+          "name" : "addRepeatedInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedNestedMessage",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name" : "clearOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "clearRepeatedInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setOptionalInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalNestedMessage",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name" : "setOptionalUint32",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskUtil"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$Builder",
+      "methods" : [
+        {
+          "name" : "setOptionalInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage",
+      "methods" : [
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage$Builder",
+      "methods" : [
+        {
+          "name" : "setBb",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$OptionalGroup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestAllTypes$RepeatedGroup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestRequired",
+      "methods" : [
+        {
+          "name" : "getA",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getB",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getC",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasA",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasB",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasC",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestRequired$Builder",
+      "methods" : [
+        {
+          "name" : "setA",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setB",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setC",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestRequiredMessage",
+      "methods" : [
+        {
+          "name" : "getRequiredMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasRequiredMessage",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "protobuf_unittest.UnittestProto$TestRequiredMessage$Builder",
+      "methods" : [
+        {
+          "name" : "getRequiredMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setRequiredMessage",
+          "parameterTypes" : [
+            "protobuf_unittest.UnittestProto$TestRequired"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$PrinterImpl$GsonHolder"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.Timestamps"
+      },
+      "type" : "sun.util.calendar.JulianCalendar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -1,13 +1,22 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.23.3",
+    "tested-versions" : [
+      "3.23.3"
+    ],
+    "allowed-packages" : [
+      "com.google.protobuf"
+    ]
+  },
+  {
     "metadata-version" : "3.23.0",
+    "test-version" : "3.22.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/$version$/protobuf-java-util-$version$-sources.jar",
     "repository-url" : "https://github.com/protocolbuffers/protobuf",
     "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v23.0/java/util/src/test",
     "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/$version$/protobuf-java-util-$version$-javadoc.jar",
     "description" : "This library provides Java utility APIs for working with Protocol Buffers, including Proto3 JSON parsing and formatting. It also includes helpers for well-known protobuf types such as timestamps, durations, field masks, structs, and values.",
-    "test-version" : "3.22.0",
     "tested-versions" : [
       "3.23.0",
       "3.23.1",

--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "3.23.3",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/$version$/protobuf-java-util-$version$-sources.jar",
+    "repository-url" : "https://github.com/protocolbuffers/protobuf",
+    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v$version$/java/util/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/$version$/protobuf-java-util-$version$-javadoc.jar",
+    "description" : "This library provides Java utility APIs for working with Protocol Buffers, including Proto3 JSON parsing and formatting. It also includes helpers for well-known protobuf types such as timestamps, durations, field masks, structs, and values.",
     "tested-versions" : [
       "3.23.3"
     ],
     "allowed-packages" : [
-      "com.google.protobuf"
+      "com.google.protobuf.util"
     ]
   },
   {

--- a/stats/com.google.protobuf/protobuf-java-util/3.23.3/execution-metrics.json
+++ b/stats/com.google.protobuf/protobuf-java-util/3.23.3/execution-metrics.json
@@ -1,0 +1,94 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T15:08:30.197733Z",
+    "library": "com.google.protobuf:protobuf-java-util:3.23.3",
+    "starting_commit": "2d53e00bd8930c4cfd750d566eca30993ea8ce5d",
+    "ending_commit": "4ef386d89102e5f726b280195646931fac4859ed",
+    "previous_library": "com.google.protobuf:protobuf-java-util:3.22.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.23.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6007,
+          "missed": 444,
+          "ratio": 0.931173,
+          "total": 6451
+        },
+        "line": {
+          "covered": 1330,
+          "missed": 86,
+          "ratio": 0.939266,
+          "total": 1416
+        },
+        "method": {
+          "covered": 252,
+          "missed": 2,
+          "ratio": 0.992126,
+          "total": 254
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.22.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5966,
+          "missed": 431,
+          "ratio": 0.932625,
+          "total": 6397
+        },
+        "line": {
+          "covered": 1320,
+          "missed": 80,
+          "ratio": 0.942857,
+          "total": 1400
+        },
+        "method": {
+          "covered": 250,
+          "missed": 2,
+          "ratio": 0.992063,
+          "total": 252
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 104502,
+      "cached_input_tokens_used": 855552,
+      "output_tokens_used": 8231,
+      "iterations": 2,
+      "cost_usd": 0.6747,
+      "tested_library_loc": 1330,
+      "metadata_entries": 219,
+      "test_only_metadata_entries": 226,
+      "previous_library_metadata_entries": 609,
+      "code_coverage_percent": 93.93,
+      "previous_library_coverage_percent": 94.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/DurationsTest.java",
+      "metadata_file": "metadata/com.google.protobuf/protobuf-java-util/3.23.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.protobuf/protobuf-java-util/3.23.3/stats.json
+++ b/stats/com.google.protobuf/protobuf-java-util/3.23.3/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.23.3",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6007,
+        "missed" : 444,
+        "ratio" : 0.931173,
+        "total" : 6451
+      },
+      "line" : {
+        "covered" : 1330,
+        "missed" : 86,
+        "ratio" : 0.939266,
+        "total" : 1416
+      },
+      "method" : {
+        "covered" : 252,
+        "missed" : 2,
+        "ratio" : 0.992126,
+        "total" : 254
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/.gitignore
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "com.google.protobuf" version "0.9.5"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    // Put well-known type .proto files on protoc include path only (do not generate code for them)
+    compileProtoPath "com.google.protobuf:protobuf-java:$libraryVersion"
+    testCompileProtoPath "com.google.protobuf:protobuf-java:$libraryVersion"
+
+    // Test protos to generate for this module
+    testProtobuf files("proto/")
+
+    testImplementation "com.google.protobuf:protobuf-java:$libraryVersion"
+    testImplementation "com.google.protobuf:protobuf-java-util:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.truth:truth:1.1.3'
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:$libraryVersion"
+    }
+}
+
+// This module is test-only. Ensure no 'main' sources (including any stale generated protos) are compiled.
+afterEvaluate {
+    sourceSets.main.proto.srcDirs = []
+    sourceSets.main.java.srcDirs = []
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/com.google.protobuf/protobuf-java-util")
+        }
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
@@ -10,6 +10,8 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+// 3.23.3 did not publish protoc executable artifacts. Runtime dependencies still use the tested version.
+String protocVersion = "3.23.4"
 
 dependencies {
     // Put well-known type .proto files on protoc include path only (do not generate code for them)
@@ -28,7 +30,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$libraryVersion"
+        artifact = "com.google.protobuf:protoc:$protocVersion"
     }
 }
 

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/gradle.properties
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 3.23.3
+metadata.dir = com.google.protobuf/protobuf-java-util/3.23.3/

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/settings.gradle
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.protobuf.protobuf-java-util_tests'

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/DurationsTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/DurationsTest.java
@@ -1,0 +1,539 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.google.protobuf.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.protobuf.util.Durations.toSecondsAsDouble;
+import static org.junit.Assert.fail;
+
+public class DurationsTest {
+    private static final Duration INVALID_MAX = Duration.newBuilder().setSeconds(Long.MAX_VALUE).setNanos(Integer.MAX_VALUE).build();
+    private static final Duration INVALID_MIN = Duration.newBuilder().setSeconds(Long.MIN_VALUE).setNanos(Integer.MIN_VALUE).build();
+
+    @Test
+    public void testIsPositive() {
+        Truth.assertThat(Durations.isPositive(Durations.ZERO)).isFalse();
+        assertThat(Durations.isPositive(Durations.fromNanos(-1))).isFalse();
+        assertThat(Durations.isPositive(Durations.fromNanos(1))).isTrue();
+    }
+
+    @Test
+    public void testIsNegative() {
+        assertThat(Durations.isNegative(Durations.ZERO)).isFalse();
+        assertThat(Durations.isNegative(Durations.fromNanos(1))).isFalse();
+        assertThat(Durations.isNegative(Durations.fromNanos(-1))).isTrue();
+    }
+
+    @Test
+    public void testCheckNotNegative() {
+        Durations.checkNotNegative(Durations.ZERO);
+        Durations.checkNotNegative(Durations.fromNanos(1));
+        Durations.checkNotNegative(Durations.fromSeconds(1));
+        try {
+            Durations.checkNotNegative(Durations.fromNanos(-1));
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo(
+                    "duration (-0.000000001s) must not be negative");
+        }
+        try {
+            Durations.checkNotNegative(Durations.fromSeconds(-1));
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("duration (-1s) must not be negative");
+        }
+    }
+
+    @Test
+    public void testCheckPositive() {
+        Durations.checkPositive(Durations.fromNanos(1));
+        Durations.checkPositive(Durations.fromSeconds(1));
+        try {
+            Durations.checkPositive(Durations.ZERO);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("duration (0s) must be positive");
+        }
+        try {
+            Durations.checkPositive(Durations.fromNanos(-1));
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("duration (-0.000000001s) must be positive");
+        }
+        try {
+            Durations.checkPositive(Durations.fromSeconds(-1));
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("duration (-1s) must be positive");
+        }
+    }
+
+    @Test
+    public void testToSecondsAsDouble() {
+        assertThat(toSecondsAsDouble(duration(0, 1))).isEqualTo(1.0e-9);
+        assertThat(toSecondsAsDouble(Durations.fromMillis(999))).isEqualTo(0.999);
+        assertThat(toSecondsAsDouble(duration(1, 0))).isEqualTo(1.0);
+        assertWithMessage("Precision loss detected")
+                .that(toSecondsAsDouble(Durations.fromNanos(1234567890987654321L)))
+                .isWithin(1.0e-6)
+                .of(1234567890.9876544);
+    }
+
+    @Test
+    public void testRoundtripConversions() {
+        for (long value : Arrays.asList(-123456, -42, -1, 0, 1, 42, 123456)) {
+            assertThat(Durations.toDays(Durations.fromDays(value))).isEqualTo(value);
+            assertThat(Durations.toHours(Durations.fromHours(value))).isEqualTo(value);
+            assertThat(Durations.toMinutes(Durations.fromMinutes(value))).isEqualTo(value);
+            assertThat(Durations.toSeconds(Durations.fromSeconds(value))).isEqualTo(value);
+            assertThat(Durations.toMillis(Durations.fromMillis(value))).isEqualTo(value);
+            assertThat(Durations.toMicros(Durations.fromMicros(value))).isEqualTo(value);
+            assertThat(Durations.toNanos(Durations.fromNanos(value))).isEqualTo(value);
+        }
+    }
+
+    @Test
+    public void testStaticFactories() {
+        Duration[] durations = {
+                Durations.fromDays(1),
+                Durations.fromHours(24),
+                Durations.fromMinutes(1440),
+                Durations.fromSeconds(86_400L),
+                Durations.fromMillis(86_400_000L),
+                Durations.fromMicros(86_400_000_000L),
+                Durations.fromNanos(86_400_000_000_000L)
+        };
+        for (Duration d1 : durations) {
+            assertThat(d1).isNotEqualTo(null);
+            for (Duration d2 : durations) {
+                assertThat(d1).isEqualTo(d2);
+            }
+        }
+    }
+
+    @Test
+    public void testMinMaxAreValid() {
+        assertThat(Durations.isValid(Durations.MAX_VALUE)).isTrue();
+        assertThat(Durations.isValid(Durations.MIN_VALUE)).isTrue();
+    }
+
+    @Test
+    public void testIsValid_false() {
+        assertThat(Durations.isValid(-315576000001L, 0)).isFalse();
+        assertThat(Durations.isValid(315576000001L, 0)).isFalse();
+        assertThat(Durations.isValid(42L, -42)).isFalse();
+        assertThat(Durations.isValid(-42L, 42)).isFalse();
+    }
+
+    @Test
+    public void testIsValid_true() {
+        assertThat(Durations.isValid(0L, 42)).isTrue();
+        assertThat(Durations.isValid(0L, -42)).isTrue();
+        assertThat(Durations.isValid(42L, 0)).isTrue();
+        assertThat(Durations.isValid(42L, 42)).isTrue();
+        assertThat(Durations.isValid(-315576000000L, 0)).isTrue();
+        assertThat(Durations.isValid(315576000000L, 0)).isTrue();
+    }
+
+    @Test
+    public void testParse_outOfRange() {
+        try {
+            Durations.parse("316576000000.123456789123456789s");
+            fail("expected ParseException");
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Duration value is out of range.");
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testDurationStringFormat() throws Exception {
+        Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
+        Timestamp end = Timestamps.parse("9999-12-31T23:59:59.999999999Z");
+        Duration duration = Timestamps.between(start, end);
+        assertThat(Durations.toString(duration)).isEqualTo("315537897599.999999999s");
+        duration = Timestamps.between(end, start);
+        assertThat(Durations.toString(duration)).isEqualTo("-315537897599.999999999s");
+        duration = Duration.newBuilder().setSeconds(1).build();
+        assertThat(Durations.toString(duration)).isEqualTo("1s");
+        duration = Duration.newBuilder().setNanos(10000000).build();
+        assertThat(Durations.toString(duration)).isEqualTo("0.010s");
+        duration = Duration.newBuilder().setNanos(10000).build();
+        assertThat(Durations.toString(duration)).isEqualTo("0.000010s");
+        duration = Duration.newBuilder().setNanos(10).build();
+        assertThat(Durations.toString(duration)).isEqualTo("0.000000010s");
+        duration = Durations.parse("0.1s");
+        assertThat(duration.getNanos()).isEqualTo(100000000);
+        duration = Durations.parse("0.0001s");
+        assertThat(duration.getNanos()).isEqualTo(100000);
+        duration = Durations.parse("0.0000001s");
+        assertThat(duration.getNanos()).isEqualTo(100);
+        duration = Durations.parseUnchecked("0.1s");
+        assertThat(duration.getNanos()).isEqualTo(100000000);
+        duration = Durations.parseUnchecked("0.0001s");
+        assertThat(duration.getNanos()).isEqualTo(100000);
+        duration = Durations.parseUnchecked("0.0000001s");
+        assertThat(duration.getNanos()).isEqualTo(100);
+        duration = Durations.parse("315576000000.999999999s");
+        assertThat(duration.getSeconds()).isEqualTo(315576000000L);
+        assertThat(duration.getNanos()).isEqualTo(999999999);
+        duration = Durations.parse("-315576000000.999999999s");
+        assertThat(duration.getSeconds()).isEqualTo(-315576000000L);
+        assertThat(duration.getNanos()).isEqualTo(-999999999);
+        duration = Durations.parseUnchecked("315576000000.999999999s");
+        assertThat(duration.getSeconds()).isEqualTo(315576000000L);
+        assertThat(duration.getNanos()).isEqualTo(999999999);
+        duration = Durations.parseUnchecked("-315576000000.999999999s");
+        assertThat(duration.getSeconds()).isEqualTo(-315576000000L);
+        assertThat(duration.getNanos()).isEqualTo(-999999999);
+    }
+
+    @Test
+    public void testDurationInvalidFormat() {
+        try {
+            Durations.toString(Duration.newBuilder().setSeconds(Durations.DURATION_SECONDS_MIN - 1).build());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.toString(Duration.newBuilder().setSeconds(Durations.DURATION_SECONDS_MAX + 1).build());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.toString(Duration.newBuilder().setSeconds(1).setNanos(-1).build());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+
+        try {
+            Durations.toString(Duration.newBuilder().setSeconds(-1).setNanos(1).build());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("-315576000001s");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("-315576000001s");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("315576000001s");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("315576000001s");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("0");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("0");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("0s0");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("0s0");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parse("--1s");
+            fail();
+        } catch (ParseException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+        try {
+            Durations.parseUnchecked("--1s");
+            fail();
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testDurationConversion() throws Exception {
+        Duration duration = Durations.parse("1.111111111s");
+        assertThat(Durations.toNanos(duration)).isEqualTo(1111111111);
+        assertThat(Durations.toMicros(duration)).isEqualTo(1111111);
+        assertThat(Durations.toMillis(duration)).isEqualTo(1111);
+        assertThat(Durations.toSeconds(duration)).isEqualTo(1);
+        duration = Durations.fromNanos(1111111111);
+        assertThat(Durations.toString(duration)).isEqualTo("1.111111111s");
+        duration = Durations.fromMicros(1111111);
+        assertThat(Durations.toString(duration)).isEqualTo("1.111111s");
+        duration = Durations.fromMillis(1111);
+        assertThat(Durations.toString(duration)).isEqualTo("1.111s");
+        duration = Durations.fromSeconds(1);
+        assertThat(Durations.toString(duration)).isEqualTo("1s");
+        duration = Durations.parse("-1.111111111s");
+        assertThat(Durations.toNanos(duration)).isEqualTo(-1111111111);
+        assertThat(Durations.toMicros(duration)).isEqualTo(-1111111);
+        assertThat(Durations.toMillis(duration)).isEqualTo(-1111);
+        assertThat(Durations.toSeconds(duration)).isEqualTo(-1);
+        duration = Durations.fromNanos(-1111111111);
+        assertThat(Durations.toString(duration)).isEqualTo("-1.111111111s");
+        duration = Durations.fromMicros(-1111111);
+        assertThat(Durations.toString(duration)).isEqualTo("-1.111111s");
+        duration = Durations.fromMillis(-1111);
+        assertThat(Durations.toString(duration)).isEqualTo("-1.111s");
+        duration = Durations.fromSeconds(-1);
+        assertThat(Durations.toString(duration)).isEqualTo("-1s");
+    }
+
+    @Test
+    public void testTimeOperations() throws Exception {
+        Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
+        Timestamp end = Timestamps.parse("9999-12-31T23:59:59.999999999Z");
+        Duration duration = Timestamps.between(start, end);
+        assertThat(Durations.toString(duration)).isEqualTo("315537897599.999999999s");
+        Timestamp value = Timestamps.add(start, duration);
+        assertThat(value).isEqualTo(end);
+        value = Timestamps.subtract(end, duration);
+        assertThat(value).isEqualTo(start);
+        duration = Timestamps.between(end, start);
+        assertThat(Durations.toString(duration)).isEqualTo("-315537897599.999999999s");
+        value = Timestamps.add(end, duration);
+        assertThat(value).isEqualTo(start);
+        value = Timestamps.subtract(start, duration);
+        assertThat(value).isEqualTo(end);
+        duration = Durations.parse("-1.125s");
+        assertThat(Durations.toString(duration)).isEqualTo("-1.125s");
+        duration = Durations.add(duration, duration);
+        assertThat(Durations.toString(duration)).isEqualTo("-2.250s");
+        duration = Durations.subtract(duration, Durations.parse("-1s"));
+        assertThat(Durations.toString(duration)).isEqualTo("-1.250s");
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(Durations.toString(duration(1, 1))).isEqualTo("1.000000001s");
+        assertThat(Durations.toString(duration(-1, -1))).isEqualTo("-1.000000001s");
+        assertThat(Durations.toString(duration(1, 0))).isEqualTo("1s");
+        assertThat(Durations.toString(duration(-1, 0))).isEqualTo("-1s");
+        assertThat(Durations.toString(duration(0, 1))).isEqualTo("0.000000001s");
+        assertThat(Durations.toString(duration(0, -1))).isEqualTo("-0.000000001s");
+    }
+
+    @Test
+    public void testAdd() {
+        assertThat(Durations.add(duration(1, 10), duration(1, 20))).isEqualTo(duration(2, 30));
+        assertThat(Durations.add(duration(1, 999999999), duration(1, 2))).isEqualTo(duration(3, 1));
+        assertThat(Durations.add(duration(1, 999999999), duration(1, 1))).isEqualTo(duration(3, 0));
+        assertThat(Durations.add(duration(1, 999999999), duration(-2, -1))).isEqualTo(duration(0, -2));
+        assertThat(Durations.add(duration(1, 999999999), duration(-2, 0))).isEqualTo(duration(0, -1));
+        assertThat(Durations.add(duration(-1, -10), duration(-1, -20))).isEqualTo(duration(-2, -30));
+        assertThat(Durations.add(duration(-1, -999999999), duration(-1, -2))).isEqualTo(duration(-3, -1));
+        assertThat(Durations.add(duration(-1, -999999999), duration(-1, -1))).isEqualTo(duration(-3, 0));
+        assertThat(Durations.add(duration(-1, -999999999), duration(2, 1))).isEqualTo(duration(0, 2));
+        assertThat(Durations.add(duration(-1, -999999999), duration(2, 0))).isEqualTo(duration(0, 1));
+    }
+
+    @Test
+    public void testSubtract() {
+        assertThat(Durations.subtract(duration(3, 2), duration(1, 1))).isEqualTo(duration(2, 1));
+        assertThat(Durations.subtract(duration(3, 10), duration(1, 10))).isEqualTo(duration(2, 0));
+        assertThat(Durations.subtract(duration(3, 1), duration(1, 2))).isEqualTo(duration(1, 999999999));
+        assertThat(Durations.subtract(duration(3, 2), duration(4, 1))).isEqualTo(duration(0, -999999999));
+        assertThat(Durations.subtract(duration(1, 1), duration(3, 2))).isEqualTo(duration(-2, -1));
+        assertThat(Durations.subtract(duration(1, 10), duration(3, 10))).isEqualTo(duration(-2, 0));
+        assertThat(Durations.subtract(duration(1, 2), duration(3, 1))).isEqualTo(duration(-1, -999999999));
+        assertThat(Durations.subtract(duration(4, 1), duration(3, 2))).isEqualTo(duration(0, 999999999));
+    }
+
+    @Test
+    public void testComparator() {
+        assertThat(Durations.comparator().compare(duration(3, 2), duration(3, 2))).isEqualTo(0);
+        assertThat(Durations.comparator().compare(duration(0, 0), duration(0, 0))).isEqualTo(0);
+        assertThat(Durations.comparator().compare(duration(3, 1), duration(1, 1))).isGreaterThan(0);
+        assertThat(Durations.comparator().compare(duration(3, 2), duration(3, 1))).isGreaterThan(0);
+        assertThat(Durations.comparator().compare(duration(1, 1), duration(3, 1))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(3, 1), duration(3, 2))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(-3, -1), duration(-1, -1))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(-3, -2), duration(-3, -1))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(-1, -1), duration(-3, -1))).isGreaterThan(0);
+        assertThat(Durations.comparator().compare(duration(-3, -1), duration(-3, -2))).isGreaterThan(0);
+        assertThat(Durations.comparator().compare(duration(-10, -1), duration(1, 1))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(0, -1), duration(0, 1))).isLessThan(0);
+        assertThat(Durations.comparator().compare(duration(0x80000000L, 0), duration(0, 0))).isGreaterThan(0);
+        assertThat(Durations.comparator().compare(duration(0xFFFFFFFF00000000L, 0), duration(0, 0))).isLessThan(0);
+        Duration duration0 = duration(-50, -500);
+        Duration duration1 = duration(-50, -400);
+        Duration duration2 = duration(50, 500);
+        Duration duration3 = duration(100, 20);
+        Duration duration4 = duration(100, 50);
+        Duration duration5 = duration(100, 150);
+        Duration duration6 = duration(150, 40);
+        List<Duration> durations = Lists.newArrayList(duration5, duration3, duration1, duration4, duration6, duration2, duration0, duration3);
+        durations.sort(Durations.comparator());
+        assertThat(durations).containsExactly(duration0, duration1, duration2, duration3, duration3, duration4, duration5, duration6).inOrder();
+    }
+
+    @Test
+    public void testCompare() {
+        assertThat(Durations.compare(duration(3, 2), duration(3, 2))).isEqualTo(0);
+        assertThat(Durations.compare(duration(0, 0), duration(0, 0))).isEqualTo(0);
+        assertThat(Durations.compare(duration(3, 1), duration(1, 1))).isGreaterThan(0);
+        assertThat(Durations.compare(duration(3, 2), duration(3, 1))).isGreaterThan(0);
+        assertThat(Durations.compare(duration(1, 1), duration(3, 1))).isLessThan(0);
+        assertThat(Durations.compare(duration(3, 1), duration(3, 2))).isLessThan(0);
+        assertThat(Durations.compare(duration(-3, -1), duration(-1, -1))).isLessThan(0);
+        assertThat(Durations.compare(duration(-3, -2), duration(-3, -1))).isLessThan(0);
+        assertThat(Durations.compare(duration(-1, -1), duration(-3, -1))).isGreaterThan(0);
+        assertThat(Durations.compare(duration(-3, -1), duration(-3, -2))).isGreaterThan(0);
+        assertThat(Durations.compare(duration(-10, -1), duration(1, 1))).isLessThan(0);
+        assertThat(Durations.compare(duration(0, -1), duration(0, 1))).isLessThan(0);
+        assertThat(Durations.compare(duration(0x80000000L, 0), duration(0, 0))).isGreaterThan(0);
+        assertThat(Durations.compare(duration(0xFFFFFFFF00000000L, 0), duration(0, 0))).isLessThan(0);
+    }
+
+    @Test
+    public void testOverflows() {
+        try {
+            Durations.toNanos(duration(315576000000L, 999999999));
+            assertWithMessage("Expected an ArithmeticException to be thrown").fail();
+        } catch (ArithmeticException expected) {
+        }
+        try {
+            Durations.add(Durations.MAX_VALUE, Durations.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.subtract(Durations.MIN_VALUE, Durations.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+
+        try {
+            Durations.toNanos(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toMicros(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toMillis(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toSeconds(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toNanos(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toMicros(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toMillis(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.toSeconds(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        assertThat(Durations.toString(Durations.fromNanos(Long.MAX_VALUE))).isEqualTo("9223372036.854775807s");
+        try {
+            Durations.fromMicros(Long.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.fromMillis(Long.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.fromSeconds(Long.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        assertThat(Durations.toString(Durations.fromNanos(Long.MIN_VALUE))).isEqualTo("-9223372036.854775808s");
+        try {
+            Durations.fromMicros(Long.MIN_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.fromMillis(Long.MIN_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            Durations.fromSeconds(Long.MIN_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    static Duration duration(long seconds, int nanos) {
+        return Durations.checkValid(
+                Durations.checkValid(Duration.newBuilder().setSeconds(seconds).setNanos(nanos)));
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/FieldMaskTreeTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.google.protobuf.util;
+
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import com.google.protobuf.UninitializedMessageException;
+import org.junit.Test;
+import protobuf_unittest.UnittestProto.NestedTestAllTypes;
+import protobuf_unittest.UnittestProto.TestAllTypes;
+import protobuf_unittest.UnittestProto.TestAllTypes.NestedMessage;
+import protobuf_unittest.UnittestProto.TestRequired;
+import protobuf_unittest.UnittestProto.TestRequiredMessage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class FieldMaskTreeTest {
+  @Test
+  public void testAddFieldPath() {
+    FieldMaskTree tree = new FieldMaskTree();
+    assertThat(tree.toString()).isEmpty();
+    tree.addFieldPath("");
+    assertThat(tree.toString()).isEmpty();
+    tree.addFieldPath("foo");
+    assertThat(tree.toString()).isEqualTo("foo");
+    tree.addFieldPath("foo");
+    assertThat(tree.toString()).isEqualTo("foo");
+    tree.addFieldPath("bar.baz");
+    assertThat(tree.toString()).isEqualTo("bar.baz,foo");
+    tree.addFieldPath("foo.bar");
+    assertThat(tree.toString()).isEqualTo("bar.baz,foo");
+    tree.addFieldPath("bar.quz");
+    assertThat(tree.toString()).isEqualTo("bar.baz,bar.quz,foo");
+    tree.addFieldPath("bar");
+    assertThat(tree.toString()).isEqualTo("bar,foo");
+  }
+
+  @Test
+  public void testMergeFromFieldMask() {
+    FieldMaskTree tree = new FieldMaskTree(FieldMaskUtil.fromString("foo,bar.baz,bar.quz"));
+    assertThat(tree.toString()).isEqualTo("bar.baz,bar.quz,foo");
+    tree.mergeFromFieldMask(FieldMaskUtil.fromString("foo.bar,bar"));
+    assertThat(tree.toString()).isEqualTo("bar,foo");
+  }
+
+  @Test
+  public void testRemoveFieldPath() {
+    String initialTreeString = "bar.baz,bar.quz.bar,foo";
+    FieldMaskTree tree;
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("");
+    assertThat(tree.toString()).isEqualTo(initialTreeString);
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("foo.bar");
+    assertThat(tree.toString()).isEqualTo(initialTreeString);
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("bar.foo");
+    assertThat(tree.toString()).isEqualTo(initialTreeString);
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("foo");
+    assertThat(tree.toString()).isEqualTo("bar.baz,bar.quz.bar");
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("bar.quz.bar");
+    assertThat(tree.toString()).isEqualTo("bar.baz,foo");
+    tree = new FieldMaskTree(FieldMaskUtil.fromString(initialTreeString));
+    tree.removeFieldPath("bar");
+    assertThat(tree.toString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void testRemoveFromFieldMask() {
+    FieldMaskTree tree = new FieldMaskTree(FieldMaskUtil.fromString("foo,bar.baz,bar.quz"));
+    assertThat(tree.toString()).isEqualTo("bar.baz,bar.quz,foo");
+    tree.removeFromFieldMask(FieldMaskUtil.fromString("foo.bar,bar"));
+    assertThat(tree.toString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void testIntersectFieldPath() {
+    FieldMaskTree tree = new FieldMaskTree(FieldMaskUtil.fromString("foo,bar.baz,bar.quz"));
+    FieldMaskTree result = new FieldMaskTree();
+    tree.intersectFieldPath("", result);
+    assertThat(result.toString()).isEmpty();
+    tree.intersectFieldPath("quz", result);
+    assertThat(result.toString()).isEmpty();
+    tree.intersectFieldPath("foo.bar", result);
+    assertThat(result.toString()).isEqualTo("foo.bar");
+    tree.intersectFieldPath("foo", result);
+    assertThat(result.toString()).isEqualTo("foo");
+    tree.intersectFieldPath("bar.foo", result);
+    assertThat(result.toString()).isEqualTo("foo");
+    tree.intersectFieldPath("bar", result);
+    assertThat(result.toString()).isEqualTo("bar.baz,bar.quz,foo");
+  }
+
+  @Test
+  public void testMerge() throws Exception {
+    testMergeImpl(true);
+    testMergeImpl(false);
+    testMergeRequire(false);
+    testMergeRequire(true);
+  }
+
+  private void merge(
+      FieldMaskTree tree,
+      Message source,
+      Message.Builder builder,
+      FieldMaskUtil.MergeOptions options,
+      boolean useDynamicMessage)
+      throws Exception {
+    if (useDynamicMessage) {
+      Message.Builder newBuilder = DynamicMessage.newBuilder(source.getDescriptorForType()).mergeFrom(builder.buildPartial().toByteArray());
+      tree.merge(DynamicMessage.newBuilder(source.getDescriptorForType()).mergeFrom(source.toByteArray()).build(),
+          newBuilder,
+          options);
+      builder.clear();
+      builder.mergeFrom(newBuilder.buildPartial());
+    } else {
+      tree.merge(source, builder, options);
+    }
+  }
+
+  private void testMergeRequire(boolean useDynamicMessage) throws Exception {
+    TestRequired value = TestRequired.newBuilder().setA(4321).setB(8765).setC(233333).build();
+    TestRequiredMessage source = TestRequiredMessage.newBuilder().setRequiredMessage(value).build();
+    FieldMaskUtil.MergeOptions options = new FieldMaskUtil.MergeOptions();
+    TestRequiredMessage.Builder builder = TestRequiredMessage.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("required_message.a"),
+        source, builder, options, useDynamicMessage);
+    assertThat(builder.hasRequiredMessage()).isTrue();
+    assertThat(builder.getRequiredMessage().hasA()).isTrue();
+    assertThat(builder.getRequiredMessage().hasB()).isFalse();
+    assertThat(builder.getRequiredMessage().hasC()).isFalse();
+    merge(new FieldMaskTree().addFieldPath("required_message.b").addFieldPath("required_message.c"),
+        source, builder, options, useDynamicMessage);
+    try {
+      assertThat(source).isEqualTo(builder.build());
+    } catch (UninitializedMessageException e) {
+      throw new AssertionError("required field isn't set", e);
+    }
+  }
+
+  private void testMergeImpl(boolean useDynamicMessage) throws Exception {
+    TestAllTypes value = TestAllTypes.newBuilder()
+            .setOptionalInt32(1234)
+            .setOptionalNestedMessage(NestedMessage.newBuilder().setBb(5678))
+            .addRepeatedInt32(4321)
+            .addRepeatedNestedMessage(NestedMessage.newBuilder().setBb(8765))
+            .build();
+    NestedTestAllTypes source = NestedTestAllTypes.newBuilder()
+            .setPayload(value)
+            .setChild(NestedTestAllTypes.newBuilder().setPayload(value))
+            .build();
+    FieldMaskUtil.MergeOptions options = new FieldMaskUtil.MergeOptions();
+    NestedTestAllTypes.Builder builder = NestedTestAllTypes.newBuilder();
+    builder.getPayloadBuilder().addRepeatedInt32(1000);
+    merge(new FieldMaskTree(), source, builder, options, useDynamicMessage);
+    NestedTestAllTypes.Builder expected = NestedTestAllTypes.newBuilder();
+    expected.getPayloadBuilder().addRepeatedInt32(1000);
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.optional_int32"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getPayloadBuilder().setOptionalInt32(1234);
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.optional_nested_message"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getPayloadBuilder().setOptionalNestedMessage(NestedMessage.newBuilder().setBb(5678));
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.repeated_int32"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getPayloadBuilder().addRepeatedInt32(4321);
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.repeated_nested_message"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getPayloadBuilder().addRepeatedNestedMessage(NestedMessage.newBuilder().setBb(8765));
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("child.payload.optional_int32"),
+        source,
+        builder,
+        options,
+        useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getChildBuilder().getPayloadBuilder().setOptionalInt32(1234);
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("child.payload.optional_nested_message"),
+        source,
+        builder,
+        options,
+        useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getChildBuilder().getPayloadBuilder()
+        .setOptionalNestedMessage(NestedMessage.newBuilder().setBb(5678));
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("child.payload.repeated_int32"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getChildBuilder().getPayloadBuilder().addRepeatedInt32(4321);
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("child.payload.repeated_nested_message"), source, builder, options, useDynamicMessage);
+    expected = NestedTestAllTypes.newBuilder();
+    expected.getChildBuilder().getPayloadBuilder()
+        .addRepeatedNestedMessage(NestedMessage.newBuilder().setBb(8765));
+    assertThat(builder.build()).isEqualTo(expected.build());
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("child").addFieldPath("payload"), source, builder, options, useDynamicMessage);
+    assertThat(builder.build()).isEqualTo(source);
+    builder = NestedTestAllTypes.newBuilder();
+    builder.getPayloadBuilder().addRepeatedInt32(1000);
+    merge(new FieldMaskTree().addFieldPath("payload.repeated_int32"), source, builder, options, useDynamicMessage);
+    assertThat(builder.getPayload().getRepeatedInt32Count()).isEqualTo(2);
+    assertThat(builder.getPayload().getRepeatedInt32(0)).isEqualTo(1000);
+    assertThat(builder.getPayload().getRepeatedInt32(1)).isEqualTo(4321);
+    options.setReplaceRepeatedFields(true);
+    merge(new FieldMaskTree().addFieldPath("payload.repeated_int32"), source, builder, options, useDynamicMessage);
+    assertThat(builder.getPayload().getRepeatedInt32Count()).isEqualTo(1);
+    assertThat(builder.getPayload().getRepeatedInt32(0)).isEqualTo(4321);
+    builder = NestedTestAllTypes.newBuilder();
+    builder.getPayloadBuilder().setOptionalInt32(1000);
+    builder.getPayloadBuilder().setOptionalUint32(2000);
+    merge(new FieldMaskTree().addFieldPath("payload"), source, builder, options, useDynamicMessage);
+    assertThat(builder.getPayload().getOptionalInt32()).isEqualTo(1234);
+    assertThat(builder.getPayload().getOptionalUint32()).isEqualTo(2000);
+    NestedTestAllTypes clearedSource = source.toBuilder().clearPayload().build();
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload"), clearedSource, builder, options, useDynamicMessage);
+    assertThat(builder.hasPayload()).isFalse();
+    builder = NestedTestAllTypes.newBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.optional_int32"), clearedSource, builder, options, useDynamicMessage);
+    assertThat(builder.hasPayload()).isFalse();
+    options.setReplaceMessageFields(true);
+    builder = NestedTestAllTypes.newBuilder();
+    builder.getPayloadBuilder().setOptionalInt32(1000);
+    builder.getPayloadBuilder().setOptionalUint32(2000);
+    merge(new FieldMaskTree().addFieldPath("payload"), source, builder, options, useDynamicMessage);
+    assertThat(builder.getPayload().getOptionalInt32()).isEqualTo(1234);
+    assertThat(builder.getPayload().getOptionalUint32()).isEqualTo(0);
+    builder = NestedTestAllTypes.newBuilder();
+    builder.getPayloadBuilder().setOptionalInt32(1000);
+    builder.getPayloadBuilder().setOptionalUint32(2000);
+    merge(new FieldMaskTree().addFieldPath("payload"), clearedSource, builder, options, useDynamicMessage);
+    assertThat(builder.hasPayload()).isFalse();
+    builder = source.toBuilder();
+    builder.getPayloadBuilder().clearOptionalInt32();
+    NestedTestAllTypes sourceWithPayloadInt32Unset = builder.build();
+    builder = source.toBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.optional_int32"), sourceWithPayloadInt32Unset, builder, options, useDynamicMessage);
+    assertThat(builder.getPayload().hasOptionalInt32()).isTrue();
+    assertThat(builder.getPayload().getOptionalInt32()).isEqualTo(0);
+    options.setReplacePrimitiveFields(true);
+    builder = source.toBuilder();
+    merge(new FieldMaskTree().addFieldPath("payload.optional_int32"), sourceWithPayloadInt32Unset, builder, options, useDynamicMessage);
+    assertThat(builder.hasPayload()).isTrue();
+    assertThat(builder.getPayload().hasOptionalInt32()).isFalse();
+  }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -1,0 +1,1995 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.google.protobuf.util;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonSyntaxException;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Message;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestAllTypes;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestAllTypes.AliasedEnum;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestAllTypes.NestedEnum;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestAllTypes.NestedMessage;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestAny;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestCustomJsonName;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestDuration;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestFieldMask;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestMap;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestOneof;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestRecursive;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestStruct;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestTimestamp;
+import com_google_protobuf.protobuf_java_util.JsonTestProto.TestWrappers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@SuppressWarnings({"UnnecessaryUnicodeEscape", "SameParameterValue", "UnpredictableBigDecimalConstructorCall"})
+public class JsonFormatTest {
+    private static Locale originalLocale;
+
+    @BeforeClass
+    public static void setLocale() {
+        originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("hi-IN"));
+    }
+
+    @AfterClass
+    public static void resetLocale() {
+        Locale.setDefault(originalLocale);
+    }
+
+    private void setAllFields(TestAllTypes.Builder builder) {
+        builder.setOptionalInt32(1234);
+        builder.setOptionalInt64(1234567890123456789L);
+        builder.setOptionalUint32(5678);
+        builder.setOptionalUint64(2345678901234567890L);
+        builder.setOptionalSint32(9012);
+        builder.setOptionalSint64(3456789012345678901L);
+        builder.setOptionalFixed32(3456);
+        builder.setOptionalFixed64(4567890123456789012L);
+        builder.setOptionalSfixed32(7890);
+        builder.setOptionalSfixed64(5678901234567890123L);
+        builder.setOptionalFloat(1.5f);
+        builder.setOptionalDouble(1.25);
+        builder.setOptionalBool(true);
+        builder.setOptionalString("Hello world!");
+        builder.setOptionalBytes(ByteString.copyFrom(new byte[]{0, 1, 2}));
+        builder.setOptionalNestedEnum(NestedEnum.BAR);
+        builder.getOptionalNestedMessageBuilder().setValue(100);
+        builder.addRepeatedInt32(1234);
+        builder.addRepeatedInt64(1234567890123456789L);
+        builder.addRepeatedUint32(5678);
+        builder.addRepeatedUint64(2345678901234567890L);
+        builder.addRepeatedSint32(9012);
+        builder.addRepeatedSint64(3456789012345678901L);
+        builder.addRepeatedFixed32(3456);
+        builder.addRepeatedFixed64(4567890123456789012L);
+        builder.addRepeatedSfixed32(7890);
+        builder.addRepeatedSfixed64(5678901234567890123L);
+        builder.addRepeatedFloat(1.5f);
+        builder.addRepeatedDouble(1.25);
+        builder.addRepeatedBool(true);
+        builder.addRepeatedString("Hello world!");
+        builder.addRepeatedBytes(ByteString.copyFrom(new byte[]{0, 1, 2}));
+        builder.addRepeatedNestedEnum(NestedEnum.BAR);
+        builder.addRepeatedNestedMessageBuilder().setValue(100);
+        builder.addRepeatedInt32(234);
+        builder.addRepeatedInt64(234567890123456789L);
+        builder.addRepeatedUint32(678);
+        builder.addRepeatedUint64(345678901234567890L);
+        builder.addRepeatedSint32(10);
+        builder.addRepeatedSint64(456789012345678901L);
+        builder.addRepeatedFixed32(456);
+        builder.addRepeatedFixed64(567890123456789012L);
+        builder.addRepeatedSfixed32(890);
+        builder.addRepeatedSfixed64(678901234567890123L);
+        builder.addRepeatedFloat(11.5f);
+        builder.addRepeatedDouble(11.25);
+        builder.addRepeatedBool(true);
+        builder.addRepeatedString("ello world!");
+        builder.addRepeatedBytes(ByteString.copyFrom(new byte[]{1, 2}));
+        builder.addRepeatedNestedEnum(NestedEnum.BAZ);
+        builder.addRepeatedNestedMessageBuilder().setValue(200);
+    }
+
+    private void assertRoundTripEquals(Message message) throws Exception {
+        assertRoundTripEquals(message, TypeRegistry.getEmptyTypeRegistry());
+    }
+
+    private void assertRoundTripEquals(Message message, TypeRegistry registry) throws Exception {
+        JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+        JsonFormat.Parser parser = JsonFormat.parser().usingTypeRegistry(registry);
+        Message.Builder builder = message.newBuilderForType();
+        parser.merge(printer.print(message), builder);
+        Message parsedMessage = builder.build();
+        assertThat(parsedMessage.toString()).isEqualTo(message.toString());
+    }
+
+    private void assertRoundTripEquals(Message message, com.google.protobuf.TypeRegistry registry) throws Exception {
+        JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+        JsonFormat.Parser parser = JsonFormat.parser().usingTypeRegistry(registry);
+        Message.Builder builder = message.newBuilderForType();
+        parser.merge(printer.print(message), builder);
+        Message parsedMessage = builder.build();
+        assertThat(parsedMessage.toString()).isEqualTo(message.toString());
+    }
+
+    private String toJsonString(Message message) throws IOException {
+        return JsonFormat.printer().print(message);
+    }
+
+    private String toCompactJsonString(Message message) throws IOException {
+        return JsonFormat.printer().omittingInsignificantWhitespace().print(message);
+    }
+
+    private String toSortedJsonString(Message message) throws IOException {
+        return JsonFormat.printer().sortingMapKeys().print(message);
+    }
+
+    private void mergeFromJson(String json, Message.Builder builder) throws IOException {
+        JsonFormat.parser().merge(json, builder);
+    }
+
+    private void mergeFromJsonIgnoringUnknownFields(String json, Message.Builder builder) throws IOException {
+        JsonFormat.parser().ignoringUnknownFields().merge(json, builder);
+    }
+
+    @Test
+    public void testAllFields() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        setAllFields(builder);
+        TestAllTypes message = builder.build();
+        assertThat(toJsonString(message)).isEqualTo(
+                """
+                        {
+                          "optionalInt32": 1234,
+                          "optionalInt64": "1234567890123456789",
+                          "optionalUint32": 5678,
+                          "optionalUint64": "2345678901234567890",
+                          "optionalSint32": 9012,
+                          "optionalSint64": "3456789012345678901",
+                          "optionalFixed32": 3456,
+                          "optionalFixed64": "4567890123456789012",
+                          "optionalSfixed32": 7890,
+                          "optionalSfixed64": "5678901234567890123",
+                          "optionalFloat": 1.5,
+                          "optionalDouble": 1.25,
+                          "optionalBool": true,
+                          "optionalString": "Hello world!",
+                          "optionalBytes": "AAEC",
+                          "optionalNestedMessage": {
+                            "value": 100
+                          },
+                          "optionalNestedEnum": "BAR",
+                          "repeatedInt32": [1234, 234],
+                          "repeatedInt64": ["1234567890123456789", "234567890123456789"],
+                          "repeatedUint32": [5678, 678],
+                          "repeatedUint64": ["2345678901234567890", "345678901234567890"],
+                          "repeatedSint32": [9012, 10],
+                          "repeatedSint64": ["3456789012345678901", "456789012345678901"],
+                          "repeatedFixed32": [3456, 456],
+                          "repeatedFixed64": ["4567890123456789012", "567890123456789012"],
+                          "repeatedSfixed32": [7890, 890],
+                          "repeatedSfixed64": ["5678901234567890123", "678901234567890123"],
+                          "repeatedFloat": [1.5, 11.5],
+                          "repeatedDouble": [1.25, 11.25],
+                          "repeatedBool": [true, true],
+                          "repeatedString": ["Hello world!", "ello world!"],
+                          "repeatedBytes": ["AAEC", "AQI="],
+                          "repeatedNestedMessage": [{
+                            "value": 100
+                          }, {
+                            "value": 200
+                          }],
+                          "repeatedNestedEnum": ["BAR", "BAZ"]
+                        }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testUnknownEnumValues() throws Exception {
+        TestAllTypes message =
+                TestAllTypes.newBuilder()
+                        .setOptionalNestedEnumValue(12345)
+                        .addRepeatedNestedEnumValue(12345)
+                        .addRepeatedNestedEnumValue(0)
+                        .build();
+        assertThat(toJsonString(message)).isEqualTo(
+                """
+                        {
+                          "optionalNestedEnum": 12345,
+                          "repeatedNestedEnum": [12345, "FOO"]
+                        }""");
+        assertRoundTripEquals(message);
+        TestMap.Builder mapBuilder = TestMap.newBuilder();
+        mapBuilder.putInt32ToEnumMapValue(1, 0);
+        mapBuilder.putInt32ToEnumMapValue(2, 12345);
+        TestMap mapMessage = mapBuilder.build();
+        assertThat(toJsonString(mapMessage)).isEqualTo(
+                """
+                        {
+                          "int32ToEnumMap": {
+                            "1": "FOO",
+                            "2": 12345
+                          }
+                        }""");
+        assertRoundTripEquals(mapMessage);
+    }
+
+    @Test
+    public void testSpecialFloatValues() throws Exception {
+        TestAllTypes message =
+                TestAllTypes.newBuilder()
+                        .addRepeatedFloat(Float.NaN)
+                        .addRepeatedFloat(Float.POSITIVE_INFINITY)
+                        .addRepeatedFloat(Float.NEGATIVE_INFINITY)
+                        .addRepeatedDouble(Double.NaN)
+                        .addRepeatedDouble(Double.POSITIVE_INFINITY)
+                        .addRepeatedDouble(Double.NEGATIVE_INFINITY)
+                        .build();
+        assertThat(toJsonString(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "repeatedFloat": ["NaN", "Infinity", "-Infinity"],
+                                  "repeatedDouble": ["NaN", "Infinity", "-Infinity"]
+                                }""");
+
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testParserAcceptStringForNumericField() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        mergeFromJson(
+                """
+                        {
+                          "optionalInt32": "1234",
+                          "optionalUint32": "5678",
+                          "optionalSint32": "9012",
+                          "optionalFixed32": "3456",
+                          "optionalSfixed32": "7890",
+                          "optionalFloat": "1.5",
+                          "optionalDouble": "1.25",
+                          "optionalBool": "true"
+                        }""",
+                builder);
+        TestAllTypes message = builder.build();
+        assertThat(message.getOptionalInt32()).isEqualTo(1234);
+        assertThat(message.getOptionalUint32()).isEqualTo(5678);
+        assertThat(message.getOptionalSint32()).isEqualTo(9012);
+        assertThat(message.getOptionalFixed32()).isEqualTo(3456);
+        assertThat(message.getOptionalSfixed32()).isEqualTo(7890);
+        assertThat(message.getOptionalFloat()).isEqualTo(1.5f);
+        assertThat(message.getOptionalDouble()).isEqualTo(1.25);
+        assertThat(message.getOptionalBool()).isTrue();
+    }
+
+    @Test
+    public void testParserAcceptFloatingPointValueForIntegerField() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        mergeFromJson(
+                """
+                        {
+                          "repeatedInt32": [1.000, 1e5, "1.000", "1e5"],
+                          "repeatedUint32": [1.000, 1e5, "1.000", "1e5"],
+                          "repeatedInt64": [1.000, 1e5, "1.000", "1e5"],
+                          "repeatedUint64": [1.000, 1e5, "1.000", "1e5"]
+                        }""",
+                builder);
+        int[] expectedValues = new int[]{1, 100000, 1, 100000};
+        assertThat(builder.getRepeatedInt32Count()).isEqualTo(4);
+        assertThat(builder.getRepeatedUint32Count()).isEqualTo(4);
+        assertThat(builder.getRepeatedInt64Count()).isEqualTo(4);
+        assertThat(builder.getRepeatedUint64Count()).isEqualTo(4);
+        for (int i = 0; i < 4; ++i) {
+            assertThat(builder.getRepeatedInt32(i)).isEqualTo(expectedValues[i]);
+            assertThat(builder.getRepeatedUint32(i)).isEqualTo(expectedValues[i]);
+            assertThat(builder.getRepeatedInt64(i)).isEqualTo(expectedValues[i]);
+            assertThat(builder.getRepeatedUint64(i)).isEqualTo(expectedValues[i]);
+        }
+    }
+
+    @Test
+    public void testRejectTooLargeFloat() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        double tooLarge = 2.0 * Float.MAX_VALUE;
+        try {
+            mergeFromJson("{\"" + "optionalFloat" + "\":" + tooLarge + "}", builder);
+            assertWithMessage("InvalidProtocolBufferException expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Out of range float value: " + tooLarge);
+        }
+    }
+
+    @Test
+    public void testRejectMalformedFloat() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"optionalFloat\":3.5aa}", builder);
+            assertWithMessage("InvalidProtocolBufferException expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testRejectFractionalInt64() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + "optionalInt64" + "\":" + "1.5" + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Not an int64 value: 1.5");
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testRejectFractionalInt32() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + "optionalInt32" + "\":" + "1.5" + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Not an int32 value: 1.5");
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testRejectFractionalUnsignedInt32() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + "optionalUint32" + "\":" + "1.5" + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Not an uint32 value: 1.5");
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testRejectFractionalUnsignedInt64() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + "optionalUint64" + "\":" + "1.5" + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo("Not an uint64 value: 1.5");
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    private void assertRejects(String name, String value) throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + name + "\":" + value + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().contains(value);
+        }
+        try {
+            mergeFromJson("{\"" + name + "\":\"" + value + "\"}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().contains(value);
+        }
+    }
+
+    private void assertAccepts(String name, String value) throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        mergeFromJson("{\"" + name + "\":" + value + "}", builder);
+        builder.clear();
+        mergeFromJson("{\"" + name + "\":\"" + value + "\"}", builder);
+    }
+
+    @Test
+    public void testParserRejectOutOfRangeNumericValues() throws Exception {
+        assertAccepts("optionalInt32", String.valueOf(Integer.MAX_VALUE));
+        assertAccepts("optionalInt32", String.valueOf(Integer.MIN_VALUE));
+        assertRejects("optionalInt32", String.valueOf(Integer.MAX_VALUE + 1L));
+        assertRejects("optionalInt32", String.valueOf(Integer.MIN_VALUE - 1L));
+        assertAccepts("optionalUint32", String.valueOf(Integer.MAX_VALUE + 1L));
+        assertRejects("optionalUint32", "123456789012345");
+        assertRejects("optionalUint32", "-1");
+        BigInteger one = BigInteger.ONE;
+        BigInteger maxLong = new BigInteger(String.valueOf(Long.MAX_VALUE));
+        BigInteger minLong = new BigInteger(String.valueOf(Long.MIN_VALUE));
+        assertAccepts("optionalInt64", maxLong.toString());
+        assertAccepts("optionalInt64", minLong.toString());
+        assertRejects("optionalInt64", maxLong.add(one).toString());
+        assertRejects("optionalInt64", minLong.subtract(one).toString());
+        assertAccepts("optionalUint64", maxLong.add(one).toString());
+        assertRejects("optionalUint64", "1234567890123456789012345");
+        assertRejects("optionalUint64", "-1");
+        assertAccepts("optionalBool", "true");
+        assertRejects("optionalBool", "1");
+        assertRejects("optionalBool", "0");
+        assertAccepts("optionalFloat", String.valueOf(Float.MAX_VALUE));
+        assertAccepts("optionalFloat", String.valueOf(-Float.MAX_VALUE));
+        assertRejects("optionalFloat", String.valueOf(Double.MAX_VALUE));
+        assertRejects("optionalFloat", String.valueOf(-Double.MAX_VALUE));
+        BigDecimal moreThanOne = new BigDecimal("1.000001");
+        BigDecimal maxDouble = new BigDecimal(Double.MAX_VALUE);
+        BigDecimal minDouble = new BigDecimal(-Double.MAX_VALUE);
+        assertAccepts("optionalDouble", maxDouble.toString());
+        assertAccepts("optionalDouble", minDouble.toString());
+        assertRejects("optionalDouble", maxDouble.multiply(moreThanOne).toString());
+        assertRejects("optionalDouble", minDouble.multiply(moreThanOne).toString());
+    }
+
+    @Test
+    public void testParserAcceptNull() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        mergeFromJson(
+                """
+                        {
+                          "optionalInt32": null,
+                          "optionalInt64": null,
+                          "optionalUint32": null,
+                          "optionalUint64": null,
+                          "optionalSint32": null,
+                          "optionalSint64": null,
+                          "optionalFixed32": null,
+                          "optionalFixed64": null,
+                          "optionalSfixed32": null,
+                          "optionalSfixed64": null,
+                          "optionalFloat": null,
+                          "optionalDouble": null,
+                          "optionalBool": null,
+                          "optionalString": null,
+                          "optionalBytes": null,
+                          "optionalNestedMessage": null,
+                          "optionalNestedEnum": null,
+                          "repeatedInt32": null,
+                          "repeatedInt64": null,
+                          "repeatedUint32": null,
+                          "repeatedUint64": null,
+                          "repeatedSint32": null,
+                          "repeatedSint64": null,
+                          "repeatedFixed32": null,
+                          "repeatedFixed64": null,
+                          "repeatedSfixed32": null,
+                          "repeatedSfixed64": null,
+                          "repeatedFloat": null,
+                          "repeatedDouble": null,
+                          "repeatedBool": null,
+                          "repeatedString": null,
+                          "repeatedBytes": null,
+                          "repeatedNestedMessage": null,
+                          "repeatedNestedEnum": null
+                        }""",
+                builder);
+        TestAllTypes message = builder.build();
+        assertThat(message).isEqualTo(TestAllTypes.getDefaultInstance());
+        try {
+            builder = TestAllTypes.newBuilder();
+            mergeFromJson("""
+                    {
+                      "repeatedInt32": [null, null],
+                    }""", builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+        try {
+            builder = TestAllTypes.newBuilder();
+            mergeFromJson("""
+                    {
+                      "repeatedNestedMessage": [null, null],
+                    }""", builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testNullInOneof() throws Exception {
+        TestOneof.Builder builder = TestOneof.newBuilder();
+        mergeFromJson("""
+                {
+                  "oneofNullValue": null\s
+                }""", builder);
+        TestOneof message = builder.build();
+        assertThat(message.getOneofFieldCase()).isEqualTo(TestOneof.OneofFieldCase.ONEOF_NULL_VALUE);
+        assertThat(message.getOneofNullValue()).isEqualTo(NullValue.NULL_VALUE);
+    }
+
+    @Test
+    public void testNullFirstInDuplicateOneof() throws Exception {
+        TestOneof.Builder builder = TestOneof.newBuilder();
+        mergeFromJson("{\"oneofNestedMessage\": null, \"oneofInt32\": 1}", builder);
+        TestOneof message = builder.build();
+        assertThat(message.getOneofInt32()).isEqualTo(1);
+    }
+
+    @Test
+    public void testNullLastInDuplicateOneof() throws Exception {
+        TestOneof.Builder builder = TestOneof.newBuilder();
+        mergeFromJson("{\"oneofInt32\": 1, \"oneofNestedMessage\": null}", builder);
+        TestOneof message = builder.build();
+        assertThat(message.getOneofInt32()).isEqualTo(1);
+    }
+
+    @Test
+    public void testParserRejectDuplicatedFields() throws Exception {
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "optionalNestedMessage": {},
+                              "optional_nested_message": {}
+                            }""",
+                    builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "repeatedInt32": [1, 2],
+                              "repeated_int32": [5, 6]
+                            }""",
+                    builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+        try {
+            TestOneof.Builder builder = TestOneof.newBuilder();
+            mergeFromJson("""
+                    {
+                      "oneofInt32": 1,
+                      "oneof_int32": 2
+                    }""", builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+        try {
+            TestOneof.Builder builder = TestOneof.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "oneofInt32": 1,
+                              "oneofNullValue": null
+                            }""", builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testMapFields() throws Exception {
+        TestMap.Builder builder = TestMap.newBuilder();
+        builder.putInt32ToInt32Map(1, 10);
+        builder.putInt64ToInt32Map(1234567890123456789L, 10);
+        builder.putUint32ToInt32Map(2, 20);
+        builder.putUint64ToInt32Map(2234567890123456789L, 20);
+        builder.putSint32ToInt32Map(3, 30);
+        builder.putSint64ToInt32Map(3234567890123456789L, 30);
+        builder.putFixed32ToInt32Map(4, 40);
+        builder.putFixed64ToInt32Map(4234567890123456789L, 40);
+        builder.putSfixed32ToInt32Map(5, 50);
+        builder.putSfixed64ToInt32Map(5234567890123456789L, 50);
+        builder.putBoolToInt32Map(false, 6);
+        builder.putStringToInt32Map("Hello", 10);
+        builder.putInt32ToInt64Map(1, 1234567890123456789L);
+        builder.putInt32ToUint32Map(2, 20);
+        builder.putInt32ToUint64Map(2, 2234567890123456789L);
+        builder.putInt32ToSint32Map(3, 30);
+        builder.putInt32ToSint64Map(3, 3234567890123456789L);
+        builder.putInt32ToFixed32Map(4, 40);
+        builder.putInt32ToFixed64Map(4, 4234567890123456789L);
+        builder.putInt32ToSfixed32Map(5, 50);
+        builder.putInt32ToSfixed64Map(5, 5234567890123456789L);
+        builder.putInt32ToFloatMap(6, 1.5f);
+        builder.putInt32ToDoubleMap(6, 1.25);
+        builder.putInt32ToBoolMap(7, false);
+        builder.putInt32ToStringMap(7, "World");
+        builder.putInt32ToBytesMap(8, ByteString.copyFrom(new byte[]{1, 2, 3}));
+        builder.putInt32ToMessageMap(8, NestedMessage.newBuilder().setValue(1234).build());
+        builder.putInt32ToEnumMap(9, NestedEnum.BAR);
+        TestMap message = builder.build();
+        assertThat(toJsonString(message)).isEqualTo(
+                """
+                        {
+                          "int32ToInt32Map": {
+                            "1": 10
+                          },
+                          "int64ToInt32Map": {
+                            "1234567890123456789": 10
+                          },
+                          "uint32ToInt32Map": {
+                            "2": 20
+                          },
+                          "uint64ToInt32Map": {
+                            "2234567890123456789": 20
+                          },
+                          "sint32ToInt32Map": {
+                            "3": 30
+                          },
+                          "sint64ToInt32Map": {
+                            "3234567890123456789": 30
+                          },
+                          "fixed32ToInt32Map": {
+                            "4": 40
+                          },
+                          "fixed64ToInt32Map": {
+                            "4234567890123456789": 40
+                          },
+                          "sfixed32ToInt32Map": {
+                            "5": 50
+                          },
+                          "sfixed64ToInt32Map": {
+                            "5234567890123456789": 50
+                          },
+                          "boolToInt32Map": {
+                            "false": 6
+                          },
+                          "stringToInt32Map": {
+                            "Hello": 10
+                          },
+                          "int32ToInt64Map": {
+                            "1": "1234567890123456789"
+                          },
+                          "int32ToUint32Map": {
+                            "2": 20
+                          },
+                          "int32ToUint64Map": {
+                            "2": "2234567890123456789"
+                          },
+                          "int32ToSint32Map": {
+                            "3": 30
+                          },
+                          "int32ToSint64Map": {
+                            "3": "3234567890123456789"
+                          },
+                          "int32ToFixed32Map": {
+                            "4": 40
+                          },
+                          "int32ToFixed64Map": {
+                            "4": "4234567890123456789"
+                          },
+                          "int32ToSfixed32Map": {
+                            "5": 50
+                          },
+                          "int32ToSfixed64Map": {
+                            "5": "5234567890123456789"
+                          },
+                          "int32ToFloatMap": {
+                            "6": 1.5
+                          },
+                          "int32ToDoubleMap": {
+                            "6": 1.25
+                          },
+                          "int32ToBoolMap": {
+                            "7": false
+                          },
+                          "int32ToStringMap": {
+                            "7": "World"
+                          },
+                          "int32ToBytesMap": {
+                            "8": "AQID"
+                          },
+                          "int32ToMessageMap": {
+                            "8": {
+                              "value": 1234
+                            }
+                          },
+                          "int32ToEnumMap": {
+                            "9": "BAR"
+                          }
+                        }""");
+        assertRoundTripEquals(message);
+        builder = TestMap.newBuilder();
+        builder.putInt32ToInt32Map(1, 2);
+        builder.putInt32ToInt32Map(3, 4);
+        message = builder.build();
+        assertThat(toJsonString(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "int32ToInt32Map": {
+                                    "1": 2,
+                                    "3": 4
+                                  }
+                                }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testMapNullValueIsRejected() throws Exception {
+        try {
+            TestMap.Builder builder = TestMap.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "int32ToInt32Map": {null: 1},
+                              "int32ToMessageMap": {null: 2}
+                            }""",
+                    builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+
+        try {
+            TestMap.Builder builder = TestMap.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "int32ToInt32Map": {"1": null},
+                              "int32ToMessageMap": {"2": null}
+                            }""",
+                    builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testMapEnumNullValueIsIgnored() throws Exception {
+        TestMap.Builder builder = TestMap.newBuilder();
+        mergeFromJsonIgnoringUnknownFields(
+                """
+                        {
+                          "int32ToEnumMap": {"1": null}
+                        }""", builder);
+        TestMap map = builder.build();
+        assertThat(map.getInt32ToEnumMapMap()).isEmpty();
+    }
+
+    @Test
+    public void testArrayTypeMismatch() throws IOException {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson(
+                    """
+                            {
+                              "repeated_int32": 5
+                            }""",
+                    builder);
+            assertWithMessage("should have thrown exception for incorrect type").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat()
+                    .isEqualTo("Expected an array for repeated_int32 but found 5");
+        }
+    }
+
+    @Test
+    public void testParserAcceptNonQuotedObjectKey() throws Exception {
+        TestMap.Builder builder = TestMap.newBuilder();
+        mergeFromJson(
+                """
+                        {
+                          int32ToInt32Map: {1: 2},
+                          stringToInt32Map: {hello: 3}
+                        }""", builder);
+        TestMap message = builder.build();
+        assertThat(message.getInt32ToInt32MapMap().get(1)).isEqualTo(2);
+        assertThat(message.getStringToInt32MapMap().get("hello")).isEqualTo(3);
+    }
+
+    @Test
+    public void testWrappers() throws Exception {
+        TestWrappers.Builder builder = TestWrappers.newBuilder();
+        builder.getBoolValueBuilder().setValue(false);
+        builder.getInt32ValueBuilder().setValue(0);
+        builder.getInt64ValueBuilder().setValue(0);
+        builder.getUint32ValueBuilder().setValue(0);
+        builder.getUint64ValueBuilder().setValue(0);
+        builder.getFloatValueBuilder().setValue(0.0f);
+        builder.getDoubleValueBuilder().setValue(0.0);
+        builder.getStringValueBuilder().setValue("");
+        builder.getBytesValueBuilder().setValue(ByteString.EMPTY);
+        TestWrappers message = builder.build();
+
+        assertThat(toJsonString(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "int32Value": 0,
+                                  "uint32Value": 0,
+                                  "int64Value": "0",
+                                  "uint64Value": "0",
+                                  "floatValue": 0.0,
+                                  "doubleValue": 0.0,
+                                  "boolValue": false,
+                                  "stringValue": "",
+                                  "bytesValue": ""
+                                }""");
+        assertRoundTripEquals(message);
+
+        builder = TestWrappers.newBuilder();
+        builder.getBoolValueBuilder().setValue(true);
+        builder.getInt32ValueBuilder().setValue(1);
+        builder.getInt64ValueBuilder().setValue(2);
+        builder.getUint32ValueBuilder().setValue(3);
+        builder.getUint64ValueBuilder().setValue(4);
+        builder.getFloatValueBuilder().setValue(5.0f);
+        builder.getDoubleValueBuilder().setValue(6.0);
+        builder.getStringValueBuilder().setValue("7");
+        builder.getBytesValueBuilder().setValue(ByteString.copyFrom(new byte[]{8}));
+        message = builder.build();
+
+        assertThat(toJsonString(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "int32Value": 1,
+                                  "uint32Value": 3,
+                                  "int64Value": "2",
+                                  "uint64Value": "4",
+                                  "floatValue": 5.0,
+                                  "doubleValue": 6.0,
+                                  "boolValue": true,
+                                  "stringValue": "7",
+                                  "bytesValue": "CA=="
+                                }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testTimestamp() throws Exception {
+        TestTimestamp message =
+                TestTimestamp.newBuilder()
+                        .setTimestampValue(Timestamps.parse("1970-01-01T00:00:00Z"))
+                        .build();
+
+        assertThat(toJsonString(message))
+                .isEqualTo("""
+                        {
+                          "timestampValue": "1970-01-01T00:00:00Z"
+                        }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testTimestampMergeError() throws Exception {
+        final String incorrectTimestampString = "{\"seconds\":1800,\"nanos\":0}";
+        try {
+            TestTimestamp.Builder builder = TestTimestamp.newBuilder();
+            mergeFromJson(String.format("{\"timestamp_value\": %s}", incorrectTimestampString), builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException e) {
+            assertThat(e)
+                    .hasMessageThat()
+                    .isEqualTo("Failed to parse timestamp: " + incorrectTimestampString);
+            assertThat(e).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testDuration() throws Exception {
+        TestDuration message =
+                TestDuration.newBuilder().setDurationValue(Durations.parse("12345s")).build();
+
+        assertThat(toJsonString(message)).isEqualTo("""
+                {
+                  "durationValue": "12345s"
+                }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testDurationMergeError() throws Exception {
+        final String incorrectDurationString = "{\"seconds\":10,\"nanos\":500}";
+        try {
+            TestDuration.Builder builder = TestDuration.newBuilder();
+            mergeFromJson(String.format("{\"duration_value\": %s}", incorrectDurationString), builder);
+            assertWithMessage("expected exception").fail();
+        } catch (InvalidProtocolBufferException e) {
+            assertThat(e)
+                    .hasMessageThat()
+                    .isEqualTo("Failed to parse duration: " + incorrectDurationString);
+            assertThat(e).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testFieldMask() throws Exception {
+        TestFieldMask message =
+                TestFieldMask.newBuilder()
+                        .setFieldMaskValue(FieldMaskUtil.fromString("foo.bar,baz,foo_bar.baz"))
+                        .build();
+
+        assertThat(toJsonString(message))
+                .isEqualTo("""
+                        {
+                          "fieldMaskValue": "foo.bar,baz,fooBar.baz"
+                        }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testStruct() throws Exception {
+        TestStruct.Builder builder = TestStruct.newBuilder();
+        Struct.Builder structBuilder = builder.getStructValueBuilder();
+        structBuilder.putFields("null_value", Value.newBuilder().setNullValueValue(0).build());
+        structBuilder.putFields("number_value", Value.newBuilder().setNumberValue(1.25).build());
+        structBuilder.putFields("string_value", Value.newBuilder().setStringValue("hello").build());
+        Struct.Builder subStructBuilder = Struct.newBuilder();
+        subStructBuilder.putFields("number_value", Value.newBuilder().setNumberValue(1234).build());
+        structBuilder.putFields(
+                "struct_value", Value.newBuilder().setStructValue(subStructBuilder.build()).build());
+        ListValue.Builder listBuilder = ListValue.newBuilder();
+        listBuilder.addValues(Value.newBuilder().setNumberValue(1.125).build());
+        listBuilder.addValues(Value.newBuilder().setNullValueValue(0).build());
+        structBuilder.putFields(
+                "list_value", Value.newBuilder().setListValue(listBuilder.build()).build());
+        TestStruct message = builder.build();
+
+        assertThat(toJsonString(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "structValue": {
+                                    "null_value": null,
+                                    "number_value": 1.25,
+                                    "string_value": "hello",
+                                    "struct_value": {
+                                      "number_value": 1234.0
+                                    },
+                                    "list_value": [1.125, null]
+                                  }
+                                }""");
+        assertRoundTripEquals(message);
+
+        builder = TestStruct.newBuilder();
+        builder.setValue(Value.newBuilder().setNullValueValue(0).build());
+        message = builder.build();
+        assertThat(toJsonString(message)).isEqualTo("""
+                {
+                  "value": null
+                }""");
+        assertRoundTripEquals(message);
+
+        builder = TestStruct.newBuilder();
+        listBuilder = builder.getListValueBuilder();
+        listBuilder.addValues(Value.newBuilder().setNumberValue(31831.125).build());
+        listBuilder.addValues(Value.newBuilder().setNullValueValue(0).build());
+        message = builder.build();
+        assertThat(toJsonString(message))
+                .isEqualTo("""
+                        {
+                          "listValue": [31831.125, null]
+                        }""");
+        assertRoundTripEquals(message);
+    }
+
+
+    @Test
+    public void testAnyFieldsWithCustomAddedTypeRegistry() throws Exception {
+        TestAllTypes content = TestAllTypes.newBuilder().setOptionalInt32(1234).build();
+        TestAny message = TestAny.newBuilder().setAnyValue(Any.pack(content)).build();
+        com.google.protobuf.TypeRegistry registry = com.google.protobuf.TypeRegistry.newBuilder().add(content.getDescriptorForType()).build();
+        JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+        assertThat(printer.print(message)).isEqualTo(
+                """
+                        {
+                          "anyValue": {
+                            "@type": "type.googleapis.com/json_test.TestAllTypes",
+                            "optionalInt32": 1234
+                          }
+                        }""");
+        assertRoundTripEquals(message, registry);
+        TestAny messageWithDefaultAnyValue = TestAny.newBuilder().setAnyValue(Any.getDefaultInstance()).build();
+        assertThat(printer.print(messageWithDefaultAnyValue))
+                .isEqualTo("""
+                        {
+                          "anyValue": {}
+                        }""");
+        assertRoundTripEquals(messageWithDefaultAnyValue, registry);
+        Any anyMessage = Any.pack(Any.pack(content));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Any",
+                                  "value": {
+                                    "@type": "type.googleapis.com/json_test.TestAllTypes",
+                                    "optionalInt32": 1234
+                                  }
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+    }
+
+    @Test
+    public void testAnyFields() throws Exception {
+        TestAllTypes content = TestAllTypes.newBuilder().setOptionalInt32(1234).build();
+        TestAny message = TestAny.newBuilder().setAnyValue(Any.pack(content)).build();
+        try {
+            toJsonString(message);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasMessageThat().isEqualTo(
+                    "Cannot find type for url: type.googleapis.com/json_test.TestAllTypes");
+        }
+        TypeRegistry registry = TypeRegistry.newBuilder().add(TestAllTypes.getDescriptor()).build();
+        JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+        assertThat(printer.print(message)).isEqualTo(
+                """
+                        {
+                          "anyValue": {
+                            "@type": "type.googleapis.com/json_test.TestAllTypes",
+                            "optionalInt32": 1234
+                          }
+                        }""");
+        assertRoundTripEquals(message, registry);
+        TestAny messageWithDefaultAnyValue = TestAny.newBuilder().setAnyValue(Any.getDefaultInstance()).build();
+        assertThat(printer.print(messageWithDefaultAnyValue))
+                .isEqualTo("""
+                        {
+                          "anyValue": {}
+                        }""");
+        assertRoundTripEquals(messageWithDefaultAnyValue, registry);
+        Any anyMessage = Any.pack(Any.pack(content));
+        assertThat(printer.print(anyMessage)).isEqualTo(
+                """
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Any",
+                          "value": {
+                            "@type": "type.googleapis.com/json_test.TestAllTypes",
+                            "optionalInt32": 1234
+                          }
+                        }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(Int32Value.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Int32Value",
+                                  "value": 12345
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(UInt32Value.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.UInt32Value",
+                                  "value": 12345
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(Int64Value.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Int64Value",
+                                  "value": "12345"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(UInt64Value.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.UInt64Value",
+                                  "value": "12345"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(FloatValue.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.FloatValue",
+                                  "value": 12345.0
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(DoubleValue.of(12345));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.DoubleValue",
+                                  "value": 12345.0
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(BoolValue.of(true));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.BoolValue",
+                                  "value": true
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(StringValue.of("Hello"));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.StringValue",
+                                  "value": "Hello"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(BytesValue.of(ByteString.copyFrom(new byte[]{1, 2})));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.BytesValue",
+                                  "value": "AQI="
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(Timestamps.parse("1969-12-31T23:59:59Z"));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Timestamp",
+                                  "value": "1969-12-31T23:59:59Z"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(Durations.parse("12345.10s"));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Duration",
+                                  "value": "12345.100s"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(FieldMaskUtil.fromString("foo.bar,baz"));
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.FieldMask",
+                                  "value": "foo.bar,baz"
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        Struct.Builder structBuilder = Struct.newBuilder();
+        structBuilder.putFields("number", Value.newBuilder().setNumberValue(1.125).build());
+        anyMessage = Any.pack(structBuilder.build());
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Struct",
+                                  "value": {
+                                    "number": 1.125
+                                  }
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        Value.Builder valueBuilder = Value.newBuilder();
+        valueBuilder.setNumberValue(1);
+        anyMessage = Any.pack(valueBuilder.build());
+        assertThat(printer.print(anyMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "@type": "type.googleapis.com/google.protobuf.Value",
+                                  "value": 1.0
+                                }""");
+        assertRoundTripEquals(anyMessage, registry);
+        anyMessage = Any.pack(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
+        assertThat(printer.print(anyMessage)).isEqualTo(
+                """
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Value",
+                          "value": null
+                        }""");
+        assertRoundTripEquals(anyMessage, registry);
+    }
+
+    @Test
+    public void testAnyInMaps() throws Exception {
+        TypeRegistry registry =
+                TypeRegistry.newBuilder().add(TestAllTypes.getDescriptor()).build();
+        JsonFormat.Printer printer = JsonFormat.printer().usingTypeRegistry(registry);
+
+        TestAny.Builder testAny = TestAny.newBuilder();
+        testAny.putAnyMap("int32_wrapper", Any.pack(Int32Value.of(123)));
+        testAny.putAnyMap("int64_wrapper", Any.pack(Int64Value.of(456)));
+        testAny.putAnyMap("timestamp", Any.pack(Timestamps.parse("1969-12-31T23:59:59Z")));
+        testAny.putAnyMap("duration", Any.pack(Durations.parse("12345.1s")));
+        testAny.putAnyMap("field_mask", Any.pack(FieldMaskUtil.fromString("foo.bar,baz")));
+        Value numberValue = Value.newBuilder().setNumberValue(1.125).build();
+        Struct.Builder struct = Struct.newBuilder();
+        struct.putFields("number", numberValue);
+        testAny.putAnyMap("struct", Any.pack(struct.build()));
+        Value nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+        testAny.putAnyMap(
+                "list_value",
+                Any.pack(ListValue.newBuilder().addValues(numberValue).addValues(nullValue).build()));
+        testAny.putAnyMap("number_value", Any.pack(numberValue));
+        testAny.putAnyMap("any_value_number", Any.pack(Any.pack(numberValue)));
+        testAny.putAnyMap("any_value_default", Any.pack(Any.getDefaultInstance()));
+        testAny.putAnyMap("default", Any.getDefaultInstance());
+
+        assertThat(printer.print(testAny.build()))
+                .isEqualTo(
+                        """
+                                {
+                                  "anyMap": {
+                                    "int32_wrapper": {
+                                      "@type": "type.googleapis.com/google.protobuf.Int32Value",
+                                      "value": 123
+                                    },
+                                    "int64_wrapper": {
+                                      "@type": "type.googleapis.com/google.protobuf.Int64Value",
+                                      "value": "456"
+                                    },
+                                    "timestamp": {
+                                      "@type": "type.googleapis.com/google.protobuf.Timestamp",
+                                      "value": "1969-12-31T23:59:59Z"
+                                    },
+                                    "duration": {
+                                      "@type": "type.googleapis.com/google.protobuf.Duration",
+                                      "value": "12345.100s"
+                                    },
+                                    "field_mask": {
+                                      "@type": "type.googleapis.com/google.protobuf.FieldMask",
+                                      "value": "foo.bar,baz"
+                                    },
+                                    "struct": {
+                                      "@type": "type.googleapis.com/google.protobuf.Struct",
+                                      "value": {
+                                        "number": 1.125
+                                      }
+                                    },
+                                    "list_value": {
+                                      "@type": "type.googleapis.com/google.protobuf.ListValue",
+                                      "value": [1.125, null]
+                                    },
+                                    "number_value": {
+                                      "@type": "type.googleapis.com/google.protobuf.Value",
+                                      "value": 1.125
+                                    },
+                                    "any_value_number": {
+                                      "@type": "type.googleapis.com/google.protobuf.Any",
+                                      "value": {
+                                        "@type": "type.googleapis.com/google.protobuf.Value",
+                                        "value": 1.125
+                                      }
+                                    },
+                                    "any_value_default": {
+                                      "@type": "type.googleapis.com/google.protobuf.Any",
+                                      "value": {}
+                                    },
+                                    "default": {}
+                                  }
+                                }""");
+        assertRoundTripEquals(testAny.build(), registry);
+    }
+
+    @Test
+    public void testParserMissingTypeUrl() {
+        try {
+            Any.Builder builder = Any.newBuilder();
+            mergeFromJson("""
+                    {
+                      "optionalInt32": 1234
+                    }""", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IOException ignored) {
+
+        }
+    }
+
+    @Test
+    public void testParserUnexpectedTypeUrl() {
+        try {
+            Any.Builder builder = Any.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "@type": "type.googleapis.com/json_test.UnexpectedTypes",
+                              "optionalInt32": 12345
+                            }""",
+                    builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IOException ignored) {
+
+        }
+    }
+
+    @Test
+    public void testParserRejectTrailingComma() {
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            mergeFromJson("""
+                    {
+                      "optionalInt32": 12345,
+                    }""", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IOException ignored) {
+        }
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            mergeFromJson(
+                    """
+                            {
+                              "repeatedInt32": [12345,]
+                            }""", builder);
+            assertWithMessage("IOException expected.").fail();
+        } catch (IOException ignored) {
+        }
+    }
+
+    @Test
+    public void testParserRejectInvalidBase64() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson("{\"" + "optionalBytes" + "\":" + "!@#$" + "}", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException expected) {
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+    }
+
+    @Test
+    public void testParserAcceptBase64Variants() throws Exception {
+        assertAccepts("optionalBytes", "AQI");
+        assertAccepts("optionalBytes", "-_w");
+    }
+
+    @Test
+    public void testParserRejectInvalidEnumValue() throws Exception {
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            mergeFromJson("""
+                    {
+                      "optionalNestedEnum": "XXX"
+                    }""", builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testParserUnknownFields() {
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            String json = """
+                    {
+                      "unknownField": "XXX"
+                    }""";
+            JsonFormat.parser().merge(json, builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testParserIgnoringUnknownFields() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        String json = """
+                {
+                  "unknownField": "XXX"
+                }""";
+        JsonFormat.parser().ignoringUnknownFields().merge(json, builder);
+    }
+
+    @Test
+    public void testParserIgnoringUnknownEnums() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        String json = """
+                {
+                  "optionalNestedEnum": "XXX"
+                }""";
+        JsonFormat.parser().ignoringUnknownFields().merge(json, builder);
+        assertThat(builder.getOptionalNestedEnumValue()).isEqualTo(0);
+    }
+
+    @Test
+    public void testParserSupportAliasEnums() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        String json = """
+                {
+                  "optionalAliasedEnum": "QUX"
+                }""";
+        JsonFormat.parser().merge(json, builder);
+        assertThat(builder.getOptionalAliasedEnum()).isEqualTo(AliasedEnum.ALIAS_BAZ);
+
+        builder = TestAllTypes.newBuilder();
+        json = """
+                {
+                  "optionalAliasedEnum": "qux"
+                }""";
+        JsonFormat.parser().merge(json, builder);
+        assertThat(builder.getOptionalAliasedEnum()).isEqualTo(AliasedEnum.ALIAS_BAZ);
+
+        builder = TestAllTypes.newBuilder();
+        json = """
+                {
+                  "optionalAliasedEnum": "bAz"
+                }""";
+        JsonFormat.parser().merge(json, builder);
+        assertThat(builder.getOptionalAliasedEnum()).isEqualTo(AliasedEnum.ALIAS_BAZ);
+    }
+
+    @Test
+    public void testUnknownEnumMap() throws Exception {
+        TestMap.Builder builder = TestMap.newBuilder();
+        JsonFormat.parser()
+                .ignoringUnknownFields()
+                .merge("{\n" + "  \"int32ToEnumMap\": {1: XXX, 2: FOO}" + "}", builder);
+
+        assertThat(builder.getInt32ToEnumMapMap()).containsEntry(2, NestedEnum.FOO);
+        assertThat(builder.getInt32ToEnumMapMap()).hasSize(1);
+    }
+
+    @Test
+    public void testRepeatedUnknownEnum() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        JsonFormat.parser()
+                .ignoringUnknownFields()
+                .merge("{\n" + "  \"repeatedNestedEnum\": [XXX, FOO, BAR, BAZ]" + "}", builder);
+
+        assertThat(builder.getRepeatedNestedEnum(0)).isEqualTo(NestedEnum.FOO);
+        assertThat(builder.getRepeatedNestedEnum(1)).isEqualTo(NestedEnum.BAR);
+        assertThat(builder.getRepeatedNestedEnum(2)).isEqualTo(NestedEnum.BAZ);
+        assertThat(builder.getRepeatedNestedEnumList()).hasSize(3);
+    }
+
+    @Test
+    public void testParserIntegerEnumValue() throws Exception {
+        TestAllTypes.Builder actualBuilder = TestAllTypes.newBuilder();
+        mergeFromJson("""
+                {
+                  "optionalNestedEnum": 2
+                }""", actualBuilder);
+
+        TestAllTypes expected = TestAllTypes.newBuilder().setOptionalNestedEnum(NestedEnum.BAZ).build();
+        assertThat(actualBuilder.build()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testCustomJsonName() throws Exception {
+        TestCustomJsonName message = TestCustomJsonName.newBuilder().setValue(12345).build();
+        assertThat(JsonFormat.printer().print(message))
+                .isEqualTo("""
+                        {
+                          "@value": 12345
+                        }""");
+        assertRoundTripEquals(message);
+    }
+
+    @Test
+    public void testHtmlEscape() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalString("</script>").build();
+        assertThat(toJsonString(message))
+                .isEqualTo("{\n  \"optionalString\": \"\\u003c/script\\u003e\"\n}");
+
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        JsonFormat.parser().merge(toJsonString(message), builder);
+        assertThat(builder.getOptionalString()).isEqualTo(message.getOptionalString());
+    }
+
+    @Test
+    public void testIncludingDefaultValueFields() throws Exception {
+        TestAllTypes message = TestAllTypes.getDefaultInstance();
+        assertThat(JsonFormat.printer().print(message)).isEqualTo("{\n}");
+        assertThat(JsonFormat.printer().includingDefaultValueFields().print(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "optionalInt32": 0,
+                                  "optionalInt64": "0",
+                                  "optionalUint32": 0,
+                                  "optionalUint64": "0",
+                                  "optionalSint32": 0,
+                                  "optionalSint64": "0",
+                                  "optionalFixed32": 0,
+                                  "optionalFixed64": "0",
+                                  "optionalSfixed32": 0,
+                                  "optionalSfixed64": "0",
+                                  "optionalFloat": 0.0,
+                                  "optionalDouble": 0.0,
+                                  "optionalBool": false,
+                                  "optionalString": "",
+                                  "optionalBytes": "",
+                                  "optionalNestedEnum": "FOO",
+                                  "repeatedInt32": [],
+                                  "repeatedInt64": [],
+                                  "repeatedUint32": [],
+                                  "repeatedUint64": [],
+                                  "repeatedSint32": [],
+                                  "repeatedSint64": [],
+                                  "repeatedFixed32": [],
+                                  "repeatedFixed64": [],
+                                  "repeatedSfixed32": [],
+                                  "repeatedSfixed64": [],
+                                  "repeatedFloat": [],
+                                  "repeatedDouble": [],
+                                  "repeatedBool": [],
+                                  "repeatedString": [],
+                                  "repeatedBytes": [],
+                                  "repeatedNestedMessage": [],
+                                  "repeatedNestedEnum": [],
+                                  "optionalAliasedEnum": "ALIAS_FOO"
+                                }""");
+
+        Set<FieldDescriptor> fixedFields = new HashSet<>();
+        for (FieldDescriptor fieldDesc : TestAllTypes.getDescriptor().getFields()) {
+            if (fieldDesc.getName().contains("_fixed")) {
+                fixedFields.add(fieldDesc);
+            }
+        }
+
+        assertThat(JsonFormat.printer().includingDefaultValueFields(fixedFields).print(message))
+                .isEqualTo(
+                        """
+                                {
+                                  "optionalFixed32": 0,
+                                  "optionalFixed64": "0",
+                                  "repeatedFixed32": [],
+                                  "repeatedFixed64": []
+                                }""");
+
+        TestAllTypes messageNonDefaults =
+                message.toBuilder().setOptionalInt64(1234).setOptionalFixed32(3232).build();
+        assertThat(
+                JsonFormat.printer().includingDefaultValueFields(fixedFields).print(messageNonDefaults))
+                .isEqualTo(
+                        """
+                                {
+                                  "optionalInt64": "1234",
+                                  "optionalFixed32": 3232,
+                                  "optionalFixed64": "0",
+                                  "repeatedFixed32": [],
+                                  "repeatedFixed64": []
+                                }""");
+
+        try {
+            JsonFormat.printer().includingDefaultValueFields().includingDefaultValueFields();
+            assertWithMessage("IllegalStateException is expected.").fail();
+        } catch (IllegalStateException e) {
+
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        try {
+            JsonFormat.printer().includingDefaultValueFields().includingDefaultValueFields(fixedFields);
+            assertWithMessage("IllegalStateException is expected.").fail();
+        } catch (IllegalStateException e) {
+
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        try {
+            JsonFormat.printer().includingDefaultValueFields(fixedFields).includingDefaultValueFields();
+            assertWithMessage("IllegalStateException is expected.").fail();
+        } catch (IllegalStateException e) {
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        try {
+            JsonFormat.printer()
+                    .includingDefaultValueFields(fixedFields)
+                    .includingDefaultValueFields(fixedFields);
+            assertWithMessage("IllegalStateException is expected.").fail();
+        } catch (IllegalStateException e) {
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        Set<FieldDescriptor> intFields = new HashSet<>();
+        for (FieldDescriptor fieldDesc : TestAllTypes.getDescriptor().getFields()) {
+            if (fieldDesc.getName().contains("_int")) {
+                intFields.add(fieldDesc);
+            }
+        }
+
+        try {
+            JsonFormat.printer()
+                    .includingDefaultValueFields(intFields)
+                    .includingDefaultValueFields(fixedFields);
+            assertWithMessage("IllegalStateException is expected.").fail();
+        } catch (IllegalStateException e) {
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        try {
+            JsonFormat.printer().includingDefaultValueFields(null);
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException e) {
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        try {
+            JsonFormat.printer().includingDefaultValueFields(Collections.emptySet());
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException e) {
+            assertWithMessage("Exception message should mention includingDefaultValueFields.")
+                    .that(e.getMessage().contains("includingDefaultValueFields"))
+                    .isTrue();
+        }
+
+        TestMap mapMessage = TestMap.getDefaultInstance();
+        assertThat(JsonFormat.printer().print(mapMessage)).isEqualTo("{\n}");
+        assertThat(JsonFormat.printer().includingDefaultValueFields().print(mapMessage))
+                .isEqualTo(
+                        """
+                                {
+                                  "int32ToInt32Map": {
+                                  },
+                                  "int64ToInt32Map": {
+                                  },
+                                  "uint32ToInt32Map": {
+                                  },
+                                  "uint64ToInt32Map": {
+                                  },
+                                  "sint32ToInt32Map": {
+                                  },
+                                  "sint64ToInt32Map": {
+                                  },
+                                  "fixed32ToInt32Map": {
+                                  },
+                                  "fixed64ToInt32Map": {
+                                  },
+                                  "sfixed32ToInt32Map": {
+                                  },
+                                  "sfixed64ToInt32Map": {
+                                  },
+                                  "boolToInt32Map": {
+                                  },
+                                  "stringToInt32Map": {
+                                  },
+                                  "int32ToInt64Map": {
+                                  },
+                                  "int32ToUint32Map": {
+                                  },
+                                  "int32ToUint64Map": {
+                                  },
+                                  "int32ToSint32Map": {
+                                  },
+                                  "int32ToSint64Map": {
+                                  },
+                                  "int32ToFixed32Map": {
+                                  },
+                                  "int32ToFixed64Map": {
+                                  },
+                                  "int32ToSfixed32Map": {
+                                  },
+                                  "int32ToSfixed64Map": {
+                                  },
+                                  "int32ToFloatMap": {
+                                  },
+                                  "int32ToDoubleMap": {
+                                  },
+                                  "int32ToBoolMap": {
+                                  },
+                                  "int32ToStringMap": {
+                                  },
+                                  "int32ToBytesMap": {
+                                  },
+                                  "int32ToMessageMap": {
+                                  },
+                                  "int32ToEnumMap": {
+                                  }
+                                }""");
+
+        TestOneof oneofMessage = TestOneof.getDefaultInstance();
+        assertThat(JsonFormat.printer().print(oneofMessage)).isEqualTo("{\n}");
+        assertThat(JsonFormat.printer().includingDefaultValueFields().print(oneofMessage))
+                .isEqualTo("{\n}");
+
+        oneofMessage = TestOneof.newBuilder().setOneofInt32(42).build();
+        assertThat(JsonFormat.printer().print(oneofMessage)).isEqualTo("{\n  \"oneofInt32\": 42\n}");
+        assertThat(JsonFormat.printer().includingDefaultValueFields().print(oneofMessage))
+                .isEqualTo("{\n  \"oneofInt32\": 42\n}");
+
+        TestOneof.Builder oneofBuilder = TestOneof.newBuilder();
+        mergeFromJson("""
+                {
+                  "oneofNullValue": null\s
+                }""", oneofBuilder);
+        oneofMessage = oneofBuilder.build();
+        assertThat(JsonFormat.printer().print(oneofMessage))
+                .isEqualTo("{\n  \"oneofNullValue\": null\n}");
+        assertThat(JsonFormat.printer().includingDefaultValueFields().print(oneofMessage))
+                .isEqualTo("{\n  \"oneofNullValue\": null\n}");
+    }
+
+    @Test
+    public void testPreservingProtoFieldNames() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalInt32(12345).build();
+        assertThat(JsonFormat.printer().print(message))
+                .isEqualTo("""
+                        {
+                          "optionalInt32": 12345
+                        }""");
+        assertThat(JsonFormat.printer().preservingProtoFieldNames().print(message))
+                .isEqualTo("""
+                        {
+                          "optional_int32": 12345
+                        }""");
+        TestCustomJsonName messageWithCustomJsonName =
+                TestCustomJsonName.newBuilder().setValue(12345).build();
+        assertThat(JsonFormat.printer().preservingProtoFieldNames().print(messageWithCustomJsonName))
+                .isEqualTo("""
+                        {
+                          "value": 12345
+                        }""");
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        JsonFormat.parser().merge("{\"optionalInt32\": 12345}", builder);
+        assertThat(builder.getOptionalInt32()).isEqualTo(12345);
+        builder.clear();
+        JsonFormat.parser().merge("{\"optional_int32\": 54321}", builder);
+        assertThat(builder.getOptionalInt32()).isEqualTo(54321);
+    }
+
+    @Test
+    public void testPrintingEnumsAsInts() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalNestedEnum(NestedEnum.BAR).build();
+        assertThat(JsonFormat.printer().printingEnumsAsInts().print(message))
+                .isEqualTo("""
+                        {
+                          "optionalNestedEnum": 1
+                        }""");
+    }
+
+    @Test
+    public void testOmittingInsignificantWhiteSpace() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalInt32(12345).build();
+        assertThat(JsonFormat.printer().omittingInsignificantWhitespace().print(message))
+                .isEqualTo("{" + "\"optionalInt32\":12345" + "}");
+        TestAllTypes message1 = TestAllTypes.getDefaultInstance();
+        assertThat(JsonFormat.printer().omittingInsignificantWhitespace().print(message1))
+                .isEqualTo("{}");
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        setAllFields(builder);
+        TestAllTypes message2 = builder.build();
+        assertThat(toCompactJsonString(message2))
+                .isEqualTo(
+                        "{"
+                                + "\"optionalInt32\":1234,"
+                                + "\"optionalInt64\":\"1234567890123456789\","
+                                + "\"optionalUint32\":5678,"
+                                + "\"optionalUint64\":\"2345678901234567890\","
+                                + "\"optionalSint32\":9012,"
+                                + "\"optionalSint64\":\"3456789012345678901\","
+                                + "\"optionalFixed32\":3456,"
+                                + "\"optionalFixed64\":\"4567890123456789012\","
+                                + "\"optionalSfixed32\":7890,"
+                                + "\"optionalSfixed64\":\"5678901234567890123\","
+                                + "\"optionalFloat\":1.5,"
+                                + "\"optionalDouble\":1.25,"
+                                + "\"optionalBool\":true,"
+                                + "\"optionalString\":\"Hello world!\","
+                                + "\"optionalBytes\":\"AAEC\","
+                                + "\"optionalNestedMessage\":{"
+                                + "\"value\":100"
+                                + "},"
+                                + "\"optionalNestedEnum\":\"BAR\","
+                                + "\"repeatedInt32\":[1234,234],"
+                                + "\"repeatedInt64\":[\"1234567890123456789\",\"234567890123456789\"],"
+                                + "\"repeatedUint32\":[5678,678],"
+                                + "\"repeatedUint64\":[\"2345678901234567890\",\"345678901234567890\"],"
+                                + "\"repeatedSint32\":[9012,10],"
+                                + "\"repeatedSint64\":[\"3456789012345678901\",\"456789012345678901\"],"
+                                + "\"repeatedFixed32\":[3456,456],"
+                                + "\"repeatedFixed64\":[\"4567890123456789012\",\"567890123456789012\"],"
+                                + "\"repeatedSfixed32\":[7890,890],"
+                                + "\"repeatedSfixed64\":[\"5678901234567890123\",\"678901234567890123\"],"
+                                + "\"repeatedFloat\":[1.5,11.5],"
+                                + "\"repeatedDouble\":[1.25,11.25],"
+                                + "\"repeatedBool\":[true,true],"
+                                + "\"repeatedString\":[\"Hello world!\",\"ello world!\"],"
+                                + "\"repeatedBytes\":[\"AAEC\",\"AQI=\"],"
+                                + "\"repeatedNestedMessage\":[{"
+                                + "\"value\":100"
+                                + "},{"
+                                + "\"value\":200"
+                                + "}],"
+                                + "\"repeatedNestedEnum\":[\"BAR\",\"BAZ\"]"
+                                + "}");
+    }
+
+    @Test
+    public void testEmptyWrapperTypesInAny() throws Exception {
+        TypeRegistry registry =
+                TypeRegistry.newBuilder().add(TestAllTypes.getDescriptor()).build();
+        JsonFormat.Parser parser = JsonFormat.parser().usingTypeRegistry(registry);
+
+        Any.Builder builder = Any.newBuilder();
+        parser.merge(
+                """
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.BoolValue",
+                          "value": false
+                        }
+                        """,
+                builder);
+        Any any = builder.build();
+        assertThat(any.getValue().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testRecursionLimit() throws Exception {
+        String input =
+                """
+                        {
+                          "nested": {
+                            "nested": {
+                              "nested": {
+                                "nested": {
+                                  "value": 1234
+                                }
+                              }
+                            }
+                          }
+                        }
+                        """;
+
+        JsonFormat.Parser parser = JsonFormat.parser();
+        TestRecursive.Builder builder = TestRecursive.newBuilder();
+        parser.merge(input, builder);
+        TestRecursive message = builder.build();
+        assertThat(message.getNested().getNested().getNested().getNested().getValue()).isEqualTo(1234);
+
+        parser = JsonFormat.parser().usingRecursionLimit(3);
+        builder = TestRecursive.newBuilder();
+        try {
+            parser.merge(input, builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testJsonException_forwardsIOException() {
+        InputStream throwingInputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("12345");
+            }
+        };
+        InputStreamReader throwingReader = new InputStreamReader(throwingInputStream);
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            JsonFormat.parser().merge(throwingReader, builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IOException e) {
+            assertThat(e).hasMessageThat().isEqualTo("12345");
+        }
+    }
+
+    @Test
+    public void testJsonException_forwardsJsonException() throws Exception {
+        Reader invalidJsonReader = new StringReader("{ xxx - yyy }");
+        try {
+            TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+            JsonFormat.parser().merge(invalidJsonReader, builder);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (InvalidProtocolBufferException e) {
+            assertThat(e.getCause()).isInstanceOf(JsonSyntaxException.class);
+        }
+    }
+
+    @Test
+    public void testJsonObjectForPrimitiveField() throws Exception {
+        TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+        try {
+            mergeFromJson(
+                    """
+                            {
+                              "optionalString": {
+                                "invalidNestedString": "Hello world"
+                              }
+                            }
+                            """,
+                    builder);
+        } catch (InvalidProtocolBufferException ignored) {
+        }
+    }
+
+    @Test
+    public void testSortedMapKeys() throws Exception {
+        TestMap.Builder mapBuilder = TestMap.newBuilder();
+        mapBuilder.putStringToInt32Map("\ud834\udd20", 3);
+        mapBuilder.putStringToInt32Map("foo", 99);
+        mapBuilder.putStringToInt32Map("xxx", 123);
+        mapBuilder.putStringToInt32Map("\u20ac", 1);
+        mapBuilder.putStringToInt32Map("abc", 20);
+        mapBuilder.putStringToInt32Map("19", 19);
+        mapBuilder.putStringToInt32Map("8", 8);
+        mapBuilder.putStringToInt32Map("\ufb00", 2);
+        mapBuilder.putInt32ToInt32Map(3, 3);
+        mapBuilder.putInt32ToInt32Map(10, 10);
+        mapBuilder.putInt32ToInt32Map(5, 5);
+        mapBuilder.putInt32ToInt32Map(4, 4);
+        mapBuilder.putInt32ToInt32Map(1, 1);
+        mapBuilder.putInt32ToInt32Map(2, 2);
+        mapBuilder.putInt32ToInt32Map(-3, -3);
+        TestMap mapMessage = mapBuilder.build();
+        assertThat(toSortedJsonString(mapMessage)).isEqualTo(
+                """
+                        {
+                          "int32ToInt32Map": {
+                            "-3": -3,
+                            "1": 1,
+                            "2": 2,
+                            "3": 3,
+                            "4": 4,
+                            "5": 5,
+                            "10": 10
+                          },
+                          "stringToInt32Map": {
+                            "19": 19,
+                            "8": 8,
+                            "abc": 20,
+                            "foo": 99,
+                            "xxx": 123,
+                            "\u20ac": 1,
+                            "\ufb00": 2,
+                            "\ud834\udd20": 3
+                          }
+                        }""");
+        TestMap emptyMap = TestMap.getDefaultInstance();
+        assertThat(toSortedJsonString(emptyMap)).isEqualTo("{\n}");
+    }
+
+    @Test
+    public void testPrintingEnumsAsIntsChainedAfterIncludingDefaultValueFields() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalBool(false).build();
+        assertThat(JsonFormat.printer().includingDefaultValueFields(ImmutableSet.of(message.getDescriptorForType().findFieldByName("optional_bool")))
+                .printingEnumsAsInts().print(message))
+                .isEqualTo("""
+                        {
+                          "optionalBool": false
+                        }""");
+    }
+
+    @Test
+    public void testPreservesFloatingPointNegative0() throws Exception {
+        TestAllTypes message = TestAllTypes.newBuilder().setOptionalFloat(-0.0f).setOptionalDouble(-0.0).build();
+        assertThat(JsonFormat.printer().print(message)).isEqualTo("{\n  \"optionalFloat\": -0.0,\n  \"optionalDouble\": -0.0\n}");
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
@@ -1,0 +1,786 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.google.protobuf.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.truth.Truth;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.protobuf.util.DurationsTest.duration;
+
+@SuppressWarnings("NumericOverflow")
+public class TimestampsTest {
+    private static final int MILLIS_PER_SECOND = 1000;
+    private static final long MILLIS = 1409130915111L;
+    private static final long SECONDS = MILLIS / MILLIS_PER_SECOND;
+    private static final long MICROS = MILLIS * 1000;
+    private static final long NANOS = MICROS * 1000;
+
+    @SuppressWarnings("ConstantOverflow")
+    private static final long MAX_VALUE = Long.MAX_VALUE * MILLIS_PER_SECOND + MILLIS_PER_SECOND;
+
+    @SuppressWarnings("ConstantOverflow")
+    private static final long MIN_VALUE = Long.MIN_VALUE * MILLIS_PER_SECOND;
+
+    private static final Timestamp TIMESTAMP = timestamp(1409130915, 111000000);
+    private static final Timestamp ZERO_TIMESTAMP = timestamp(0, 0);
+    private static final Timestamp ONE_OF_TIMESTAMP = timestamp(-1, 999000000);
+
+    private static final Timestamp INVALID_MAX =
+            Timestamp.newBuilder().setSeconds(Long.MAX_VALUE).setNanos(Integer.MAX_VALUE).build();
+    private static final Timestamp INVALID_MIN =
+            Timestamp.newBuilder().setSeconds(Long.MIN_VALUE).setNanos(Integer.MIN_VALUE).build();
+
+    @Test
+    public void testMinMaxAreValid() {
+        Truth.assertThat(Timestamps.isValid(Timestamps.MAX_VALUE)).isTrue();
+        assertThat(Timestamps.isValid(Timestamps.MIN_VALUE)).isTrue();
+    }
+
+
+    @Test
+    public void testIsValid_false() {
+        assertThat(Timestamps.isValid(0L, -1)).isFalse();
+        assertThat(Timestamps.isValid(1L, -1)).isFalse();
+        assertThat(Timestamps.isValid(1L, Timestamps.NANOS_PER_SECOND)).isFalse();
+        assertThat(Timestamps.isValid(-62135596801L, 0)).isFalse();
+        assertThat(Timestamps.isValid(253402300800L, 0)).isFalse();
+    }
+
+    @Test
+    public void testIsValid_true() {
+        assertThat(Timestamps.isValid(0L, 0)).isTrue();
+        assertThat(Timestamps.isValid(1L, 0)).isTrue();
+        assertThat(Timestamps.isValid(1L, 1)).isTrue();
+        assertThat(Timestamps.isValid(42L, 0)).isTrue();
+        assertThat(Timestamps.isValid(42L, 42)).isTrue();
+        assertThat(Timestamps.isValid(-62135596800L, 0)).isTrue();
+        assertThat(Timestamps.isValid(-62135596800L, 1)).isTrue();
+        assertThat(Timestamps.isValid(62135596799L, 1)).isTrue();
+        assertThat(Timestamps.isValid(253402300799L, 0)).isTrue();
+        assertThat(Timestamps.isValid(253402300798L, 1)).isTrue();
+        assertThat(Timestamps.isValid(253402300798L, Timestamps.NANOS_PER_SECOND - 1)).isTrue();
+    }
+
+    @Test
+    public void testTimestampStringFormat() throws Exception {
+        Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
+        Timestamp end = Timestamps.parse("9999-12-31T23:59:59.999999999Z");
+        assertThat(start.getSeconds()).isEqualTo(Timestamps.TIMESTAMP_SECONDS_MIN);
+        assertThat(start.getNanos()).isEqualTo(0);
+        assertThat(end.getSeconds()).isEqualTo(Timestamps.TIMESTAMP_SECONDS_MAX);
+        assertThat(end.getNanos()).isEqualTo(999999999);
+        assertThat(Timestamps.toString(start)).isEqualTo("0001-01-01T00:00:00Z");
+        assertThat(Timestamps.toString(end)).isEqualTo("9999-12-31T23:59:59.999999999Z");
+
+        Timestamp value = Timestamps.parse("1970-01-01T00:00:00Z");
+        assertThat(value.getSeconds()).isEqualTo(0);
+        assertThat(value.getNanos()).isEqualTo(0);
+        value = Timestamps.parseUnchecked("1970-01-01T00:00:00Z");
+        assertThat(value.getSeconds()).isEqualTo(0);
+        assertThat(value.getNanos()).isEqualTo(0);
+
+        value = Timestamps.parse("1969-12-31T23:59:59.999Z");
+        assertThat(value.getSeconds()).isEqualTo(-1);
+        assertThat(value.getNanos()).isEqualTo(999000000);
+        value = Timestamps.parseUnchecked("1969-12-31T23:59:59.999Z");
+        assertThat(value.getSeconds()).isEqualTo(-1);
+        assertThat(value.getNanos()).isEqualTo(999000000);
+        value = Timestamp.newBuilder().setNanos(10).build();
+        assertThat(Timestamps.toString(value)).isEqualTo("1970-01-01T00:00:00.000000010Z");
+        value = Timestamp.newBuilder().setNanos(10000).build();
+        assertThat(Timestamps.toString(value)).isEqualTo("1970-01-01T00:00:00.000010Z");
+        value = Timestamp.newBuilder().setNanos(10000000).build();
+        assertThat(Timestamps.toString(value)).isEqualTo("1970-01-01T00:00:00.010Z");
+        value = Timestamps.parse("1970-01-01T00:00:00.010+08:00");
+        assertThat(Timestamps.toString(value)).isEqualTo("1969-12-31T16:00:00.010Z");
+        value = Timestamps.parse("1970-01-01T00:00:00.010-08:00");
+        assertThat(Timestamps.toString(value)).isEqualTo("1970-01-01T08:00:00.010Z");
+        value = Timestamps.parseUnchecked("1970-01-01T00:00:00.010+08:00");
+        assertThat(Timestamps.toString(value)).isEqualTo("1969-12-31T16:00:00.010Z");
+        value = Timestamps.parseUnchecked("1970-01-01T00:00:00.010-08:00");
+        assertThat(Timestamps.toString(value)).isEqualTo("1970-01-01T08:00:00.010Z");
+    }
+
+    private volatile boolean stopParsingThreads = false;
+    private volatile String errorMessage = "";
+
+    private class ParseTimestampThread extends Thread {
+        private final String[] strings;
+        private final Timestamp[] values;
+
+        ParseTimestampThread(String[] strings, Timestamp[] values) {
+            this.strings = strings;
+            this.values = values;
+        }
+
+        @Override
+        public void run() {
+            int index = 0;
+            while (!stopParsingThreads) {
+                Timestamp result;
+                try {
+                    result = Timestamps.parse(strings[index]);
+                } catch (ParseException e) {
+                    errorMessage = "Failed to parse timestamp: " + strings[index];
+                    break;
+                }
+                if (result.getSeconds() != values[index].getSeconds()
+                        || result.getNanos() != values[index].getNanos()) {
+                    errorMessage =
+                            "Actual result: " + result + ", expected: " + values[index].toString();
+                    break;
+                }
+                index = (index + 1) % strings.length;
+            }
+        }
+    }
+
+    @Test
+    public void testTimestampConcurrentParsing() throws Exception {
+        String[] timestampStrings =
+                new String[]{
+                        "0001-01-01T00:00:00Z",
+                        "9999-12-31T23:59:59.999999999Z",
+                        "1970-01-01T00:00:00Z",
+                        "1969-12-31T23:59:59.999Z",
+                };
+        Timestamp[] timestampValues = new Timestamp[timestampStrings.length];
+        for (int i = 0; i < timestampStrings.length; i++) {
+            timestampValues[i] = Timestamps.parse(timestampStrings[i]);
+        }
+
+        final int threadCount = 16;
+        final int runningTime = 5000;
+        final List<Thread> threads = new ArrayList<>();
+
+        stopParsingThreads = false;
+        errorMessage = "";
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new ParseTimestampThread(timestampStrings, timestampValues);
+            thread.start();
+            threads.add(thread);
+        }
+        Thread.sleep(runningTime);
+        stopParsingThreads = true;
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertThat(errorMessage).isEmpty();
+    }
+
+    @Test
+    public void testTimestampInvalidFormatValueTooSmall() {
+        try {
+            Timestamp value = Timestamp.newBuilder().setSeconds(Timestamps.TIMESTAMP_SECONDS_MIN - 1).build();
+            Timestamps.toString(value);
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatValueTooLarge() {
+        try {
+            Timestamp value = Timestamp.newBuilder().setSeconds(Timestamps.TIMESTAMP_SECONDS_MAX + 1).build();
+            Timestamps.toString(value);
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatNanosTooSmall() {
+        try {
+            Timestamp value = Timestamp.newBuilder().setNanos(-1).build();
+            Timestamps.toString(value);
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatNanosTooLarge() {
+        try {
+            Timestamp value = Timestamp.newBuilder().setNanos(1000000000).build();
+            Timestamps.toString(value);
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatDateTooSmall() {
+        try {
+            Timestamps.parse("0000-01-01T00:00:00Z");
+            Assert.fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+            assertThat(expected).hasCauseThat().isNotNull();
+        }
+        try {
+            Timestamps.parseUnchecked("0000-01-01T00:00:00Z");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatDateTooLarge() {
+        try {
+            Timestamps.parse("10000-01-01T00:00:00Z");
+            Assert.fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("10000-01-01T00:00:00Z");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatMissingT() {
+        try {
+            Timestamps.parse("1970-01-01 00:00:00Z");
+            Assert.fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("1970-01-01 00:00:00Z");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidFormatMissingZ() {
+        try {
+            Timestamps.parse("1970-01-01T00:00:00");
+            assertWithMessage("ParseException is expected.").fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("1970-01-01T00:00:00");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidOffset() {
+        try {
+            Timestamps.parse("1970-01-01T00:00:00+0000");
+            assertWithMessage("ParseException is expected.").fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("1970-01-01T00:00:00+0000");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidTrailingText() {
+        try {
+            Timestamps.parse("1970-01-01T00:00:00Z0");
+            assertWithMessage("ParseException is expected.").fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("1970-01-01T00:00:00Z0");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampInvalidNanoSecond() {
+        try {
+            Timestamps.parse("1970-01-01T00:00:00.ABCZ");
+            assertWithMessage("ParseException is expected.").fail();
+        } catch (ParseException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+        try {
+            Timestamps.parseUnchecked("1970-01-01T00:00:00.ABCZ");
+            assertWithMessage("IllegalArgumentException is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+            Assert.assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampConversion() throws Exception {
+        Timestamp timestamp = Timestamps.parse("1970-01-01T00:00:01.111111111Z");
+        assertThat(Timestamps.toNanos(timestamp)).isEqualTo(1111111111);
+        assertThat(Timestamps.toMicros(timestamp)).isEqualTo(1111111);
+        assertThat(Timestamps.toMillis(timestamp)).isEqualTo(1111);
+        assertThat(Timestamps.toSeconds(timestamp)).isEqualTo(1);
+        timestamp = Timestamps.fromNanos(1111111111);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111111111Z");
+        timestamp = Timestamps.fromMicros(1111111);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111111Z");
+        timestamp = Timestamps.fromMillis(1111);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111Z");
+        timestamp = Timestamps.fromSeconds(1);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01Z");
+
+        timestamp = Timestamps.parse("1969-12-31T23:59:59.111111111Z");
+        assertThat(Timestamps.toNanos(timestamp)).isEqualTo(-888888889);
+        assertThat(Timestamps.toMicros(timestamp)).isEqualTo(-888889);
+        assertThat(Timestamps.toMillis(timestamp)).isEqualTo(-889);
+        assertThat(Timestamps.toSeconds(timestamp)).isEqualTo(-1);
+        timestamp = Timestamps.fromNanos(-888888889);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1969-12-31T23:59:59.111111111Z");
+        timestamp = Timestamps.fromMicros(-888889);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1969-12-31T23:59:59.111111Z");
+        timestamp = Timestamps.fromMillis(-889);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1969-12-31T23:59:59.111Z");
+        timestamp = Timestamps.fromSeconds(-1);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1969-12-31T23:59:59Z");
+    }
+
+    @Test
+    public void testFromDate() {
+        Date date = new Date(1111);
+        Timestamp timestamp = Timestamps.fromDate(date);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111Z");
+    }
+
+    @Test
+    public void testFromDate_after9999CE() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT-0"));
+        calendar.set(20000, Calendar.OCTOBER, 20, 5, 4, 3);
+        Date date = calendar.getTime();
+        try {
+            Timestamps.fromDate(date);
+            Assert.fail("should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().startsWith("Timestamp is not valid.");
+        }
+    }
+
+    @Test
+    public void testFromDate_beforeYear1() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT-0"));
+        calendar.set(-32, Calendar.OCTOBER, 20, 5, 4, 3);
+        Date date = calendar.getTime();
+        try {
+            Timestamps.fromDate(date);
+            Assert.fail("should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertThat(expected).hasMessageThat().startsWith("Timestamp is not valid.");
+        }
+    }
+
+    @Test
+    public void testFromDate_after2262CE() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT-0"));
+        calendar.set(2299, Calendar.OCTOBER, 20, 5, 4, 3);
+        Date date = calendar.getTime();
+        Timestamp timestamp = Timestamps.fromDate(date);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("2299-10-20T05:04:03Z");
+    }
+
+    @Test
+    public void testFromSqlTimestampSubMillisecondPrecision() {
+        java.sql.Timestamp sqlTimestamp = new java.sql.Timestamp(1111);
+        sqlTimestamp.setNanos(sqlTimestamp.getNanos() + 234567);
+        Timestamp timestamp = Timestamps.fromDate(sqlTimestamp);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111234567Z");
+    }
+
+    @Test
+    public void testFromSqlTimestamp() {
+        Date date = new java.sql.Timestamp(1111);
+        Timestamp timestamp = Timestamps.fromDate(date);
+        assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111Z");
+    }
+
+    @Test
+    public void testTimeOperations() throws Exception {
+        Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
+        Timestamp end = Timestamps.parse("9999-12-31T23:59:59.999999999Z");
+
+        Duration duration = Timestamps.between(start, end);
+        Truth.assertThat(Durations.toString(duration)).isEqualTo("315537897599.999999999s");
+        Timestamp value = Timestamps.add(start, duration);
+        assertThat(value).isEqualTo(end);
+        value = Timestamps.subtract(end, duration);
+        assertThat(value).isEqualTo(start);
+
+        duration = Timestamps.between(end, start);
+        assertThat(Durations.toString(duration)).isEqualTo("-315537897599.999999999s");
+        value = Timestamps.add(end, duration);
+        assertThat(value).isEqualTo(start);
+        value = Timestamps.subtract(start, duration);
+        assertThat(value).isEqualTo(end);
+    }
+
+    @Test
+    public void testComparator() {
+        assertThat(Timestamps.compare(timestamp(3, 2), timestamp(3, 2))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(0, 0), timestamp(0, 0))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(3, 1), timestamp(1, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(3, 2), timestamp(3, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(1, 1), timestamp(3, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(3, 1), timestamp(3, 2))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 1), timestamp(-1, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 2), timestamp(-3, 3))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-1, 1), timestamp(-3, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 1), timestamp(-3, 2))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-10, 1), timestamp(1, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(0, 1), timestamp(0, 1))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(0x80000000L, 0), timestamp(0, 0))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(0xFFFFFFFF00000000L, 0), timestamp(0, 0)))
+                .isLessThan(0);
+
+        Timestamp timestamp0 = timestamp(-50, 400);
+        Timestamp timestamp1 = timestamp(-50, 500);
+        Timestamp timestamp2 = timestamp(50, 500);
+        Timestamp timestamp3 = timestamp(100, 20);
+        Timestamp timestamp4 = timestamp(100, 50);
+        Timestamp timestamp5 = timestamp(100, 150);
+        Timestamp timestamp6 = timestamp(150, 40);
+
+        List<Timestamp> timestamps =
+                Lists.newArrayList(
+                        timestamp5,
+                        timestamp3,
+                        timestamp1,
+                        timestamp4,
+                        timestamp6,
+                        timestamp2,
+                        timestamp0,
+                        timestamp3);
+
+        timestamps.sort(Timestamps.comparator());
+        assertThat(timestamps)
+                .containsExactly(
+                        timestamp0,
+                        timestamp1,
+                        timestamp2,
+                        timestamp3,
+                        timestamp3,
+                        timestamp4,
+                        timestamp5,
+                        timestamp6)
+                .inOrder();
+    }
+
+    @Test
+    public void testCompare() {
+        assertThat(Timestamps.compare(timestamp(3, 2), timestamp(3, 2))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(0, 0), timestamp(0, 0))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(3, 1), timestamp(1, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(3, 2), timestamp(3, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(1, 1), timestamp(3, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(3, 1), timestamp(3, 2))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 1), timestamp(-1, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 2), timestamp(-3, 3))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-1, 1), timestamp(-3, 1))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(-3, 1), timestamp(-3, 2))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(-10, 1), timestamp(1, 1))).isLessThan(0);
+        assertThat(Timestamps.compare(timestamp(0, 1), timestamp(0, 1))).isEqualTo(0);
+        assertThat(Timestamps.compare(timestamp(0x80000000L, 0), timestamp(0, 0))).isGreaterThan(0);
+        assertThat(Timestamps.compare(timestamp(0xFFFFFFFF00000000L, 0), timestamp(0, 0)))
+                .isLessThan(0);
+    }
+
+    @Test
+    public void testOverflowsArithmeticException() throws Exception {
+        try {
+            Timestamps.toNanos(Timestamps.parse("9999-12-31T23:59:59.999999999Z"));
+            assertWithMessage("Expected an ArithmeticException to be thrown").fail();
+        } catch (ArithmeticException expected) {
+        }
+    }
+
+    @Test
+    public void testPositiveOverflow() {
+        try {
+            Timestamps.add(Timestamps.MAX_VALUE, Durations.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testNegativeOverflow() {
+        try {
+            Timestamps.subtract(Timestamps.MIN_VALUE, Durations.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMaxNanosecondsOverflow() {
+        try {
+            Timestamps.toNanos(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMaxMicrosecondsOverflow() {
+        try {
+            Timestamps.toMicros(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMaxMillisecondsOverflow() {
+        try {
+            Timestamps.toMillis(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMaxSecondsOverflow() {
+        try {
+            Timestamps.toSeconds(INVALID_MAX);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMinNanosecondsOverflow() {
+        try {
+            Timestamps.toNanos(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMicrosecondsMinOverflow() {
+        try {
+            Timestamps.toMicros(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testInvalidMinMillisecondsOverflow() {
+        try {
+            Timestamps.toMillis(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testOverInvalidMinSecondsflow() {
+        try {
+            Timestamps.toSeconds(INVALID_MIN);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testMaxNanosecondsConversion() {
+        assertThat(Timestamps.toString(Timestamps.fromNanos(Long.MAX_VALUE)))
+                .isEqualTo("2262-04-11T23:47:16.854775807Z");
+    }
+
+    @Test
+    public void testIllegalArgumentExceptionForMaxMicroseconds() {
+        try {
+            Timestamps.fromMicros(Long.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+
+    @Test
+    public void testIllegalArgumentExceptionForMaxMilliseconds() {
+        try {
+            Durations.fromMillis(Long.MAX_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testMinNanosecondsConversion() {
+        assertThat(Timestamps.toString(Timestamps.fromNanos(Long.MIN_VALUE)))
+                .isEqualTo("1677-09-21T00:12:43.145224192Z");
+    }
+
+    @Test
+    public void testIllegalArgumentExceptionForMinMicroseconds() {
+        try {
+            Timestamps.fromMicros(Long.MIN_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+
+    @Test
+    public void testIllegalArgumentExceptionForMinMilliseconds() {
+        try {
+            Timestamps.fromMillis(Long.MIN_VALUE);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testConvertFromSeconds() {
+        assertThat(Timestamps.fromSeconds(SECONDS).getSeconds()).isEqualTo(TIMESTAMP.getSeconds());
+        assertThat(Timestamps.EPOCH).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromSeconds(MAX_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromSeconds(MIN_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+    }
+
+    @Test
+    public void testConvertFromMillis() {
+        assertThat(Timestamps.fromMillis(MILLIS)).isEqualTo(TIMESTAMP);
+        assertThat(Timestamps.EPOCH).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromMillis(-1)).isEqualTo(ONE_OF_TIMESTAMP);
+        assertThat(Timestamps.fromMillis(MAX_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromMillis(MIN_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+    }
+
+    @Test
+    public void testConvertFromMicros() {
+        assertThat(Timestamps.fromMicros(MICROS)).isEqualTo(TIMESTAMP);
+        assertThat(Timestamps.EPOCH).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromMicros(-1000)).isEqualTo(ONE_OF_TIMESTAMP);
+        assertThat(Timestamps.fromMicros(MAX_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromMicros(MIN_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+    }
+
+    @Test
+    public void testConvertToSeconds() {
+        assertThat(Timestamps.toSeconds(TIMESTAMP)).isEqualTo(SECONDS);
+        assertThat(Timestamps.toSeconds(ZERO_TIMESTAMP)).isEqualTo(0);
+        assertThat(Timestamps.toSeconds(ONE_OF_TIMESTAMP)).isEqualTo(-1);
+    }
+
+    @Test
+    public void testConvertToMillis() {
+        assertThat(Timestamps.toMillis(TIMESTAMP)).isEqualTo(MILLIS);
+        assertThat(Timestamps.toMillis(ZERO_TIMESTAMP)).isEqualTo(0);
+        assertThat(Timestamps.toMillis(ONE_OF_TIMESTAMP)).isEqualTo(-1);
+    }
+
+    @Test
+    public void testConvertToMicros() {
+        assertThat(Timestamps.toMicros(TIMESTAMP)).isEqualTo(MICROS);
+        assertThat(Timestamps.toMicros(ZERO_TIMESTAMP)).isEqualTo(0);
+        assertThat(Timestamps.toMicros(ONE_OF_TIMESTAMP)).isEqualTo(-1000);
+    }
+
+    @Test
+    public void testConvertFromMillisAboveTimestampMaxLimit() {
+        long timestampMaxSeconds = 253402300799L;
+        try {
+            Timestamps.fromMillis((timestampMaxSeconds + 1) * MILLIS_PER_SECOND);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testConvertFromMillisBelowTimestampMaxLimit() {
+        long timestampMinSeconds = -62135596800L;
+        try {
+            Timestamps.fromMillis((timestampMinSeconds - 1) * MILLIS_PER_SECOND);
+            assertWithMessage("Expected an IllegalArgumentException to be thrown").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testConvertFromNanos() {
+        assertThat(Timestamps.fromNanos(NANOS)).isEqualTo(TIMESTAMP);
+        assertThat(Timestamps.fromNanos(0)).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromNanos(-1000000)).isEqualTo(ONE_OF_TIMESTAMP);
+        assertThat(Timestamps.fromNanos(MAX_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+        assertThat(Timestamps.fromNanos(MIN_VALUE)).isEqualTo(ZERO_TIMESTAMP);
+    }
+
+    @Test
+    public void testConvertToNanos() {
+        assertThat(Timestamps.toNanos(TIMESTAMP)).isEqualTo(NANOS);
+        assertThat(Timestamps.toNanos(ZERO_TIMESTAMP)).isEqualTo(0);
+        assertThat(Timestamps.toNanos(ONE_OF_TIMESTAMP)).isEqualTo(-1000000);
+    }
+
+    @Test
+    public void testAdd() {
+        assertThat(Timestamps.add(timestamp(1, 10), duration(1, 20))).isEqualTo(timestamp(2, 30));
+        assertThat(Timestamps.add(timestamp(1, 10), duration(-1, -11)))
+                .isEqualTo(timestamp(-1, 999999999));
+        assertThat(Timestamps.add(timestamp(10, 10), duration(-1, -11)))
+                .isEqualTo(timestamp(8, 999999999));
+        assertThat(Timestamps.add(timestamp(1, 1), duration(1, 999999999))).isEqualTo(timestamp(3, 0));
+        assertThat(Timestamps.add(timestamp(1, 2), duration(1, 999999999))).isEqualTo(timestamp(3, 1));
+    }
+
+    @Test
+    public void testSubtractDuration() {
+        assertThat(Timestamps.subtract(timestamp(1, 10), duration(-1, -20)))
+                .isEqualTo(timestamp(2, 30));
+        assertThat(Timestamps.subtract(timestamp(1, 10), duration(1, 11)))
+                .isEqualTo(timestamp(-1, 999999999));
+        assertThat(Timestamps.subtract(timestamp(10, 10), duration(1, 11)))
+                .isEqualTo(timestamp(8, 999999999));
+        assertThat(Timestamps.subtract(timestamp(1, 1), duration(-1, -999999999)))
+                .isEqualTo(timestamp(3, 0));
+        assertThat(Timestamps.subtract(timestamp(1, 2), duration(-1, -999999999)))
+                .isEqualTo(timestamp(3, 1));
+    }
+
+    static Timestamp timestamp(long seconds, int nanos) {
+        return Timestamps.checkValid(
+                Timestamps.checkValid(Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos)));
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
@@ -433,6 +433,17 @@ public class TimestampsTest {
     }
 
     @Test
+    public void testNowReturnsValidCurrentTimestamp() {
+        long beforeMillis = System.currentTimeMillis();
+        Timestamp timestamp = Timestamps.now();
+        long afterMillis = System.currentTimeMillis();
+
+        assertThat(Timestamps.isValid(timestamp)).isTrue();
+        assertThat(Timestamps.toMillis(timestamp)).isAtLeast(beforeMillis);
+        assertThat(Timestamps.toMillis(timestamp)).isAtMost(afterMillis);
+    }
+
+    @Test
     public void testTimeOperations() throws Exception {
         Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
         Timestamp end = Timestamps.parse("9999-12-31T23:59:59.999999999Z");

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/FieldMaskUtilTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/FieldMaskUtilTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_java_util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.util.FieldMaskUtil;
+import org.junit.Test;
+import protobuf_unittest.UnittestProto.NestedTestAllTypes;
+import protobuf_unittest.UnittestProto.TestAllTypes;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@SuppressWarnings("UnusedAssignment")
+public class FieldMaskUtilTest {
+    @Test
+    public void testIsValid() {
+        Truth.assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "nonexist")).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.optional_int32")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.repeated_int32")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.optional_nested_message")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.repeated_nested_message")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.nonexist")).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, FieldMaskUtil.fromString("payload"))).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, FieldMaskUtil.fromString("nonexist"))).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, FieldMaskUtil.fromString("payload,nonexist"))).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.getDescriptor(), "payload")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.getDescriptor(), "nonexist")).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.getDescriptor(), FieldMaskUtil.fromString("payload"))).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.getDescriptor(), FieldMaskUtil.fromString("nonexist"))).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.optional_nested_message.bb")).isTrue();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.repeated_nested_message.bb")).isFalse();
+        assertThat(FieldMaskUtil.isValid(NestedTestAllTypes.class, "payload.optional_int32.bb")).isFalse();
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(FieldMaskUtil.toString(FieldMask.getDefaultInstance())).isEmpty();
+        FieldMask mask = FieldMask.newBuilder().addPaths("foo").build();
+        assertThat(FieldMaskUtil.toString(mask)).isEqualTo("foo");
+        mask = FieldMask.newBuilder().addPaths("foo").addPaths("bar").build();
+        assertThat(FieldMaskUtil.toString(mask)).isEqualTo("foo,bar");
+        mask = FieldMask.newBuilder().addPaths("").addPaths("foo").addPaths("").addPaths("bar").addPaths("").build();
+        assertThat(FieldMaskUtil.toString(mask)).isEqualTo("foo,bar");
+    }
+
+    @Test
+    public void testFromString() {
+        FieldMask mask = FieldMaskUtil.fromString("");
+        assertThat(mask.getPathsCount()).isEqualTo(0);
+        mask = FieldMaskUtil.fromString("foo");
+        assertThat(mask.getPathsCount()).isEqualTo(1);
+        assertThat(mask.getPaths(0)).isEqualTo("foo");
+        mask = FieldMaskUtil.fromString("foo,bar.baz");
+        assertThat(mask.getPathsCount()).isEqualTo(2);
+        assertThat(mask.getPaths(0)).isEqualTo("foo");
+        assertThat(mask.getPaths(1)).isEqualTo("bar.baz");
+        mask = FieldMaskUtil.fromString(",foo,,bar,");
+        assertThat(mask.getPathsCount()).isEqualTo(2);
+        assertThat(mask.getPaths(0)).isEqualTo("foo");
+        assertThat(mask.getPaths(1)).isEqualTo("bar");
+        mask = FieldMaskUtil.fromString(NestedTestAllTypes.class, ",payload");
+        try {
+            mask = FieldMaskUtil.fromString(NestedTestAllTypes.class, "payload,nonexist");
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void testFromFieldNumbers() {
+        FieldMask mask = FieldMaskUtil.fromFieldNumbers(TestAllTypes.class);
+        assertThat(mask.getPathsCount()).isEqualTo(0);
+        mask = FieldMaskUtil.fromFieldNumbers(TestAllTypes.class, TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER);
+        assertThat(mask.getPathsCount()).isEqualTo(1);
+        assertThat(mask.getPaths(0)).isEqualTo("optional_int32");
+        mask = FieldMaskUtil.fromFieldNumbers(
+                TestAllTypes.class,
+                TestAllTypes.OPTIONAL_INT32_FIELD_NUMBER,
+                TestAllTypes.OPTIONAL_INT64_FIELD_NUMBER);
+        assertThat(mask.getPathsCount()).isEqualTo(2);
+        assertThat(mask.getPaths(0)).isEqualTo("optional_int32");
+        assertThat(mask.getPaths(1)).isEqualTo("optional_int64");
+        try {
+            int invalidFieldNumber = 1000;
+            mask = FieldMaskUtil.fromFieldNumbers(TestAllTypes.class, invalidFieldNumber);
+            assertWithMessage("Exception is expected.").fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testToJsonString() {
+        FieldMask mask = FieldMask.getDefaultInstance();
+        assertThat(FieldMaskUtil.toJsonString(mask)).isEmpty();
+        mask = FieldMask.newBuilder().addPaths("foo").build();
+        assertThat(FieldMaskUtil.toJsonString(mask)).isEqualTo("foo");
+        mask = FieldMask.newBuilder().addPaths("foo.bar_baz").addPaths("").build();
+        assertThat(FieldMaskUtil.toJsonString(mask)).isEqualTo("foo.barBaz");
+        mask = FieldMask.newBuilder().addPaths("foo").addPaths("bar_baz").build();
+        assertThat(FieldMaskUtil.toJsonString(mask)).isEqualTo("foo,barBaz");
+    }
+
+    @Test
+    public void testFromJsonString() {
+        FieldMask mask = FieldMaskUtil.fromJsonString("");
+        assertThat(mask.getPathsCount()).isEqualTo(0);
+        mask = FieldMaskUtil.fromJsonString("foo");
+        assertThat(mask.getPathsCount()).isEqualTo(1);
+        assertThat(mask.getPaths(0)).isEqualTo("foo");
+        mask = FieldMaskUtil.fromJsonString("foo.barBaz");
+        assertThat(mask.getPathsCount()).isEqualTo(1);
+        assertThat(mask.getPaths(0)).isEqualTo("foo.bar_baz");
+        mask = FieldMaskUtil.fromJsonString("foo,barBaz");
+        assertThat(mask.getPathsCount()).isEqualTo(2);
+        assertThat(mask.getPaths(0)).isEqualTo("foo");
+        assertThat(mask.getPaths(1)).isEqualTo("bar_baz");
+    }
+
+    @Test
+    public void testFromStringList() {
+        FieldMask mask = FieldMaskUtil.fromStringList(NestedTestAllTypes.class, ImmutableList.of("payload.repeated_nested_message", "child"));
+        assertThat(mask).isEqualTo(FieldMask.newBuilder()
+                .addPaths("payload.repeated_nested_message")
+                .addPaths("child")
+                .build());
+        mask = FieldMaskUtil.fromStringList(NestedTestAllTypes.getDescriptor(), ImmutableList.of("payload.repeated_nested_message", "child"));
+        assertThat(mask).isEqualTo(FieldMask.newBuilder().addPaths("payload.repeated_nested_message").addPaths("child").build());
+        mask = FieldMaskUtil.fromStringList(ImmutableList.of("payload.repeated_nested_message", "child"));
+        assertThat(mask).isEqualTo(FieldMask.newBuilder()
+                .addPaths("payload.repeated_nested_message")
+                .addPaths("child")
+                .build());
+    }
+
+    @Test
+    public void testUnion() {
+        FieldMask mask1 = FieldMaskUtil.fromString("foo,bar.baz,bar.quz");
+        FieldMask mask2 = FieldMaskUtil.fromString("foo.bar,bar");
+        FieldMask result = FieldMaskUtil.union(mask1, mask2);
+        assertThat(FieldMaskUtil.toString(result)).isEqualTo("bar,foo");
+    }
+
+    @Test
+    public void testUnion_usingVarArgs() {
+        FieldMask mask1 = FieldMaskUtil.fromString("foo");
+        FieldMask mask2 = FieldMaskUtil.fromString("foo.bar,bar.quz");
+        FieldMask mask3 = FieldMaskUtil.fromString("bar.quz");
+        FieldMask mask4 = FieldMaskUtil.fromString("bar");
+        FieldMask result = FieldMaskUtil.union(mask1, mask2, mask3, mask4);
+        assertThat(FieldMaskUtil.toString(result)).isEqualTo("bar,foo");
+    }
+
+    @Test
+    public void testSubstract() {
+        FieldMask mask1 = FieldMaskUtil.fromString("foo,bar.baz,bar.quz");
+        FieldMask mask2 = FieldMaskUtil.fromString("foo.bar,bar");
+        FieldMask result = FieldMaskUtil.subtract(mask1, mask2);
+        assertThat(FieldMaskUtil.toString(result)).isEqualTo("foo");
+    }
+
+    @Test
+    public void testSubstract_usingVarArgs() {
+        FieldMask mask1 = FieldMaskUtil.fromString("foo,bar.baz,bar.quz.bar");
+        FieldMask mask2 = FieldMaskUtil.fromString("foo.bar,bar.baz.quz");
+        FieldMask mask3 = FieldMaskUtil.fromString("bar.quz");
+        FieldMask mask4 = FieldMaskUtil.fromString("foo,bar.baz");
+        FieldMask result = FieldMaskUtil.subtract(mask1, mask2, mask3, mask4);
+        assertThat(FieldMaskUtil.toString(result)).isEmpty();
+    }
+
+    @Test
+    public void testIntersection() {
+        FieldMask mask1 = FieldMaskUtil.fromString("foo,bar.baz,bar.quz");
+        FieldMask mask2 = FieldMaskUtil.fromString("foo.bar,bar");
+        FieldMask result = FieldMaskUtil.intersection(mask1, mask2);
+        assertThat(FieldMaskUtil.toString(result)).isEqualTo("bar.baz,bar.quz,foo.bar");
+    }
+
+    @Test
+    public void testMerge() {
+        NestedTestAllTypes source = NestedTestAllTypes.newBuilder().setPayload(TestAllTypes.newBuilder().setOptionalInt32(1234)).build();
+        NestedTestAllTypes.Builder builder = NestedTestAllTypes.newBuilder();
+        FieldMaskUtil.merge(FieldMaskUtil.fromString("payload"), source, builder);
+        assertThat(builder.getPayload().getOptionalInt32()).isEqualTo(1234);
+    }
+
+    @Test
+    public void testTrim() {
+        NestedTestAllTypes source = NestedTestAllTypes.newBuilder().setPayload(TestAllTypes.newBuilder()
+                                .setOptionalInt32(1234)
+                                .setOptionalString("1234")
+                                .setOptionalBool(true))
+                .build();
+        FieldMask mask = FieldMaskUtil.fromStringList(ImmutableList.of("payload.optional_int32", "payload.optional_string"));
+        NestedTestAllTypes actual = FieldMaskUtil.trim(mask, source);
+        assertThat(actual).isEqualTo(NestedTestAllTypes.newBuilder().setPayload(TestAllTypes.newBuilder().setOptionalInt32(1234).setOptionalString("1234"))
+                .build());
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/StructsTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/StructsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_java_util;
+
+import com.google.common.truth.Truth;
+import com.google.protobuf.Struct;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Structs;
+import com.google.protobuf.util.Values;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class StructsTest {
+    @Test
+    public void test1pair_constructsObject() throws Exception {
+        Struct.Builder expected = Struct.newBuilder();
+        JsonFormat.parser().merge("{\"k1\": 1}", expected);
+        Truth.assertThat(Structs.of("k1", Values.of(1))).isEqualTo(expected.build());
+    }
+
+    @Test
+    public void test2pair_constructsObject() throws Exception {
+        Struct.Builder expected = Struct.newBuilder();
+        JsonFormat.parser().merge("{\"k1\": 1, \"k2\": 2}", expected);
+        assertThat(Structs.of("k1", Values.of(1), "k2", Values.of(2))).isEqualTo(expected.build());
+    }
+
+    @Test
+    public void test3pair_constructsObject() throws Exception {
+        Struct.Builder expected = Struct.newBuilder();
+        JsonFormat.parser().merge("{\"k1\": 1, \"k2\": 2, \"k3\": 3}", expected);
+        assertThat(Structs.of("k1", Values.of(1), "k2", Values.of(2), "k3", Values.of(3)))
+                .isEqualTo(expected.build());
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/ValuesTest.java
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com_google_protobuf/protobuf_java_util/ValuesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_protobuf.protobuf_java_util;
+
+import com.google.common.truth.Truth;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.protobuf.util.Values;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class ValuesTest {
+    @Test
+    public void testOfNull_IsNullValue() {
+        Truth.assertThat(Values.ofNull()).isEqualTo(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
+    }
+
+    @Test
+    public void testOfBoolean_ConstructsValue() {
+        assertThat(Values.of(true)).isEqualTo(Value.newBuilder().setBoolValue(true).build());
+        assertThat(Values.of(false)).isEqualTo(Value.newBuilder().setBoolValue(false).build());
+    }
+
+    @Test
+    public void testOfNumeric_ConstructsValue() {
+        assertThat(Values.of(100)).isEqualTo(Value.newBuilder().setNumberValue(100).build());
+        assertThat(Values.of(1000L)).isEqualTo(Value.newBuilder().setNumberValue(1000).build());
+        assertThat(Values.of(1000.23f)).isEqualTo(Value.newBuilder().setNumberValue(1000.23f).build());
+        assertThat(Values.of(10000.23)).isEqualTo(Value.newBuilder().setNumberValue(10000.23).build());
+    }
+
+    @Test
+    public void testOfString_ConstructsValue() {
+        assertThat(Values.of("")).isEqualTo(Value.newBuilder().setStringValue("").build());
+        assertThat(Values.of("foo")).isEqualTo(Value.newBuilder().setStringValue("foo").build());
+    }
+
+    @Test
+    public void testOfStruct_ConstructsValue() {
+        Struct.Builder builder = Struct.newBuilder();
+        builder.putFields("a", Values.of("a"));
+        builder.putFields("b", Values.of("b"));
+        assertThat(Values.of(builder.build())).isEqualTo(Value.newBuilder().setStructValue(builder.build()).build());
+    }
+
+    @Test
+    public void testOfListValue_ConstructsInstance() {
+        ListValue.Builder builder = ListValue.newBuilder();
+        builder.addValues(Values.of(1));
+        builder.addValues(Values.of(2));
+        assertThat(Values.of(builder.build())).isEqualTo(Value.newBuilder().setListValue(builder.build()).build());
+    }
+
+    @Test
+    public void testOfIterable_ReturnsTheValue() {
+        ListValue.Builder builder = ListValue.newBuilder();
+        builder.addValues(Values.of(1));
+        builder.addValues(Values.of(2));
+        builder.addValues(Values.of(true));
+        builder.addValues(Value.newBuilder().setListValue(builder.build()).build());
+        List<Value> list = new ArrayList<>();
+        list.add(Values.of(1));
+        list.add(Values.of(2));
+        list.add(Values.of(true));
+        List<Value> copyList = new ArrayList<>(list);
+        list.add(Values.of(copyList));
+        assertThat(Values.of(list)).isEqualTo(Value.newBuilder().setListValue(builder).build());
+        assertThat(Values.of(new ArrayList<>())).isEqualTo(Value.newBuilder().setListValue(ListValue.getDefaultInstance()).build());
+    }
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/json_test.proto
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/json_test.proto
@@ -1,0 +1,151 @@
+syntax = "proto3";
+
+package json_test;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option java_package = "com_google_protobuf.protobuf_java_util";
+option java_outer_classname = "JsonTestProto";
+
+message TestAllTypes {
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+  enum AliasedEnum {
+    option allow_alias = true;
+    ALIAS_FOO = 0;
+    ALIAS_BAR = 1;
+    ALIAS_BAZ = 2;
+    QUX = 2;
+    qux = 2;
+    bAz = 2;
+  }
+  message NestedMessage {
+    int32 value = 1;
+  }
+  int32 optional_int32 = 1;
+  int64 optional_int64 = 2;
+  uint32 optional_uint32 = 3;
+  uint64 optional_uint64 = 4;
+  sint32 optional_sint32 = 5;
+  sint64 optional_sint64 = 6;
+  fixed32 optional_fixed32 = 7;
+  fixed64 optional_fixed64 = 8;
+  sfixed32 optional_sfixed32 = 9;
+  sfixed64 optional_sfixed64 = 10;
+  float optional_float = 11;
+  double optional_double = 12;
+  bool optional_bool = 13;
+  string optional_string = 14;
+  bytes optional_bytes = 15;
+  NestedMessage optional_nested_message = 18;
+  NestedEnum optional_nested_enum = 21;
+  AliasedEnum optional_aliased_enum = 52;
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated NestedEnum repeated_nested_enum = 51;
+}
+
+message TestOneof {
+  oneof oneof_field {
+    int32 oneof_int32 = 1;
+    TestAllTypes.NestedMessage oneof_nested_message = 2;
+    google.protobuf.NullValue oneof_null_value = 3;
+  }
+}
+
+message TestMap {
+  map<int32, int32> int32_to_int32_map = 1;
+  map<int64, int32> int64_to_int32_map = 2;
+  map<uint32, int32> uint32_to_int32_map = 3;
+  map<uint64, int32> uint64_to_int32_map = 4;
+  map<sint32, int32> sint32_to_int32_map = 5;
+  map<sint64, int32> sint64_to_int32_map = 6;
+  map<fixed32, int32> fixed32_to_int32_map = 7;
+  map<fixed64, int32> fixed64_to_int32_map = 8;
+  map<sfixed32, int32> sfixed32_to_int32_map = 9;
+  map<sfixed64, int32> sfixed64_to_int32_map = 10;
+  map<bool, int32> bool_to_int32_map = 11;
+  map<string, int32> string_to_int32_map = 12;
+  map<int32, int64> int32_to_int64_map = 101;
+  map<int32, uint32> int32_to_uint32_map = 102;
+  map<int32, uint64> int32_to_uint64_map = 103;
+  map<int32, sint32> int32_to_sint32_map = 104;
+  map<int32, sint64> int32_to_sint64_map = 105;
+  map<int32, fixed32> int32_to_fixed32_map = 106;
+  map<int32, fixed64> int32_to_fixed64_map = 107;
+  map<int32, sfixed32> int32_to_sfixed32_map = 108;
+  map<int32, sfixed64> int32_to_sfixed64_map = 109;
+  map<int32, float> int32_to_float_map = 110;
+  map<int32, double> int32_to_double_map = 111;
+  map<int32, bool> int32_to_bool_map = 112;
+  map<int32, string> int32_to_string_map = 113;
+  map<int32, bytes> int32_to_bytes_map = 114;
+  map<int32, TestAllTypes.NestedMessage> int32_to_message_map = 115;
+  map<int32, TestAllTypes.NestedEnum> int32_to_enum_map = 116;
+}
+
+message TestWrappers {
+  google.protobuf.Int32Value int32_value = 1;
+  google.protobuf.UInt32Value uint32_value = 2;
+  google.protobuf.Int64Value int64_value = 3;
+  google.protobuf.UInt64Value uint64_value = 4;
+  google.protobuf.FloatValue float_value = 5;
+  google.protobuf.DoubleValue double_value = 6;
+  google.protobuf.BoolValue bool_value = 7;
+  google.protobuf.StringValue string_value = 8;
+  google.protobuf.BytesValue bytes_value = 9;
+}
+
+message TestTimestamp {
+  google.protobuf.Timestamp timestamp_value = 1;
+}
+
+message TestDuration {
+  google.protobuf.Duration duration_value = 1;
+}
+
+message TestFieldMask {
+  google.protobuf.FieldMask field_mask_value = 1;
+}
+
+message TestStruct {
+  google.protobuf.Struct struct_value = 1;
+  google.protobuf.Value value = 2;
+  google.protobuf.ListValue list_value = 3;
+}
+
+message TestAny {
+  google.protobuf.Any any_value = 1;
+  map<string, google.protobuf.Any> any_map = 2;
+}
+
+message TestCustomJsonName {
+  int32 value = 1 [json_name = "@value"];
+}
+
+message TestRecursive {
+  int32 value = 1;
+  TestRecursive nested = 2;
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest.proto
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest.proto
@@ -1,0 +1,1257 @@
+// LINT: ALLOW_GROUPS, LEGACY_NAMES
+
+syntax = "proto2";
+
+option cc_generic_services = true;
+option java_generic_services = true;
+option py_generic_services = true;
+option cc_enable_arenas = true;
+
+import "com_google_protobuf/protobuf_java_util/unittest_import.proto";
+
+package protobuf_unittest;
+
+option optimize_for = SPEED;
+
+option java_outer_classname = "UnittestProto";
+
+message TestAllTypes {
+  message NestedMessage {
+    optional int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+    NEG = -1;
+  }
+
+  optional    int32 optional_int32    =  1;
+  optional    int64 optional_int64    =  2;
+  optional   uint32 optional_uint32   =  3;
+  optional   uint64 optional_uint64   =  4;
+  optional   sint32 optional_sint32   =  5;
+  optional   sint64 optional_sint64   =  6;
+  optional  fixed32 optional_fixed32  =  7;
+  optional  fixed64 optional_fixed64  =  8;
+  optional sfixed32 optional_sfixed32 =  9;
+  optional sfixed64 optional_sfixed64 = 10;
+  optional    float optional_float    = 11;
+  optional   double optional_double   = 12;
+  optional     bool optional_bool     = 13;
+  optional   string optional_string   = 14;
+  optional    bytes optional_bytes    = 15;
+
+  optional group OptionalGroup = 16 {
+    optional int32 a = 17;
+  }
+
+  optional NestedMessage                        optional_nested_message  = 18;
+  optional ForeignMessage                       optional_foreign_message = 19;
+  optional protobuf_unittest_import.ImportMessage optional_import_message  = 20;
+
+  optional NestedEnum                           optional_nested_enum     = 21;
+  optional ForeignEnum                          optional_foreign_enum    = 22;
+  optional protobuf_unittest_import.ImportEnum    optional_import_enum     = 23;
+
+  optional string optional_string_piece = 24 [ctype=STRING_PIECE];
+  optional string optional_cord = 25 [ctype=CORD];
+
+  optional protobuf_unittest_import.PublicImportMessage
+      optional_public_import_message = 26;
+
+  optional NestedMessage optional_lazy_message = 27 [lazy=true];
+  optional NestedMessage optional_unverified_lazy_message = 28 [unverified_lazy=true];
+
+  repeated    int32 repeated_int32    = 31;
+  repeated    int64 repeated_int64    = 32;
+  repeated   uint32 repeated_uint32   = 33;
+  repeated   uint64 repeated_uint64   = 34;
+  repeated   sint32 repeated_sint32   = 35;
+  repeated   sint64 repeated_sint64   = 36;
+  repeated  fixed32 repeated_fixed32  = 37;
+  repeated  fixed64 repeated_fixed64  = 38;
+  repeated sfixed32 repeated_sfixed32 = 39;
+  repeated sfixed64 repeated_sfixed64 = 40;
+  repeated    float repeated_float    = 41;
+  repeated   double repeated_double   = 42;
+  repeated     bool repeated_bool     = 43;
+  repeated   string repeated_string   = 44;
+  repeated    bytes repeated_bytes    = 45;
+
+  repeated group RepeatedGroup = 46 {
+    optional int32 a = 47;
+  }
+
+  repeated NestedMessage                        repeated_nested_message  = 48;
+  repeated ForeignMessage                       repeated_foreign_message = 49;
+  repeated protobuf_unittest_import.ImportMessage repeated_import_message  = 50;
+
+  repeated NestedEnum                           repeated_nested_enum     = 51;
+  repeated ForeignEnum                          repeated_foreign_enum    = 52;
+  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum     = 53;
+
+  repeated string repeated_string_piece = 54 [ctype=STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype=CORD];
+
+  repeated NestedMessage repeated_lazy_message = 57 [lazy=true];
+
+  optional    int32 default_int32    = 61 [default =  41    ];
+  optional    int64 default_int64    = 62 [default =  42    ];
+  optional   uint32 default_uint32   = 63 [default =  43    ];
+  optional   uint64 default_uint64   = 64 [default =  44    ];
+  optional   sint32 default_sint32   = 65 [default = -45    ];
+  optional   sint64 default_sint64   = 66 [default =  46    ];
+  optional  fixed32 default_fixed32  = 67 [default =  47    ];
+  optional  fixed64 default_fixed64  = 68 [default =  48    ];
+  optional sfixed32 default_sfixed32 = 69 [default =  49    ];
+  optional sfixed64 default_sfixed64 = 70 [default = -50    ];
+  optional    float default_float    = 71 [default =  51.5  ];
+  optional   double default_double   = 72 [default =  52e3  ];
+  optional     bool default_bool     = 73 [default = true   ];
+  optional   string default_string   = 74 [default = "hello"];
+  optional    bytes default_bytes    = 75 [default = "world"];
+
+  optional NestedEnum  default_nested_enum  = 81 [default = BAR        ];
+  optional ForeignEnum default_foreign_enum = 82 [default = FOREIGN_BAR];
+  optional protobuf_unittest_import.ImportEnum
+      default_import_enum = 83 [default = IMPORT_BAR];
+
+  optional string default_string_piece = 84 [ctype=STRING_PIECE,default="abc"];
+  optional string default_cord = 85 [ctype=CORD,default="123"];
+
+  oneof oneof_field {
+    uint32 oneof_uint32 = 111;
+    NestedMessage oneof_nested_message = 112;
+    string oneof_string = 113;
+    bytes oneof_bytes = 114;
+  }
+}
+
+message NestedTestAllTypes {
+  optional NestedTestAllTypes child = 1;
+  optional TestAllTypes payload = 2;
+  repeated NestedTestAllTypes repeated_child = 3;
+  optional NestedTestAllTypes lazy_child = 4 [lazy=true];
+  optional TestAllTypes eager_child = 5 [lazy=false];
+}
+
+message TestDeprecatedFields {
+  optional int32 deprecated_int32 = 1 [deprecated=true];
+  oneof oneof_fields {
+    int32 deprecated_int32_in_oneof = 2 [deprecated=true];
+  }
+}
+
+message TestDeprecatedMessage {
+  option deprecated = true;
+}
+
+message ForeignMessage {
+  optional int32 c = 1;
+  optional int32 d = 2;
+}
+
+enum ForeignEnum {
+  FOREIGN_FOO = 4;
+  FOREIGN_BAR = 5;
+  FOREIGN_BAZ = 6;
+}
+
+message TestReservedFields {
+  reserved 2, 15, 9 to 11;
+  reserved "bar", "baz";
+}
+
+message TestAllExtensions {
+  extensions 1 to max;
+}
+
+extend TestAllExtensions {
+  optional    int32 optional_int32_extension    =  1;
+  optional    int64 optional_int64_extension    =  2;
+  optional   uint32 optional_uint32_extension   =  3;
+  optional   uint64 optional_uint64_extension   =  4;
+  optional   sint32 optional_sint32_extension   =  5;
+  optional   sint64 optional_sint64_extension   =  6;
+  optional  fixed32 optional_fixed32_extension  =  7;
+  optional  fixed64 optional_fixed64_extension  =  8;
+  optional sfixed32 optional_sfixed32_extension =  9;
+  optional sfixed64 optional_sfixed64_extension = 10;
+  optional    float optional_float_extension    = 11;
+  optional   double optional_double_extension   = 12;
+  optional     bool optional_bool_extension     = 13;
+  optional   string optional_string_extension   = 14;
+  optional    bytes optional_bytes_extension    = 15;
+
+  optional group OptionalGroup_extension = 16 {
+    optional int32 a = 17;
+  }
+
+  optional TestAllTypes.NestedMessage optional_nested_message_extension = 18;
+  optional ForeignMessage optional_foreign_message_extension = 19;
+  optional protobuf_unittest_import.ImportMessage
+    optional_import_message_extension = 20;
+
+  optional TestAllTypes.NestedEnum optional_nested_enum_extension = 21;
+  optional ForeignEnum optional_foreign_enum_extension = 22;
+  optional protobuf_unittest_import.ImportEnum
+    optional_import_enum_extension = 23;
+
+  optional string optional_string_piece_extension = 24 [ctype=STRING_PIECE];
+  optional string optional_cord_extension = 25 [ctype=CORD];
+
+  optional protobuf_unittest_import.PublicImportMessage
+    optional_public_import_message_extension = 26;
+
+  optional TestAllTypes.NestedMessage
+    optional_lazy_message_extension = 27 [lazy=true];
+  optional TestAllTypes.NestedMessage
+    optional_unverified_lazy_message_extension = 28 [unverified_lazy=true];
+
+  repeated    int32 repeated_int32_extension    = 31;
+  repeated    int64 repeated_int64_extension    = 32;
+  repeated   uint32 repeated_uint32_extension   = 33;
+  repeated   uint64 repeated_uint64_extension   = 34;
+  repeated   sint32 repeated_sint32_extension   = 35;
+  repeated   sint64 repeated_sint64_extension   = 36;
+  repeated  fixed32 repeated_fixed32_extension  = 37;
+  repeated  fixed64 repeated_fixed64_extension  = 38;
+  repeated sfixed32 repeated_sfixed32_extension = 39;
+  repeated sfixed64 repeated_sfixed64_extension = 40;
+  repeated    float repeated_float_extension    = 41;
+  repeated   double repeated_double_extension   = 42;
+  repeated     bool repeated_bool_extension     = 43;
+  repeated   string repeated_string_extension   = 44;
+  repeated    bytes repeated_bytes_extension    = 45;
+
+  repeated group RepeatedGroup_extension = 46 {
+    optional int32 a = 47;
+  }
+
+  repeated TestAllTypes.NestedMessage repeated_nested_message_extension = 48;
+  repeated ForeignMessage repeated_foreign_message_extension = 49;
+  repeated protobuf_unittest_import.ImportMessage
+    repeated_import_message_extension = 50;
+
+  repeated TestAllTypes.NestedEnum repeated_nested_enum_extension = 51;
+  repeated ForeignEnum repeated_foreign_enum_extension = 52;
+  repeated protobuf_unittest_import.ImportEnum
+    repeated_import_enum_extension = 53;
+
+  repeated string repeated_string_piece_extension = 54 [ctype=STRING_PIECE];
+  repeated string repeated_cord_extension = 55 [ctype=CORD];
+
+  repeated TestAllTypes.NestedMessage
+    repeated_lazy_message_extension = 57 [lazy=true];
+
+  optional    int32 default_int32_extension    = 61 [default =  41    ];
+  optional    int64 default_int64_extension    = 62 [default =  42    ];
+  optional   uint32 default_uint32_extension   = 63 [default =  43    ];
+  optional   uint64 default_uint64_extension   = 64 [default =  44    ];
+  optional   sint32 default_sint32_extension   = 65 [default = -45    ];
+  optional   sint64 default_sint64_extension   = 66 [default =  46    ];
+  optional  fixed32 default_fixed32_extension  = 67 [default =  47    ];
+  optional  fixed64 default_fixed64_extension  = 68 [default =  48    ];
+  optional sfixed32 default_sfixed32_extension = 69 [default =  49    ];
+  optional sfixed64 default_sfixed64_extension = 70 [default = -50    ];
+  optional    float default_float_extension    = 71 [default =  51.5  ];
+  optional   double default_double_extension   = 72 [default =  52e3  ];
+  optional     bool default_bool_extension     = 73 [default = true   ];
+  optional   string default_string_extension   = 74 [default = "hello"];
+  optional    bytes default_bytes_extension    = 75 [default = "world"];
+
+  optional TestAllTypes.NestedEnum
+    default_nested_enum_extension = 81 [default = BAR];
+  optional ForeignEnum
+    default_foreign_enum_extension = 82 [default = FOREIGN_BAR];
+  optional protobuf_unittest_import.ImportEnum
+    default_import_enum_extension = 83 [default = IMPORT_BAR];
+
+  optional string default_string_piece_extension = 84 [ctype=STRING_PIECE,
+                                                       default="abc"];
+  optional string default_cord_extension = 85 [ctype=CORD, default="123"];
+
+  optional uint32 oneof_uint32_extension = 111;
+  optional TestAllTypes.NestedMessage oneof_nested_message_extension = 112;
+  optional string oneof_string_extension = 113;
+  optional bytes oneof_bytes_extension = 114;
+}
+
+message TestGroup {
+  optional group OptionalGroup = 16 {
+    optional int32 a = 17;
+  }
+  optional ForeignEnum optional_foreign_enum = 22;
+}
+
+message TestGroupExtension {
+  extensions 1 to max;
+}
+
+message TestNestedExtension {
+  extend TestAllExtensions {
+    optional string test = 1002 [default="test"];
+    optional string nested_string_extension = 1003;
+  }
+
+  extend TestGroupExtension {
+    optional group OptionalGroup_extension = 16 {
+      optional int32 a = 17;
+    }
+    optional ForeignEnum optional_foreign_enum_extension = 22;
+  }
+}
+
+message TestChildExtension {
+  optional string a = 1;
+  optional string b = 2;
+  optional TestAllExtensions optional_extension = 3;
+}
+
+message TestChildExtensionData {
+  message NestedTestAllExtensionsData {
+    message NestedDynamicExtensions {
+      optional int32 a = 1;
+      optional int32 b = 2;
+    }
+    optional NestedDynamicExtensions dynamic = 409707008;
+  }
+  optional string a = 1;
+  optional string b = 2;
+  optional NestedTestAllExtensionsData optional_extension = 3;
+}
+
+message TestNestedChildExtension {
+  optional int32 a = 1;
+  optional TestChildExtension child = 2;
+}
+
+message TestNestedChildExtensionData {
+  optional int32 a = 1;
+  optional TestChildExtensionData child = 2;
+}
+
+message TestRequired {
+  required int32 a = 1;
+  optional int32 dummy2 = 2;
+  required int32 b = 3;
+
+  extend TestAllExtensions {
+    optional TestRequired single = 1000;
+    repeated TestRequired multi  = 1001;
+  }
+
+  optional int32 dummy4  =  4;
+  optional int32 dummy5  =  5;
+  optional int32 dummy6  =  6;
+  optional int32 dummy7  =  7;
+  optional int32 dummy8  =  8;
+  optional int32 dummy9  =  9;
+  optional int32 dummy10 = 10;
+  optional int32 dummy11 = 11;
+  optional int32 dummy12 = 12;
+  optional int32 dummy13 = 13;
+  optional int32 dummy14 = 14;
+  optional int32 dummy15 = 15;
+  optional int32 dummy16 = 16;
+  optional int32 dummy17 = 17;
+  optional int32 dummy18 = 18;
+  optional int32 dummy19 = 19;
+  optional int32 dummy20 = 20;
+  optional int32 dummy21 = 21;
+  optional int32 dummy22 = 22;
+  optional int32 dummy23 = 23;
+  optional int32 dummy24 = 24;
+  optional int32 dummy25 = 25;
+  optional int32 dummy26 = 26;
+  optional int32 dummy27 = 27;
+  optional int32 dummy28 = 28;
+  optional int32 dummy29 = 29;
+  optional int32 dummy30 = 30;
+  optional int32 dummy31 = 31;
+  optional int32 dummy32 = 32;
+
+  required int32 c = 33;
+
+  optional ForeignMessage optional_foreign = 34;
+}
+
+message TestRequiredForeign {
+  optional TestRequired optional_message = 1;
+  repeated TestRequired repeated_message = 2;
+  optional int32 dummy = 3;
+}
+
+message TestRequiredMessage {
+  optional TestRequired optional_message = 1;
+  repeated TestRequired repeated_message = 2;
+  required TestRequired required_message = 3;
+}
+
+message TestNestedRequiredForeign {
+  optional TestNestedRequiredForeign child = 1;
+  optional TestRequiredForeign payload = 2;
+  optional int32 dummy = 3;
+}
+
+message TestForeignNested {
+  optional TestAllTypes.NestedMessage foreign_nested = 1;
+}
+
+message TestEmptyMessage {
+}
+
+message TestEmptyMessageWithExtensions {
+  extensions 1 to max;
+}
+
+message TestPickleNestedMessage {
+  message NestedMessage {
+    optional int32 bb = 1;
+    message NestedNestedMessage {
+      optional int32 cc = 1;
+    }
+  }
+}
+
+message TestMultipleExtensionRanges {
+  extensions 42;
+  extensions 4143 to 4243;
+  extensions 65536 to max;
+}
+
+message TestReallyLargeTagNumber {
+  optional int32 a = 1;
+  optional int32 bb = 268435455;
+}
+
+message TestRecursiveMessage {
+  optional TestRecursiveMessage a = 1;
+  optional int32 i = 2;
+}
+
+message TestMutualRecursionA {
+  message SubMessage {
+    optional TestMutualRecursionB b = 1;
+  }
+  optional TestMutualRecursionB bb = 1;
+  optional group SubGroup = 2 {
+    optional SubMessage sub_message = 3;
+    optional TestAllTypes not_in_this_scc = 4;
+  }
+}
+
+message TestMutualRecursionB {
+  optional TestMutualRecursionA a = 1;
+  optional int32 optional_int32 = 2;
+}
+
+message TestIsInitialized {
+  message SubMessage {
+    optional group SubGroup = 1 {
+      required int32 i = 2;
+    }
+  }
+  optional SubMessage sub_message = 1;
+}
+
+message TestDupFieldNumber {
+  optional int32 a = 1;
+  optional group Foo = 2 { optional int32 a = 1; }
+  optional group Bar = 3 { optional int32 a = 1; }
+}
+
+
+message TestEagerMessage {
+  optional TestAllTypes sub_message = 1 [lazy=false];
+}
+message TestLazyMessage {
+  optional TestAllTypes sub_message = 1 [lazy=true];
+}
+message TestEagerMaybeLazy {
+  message NestedMessage {
+    optional TestPackedTypes packed = 1;
+  }
+  optional TestAllTypes message_foo = 1;
+  optional TestAllTypes message_bar = 2;
+  optional NestedMessage message_baz = 3;
+}
+
+message TestNestedMessageHasBits {
+  message NestedMessage {
+    repeated int32 nestedmessage_repeated_int32 = 1;
+    repeated ForeignMessage nestedmessage_repeated_foreignmessage = 2;
+  }
+  optional NestedMessage optional_nested_message = 1;
+}
+
+enum TestEnumWithDupValue {
+  option allow_alias = true;
+
+  FOO1 = 1;
+  BAR1 = 2;
+  BAZ = 3;
+  FOO2 = 1;
+  BAR2 = 2;
+}
+
+enum TestSparseEnum {
+  SPARSE_A = 123;
+  SPARSE_B = 62374;
+  SPARSE_C = 12589234;
+  SPARSE_D = -15;
+  SPARSE_E = -53452;
+  SPARSE_F = 0;
+  SPARSE_G = 2;
+}
+
+message TestCamelCaseFieldNames {
+  optional int32 PrimitiveField = 1;
+  optional string StringField = 2;
+  optional ForeignEnum EnumField = 3;
+  optional ForeignMessage MessageField = 4;
+  optional string StringPieceField = 5 [ctype=STRING_PIECE];
+  optional string CordField = 6 [ctype=CORD];
+
+  repeated int32 RepeatedPrimitiveField = 7;
+  repeated string RepeatedStringField = 8;
+  repeated ForeignEnum RepeatedEnumField = 9;
+  repeated ForeignMessage RepeatedMessageField = 10;
+  repeated string RepeatedStringPieceField = 11 [ctype=STRING_PIECE];
+  repeated string RepeatedCordField = 12 [ctype=CORD];
+}
+
+message TestFieldOrderings {
+  optional string my_string = 11;
+  extensions 2 to 10;
+  optional int64 my_int = 1;
+  extensions 12 to 100;
+  optional float my_float = 101;
+  message NestedMessage {
+    optional int64 oo = 2;
+    optional int32 bb = 1;
+  }
+
+  optional NestedMessage optional_nested_message  = 200;
+}
+
+extend TestFieldOrderings {
+  optional string my_extension_string = 50;
+  optional int32 my_extension_int = 5;
+}
+
+message TestExtensionOrderings1 {
+  extend TestFieldOrderings {
+    optional TestExtensionOrderings1 test_ext_orderings1 = 13;
+  }
+  optional string my_string = 1;
+}
+
+message TestExtensionOrderings2 {
+  extend TestFieldOrderings {
+    optional TestExtensionOrderings2 test_ext_orderings2 = 12;
+  }
+  message TestExtensionOrderings3 {
+    extend TestFieldOrderings {
+      optional TestExtensionOrderings3 test_ext_orderings3 = 14;
+    }
+    optional string my_string = 1;
+  }
+  optional string my_string = 1;
+}
+
+message TestExtremeDefaultValues {
+  optional bytes escaped_bytes = 1 [default = "\0\001\a\b\f\n\r\t\v\\\'\"\xfe"];
+  optional uint32 large_uint32 = 2 [default = 0xFFFFFFFF];
+  optional uint64 large_uint64 = 3 [default = 0xFFFFFFFFFFFFFFFF];
+  optional  int32 small_int32  = 4 [default = -0x7FFFFFFF];
+  optional  int64 small_int64  = 5 [default = -0x7FFFFFFFFFFFFFFF];
+  optional  int32 really_small_int32 = 21 [default = -0x80000000];
+  optional  int64 really_small_int64 = 22 [default = -0x8000000000000000];
+  optional string utf8_string = 6 [default = "\341\210\264"];
+  optional float zero_float = 7 [default = 0];
+  optional float one_float = 8 [default = 1];
+  optional float small_float = 9 [default = 1.5];
+  optional float negative_one_float = 10 [default = -1];
+  optional float negative_float = 11 [default = -1.5];
+  optional float large_float = 12 [default = 2E8];
+  optional float small_negative_float = 13 [default = -8e-28];
+  optional double inf_double = 14 [default = inf];
+  optional double neg_inf_double = 15 [default = -inf];
+  optional double nan_double = 16 [default = nan];
+  optional float inf_float = 17 [default = inf];
+  optional float neg_inf_float = 18 [default = -inf];
+  optional float nan_float = 19 [default = nan];
+  optional string cpp_trigraph = 20 [default = "? \? ?? \?? \??? ??/ ?\?-"];
+  optional string string_with_zero       = 23 [default = "hel\000lo"];
+  optional  bytes bytes_with_zero        = 24 [default = "wor\000ld"];
+  optional string string_piece_with_zero = 25 [ctype=STRING_PIECE,
+                                               default="ab\000c"];
+  optional string cord_with_zero         = 26 [ctype=CORD,
+                                               default="12\0003"];
+  optional string replacement_string     = 27 [default="${unknown}"];
+}
+
+message SparseEnumMessage {
+  optional TestSparseEnum sparse_enum = 1;
+}
+
+message OneString {
+  optional string data = 1;
+}
+
+message MoreString {
+  repeated string data = 1;
+}
+
+message OneBytes {
+  optional bytes data = 1;
+}
+
+message MoreBytes {
+  repeated bytes data = 1;
+}
+
+message ManyOptionalString {
+  optional string str1 = 1;
+  optional string str2 = 2;
+  optional string str3 = 3;
+  optional string str4 = 4;
+  optional string str5 = 5;
+  optional string str6 = 6;
+  optional string str7 = 7;
+  optional string str8 = 8;
+  optional string str9 = 9;
+  optional string str10 = 10;
+  optional string str11 = 11;
+  optional string str12 = 12;
+  optional string str13 = 13;
+  optional string str14 = 14;
+  optional string str15 = 15;
+  optional string str16 = 16;
+  optional string str17 = 17;
+  optional string str18 = 18;
+  optional string str19 = 19;
+  optional string str20 = 20;
+  optional string str21 = 21;
+  optional string str22 = 22;
+  optional string str23 = 23;
+  optional string str24 = 24;
+  optional string str25 = 25;
+  optional string str26 = 26;
+  optional string str27 = 27;
+  optional string str28 = 28;
+  optional string str29 = 29;
+  optional string str30 = 30;
+  optional string str31 = 31;
+  optional string str32 = 32;
+}
+
+message Int32Message {
+  optional int32 data = 1;
+}
+
+message Uint32Message {
+  optional uint32 data = 1;
+}
+
+message Int64Message {
+  optional int64 data = 1;
+}
+
+message Uint64Message {
+  optional uint64 data = 1;
+}
+
+message BoolMessage {
+  optional bool data = 1;
+}
+
+message TestOneof {
+  oneof foo {
+    int32 foo_int = 1;
+    string foo_string = 2;
+    TestAllTypes foo_message = 3;
+    group FooGroup = 4 {
+      optional int32 a = 5;
+      optional string b = 6;
+    }
+  }
+}
+
+message TestOneofBackwardsCompatible {
+  optional int32 foo_int = 1;
+  optional string foo_string = 2;
+  optional TestAllTypes foo_message = 3;
+  optional group FooGroup = 4 {
+    optional int32 a = 5;
+    optional string b = 6;
+  }
+}
+
+message TestOneof2 {
+  oneof foo {
+    int32 foo_int = 1;
+    string foo_string = 2;
+    string foo_cord = 3 [ctype=CORD];
+    string foo_string_piece = 4 [ctype=STRING_PIECE];
+    bytes foo_bytes = 5;
+    NestedEnum foo_enum = 6;
+    NestedMessage foo_message = 7;
+    group FooGroup = 8 {
+      optional int32 a = 9;
+      optional string b = 10;
+    }
+    NestedMessage foo_lazy_message = 11 [lazy=true];
+  }
+
+  oneof bar {
+    int32 bar_int = 12 [default = 5];
+    string bar_string = 13 [default = "STRING"];
+    string bar_cord = 14 [ctype=CORD, default = "CORD"];
+    string bar_string_piece = 15 [ctype=STRING_PIECE, default = "SPIECE"];
+    bytes bar_bytes = 16 [default = "BYTES"];
+    NestedEnum bar_enum = 17 [default = BAR];
+    string bar_string_with_empty_default = 20 [default = ""];
+    string bar_cord_with_empty_default = 21 [ctype=CORD, default = ""];
+    string bar_string_piece_with_empty_default = 22 [ctype=STRING_PIECE, default = ""];
+    bytes bar_bytes_with_empty_default = 23 [default = ""];
+  }
+
+  optional int32 baz_int = 18;
+  optional string baz_string = 19 [default = "BAZ"];
+
+  message NestedMessage {
+    optional int64 moo_int = 1;
+    repeated int32 corge_int = 2;
+  }
+
+  enum NestedEnum {
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+  }
+}
+
+message TestRequiredOneof {
+  oneof foo {
+    int32 foo_int = 1;
+    string foo_string = 2;
+    NestedMessage foo_message = 3;
+  }
+  message NestedMessage {
+    required double required_double = 1;
+  }
+}
+
+message TestPackedTypes {
+  repeated    int32 packed_int32    =  90 [packed = true];
+  repeated    int64 packed_int64    =  91 [packed = true];
+  repeated   uint32 packed_uint32   =  92 [packed = true];
+  repeated   uint64 packed_uint64   =  93 [packed = true];
+  repeated   sint32 packed_sint32   =  94 [packed = true];
+  repeated   sint64 packed_sint64   =  95 [packed = true];
+  repeated  fixed32 packed_fixed32  =  96 [packed = true];
+  repeated  fixed64 packed_fixed64  =  97 [packed = true];
+  repeated sfixed32 packed_sfixed32 =  98 [packed = true];
+  repeated sfixed64 packed_sfixed64 =  99 [packed = true];
+  repeated    float packed_float    = 100 [packed = true];
+  repeated   double packed_double   = 101 [packed = true];
+  repeated     bool packed_bool     = 102 [packed = true];
+  repeated ForeignEnum packed_enum  = 103 [packed = true];
+}
+
+message TestUnpackedTypes {
+  repeated    int32 unpacked_int32    =  90 [packed = false];
+  repeated    int64 unpacked_int64    =  91 [packed = false];
+  repeated   uint32 unpacked_uint32   =  92 [packed = false];
+  repeated   uint64 unpacked_uint64   =  93 [packed = false];
+  repeated   sint32 unpacked_sint32   =  94 [packed = false];
+  repeated   sint64 unpacked_sint64   =  95 [packed = false];
+  repeated  fixed32 unpacked_fixed32  =  96 [packed = false];
+  repeated  fixed64 unpacked_fixed64  =  97 [packed = false];
+  repeated sfixed32 unpacked_sfixed32 =  98 [packed = false];
+  repeated sfixed64 unpacked_sfixed64 =  99 [packed = false];
+  repeated    float unpacked_float    = 100 [packed = false];
+  repeated   double unpacked_double   = 101 [packed = false];
+  repeated     bool unpacked_bool     = 102 [packed = false];
+  repeated ForeignEnum unpacked_enum  = 103 [packed = false];
+}
+
+message TestPackedExtensions {
+  extensions 1 to max;
+}
+
+extend TestPackedExtensions {
+  repeated    int32 packed_int32_extension    =  90 [packed = true];
+  repeated    int64 packed_int64_extension    =  91 [packed = true];
+  repeated   uint32 packed_uint32_extension   =  92 [packed = true];
+  repeated   uint64 packed_uint64_extension   =  93 [packed = true];
+  repeated   sint32 packed_sint32_extension   =  94 [packed = true];
+  repeated   sint64 packed_sint64_extension   =  95 [packed = true];
+  repeated  fixed32 packed_fixed32_extension  =  96 [packed = true];
+  repeated  fixed64 packed_fixed64_extension  =  97 [packed = true];
+  repeated sfixed32 packed_sfixed32_extension =  98 [packed = true];
+  repeated sfixed64 packed_sfixed64_extension =  99 [packed = true];
+  repeated    float packed_float_extension    = 100 [packed = true];
+  repeated   double packed_double_extension   = 101 [packed = true];
+  repeated     bool packed_bool_extension     = 102 [packed = true];
+  repeated ForeignEnum packed_enum_extension  = 103 [packed = true];
+}
+
+message TestUnpackedExtensions {
+  extensions 1 to max;
+}
+
+extend TestUnpackedExtensions {
+  repeated    int32 unpacked_int32_extension    =  90 [packed = false];
+  repeated    int64 unpacked_int64_extension    =  91 [packed = false];
+  repeated   uint32 unpacked_uint32_extension   =  92 [packed = false];
+  repeated   uint64 unpacked_uint64_extension   =  93 [packed = false];
+  repeated   sint32 unpacked_sint32_extension   =  94 [packed = false];
+  repeated   sint64 unpacked_sint64_extension   =  95 [packed = false];
+  repeated  fixed32 unpacked_fixed32_extension  =  96 [packed = false];
+  repeated  fixed64 unpacked_fixed64_extension  =  97 [packed = false];
+  repeated sfixed32 unpacked_sfixed32_extension =  98 [packed = false];
+  repeated sfixed64 unpacked_sfixed64_extension =  99 [packed = false];
+  repeated    float unpacked_float_extension    = 100 [packed = false];
+  repeated   double unpacked_double_extension   = 101 [packed = false];
+  repeated     bool unpacked_bool_extension     = 102 [packed = false];
+  repeated ForeignEnum unpacked_enum_extension  = 103 [packed = false];
+}
+
+message TestDynamicExtensions {
+  enum DynamicEnumType {
+    DYNAMIC_FOO = 2200;
+    DYNAMIC_BAR = 2201;
+    DYNAMIC_BAZ = 2202;
+  }
+  message DynamicMessageType {
+    optional int32 dynamic_field = 2100;
+  }
+
+  optional fixed32 scalar_extension = 2000;
+  optional ForeignEnum enum_extension = 2001;
+  optional DynamicEnumType dynamic_enum_extension = 2002;
+
+  optional ForeignMessage message_extension = 2003;
+  optional DynamicMessageType dynamic_message_extension = 2004;
+
+  repeated string repeated_extension = 2005;
+  repeated sint32 packed_extension = 2006 [packed = true];
+}
+
+message TestRepeatedScalarDifferentTagSizes {
+  repeated fixed32 repeated_fixed32 = 12;
+  repeated int32   repeated_int32   = 13;
+  repeated fixed64 repeated_fixed64 = 2046;
+  repeated int64   repeated_int64   = 2047;
+  repeated float   repeated_float   = 262142;
+  repeated uint64  repeated_uint64  = 262143;
+}
+
+message TestParsingMerge {
+  message RepeatedFieldsGenerator {
+    repeated TestAllTypes field1 = 1;
+    repeated TestAllTypes field2 = 2;
+    repeated TestAllTypes field3 = 3;
+    repeated group Group1 = 10 {
+      optional TestAllTypes field1 = 11;
+    }
+    repeated group Group2 = 20 {
+      optional TestAllTypes field1 = 21;
+    }
+    repeated TestAllTypes ext1 = 1000;
+    repeated TestAllTypes ext2 = 1001;
+  }
+  required TestAllTypes required_all_types = 1;
+  optional TestAllTypes optional_all_types = 2;
+  repeated TestAllTypes repeated_all_types = 3;
+  optional group OptionalGroup = 10 {
+    optional TestAllTypes optional_group_all_types = 11;
+  }
+  repeated group RepeatedGroup = 20 {
+    optional TestAllTypes repeated_group_all_types = 21;
+  }
+  extensions 1000 to max;
+  extend TestParsingMerge {
+    optional TestAllTypes optional_ext = 1000;
+    repeated TestAllTypes repeated_ext = 1001;
+  }
+}
+
+message TestMergeException {
+  optional TestAllExtensions all_extensions = 1;
+}
+
+message TestCommentInjectionMessage {
+  optional string a = 1 [default="*/ <- Neither should this."];
+}
+
+message TestMessageSize {
+  optional bool m1 = 1;
+  optional int64 m2 = 2;
+  optional bool m3 = 3;
+  optional string m4 = 4;
+  optional int32 m5 = 5;
+  optional int64 m6 = 6;
+}
+
+message FooRequest  {}
+message FooResponse {}
+
+message FooClientMessage {}
+message FooServerMessage{}
+
+service TestService {
+  rpc Foo(FooRequest) returns (FooResponse);
+  rpc Bar(BarRequest) returns (BarResponse);
+}
+
+
+message BarRequest  {}
+message BarResponse {}
+
+message TestJsonName {
+  optional int32 field_name1 = 1;
+  optional int32 fieldName2 = 2;
+  optional int32 FieldName3 = 3;
+  optional int32 _field_name4 = 4;
+  optional int32 FIELD_NAME5 = 5;
+  optional int32 field_name6 = 6 [json_name = "@type"];
+  optional int32 fieldname7 = 7;
+}
+
+message TestHugeFieldNumbers {
+  optional int32 optional_int32 = 536870000;
+  optional int32 fixed_32 = 536870001;
+  repeated int32 repeated_int32 = 536870002 [packed = false];
+  repeated int32 packed_int32 = 536870003 [packed = true];
+
+  optional ForeignEnum optional_enum = 536870004;
+  optional string optional_string = 536870005;
+  optional bytes optional_bytes = 536870006;
+  optional ForeignMessage optional_message = 536870007;
+
+  optional group OptionalGroup = 536870008 {
+    optional int32 group_a = 536870009;
+  }
+
+  map<string, string> string_string_map = 536870010;
+
+  oneof oneof_field {
+    uint32 oneof_uint32 = 536870011;
+    TestAllTypes oneof_test_all_types = 536870012;
+    string oneof_string = 536870013;
+    bytes oneof_bytes = 536870014;
+  }
+
+  extensions  536860000 to 536869999;
+}
+
+extend TestHugeFieldNumbers {
+  optional TestAllTypes test_all_types = 536860000;
+}
+
+message TestExtensionInsideTable {
+  optional int32 field1 = 1;
+  optional int32 field2 = 2;
+  optional int32 field3 = 3;
+  optional int32 field4 = 4;
+  extensions 5 to 5;
+  optional int32 field6 = 6;
+  optional int32 field7 = 7;
+  optional int32 field8 = 8;
+  optional int32 field9 = 9;
+  optional int32 field10 = 10;
+}
+
+extend TestExtensionInsideTable {
+  optional int32 test_extension_inside_table_extension = 5;
+}
+
+message TestNestedGroupExtensionOuter {
+  optional group Layer1OptionalGroup = 1 {
+    repeated group Layer2RepeatedGroup = 2 {
+      extensions 3
+      ;
+      optional string another_field = 6;
+    }
+    repeated group Layer2AnotherOptionalRepeatedGroup = 4 {
+      optional string but_why_tho = 5;
+    }
+  }
+}
+
+message TestNestedGroupExtensionInnerExtension {
+  optional string inner_name= 1;
+}
+
+extend TestNestedGroupExtensionOuter.Layer1OptionalGroup.Layer2RepeatedGroup {
+  optional TestNestedGroupExtensionInnerExtension inner = 3;
+}
+
+enum VeryLargeEnum {
+  ENUM_LABEL_DEFAULT = 0;
+  ENUM_LABEL_1 = 1;
+  ENUM_LABEL_2 = 2;
+  ENUM_LABEL_3 = 3;
+  ENUM_LABEL_4 = 4;
+  ENUM_LABEL_5 = 5;
+  ENUM_LABEL_6 = 6;
+  ENUM_LABEL_7 = 7;
+  ENUM_LABEL_8 = 8;
+  ENUM_LABEL_9 = 9;
+  ENUM_LABEL_10 = 10;
+  ENUM_LABEL_11 = 11;
+  ENUM_LABEL_12 = 12;
+  ENUM_LABEL_13 = 13;
+  ENUM_LABEL_14 = 14;
+  ENUM_LABEL_15 = 15;
+  ENUM_LABEL_16 = 16;
+  ENUM_LABEL_17 = 17;
+  ENUM_LABEL_18 = 18;
+  ENUM_LABEL_19 = 19;
+  ENUM_LABEL_20 = 20;
+  ENUM_LABEL_21 = 21;
+  ENUM_LABEL_22 = 22;
+  ENUM_LABEL_23 = 23;
+  ENUM_LABEL_24 = 24;
+  ENUM_LABEL_25 = 25;
+  ENUM_LABEL_26 = 26;
+  ENUM_LABEL_27 = 27;
+  ENUM_LABEL_28 = 28;
+  ENUM_LABEL_29 = 29;
+  ENUM_LABEL_30 = 30;
+  ENUM_LABEL_31 = 31;
+  ENUM_LABEL_32 = 32;
+  ENUM_LABEL_33 = 33;
+  ENUM_LABEL_34 = 34;
+  ENUM_LABEL_35 = 35;
+  ENUM_LABEL_36 = 36;
+  ENUM_LABEL_37 = 37;
+  ENUM_LABEL_38 = 38;
+  ENUM_LABEL_39 = 39;
+  ENUM_LABEL_40 = 40;
+  ENUM_LABEL_41 = 41;
+  ENUM_LABEL_42 = 42;
+  ENUM_LABEL_43 = 43;
+  ENUM_LABEL_44 = 44;
+  ENUM_LABEL_45 = 45;
+  ENUM_LABEL_46 = 46;
+  ENUM_LABEL_47 = 47;
+  ENUM_LABEL_48 = 48;
+  ENUM_LABEL_49 = 49;
+  ENUM_LABEL_50 = 50;
+  ENUM_LABEL_51 = 51;
+  ENUM_LABEL_52 = 52;
+  ENUM_LABEL_53 = 53;
+  ENUM_LABEL_54 = 54;
+  ENUM_LABEL_55 = 55;
+  ENUM_LABEL_56 = 56;
+  ENUM_LABEL_57 = 57;
+  ENUM_LABEL_58 = 58;
+  ENUM_LABEL_59 = 59;
+  ENUM_LABEL_60 = 60;
+  ENUM_LABEL_61 = 61;
+  ENUM_LABEL_62 = 62;
+  ENUM_LABEL_63 = 63;
+  ENUM_LABEL_64 = 64;
+  ENUM_LABEL_65 = 65;
+  ENUM_LABEL_66 = 66;
+  ENUM_LABEL_67 = 67;
+  ENUM_LABEL_68 = 68;
+  ENUM_LABEL_69 = 69;
+  ENUM_LABEL_70 = 70;
+  ENUM_LABEL_71 = 71;
+  ENUM_LABEL_72 = 72;
+  ENUM_LABEL_73 = 73;
+  ENUM_LABEL_74 = 74;
+  ENUM_LABEL_75 = 75;
+  ENUM_LABEL_76 = 76;
+  ENUM_LABEL_77 = 77;
+  ENUM_LABEL_78 = 78;
+  ENUM_LABEL_79 = 79;
+  ENUM_LABEL_80 = 80;
+  ENUM_LABEL_81 = 81;
+  ENUM_LABEL_82 = 82;
+  ENUM_LABEL_83 = 83;
+  ENUM_LABEL_84 = 84;
+  ENUM_LABEL_85 = 85;
+  ENUM_LABEL_86 = 86;
+  ENUM_LABEL_87 = 87;
+  ENUM_LABEL_88 = 88;
+  ENUM_LABEL_89 = 89;
+  ENUM_LABEL_90 = 90;
+  ENUM_LABEL_91 = 91;
+  ENUM_LABEL_92 = 92;
+  ENUM_LABEL_93 = 93;
+  ENUM_LABEL_94 = 94;
+  ENUM_LABEL_95 = 95;
+  ENUM_LABEL_96 = 96;
+  ENUM_LABEL_97 = 97;
+  ENUM_LABEL_98 = 98;
+  ENUM_LABEL_99 = 99;
+  ENUM_LABEL_100 = 100;
+};
+
+message TestExtensionRangeSerialize {
+  optional int32 foo_one = 1;
+
+  extensions 2 to 2;
+  extensions 3 to 4;
+
+  optional int32 foo_two = 6;
+  optional int32 foo_three = 7;
+
+  extensions 9 to 10;
+
+  optional int32 foo_four = 13;
+
+  extensions 15 to 15;
+  extensions 17 to 17;
+  extensions 19 to 19;
+
+  extend TestExtensionRangeSerialize {
+    optional int32 bar_one = 2;
+    optional int32 bar_two = 4;
+
+    optional int32 bar_three = 10;
+
+    optional int32 bar_four = 15;
+    optional int32 bar_five = 19;
+  }
+}
+
+message TestVerifyInt32Simple {
+    optional int32 optional_int32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+}
+
+message TestVerifyInt32 {
+    optional int32 optional_int32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyMostlyInt32 {
+    optional int64 optional_int64_30 = 30;
+
+    optional int32 optional_int32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_3 = 3;
+    optional int32 optional_int32_4 = 4;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyMostlyInt32BigFieldNumber {
+    optional int64 optional_int64_30 = 30;
+    optional int32 optional_int32_300 = 300;
+
+    optional int32 optional_int32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_3 = 3;
+    optional int32 optional_int32_4 = 4;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyUint32Simple {
+    optional uint32 optional_uint32_1 = 1;
+    optional uint32 optional_uint32_2 = 2;
+    optional uint32 optional_uint32_63 = 63;
+    optional uint32 optional_uint32_64 = 64;
+}
+
+message TestVerifyUint32 {
+    optional uint32 optional_uint32_1 = 1;
+    optional uint32 optional_uint32_2 = 2;
+    optional uint32 optional_uint32_63 = 63;
+    optional uint32 optional_uint32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyOneUint32 {
+    optional uint32 optional_uint32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyOneInt32BigFieldNumber {
+    optional int32 optional_int32_65 = 65;
+
+    optional int64 optional_int64_1 = 1;
+    optional int64 optional_int64_2 = 2;
+    optional int64 optional_int64_63 = 63;
+    optional int64 optional_int64_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyInt32BigFieldNumber {
+    optional int32 optional_int32_1000 = 1000;
+    optional int32 optional_int32_65 = 65;
+
+    optional int32 optional_int32_1 = 1;
+    optional int32 optional_int32_2 = 2;
+    optional int32 optional_int32_63 = 63;
+    optional int32 optional_int32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyUint32BigFieldNumber {
+    optional uint32 optional_uint32_1000 = 1000;
+    optional uint32 optional_uint32_65 = 65;
+
+    optional uint32 optional_uint32_1 = 1;
+    optional uint32 optional_uint32_2 = 2;
+    optional uint32 optional_uint32_63 = 63;
+    optional uint32 optional_uint32_64 = 64;
+
+    optional TestAllTypes optional_all_types = 9;
+    repeated TestAllTypes repeated_all_types = 10;
+}
+
+message TestVerifyBigFieldNumberUint32 {
+  message Nested {
+    optional uint32 optional_uint32_5000 = 5000;
+    optional uint32 optional_uint32_1000 = 1000;
+    optional uint32 optional_uint32_66 = 66;
+    optional uint32 optional_uint32_65 = 65;
+
+    optional uint32 optional_uint32_1 = 1;
+    optional uint32 optional_uint32_2 = 2;
+    optional uint32 optional_uint32_63 = 63;
+    optional uint32 optional_uint32_64 = 64;
+
+    optional Nested optional_nested = 9;
+    repeated Nested repeated_nested = 10;
+  }
+  optional Nested optional_nested = 1;
+}
+
+

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest_import.proto
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest_import.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+package protobuf_unittest_import;
+
+option optimize_for = SPEED;
+option cc_enable_arenas = true;
+
+option java_package = "com_google_protobuf.protobuf_java_util";
+
+import public "com_google_protobuf/protobuf_java_util/unittest_import_public.proto";
+
+message ImportMessage {
+  optional int32 d = 1;
+}
+
+enum ImportEnum {
+  IMPORT_FOO = 7;
+  IMPORT_BAR = 8;
+  IMPORT_BAZ = 9;
+}
+
+enum ImportEnumForMap {
+  UNKNOWN = 0;
+  FOO = 1;
+  BAR = 2;
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest_import_public.proto
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/proto/com_google_protobuf/protobuf_java_util/unittest_import_public.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package protobuf_unittest_import;
+
+option java_package = "com_google_protobuf.protobuf_java_util";
+
+message PublicImportMessage {
+  optional int32 e = 1;
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/protobuf-java-util-test-metadata/reflect-config.json
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/protobuf-java-util-test-metadata/reflect-config.json
@@ -1,0 +1,5283 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes",
+    "methods": [
+      {
+        "name": "getOptionalAliasedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalAliasedEnumValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnumValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBool",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBoolCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBoolList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytes",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBytesCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytesList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDouble",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedDoubleCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDoubleList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloat",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFloatCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloatList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumValue",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedString",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedMessage",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$AliasedEnum",
+    "methods": [
+      {
+        "name": "getValueDescriptor",
+        "parameterTypes": []
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "com.google.protobuf.Descriptors$EnumValueDescriptor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$Builder",
+    "methods": [
+      {
+        "name": "addRepeatedBool",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "addRepeatedBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "addRepeatedDouble",
+        "parameterTypes": [
+          "double"
+        ]
+      },
+      {
+        "name": "addRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedFixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedFloat",
+        "parameterTypes": [
+          "float"
+        ]
+      },
+      {
+        "name": "addRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedInt64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedNestedEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "addRepeatedNestedEnumValue",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedNestedMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "addRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedSfixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedSint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "addRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedUint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "clearOptionalAliasedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalAliasedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalAliasedEnumValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnumValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBool",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBoolCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBoolList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytes",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBytesCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytesList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDouble",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedDoubleCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDoubleList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloat",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFloatCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloatList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumValue",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedString",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "setOptionalAliasedEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$AliasedEnum"
+        ]
+      },
+      {
+        "name": "setOptionalAliasedEnumValue",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalBool",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setOptionalBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalDouble",
+        "parameterTypes": [
+          "double"
+        ]
+      },
+      {
+        "name": "setOptionalFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalFixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalFloat",
+        "parameterTypes": [
+          "float"
+        ]
+      },
+      {
+        "name": "setOptionalInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalInt64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalNestedEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "setOptionalNestedEnumValue",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalNestedMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setOptionalSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalSfixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalSint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setOptionalStringBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalUint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedBool",
+        "parameterTypes": [
+          "int",
+          "boolean"
+        ]
+      },
+      {
+        "name": "setRepeatedBytes",
+        "parameterTypes": [
+          "int",
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setRepeatedDouble",
+        "parameterTypes": [
+          "int",
+          "double"
+        ]
+      },
+      {
+        "name": "setRepeatedFixed32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedFixed64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedFloat",
+        "parameterTypes": [
+          "int",
+          "float"
+        ]
+      },
+      {
+        "name": "setRepeatedInt32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedInt64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedNestedEnum",
+        "parameterTypes": [
+          "int",
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "setRepeatedNestedEnumValue",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedNestedMessage",
+        "parameterTypes": [
+          "int",
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedSfixed32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedSfixed64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedSint32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedSint64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedString",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setRepeatedUint32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedUint64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum",
+    "methods": [
+      {
+        "name": "getValueDescriptor",
+        "parameterTypes": []
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "com.google.protobuf.Descriptors$EnumValueDescriptor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage",
+    "methods": [
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage$Builder",
+    "methods": [
+      {
+        "name": "clearValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setValue",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny",
+    "methods": [
+      {
+        "name": "getAnyValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultInstance",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasAnyValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny$Builder",
+    "methods": [
+      {
+        "name": "clearAnyValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAnyValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAnyValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasAnyValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setAnyValue",
+        "parameterTypes": [
+          "com.google.protobuf.Any"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName",
+    "methods": [
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName$Builder",
+    "methods": [
+      {
+        "name": "clearValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setValue",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration",
+    "methods": [
+      {
+        "name": "getDurationValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDurationValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration$Builder",
+    "methods": [
+      {
+        "name": "clearDurationValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDurationValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDurationValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDurationValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setDurationValue",
+        "parameterTypes": [
+          "com.google.protobuf.Duration"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask",
+    "methods": [
+      {
+        "name": "getFieldMaskValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasFieldMaskValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask$Builder",
+    "methods": [
+      {
+        "name": "clearFieldMaskValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFieldMaskValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFieldMaskValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasFieldMaskValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setFieldMaskValue",
+        "parameterTypes": [
+          "com.google.protobuf.FieldMask"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestMap",
+    "methods": [
+      {
+        "name": "getDefaultInstance",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof",
+    "methods": [
+      {
+        "name": "getOneofFieldCase",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNullValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNullValueValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormat$ParserImpl"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+    "methods": [
+      {
+        "name": "getOneofFieldCase",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+    "methods": [
+      {
+        "name": "clearOneofField",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofNullValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofFieldCase",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNullValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNullValueValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setOneofInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOneofNestedMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setOneofNullValue",
+        "parameterTypes": [
+          "com.google.protobuf.NullValue"
+        ]
+      },
+      {
+        "name": "setOneofNullValueValue",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive",
+    "methods": [
+      {
+        "name": "getNested",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasNested",
+        "parameterTypes": []
+      },
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive$Builder",
+    "methods": [
+      {
+        "name": "clearNested",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getNested",
+        "parameterTypes": []
+      },
+      {
+        "name": "getNestedBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasNested",
+        "parameterTypes": []
+      },
+      {
+        "name": "setNested",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive"
+        ]
+      },
+      {
+        "name": "setValue",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct",
+    "methods": [
+      {
+        "name": "getListValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStructValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasListValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasStructValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct$Builder",
+    "methods": [
+      {
+        "name": "clearListValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearStructValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getListValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getListValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStructValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStructValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasListValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasStructValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setListValue",
+        "parameterTypes": [
+          "com.google.protobuf.ListValue"
+        ]
+      },
+      {
+        "name": "setStructValue",
+        "parameterTypes": [
+          "com.google.protobuf.Struct"
+        ]
+      },
+      {
+        "name": "setValue",
+        "parameterTypes": [
+          "com.google.protobuf.Value"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp",
+    "methods": [
+      {
+        "name": "getTimestampValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasTimestampValue",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp$Builder",
+    "methods": [
+      {
+        "name": "clearTimestampValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestampValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTimestampValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasTimestampValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "setTimestampValue",
+        "parameterTypes": [
+          "com.google.protobuf.Timestamp"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers",
+    "methods": [
+      {
+        "name": "getBoolValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBytesValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDoubleValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFloatValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStringValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBoolValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBytesValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDoubleValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasFloatValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasInt32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasInt64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasStringValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasUint32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasUint64Value",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers$Builder",
+    "methods": [
+      {
+        "name": "clearBoolValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearBytesValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDoubleValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearFloatValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearInt32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearInt64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearStringValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearUint32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearUint64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBoolValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBoolValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBytesValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBytesValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDoubleValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDoubleValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFloatValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFloatValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt32ValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getInt64ValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStringValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStringValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint32ValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUint64ValueBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBoolValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBytesValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDoubleValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasFloatValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasInt32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasInt64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasStringValue",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasUint32Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasUint64Value",
+        "parameterTypes": []
+      },
+      {
+        "name": "setBoolValue",
+        "parameterTypes": [
+          "com.google.protobuf.BoolValue"
+        ]
+      },
+      {
+        "name": "setBytesValue",
+        "parameterTypes": [
+          "com.google.protobuf.BytesValue"
+        ]
+      },
+      {
+        "name": "setDoubleValue",
+        "parameterTypes": [
+          "com.google.protobuf.DoubleValue"
+        ]
+      },
+      {
+        "name": "setFloatValue",
+        "parameterTypes": [
+          "com.google.protobuf.FloatValue"
+        ]
+      },
+      {
+        "name": "setInt32Value",
+        "parameterTypes": [
+          "com.google.protobuf.Int32Value"
+        ]
+      },
+      {
+        "name": "setInt64Value",
+        "parameterTypes": [
+          "com.google.protobuf.Int64Value"
+        ]
+      },
+      {
+        "name": "setStringValue",
+        "parameterTypes": [
+          "com.google.protobuf.StringValue"
+        ]
+      },
+      {
+        "name": "setUint32Value",
+        "parameterTypes": [
+          "com.google.protobuf.UInt32Value"
+        ]
+      },
+      {
+        "name": "setUint64Value",
+        "parameterTypes": [
+          "com.google.protobuf.UInt64Value"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum",
+    "methods": [
+      {
+        "name": "getValueDescriptor",
+        "parameterTypes": []
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "com.google.protobuf.Descriptors$EnumValueDescriptor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "com_google_protobuf.protobuf_java_util.UnittestImportPublic$PublicImportMessage",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$ForeignEnum",
+    "methods": [
+      {
+        "name": "getValueDescriptor",
+        "parameterTypes": []
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "com.google.protobuf.Descriptors$EnumValueDescriptor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$ForeignMessage",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+    "methods": [
+      {
+        "name": "getChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getEagerChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLazyChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedChild",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedChildCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedChildList",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasEagerChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasLazyChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskUtil"
+    },
+    "name": "protobuf_unittest.UnittestProto$NestedTestAllTypes",
+    "methods": [
+      {
+        "name": "getDefaultInstance",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasPayload",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+    "methods": [
+      {
+        "name": "addRepeatedChild",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+        ]
+      },
+      {
+        "name": "clearChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearEagerChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearLazyChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getChildBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getEagerChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getEagerChildBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLazyChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "getLazyChildBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPayloadBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedChild",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedChildBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedChildCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedChildList",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasEagerChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasLazyChild",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "setChild",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+        ]
+      },
+      {
+        "name": "setEagerChild",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes"
+        ]
+      },
+      {
+        "name": "setLazyChild",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+        ]
+      },
+      {
+        "name": "setPayload",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes"
+        ]
+      },
+      {
+        "name": "setRepeatedChild",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$NestedTestAllTypes"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskUtil"
+    },
+    "name": "protobuf_unittest.UnittestProto$NestedTestAllTypes$Builder",
+    "methods": [
+      {
+        "name": "getPayload",
+        "parameterTypes": []
+      },
+      {
+        "name": "setPayload",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes",
+    "methods": [
+      {
+        "name": "getDefaultBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultCordBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringPieceBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofFieldCase",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalCordBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalPublicImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringPieceBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUnverifiedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBool",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBoolCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBoolList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytes",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBytesCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytesList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedCord",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedCordCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedCordList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDouble",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedDoubleCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDoubleList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloat",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFloatCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloatList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedForeignEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedForeignMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedGroup",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedGroupCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedGroupList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedImportEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedImportMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedLazyMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedLazyMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedLazyMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedString",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringPiece",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringPieceCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringPieceList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalPublicImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUnverifiedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskUtil"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes",
+    "methods": [
+      {
+        "name": "getDefaultInstance",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$Builder",
+    "methods": [
+      {
+        "name": "addRepeatedBool",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "addRepeatedBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "addRepeatedCord",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "addRepeatedDouble",
+        "parameterTypes": [
+          "double"
+        ]
+      },
+      {
+        "name": "addRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedFixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedFloat",
+        "parameterTypes": [
+          "float"
+        ]
+      },
+      {
+        "name": "addRepeatedForeignEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$ForeignEnum"
+        ]
+      },
+      {
+        "name": "addRepeatedForeignMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$ForeignMessage"
+        ]
+      },
+      {
+        "name": "addRepeatedGroup",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$RepeatedGroup"
+        ]
+      },
+      {
+        "name": "addRepeatedImportEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+        ]
+      },
+      {
+        "name": "addRepeatedImportMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage"
+        ]
+      },
+      {
+        "name": "addRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedInt64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedLazyMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "addRepeatedNestedEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "addRepeatedNestedMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "addRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedSfixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedSint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "addRepeatedString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "addRepeatedStringPiece",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "addRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "addRepeatedUint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "clearDefaultBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearDefaultUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofField",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOneofUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalPublicImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearOptionalUnverifiedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedString",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultCordBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultStringPieceBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDefaultUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofFieldCase",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofNestedMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOneofUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalCordBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalForeignMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalGroupBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalImportMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalLazyMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalNestedMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalPublicImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalPublicImportMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalStringPieceBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUnverifiedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalUnverifiedLazyMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBool",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBoolCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBoolList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytes",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedBytesCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedBytesList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedCord",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedCordCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedCordList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDouble",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedDoubleCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedDoubleList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloat",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedFloatCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedFloatList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedForeignEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedForeignMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedForeignMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedForeignMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedGroup",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedGroupBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedGroupCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedGroupList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedImportEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedImportMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedImportMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedImportMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedInt64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedInt64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedLazyMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedLazyMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedLazyMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedLazyMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnum",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedEnumCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedEnumList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedNestedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedNestedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSfixed64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSfixed64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedSint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedSint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedString",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringPiece",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedStringPieceCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedStringPieceList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint32Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint32List",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedUint64Count",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedUint64List",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasDefaultUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOneofUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalBool",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalCord",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalDouble",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalFloat",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalForeignEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalForeignMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalGroup",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalImportEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalInt32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalInt64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalNestedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalPublicImportMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSfixed32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSfixed64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalSint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalString",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalStringPiece",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUint32",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUint64",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalUnverifiedLazyMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "setDefaultBool",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setDefaultBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setDefaultCord",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDefaultCordBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setDefaultDouble",
+        "parameterTypes": [
+          "double"
+        ]
+      },
+      {
+        "name": "setDefaultFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setDefaultFixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setDefaultFloat",
+        "parameterTypes": [
+          "float"
+        ]
+      },
+      {
+        "name": "setDefaultForeignEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$ForeignEnum"
+        ]
+      },
+      {
+        "name": "setDefaultImportEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+        ]
+      },
+      {
+        "name": "setDefaultInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setDefaultInt64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setDefaultNestedEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "setDefaultSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setDefaultSfixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setDefaultSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setDefaultSint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setDefaultString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDefaultStringBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setDefaultStringPiece",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setDefaultStringPieceBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setDefaultUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setDefaultUint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOneofBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOneofNestedMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setOneofString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setOneofStringBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOneofUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalBool",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "setOptionalBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalCord",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setOptionalCordBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalDouble",
+        "parameterTypes": [
+          "double"
+        ]
+      },
+      {
+        "name": "setOptionalFixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalFixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalFloat",
+        "parameterTypes": [
+          "float"
+        ]
+      },
+      {
+        "name": "setOptionalForeignEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$ForeignEnum"
+        ]
+      },
+      {
+        "name": "setOptionalForeignMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$ForeignMessage"
+        ]
+      },
+      {
+        "name": "setOptionalGroup",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$OptionalGroup"
+        ]
+      },
+      {
+        "name": "setOptionalImportEnum",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+        ]
+      },
+      {
+        "name": "setOptionalImportMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage"
+        ]
+      },
+      {
+        "name": "setOptionalInt32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalInt64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalLazyMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setOptionalNestedEnum",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "setOptionalNestedMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setOptionalPublicImportMessage",
+        "parameterTypes": [
+          "com_google_protobuf.protobuf_java_util.UnittestImportPublic$PublicImportMessage"
+        ]
+      },
+      {
+        "name": "setOptionalSfixed32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalSfixed64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalSint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalSint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setOptionalStringBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalStringPiece",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setOptionalStringPieceBytes",
+        "parameterTypes": [
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setOptionalUint32",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setOptionalUint64",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "setOptionalUnverifiedLazyMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedBool",
+        "parameterTypes": [
+          "int",
+          "boolean"
+        ]
+      },
+      {
+        "name": "setRepeatedBytes",
+        "parameterTypes": [
+          "int",
+          "com.google.protobuf.ByteString"
+        ]
+      },
+      {
+        "name": "setRepeatedCord",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setRepeatedDouble",
+        "parameterTypes": [
+          "int",
+          "double"
+        ]
+      },
+      {
+        "name": "setRepeatedFixed32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedFixed64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedFloat",
+        "parameterTypes": [
+          "int",
+          "float"
+        ]
+      },
+      {
+        "name": "setRepeatedForeignEnum",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$ForeignEnum"
+        ]
+      },
+      {
+        "name": "setRepeatedForeignMessage",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$ForeignMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedGroup",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$TestAllTypes$RepeatedGroup"
+        ]
+      },
+      {
+        "name": "setRepeatedImportEnum",
+        "parameterTypes": [
+          "int",
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+        ]
+      },
+      {
+        "name": "setRepeatedImportMessage",
+        "parameterTypes": [
+          "int",
+          "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedInt32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedInt64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedLazyMessage",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedNestedEnum",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum"
+        ]
+      },
+      {
+        "name": "setRepeatedNestedMessage",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage"
+        ]
+      },
+      {
+        "name": "setRepeatedSfixed32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedSfixed64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedSint32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedSint64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "setRepeatedString",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setRepeatedStringPiece",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setRepeatedUint32",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "setRepeatedUint64",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$NestedEnum",
+    "methods": [
+      {
+        "name": "getValueDescriptor",
+        "parameterTypes": []
+      },
+      {
+        "name": "valueOf",
+        "parameterTypes": [
+          "com.google.protobuf.Descriptors$EnumValueDescriptor"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage",
+    "methods": [
+      {
+        "name": "getBb",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBb",
+        "parameterTypes": []
+      },
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$NestedMessage$Builder",
+    "methods": [
+      {
+        "name": "clearBb",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBb",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasBb",
+        "parameterTypes": []
+      },
+      {
+        "name": "setBb",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$OptionalGroup",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestAllTypes$RepeatedGroup",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestRequired",
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestRequired$Builder",
+    "allPublicMethods": true,
+    "methods": [
+      {
+        "name": "setA",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setB",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "setC",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestRequiredMessage",
+    "methods": [
+      {
+        "name": "getOptionalMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRequiredMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasRequiredMessage",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.FieldMaskTreeTest"
+    },
+    "name": "protobuf_unittest.UnittestProto$TestRequiredMessage$Builder",
+    "methods": [
+      {
+        "name": "addRepeatedMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestRequired"
+        ]
+      },
+      {
+        "name": "clearOptionalMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRepeatedMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "clearRequiredMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getOptionalMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedMessage",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedMessageBuilder",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "getRepeatedMessageCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRepeatedMessageList",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRequiredMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRequiredMessageBuilder",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasOptionalMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasRequiredMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "setOptionalMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestRequired"
+        ]
+      },
+      {
+        "name": "setRepeatedMessage",
+        "parameterTypes": [
+          "int",
+          "protobuf_unittest.UnittestProto$TestRequired"
+        ]
+      },
+      {
+        "name": "setRequiredMessage",
+        "parameterTypes": [
+          "protobuf_unittest.UnittestProto$TestRequired"
+        ]
+      }
+    ]
+  }
+]

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/protobuf-java-util-test-metadata/reflect-config.json
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/protobuf-java-util-test-metadata/reflect-config.json
@@ -1477,7 +1477,8 @@
         "name": "getOneofNullValueValue",
         "parameterTypes": []
       }
-    ]
+    ],
+    "allPublicMethods": true
   },
   {
     "condition": {
@@ -1489,7 +1490,8 @@
         "name": "getOneofFieldCase",
         "parameterTypes": []
       }
-    ]
+    ],
+    "allPublicMethods": true
   },
   {
     "condition": {
@@ -1561,7 +1563,8 @@
           "int"
         ]
       }
-    ]
+    ],
+    "allPublicMethods": true
   },
   {
     "condition": {
@@ -5279,5 +5282,250 @@
         ]
       }
     ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Any",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Any$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.BoolValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.BoolValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.BytesValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.BytesValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.DoubleValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.DoubleValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Duration",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Duration$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Empty",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Empty$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.FieldMask",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.FieldMask$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.FloatValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.FloatValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Int32Value",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Int32Value$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Int64Value",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Int64Value$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.ListValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.ListValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.NullValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.StringValue",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.StringValue$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Struct",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Struct$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Timestamp",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Timestamp$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.UInt32Value",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.UInt32Value$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.UInt64Value",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.UInt64Value$Builder",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Value",
+    "allPublicMethods": true
+  },
+  {
+    "condition": {
+      "typeReachable": "com.google.protobuf.util.JsonFormatTest"
+    },
+    "name": "com.google.protobuf.Value$Builder",
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,1130 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes",
+      "methods" : [
+        {
+          "name" : "getOptionalAliasedEnumValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalBool",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalBytes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalDouble",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFixed32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFixed64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFloat",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalInt64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalNestedEnumValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSfixed32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSfixed64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSint32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSint64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalString",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalUint32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalUint64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedBoolList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedBytesList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedDoubleList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFixed32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFixed64List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFloatList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedInt32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedInt64List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedNestedEnumCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedNestedEnumValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "getRepeatedNestedMessageList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSfixed32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSfixed64List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSint32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSint64List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedStringList",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedUint32List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedUint64List",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$AliasedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$Builder",
+      "methods" : [
+        {
+          "name" : "addRepeatedBool",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "addRepeatedBytes",
+          "parameterTypes" : [
+            "com.google.protobuf.ByteString"
+          ]
+        },
+        {
+          "name" : "addRepeatedDouble",
+          "parameterTypes" : [
+            "double"
+          ]
+        },
+        {
+          "name" : "addRepeatedFixed32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedFixed64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "addRepeatedFloat",
+          "parameterTypes" : [
+            "float"
+          ]
+        },
+        {
+          "name" : "addRepeatedInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedInt64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "addRepeatedNestedEnumValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedNestedMessage",
+          "parameterTypes" : [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name" : "addRepeatedSfixed32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedSfixed64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "addRepeatedSint32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedSint64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "addRepeatedString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "addRepeatedUint32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "addRepeatedUint64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "getOptionalAliasedEnumValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalBool",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalBytes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalDouble",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFixed32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFixed64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalFloat",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalInt64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalNestedEnumValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSfixed32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSfixed64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSint32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalSint64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalString",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalUint32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOptionalUint64",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedBoolCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedBytesCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedDoubleCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFixed32Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFixed64Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedFloatCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedInt32Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedInt64Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedNestedEnumCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedNestedMessageCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSfixed32Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSfixed64Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSint32Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedSint64Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedStringCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedUint32Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getRepeatedUint64Count",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOptionalNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setOptionalAliasedEnumValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalBool",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setOptionalBytes",
+          "parameterTypes" : [
+            "com.google.protobuf.ByteString"
+          ]
+        },
+        {
+          "name" : "setOptionalDouble",
+          "parameterTypes" : [
+            "double"
+          ]
+        },
+        {
+          "name" : "setOptionalFixed32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalFixed64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setOptionalFloat",
+          "parameterTypes" : [
+            "float"
+          ]
+        },
+        {
+          "name" : "setOptionalInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalInt64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setOptionalNestedEnumValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalNestedMessage",
+          "parameterTypes" : [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage"
+          ]
+        },
+        {
+          "name" : "setOptionalSfixed32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalSfixed64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setOptionalSint32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalSint64",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setOptionalString",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setOptionalUint32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOptionalUint64",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAllTypes$NestedMessage$Builder",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny",
+      "methods" : [
+        {
+          "name" : "getAnyValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasAnyValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestAny$Builder",
+      "methods" : [
+        {
+          "name" : "hasAnyValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAnyValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Any"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestCustomJsonName$Builder",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration",
+      "methods" : [
+        {
+          "name" : "getDurationValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasDurationValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestDuration$Builder",
+      "methods" : [
+        {
+          "name" : "hasDurationValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setDurationValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Duration"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask",
+      "methods" : [
+        {
+          "name" : "getFieldMaskValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasFieldMaskValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestFieldMask$Builder",
+      "methods" : [
+        {
+          "name" : "hasFieldMaskValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setFieldMaskValue",
+          "parameterTypes" : [
+            "com.google.protobuf.FieldMask"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestMap",
+      "methods" : [
+        {
+          "name" : "getDefaultInstance",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof",
+      "methods" : [
+        {
+          "name" : "getOneofFieldCase",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOneofInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOneofNullValueValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOneofInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOneofNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOneofNullValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormat$ParserImpl"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+      "methods" : [
+        {
+          "name" : "getOneofFieldCase",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestOneof$Builder",
+      "methods" : [
+        {
+          "name" : "hasOneofInt32",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOneofNestedMessage",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasOneofNullValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setOneofInt32",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setOneofNullValueValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive",
+      "methods" : [
+        {
+          "name" : "newBuilder",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive$Builder",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasNested",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setNested",
+          "parameterTypes" : [
+            "com_google_protobuf.protobuf_java_util.JsonTestProto$TestRecursive"
+          ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct",
+      "methods" : [
+        {
+          "name" : "getListValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getStructValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasListValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasStructValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestStruct$Builder",
+      "methods" : [
+        {
+          "name" : "hasListValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasStructValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setListValue",
+          "parameterTypes" : [
+            "com.google.protobuf.ListValue"
+          ]
+        },
+        {
+          "name" : "setStructValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Struct"
+          ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp",
+      "methods" : [
+        {
+          "name" : "getTimestampValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasTimestampValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestTimestamp$Builder",
+      "methods" : [
+        {
+          "name" : "hasTimestampValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setTimestampValue",
+          "parameterTypes" : [
+            "com.google.protobuf.Timestamp"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers",
+      "methods" : [
+        {
+          "name" : "getBoolValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getBytesValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getDoubleValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getFloatValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getInt32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getInt64Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getStringValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUint32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getUint64Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasBoolValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasBytesValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasDoubleValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasFloatValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasInt32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasInt64Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasStringValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasUint32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasUint64Value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.JsonFormatTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.JsonTestProto$TestWrappers$Builder",
+      "methods" : [
+        {
+          "name" : "hasBoolValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasBytesValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasDoubleValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasFloatValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasInt32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasInt64Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasStringValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasUint32Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasUint64Value",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setBoolValue",
+          "parameterTypes" : [
+            "com.google.protobuf.BoolValue"
+          ]
+        },
+        {
+          "name" : "setBytesValue",
+          "parameterTypes" : [
+            "com.google.protobuf.BytesValue"
+          ]
+        },
+        {
+          "name" : "setDoubleValue",
+          "parameterTypes" : [
+            "com.google.protobuf.DoubleValue"
+          ]
+        },
+        {
+          "name" : "setFloatValue",
+          "parameterTypes" : [
+            "com.google.protobuf.FloatValue"
+          ]
+        },
+        {
+          "name" : "setInt32Value",
+          "parameterTypes" : [
+            "com.google.protobuf.Int32Value"
+          ]
+        },
+        {
+          "name" : "setInt64Value",
+          "parameterTypes" : [
+            "com.google.protobuf.Int64Value"
+          ]
+        },
+        {
+          "name" : "setStringValue",
+          "parameterTypes" : [
+            "com.google.protobuf.StringValue"
+          ]
+        },
+        {
+          "name" : "setUint32Value",
+          "parameterTypes" : [
+            "com.google.protobuf.UInt32Value"
+          ]
+        },
+        {
+          "name" : "setUint64Value",
+          "parameterTypes" : [
+            "com.google.protobuf.UInt64Value"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.UnittestImport$ImportEnum"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.UnittestImport$ImportMessage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.google.protobuf.util.FieldMaskTreeTest"
+      },
+      "type" : "com_google_protobuf.protobuf_java_util.UnittestImportPublic$PublicImportMessage"
+    }
+  ]
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:01">
+<testsuite name="JUnit Jupiter" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1653-0e5db409/tests/src/com.google.protobuf/protobuf-java-util/3.23.3"/>

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:01">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1653-0e5db409/tests/src/com.google.protobuf/protobuf-java-util/3.23.3"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="166" skipped="0" failures="0" errors="0" time="5.031" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:01">
+<testsuite name="JUnit Vintage" tests="166" skipped="0" failures="0" errors="0" time="5.018" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1653-0e5db409/tests/src/com.google.protobuf/protobuf-java-util/3.23.3"/>
@@ -88,7 +87,7 @@ unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTes
 display-name: testMinMaxAreValid
 ]]></system-out>
 </testcase>
-<testcase name="testMerge" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0.005">
+<testcase name="testMerge" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testMerge(com.google.protobuf.util.FieldMaskTreeTest)]
 display-name: testMerge
@@ -304,7 +303,7 @@ unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTes
 display-name: testTimestampInvalidFormatValueTooLarge
 ]]></system-out>
 </testcase>
-<testcase name="testWrappers" classname="com.google.protobuf.util.JsonFormatTest" time="0.002">
+<testcase name="testWrappers" classname="com.google.protobuf.util.JsonFormatTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testWrappers(com.google.protobuf.util.JsonFormatTest)]
 display-name: testWrappers
@@ -676,7 +675,7 @@ unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTes
 display-name: testParserRejectOutOfRangeNumericValues
 ]]></system-out>
 </testcase>
-<testcase name="testParserRejectTrailingComma" classname="com.google.protobuf.util.JsonFormatTest" time="0.003">
+<testcase name="testParserRejectTrailingComma" classname="com.google.protobuf.util.JsonFormatTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectTrailingComma(com.google.protobuf.util.JsonFormatTest)]
 display-name: testParserRejectTrailingComma
@@ -964,7 +963,7 @@ unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTes
 display-name: testAnyFieldsWithCustomAddedTypeRegistry
 ]]></system-out>
 </testcase>
-<testcase name="testTimestampConcurrentParsing" classname="com.google.protobuf.util.TimestampsTest" time="5.013">
+<testcase name="testTimestampConcurrentParsing" classname="com.google.protobuf.util.TimestampsTest" time="5.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampConcurrentParsing(com.google.protobuf.util.TimestampsTest)]
 display-name: testTimestampConcurrentParsing

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,1055 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="166" skipped="0" failures="0" errors="0" time="5.031" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:01">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1653-0e5db409/tests/src/com.google.protobuf/protobuf-java-util/3.23.3"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="testParserSupportAliasEnums" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserSupportAliasEnums(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserSupportAliasEnums
+]]></system-out>
+</testcase>
+<testcase name="testSubstract" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testSubstract(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testSubstract
+]]></system-out>
+</testcase>
+<testcase name="testParserRejectInvalidBase64" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectInvalidBase64(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserRejectInvalidBase64
+]]></system-out>
+</testcase>
+<testcase name="testPrintingEnumsAsIntsChainedAfterIncludingDefaultValueFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testPrintingEnumsAsIntsChainedAfterIncludingDefaultValueFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testPrintingEnumsAsIntsChainedAfterIncludingDefaultValueFields
+]]></system-out>
+</testcase>
+<testcase name="testTimestampMergeError" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testTimestampMergeError(com.google.protobuf.util.JsonFormatTest)]
+display-name: testTimestampMergeError
+]]></system-out>
+</testcase>
+<testcase name="testMinMaxAreValid" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testMinMaxAreValid(com.google.protobuf.util.TimestampsTest)]
+display-name: testMinMaxAreValid
+]]></system-out>
+</testcase>
+<testcase name="testMerge" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testMerge(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testMerge
+]]></system-out>
+</testcase>
+<testcase name="testNullFirstInDuplicateOneof" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testNullFirstInDuplicateOneof(com.google.protobuf.util.JsonFormatTest)]
+display-name: testNullFirstInDuplicateOneof
+]]></system-out>
+</testcase>
+<testcase name="testMerge" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testMerge(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testMerge
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMaxMillisecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMaxMillisecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMaxMillisecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testFromStringList" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testFromStringList(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testFromStringList
+]]></system-out>
+</testcase>
+<testcase name="testParserAcceptNull" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserAcceptNull(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserAcceptNull
+]]></system-out>
+</testcase>
+<testcase name="testIsValid_false" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testIsValid_false(com.google.protobuf.util.DurationsTest)]
+display-name: testIsValid_false
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatDateTooLarge" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatDateTooLarge(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatDateTooLarge
+]]></system-out>
+</testcase>
+<testcase name="testCheckNotNegative" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testCheckNotNegative(com.google.protobuf.util.DurationsTest)]
+display-name: testCheckNotNegative
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidOffset" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidOffset(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidOffset
+]]></system-out>
+</testcase>
+<testcase name="testRejectFractionalUnsignedInt64" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectFractionalUnsignedInt64(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectFractionalUnsignedInt64
+]]></system-out>
+</testcase>
+<testcase name="testFromSqlTimestampSubMillisecondPrecision" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromSqlTimestampSubMillisecondPrecision(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromSqlTimestampSubMillisecondPrecision
+]]></system-out>
+</testcase>
+<testcase name="testStaticFactories" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testStaticFactories(com.google.protobuf.util.DurationsTest)]
+display-name: testStaticFactories
+]]></system-out>
+</testcase>
+<testcase name="testHtmlEscape" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testHtmlEscape(com.google.protobuf.util.JsonFormatTest)]
+display-name: testHtmlEscape
+]]></system-out>
+</testcase>
+<testcase name="testAdd" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testAdd(com.google.protobuf.util.DurationsTest)]
+display-name: testAdd
+]]></system-out>
+</testcase>
+<testcase name="testJsonObjectForPrimitiveField" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testJsonObjectForPrimitiveField(com.google.protobuf.util.JsonFormatTest)]
+display-name: testJsonObjectForPrimitiveField
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromMillisBelowTimestampMaxLimit" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromMillisBelowTimestampMaxLimit(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromMillisBelowTimestampMaxLimit
+]]></system-out>
+</testcase>
+<testcase name="testOmittingInsignificantWhiteSpace" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testOmittingInsignificantWhiteSpace(com.google.protobuf.util.JsonFormatTest)]
+display-name: testOmittingInsignificantWhiteSpace
+]]></system-out>
+</testcase>
+<testcase name="test3pair_constructsObject" classname="com_google_protobuf.protobuf_java_util.StructsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.StructsTest]/[test:test3pair_constructsObject(com_google_protobuf.protobuf_java_util.StructsTest)]
+display-name: test3pair_constructsObject
+]]></system-out>
+</testcase>
+<testcase name="testRejectFractionalUnsignedInt32" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectFractionalUnsignedInt32(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectFractionalUnsignedInt32
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidNanoSecond" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidNanoSecond(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidNanoSecond
+]]></system-out>
+</testcase>
+<testcase name="testParserAcceptStringForNumericField" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserAcceptStringForNumericField(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserAcceptStringForNumericField
+]]></system-out>
+</testcase>
+<testcase name="testSubstract_usingVarArgs" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testSubstract_usingVarArgs(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testSubstract_usingVarArgs
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromNanos" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromNanos(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromNanos
+]]></system-out>
+</testcase>
+<testcase name="testArrayTypeMismatch" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testArrayTypeMismatch(com.google.protobuf.util.JsonFormatTest)]
+display-name: testArrayTypeMismatch
+]]></system-out>
+</testcase>
+<testcase name="testParserAcceptBase64Variants" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserAcceptBase64Variants(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserAcceptBase64Variants
+]]></system-out>
+</testcase>
+<testcase name="testTrim" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testTrim(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testTrim
+]]></system-out>
+</testcase>
+<testcase name="testPreservingProtoFieldNames" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testPreservingProtoFieldNames(com.google.protobuf.util.JsonFormatTest)]
+display-name: testPreservingProtoFieldNames
+]]></system-out>
+</testcase>
+<testcase name="testIllegalArgumentExceptionForMaxMilliseconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIllegalArgumentExceptionForMaxMilliseconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testIllegalArgumentExceptionForMaxMilliseconds
+]]></system-out>
+</testcase>
+<testcase name="testMinNanosecondsConversion" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testMinNanosecondsConversion(com.google.protobuf.util.TimestampsTest)]
+display-name: testMinNanosecondsConversion
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMaxSecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMaxSecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMaxSecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testStruct" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testStruct(com.google.protobuf.util.JsonFormatTest)]
+display-name: testStruct
+]]></system-out>
+</testcase>
+<testcase name="testTimestampConversion" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampConversion(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampConversion
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromSeconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromSeconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromSeconds
+]]></system-out>
+</testcase>
+<testcase name="testRepeatedUnknownEnum" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRepeatedUnknownEnum(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRepeatedUnknownEnum
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatValueTooLarge" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatValueTooLarge(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatValueTooLarge
+]]></system-out>
+</testcase>
+<testcase name="testWrappers" classname="com.google.protobuf.util.JsonFormatTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testWrappers(com.google.protobuf.util.JsonFormatTest)]
+display-name: testWrappers
+]]></system-out>
+</testcase>
+<testcase name="testParserRejectInvalidEnumValue" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectInvalidEnumValue(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserRejectInvalidEnumValue
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatMissingT" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatMissingT(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatMissingT
+]]></system-out>
+</testcase>
+<testcase name="testFromJsonString" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testFromJsonString(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testFromJsonString
+]]></system-out>
+</testcase>
+<testcase name="testOfListValue_ConstructsInstance" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfListValue_ConstructsInstance(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfListValue_ConstructsInstance
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMinMillisecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMinMillisecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMinMillisecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testJsonException_forwardsIOException" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testJsonException_forwardsIOException(com.google.protobuf.util.JsonFormatTest)]
+display-name: testJsonException_forwardsIOException
+]]></system-out>
+</testcase>
+<testcase name="testJsonException_forwardsJsonException" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testJsonException_forwardsJsonException(com.google.protobuf.util.JsonFormatTest)]
+display-name: testJsonException_forwardsJsonException
+]]></system-out>
+</testcase>
+<testcase name="testNullLastInDuplicateOneof" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testNullLastInDuplicateOneof(com.google.protobuf.util.JsonFormatTest)]
+display-name: testNullLastInDuplicateOneof
+]]></system-out>
+</testcase>
+<testcase name="testToSecondsAsDouble" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testToSecondsAsDouble(com.google.protobuf.util.DurationsTest)]
+display-name: testToSecondsAsDouble
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMaxMicrosecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMaxMicrosecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMaxMicrosecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testIllegalArgumentExceptionForMaxMicroseconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIllegalArgumentExceptionForMaxMicroseconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testIllegalArgumentExceptionForMaxMicroseconds
+]]></system-out>
+</testcase>
+<testcase name="testSubtract" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testSubtract(com.google.protobuf.util.DurationsTest)]
+display-name: testSubtract
+]]></system-out>
+</testcase>
+<testcase name="testIntersectFieldPath" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testIntersectFieldPath(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testIntersectFieldPath
+]]></system-out>
+</testcase>
+<testcase name="testToString" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testToString(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testToString
+]]></system-out>
+</testcase>
+<testcase name="testNegativeOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testNegativeOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testNegativeOverflow
+]]></system-out>
+</testcase>
+<testcase name="testMapEnumNullValueIsIgnored" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testMapEnumNullValueIsIgnored(com.google.protobuf.util.JsonFormatTest)]
+display-name: testMapEnumNullValueIsIgnored
+]]></system-out>
+</testcase>
+<testcase name="testUnknownEnumMap" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testUnknownEnumMap(com.google.protobuf.util.JsonFormatTest)]
+display-name: testUnknownEnumMap
+]]></system-out>
+</testcase>
+<testcase name="testTimeOperations" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testTimeOperations(com.google.protobuf.util.DurationsTest)]
+display-name: testTimeOperations
+]]></system-out>
+</testcase>
+<testcase name="testDurationInvalidFormat" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testDurationInvalidFormat(com.google.protobuf.util.DurationsTest)]
+display-name: testDurationInvalidFormat
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatValueTooSmall" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatValueTooSmall(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatValueTooSmall
+]]></system-out>
+</testcase>
+<testcase name="testOfNull_IsNullValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfNull_IsNullValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfNull_IsNullValue
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatNanosTooLarge" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatNanosTooLarge(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatNanosTooLarge
+]]></system-out>
+</testcase>
+<testcase name="testParserUnknownFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserUnknownFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserUnknownFields
+]]></system-out>
+</testcase>
+<testcase name="testAdd" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testAdd(com.google.protobuf.util.TimestampsTest)]
+display-name: testAdd
+]]></system-out>
+</testcase>
+<testcase name="testComparator" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testComparator(com.google.protobuf.util.DurationsTest)]
+display-name: testComparator
+]]></system-out>
+</testcase>
+<testcase name="testFromDate_after9999CE" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromDate_after9999CE(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromDate_after9999CE
+]]></system-out>
+</testcase>
+<testcase name="testFromDate_beforeYear1" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromDate_beforeYear1(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromDate_beforeYear1
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatMissingZ" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatMissingZ(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatMissingZ
+]]></system-out>
+</testcase>
+<testcase name="testOfIterable_ReturnsTheValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfIterable_ReturnsTheValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfIterable_ReturnsTheValue
+]]></system-out>
+</testcase>
+<testcase name="testRejectFractionalInt32" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectFractionalInt32(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectFractionalInt32
+]]></system-out>
+</testcase>
+<testcase name="testCompare" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testCompare(com.google.protobuf.util.TimestampsTest)]
+display-name: testCompare
+]]></system-out>
+</testcase>
+<testcase name="testOverflows" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testOverflows(com.google.protobuf.util.DurationsTest)]
+display-name: testOverflows
+]]></system-out>
+</testcase>
+<testcase name="testConvertToMicros" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertToMicros(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertToMicros
+]]></system-out>
+</testcase>
+<testcase name="testRemoveFieldPath" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testRemoveFieldPath(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testRemoveFieldPath
+]]></system-out>
+</testcase>
+<testcase name="testParserIgnoringUnknownFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserIgnoringUnknownFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserIgnoringUnknownFields
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromMillisAboveTimestampMaxLimit" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromMillisAboveTimestampMaxLimit(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromMillisAboveTimestampMaxLimit
+]]></system-out>
+</testcase>
+<testcase name="testUnion_usingVarArgs" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testUnion_usingVarArgs(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testUnion_usingVarArgs
+]]></system-out>
+</testcase>
+<testcase name="testEmptyWrapperTypesInAny" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testEmptyWrapperTypesInAny(com.google.protobuf.util.JsonFormatTest)]
+display-name: testEmptyWrapperTypesInAny
+]]></system-out>
+</testcase>
+<testcase name="testRejectFractionalInt64" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectFractionalInt64(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectFractionalInt64
+]]></system-out>
+</testcase>
+<testcase name="testConvertToNanos" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertToNanos(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertToNanos
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMinNanosecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMinNanosecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMinNanosecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testParserRejectDuplicatedFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectDuplicatedFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserRejectDuplicatedFields
+]]></system-out>
+</testcase>
+<testcase name="testIsPositive" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testIsPositive(com.google.protobuf.util.DurationsTest)]
+display-name: testIsPositive
+]]></system-out>
+</testcase>
+<testcase name="testAddFieldPath" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testAddFieldPath(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testAddFieldPath
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMicrosecondsMinOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMicrosecondsMinOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMicrosecondsMinOverflow
+]]></system-out>
+</testcase>
+<testcase name="testIsValid_false" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIsValid_false(com.google.protobuf.util.TimestampsTest)]
+display-name: testIsValid_false
+]]></system-out>
+</testcase>
+<testcase name="testConvertToMillis" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertToMillis(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertToMillis
+]]></system-out>
+</testcase>
+<testcase name="testRecursionLimit" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRecursionLimit(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRecursionLimit
+]]></system-out>
+</testcase>
+<testcase name="testRejectMalformedFloat" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectMalformedFloat(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectMalformedFloat
+]]></system-out>
+</testcase>
+<testcase name="testIsValid_true" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testIsValid_true(com.google.protobuf.util.DurationsTest)]
+display-name: testIsValid_true
+]]></system-out>
+</testcase>
+<testcase name="testFromSqlTimestamp" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromSqlTimestamp(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromSqlTimestamp
+]]></system-out>
+</testcase>
+<testcase name="testOverInvalidMinSecondsflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testOverInvalidMinSecondsflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testOverInvalidMinSecondsflow
+]]></system-out>
+</testcase>
+<testcase name="testOfNumeric_ConstructsValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfNumeric_ConstructsValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfNumeric_ConstructsValue
+]]></system-out>
+</testcase>
+<testcase name="testConvertToSeconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertToSeconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertToSeconds
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatDateTooSmall" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatDateTooSmall(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatDateTooSmall
+]]></system-out>
+</testcase>
+<testcase name="testOfStruct_ConstructsValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfStruct_ConstructsValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfStruct_ConstructsValue
+]]></system-out>
+</testcase>
+<testcase name="testOfBoolean_ConstructsValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfBoolean_ConstructsValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfBoolean_ConstructsValue
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromMicros" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromMicros(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromMicros
+]]></system-out>
+</testcase>
+<testcase name="testIncludingDefaultValueFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testIncludingDefaultValueFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testIncludingDefaultValueFields
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidFormatNanosTooSmall" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidFormatNanosTooSmall(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidFormatNanosTooSmall
+]]></system-out>
+</testcase>
+<testcase name="testParserRejectOutOfRangeNumericValues" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectOutOfRangeNumericValues(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserRejectOutOfRangeNumericValues
+]]></system-out>
+</testcase>
+<testcase name="testParserRejectTrailingComma" classname="com.google.protobuf.util.JsonFormatTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserRejectTrailingComma(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserRejectTrailingComma
+]]></system-out>
+</testcase>
+<testcase name="testSortedMapKeys" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testSortedMapKeys(com.google.protobuf.util.JsonFormatTest)]
+display-name: testSortedMapKeys
+]]></system-out>
+</testcase>
+<testcase name="testIsValid_true" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIsValid_true(com.google.protobuf.util.TimestampsTest)]
+display-name: testIsValid_true
+]]></system-out>
+</testcase>
+<testcase name="testCompare" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testCompare(com.google.protobuf.util.DurationsTest)]
+display-name: testCompare
+]]></system-out>
+</testcase>
+<testcase name="testDurationMergeError" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testDurationMergeError(com.google.protobuf.util.JsonFormatTest)]
+display-name: testDurationMergeError
+]]></system-out>
+</testcase>
+<testcase name="testParserAcceptNonQuotedObjectKey" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserAcceptNonQuotedObjectKey(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserAcceptNonQuotedObjectKey
+]]></system-out>
+</testcase>
+<testcase name="testFromDate" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromDate(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromDate
+]]></system-out>
+</testcase>
+<testcase name="testParserIgnoringUnknownEnums" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserIgnoringUnknownEnums(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserIgnoringUnknownEnums
+]]></system-out>
+</testcase>
+<testcase name="testParserAcceptFloatingPointValueForIntegerField" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserAcceptFloatingPointValueForIntegerField(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserAcceptFloatingPointValueForIntegerField
+]]></system-out>
+</testcase>
+<testcase name="testPrintingEnumsAsInts" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testPrintingEnumsAsInts(com.google.protobuf.util.JsonFormatTest)]
+display-name: testPrintingEnumsAsInts
+]]></system-out>
+</testcase>
+<testcase name="testAnyFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testAnyFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testAnyFields
+]]></system-out>
+</testcase>
+<testcase name="testTimeOperations" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimeOperations(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimeOperations
+]]></system-out>
+</testcase>
+<testcase name="testOfString_ConstructsValue" classname="com_google_protobuf.protobuf_java_util.ValuesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.ValuesTest]/[test:testOfString_ConstructsValue(com_google_protobuf.protobuf_java_util.ValuesTest)]
+display-name: testOfString_ConstructsValue
+]]></system-out>
+</testcase>
+<testcase name="test2pair_constructsObject" classname="com_google_protobuf.protobuf_java_util.StructsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.StructsTest]/[test:test2pair_constructsObject(com_google_protobuf.protobuf_java_util.StructsTest)]
+display-name: test2pair_constructsObject
+]]></system-out>
+</testcase>
+<testcase name="testToString" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testToString(com.google.protobuf.util.DurationsTest)]
+display-name: testToString
+]]></system-out>
+</testcase>
+<testcase name="testDuration" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testDuration(com.google.protobuf.util.JsonFormatTest)]
+display-name: testDuration
+]]></system-out>
+</testcase>
+<testcase name="testInvalidMaxNanosecondsOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testInvalidMaxNanosecondsOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testInvalidMaxNanosecondsOverflow
+]]></system-out>
+</testcase>
+<testcase name="testIllegalArgumentExceptionForMinMilliseconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIllegalArgumentExceptionForMinMilliseconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testIllegalArgumentExceptionForMinMilliseconds
+]]></system-out>
+</testcase>
+<testcase name="testComparator" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testComparator(com.google.protobuf.util.TimestampsTest)]
+display-name: testComparator
+]]></system-out>
+</testcase>
+<testcase name="testPositiveOverflow" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testPositiveOverflow(com.google.protobuf.util.TimestampsTest)]
+display-name: testPositiveOverflow
+]]></system-out>
+</testcase>
+<testcase name="testSpecialFloatValues" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testSpecialFloatValues(com.google.protobuf.util.JsonFormatTest)]
+display-name: testSpecialFloatValues
+]]></system-out>
+</testcase>
+<testcase name="testFromDate_after2262CE" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testFromDate_after2262CE(com.google.protobuf.util.TimestampsTest)]
+display-name: testFromDate_after2262CE
+]]></system-out>
+</testcase>
+<testcase name="testToJsonString" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testToJsonString(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testToJsonString
+]]></system-out>
+</testcase>
+<testcase name="testFromFieldNumbers" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testFromFieldNumbers(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testFromFieldNumbers
+]]></system-out>
+</testcase>
+<testcase name="testMapFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testMapFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testMapFields
+]]></system-out>
+</testcase>
+<testcase name="testFieldMask" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testFieldMask(com.google.protobuf.util.JsonFormatTest)]
+display-name: testFieldMask
+]]></system-out>
+</testcase>
+<testcase name="testNullInOneof" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testNullInOneof(com.google.protobuf.util.JsonFormatTest)]
+display-name: testNullInOneof
+]]></system-out>
+</testcase>
+<testcase name="testTimestampStringFormat" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampStringFormat(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampStringFormat
+]]></system-out>
+</testcase>
+<testcase name="testMapNullValueIsRejected" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testMapNullValueIsRejected(com.google.protobuf.util.JsonFormatTest)]
+display-name: testMapNullValueIsRejected
+]]></system-out>
+</testcase>
+<testcase name="testFromString" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testFromString(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testFromString
+]]></system-out>
+</testcase>
+<testcase name="test1pair_constructsObject" classname="com_google_protobuf.protobuf_java_util.StructsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.StructsTest]/[test:test1pair_constructsObject(com_google_protobuf.protobuf_java_util.StructsTest)]
+display-name: test1pair_constructsObject
+]]></system-out>
+</testcase>
+<testcase name="testIsNegative" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testIsNegative(com.google.protobuf.util.DurationsTest)]
+display-name: testIsNegative
+]]></system-out>
+</testcase>
+<testcase name="testParse_outOfRange" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testParse_outOfRange(com.google.protobuf.util.DurationsTest)]
+display-name: testParse_outOfRange
+]]></system-out>
+</testcase>
+<testcase name="testAnyInMaps" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testAnyInMaps(com.google.protobuf.util.JsonFormatTest)]
+display-name: testAnyInMaps
+]]></system-out>
+</testcase>
+<testcase name="testMinMaxAreValid" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testMinMaxAreValid(com.google.protobuf.util.DurationsTest)]
+display-name: testMinMaxAreValid
+]]></system-out>
+</testcase>
+<testcase name="testSubtractDuration" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testSubtractDuration(com.google.protobuf.util.TimestampsTest)]
+display-name: testSubtractDuration
+]]></system-out>
+</testcase>
+<testcase name="testDurationConversion" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testDurationConversion(com.google.protobuf.util.DurationsTest)]
+display-name: testDurationConversion
+]]></system-out>
+</testcase>
+<testcase name="testParserIntegerEnumValue" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserIntegerEnumValue(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserIntegerEnumValue
+]]></system-out>
+</testcase>
+<testcase name="testUnion" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testUnion(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testUnion
+]]></system-out>
+</testcase>
+<testcase name="testCustomJsonName" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testCustomJsonName(com.google.protobuf.util.JsonFormatTest)]
+display-name: testCustomJsonName
+]]></system-out>
+</testcase>
+<testcase name="testOverflowsArithmeticException" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testOverflowsArithmeticException(com.google.protobuf.util.TimestampsTest)]
+display-name: testOverflowsArithmeticException
+]]></system-out>
+</testcase>
+<testcase name="testMergeFromFieldMask" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testMergeFromFieldMask(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testMergeFromFieldMask
+]]></system-out>
+</testcase>
+<testcase name="testRoundtripConversions" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testRoundtripConversions(com.google.protobuf.util.DurationsTest)]
+display-name: testRoundtripConversions
+]]></system-out>
+</testcase>
+<testcase name="testAllFields" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testAllFields(com.google.protobuf.util.JsonFormatTest)]
+display-name: testAllFields
+]]></system-out>
+</testcase>
+<testcase name="testTimestamp" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testTimestamp(com.google.protobuf.util.JsonFormatTest)]
+display-name: testTimestamp
+]]></system-out>
+</testcase>
+<testcase name="testIntersection" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testIntersection(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testIntersection
+]]></system-out>
+</testcase>
+<testcase name="testDurationStringFormat" classname="com.google.protobuf.util.DurationsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testDurationStringFormat(com.google.protobuf.util.DurationsTest)]
+display-name: testDurationStringFormat
+]]></system-out>
+</testcase>
+<testcase name="testAnyFieldsWithCustomAddedTypeRegistry" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testAnyFieldsWithCustomAddedTypeRegistry(com.google.protobuf.util.JsonFormatTest)]
+display-name: testAnyFieldsWithCustomAddedTypeRegistry
+]]></system-out>
+</testcase>
+<testcase name="testTimestampConcurrentParsing" classname="com.google.protobuf.util.TimestampsTest" time="5.013">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampConcurrentParsing(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampConcurrentParsing
+]]></system-out>
+</testcase>
+<testcase name="testMaxNanosecondsConversion" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testMaxNanosecondsConversion(com.google.protobuf.util.TimestampsTest)]
+display-name: testMaxNanosecondsConversion
+]]></system-out>
+</testcase>
+<testcase name="testNowReturnsValidCurrentTimestamp" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testNowReturnsValidCurrentTimestamp(com.google.protobuf.util.TimestampsTest)]
+display-name: testNowReturnsValidCurrentTimestamp
+]]></system-out>
+</testcase>
+<testcase name="testRejectTooLargeFloat" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testRejectTooLargeFloat(com.google.protobuf.util.JsonFormatTest)]
+display-name: testRejectTooLargeFloat
+]]></system-out>
+</testcase>
+<testcase name="testTimestampInvalidTrailingText" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testTimestampInvalidTrailingText(com.google.protobuf.util.TimestampsTest)]
+display-name: testTimestampInvalidTrailingText
+]]></system-out>
+</testcase>
+<testcase name="testRemoveFromFieldMask" classname="com.google.protobuf.util.FieldMaskTreeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.FieldMaskTreeTest]/[test:testRemoveFromFieldMask(com.google.protobuf.util.FieldMaskTreeTest)]
+display-name: testRemoveFromFieldMask
+]]></system-out>
+</testcase>
+<testcase name="testParserMissingTypeUrl" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserMissingTypeUrl(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserMissingTypeUrl
+]]></system-out>
+</testcase>
+<testcase name="testIllegalArgumentExceptionForMinMicroseconds" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testIllegalArgumentExceptionForMinMicroseconds(com.google.protobuf.util.TimestampsTest)]
+display-name: testIllegalArgumentExceptionForMinMicroseconds
+]]></system-out>
+</testcase>
+<testcase name="testCheckPositive" classname="com.google.protobuf.util.DurationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.DurationsTest]/[test:testCheckPositive(com.google.protobuf.util.DurationsTest)]
+display-name: testCheckPositive
+]]></system-out>
+</testcase>
+<testcase name="testIsValid" classname="com_google_protobuf.protobuf_java_util.FieldMaskUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com_google_protobuf.protobuf_java_util.FieldMaskUtilTest]/[test:testIsValid(com_google_protobuf.protobuf_java_util.FieldMaskUtilTest)]
+display-name: testIsValid
+]]></system-out>
+</testcase>
+<testcase name="testUnknownEnumValues" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testUnknownEnumValues(com.google.protobuf.util.JsonFormatTest)]
+display-name: testUnknownEnumValues
+]]></system-out>
+</testcase>
+<testcase name="testParserUnexpectedTypeUrl" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testParserUnexpectedTypeUrl(com.google.protobuf.util.JsonFormatTest)]
+display-name: testParserUnexpectedTypeUrl
+]]></system-out>
+</testcase>
+<testcase name="testPreservesFloatingPointNegative0" classname="com.google.protobuf.util.JsonFormatTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.JsonFormatTest]/[test:testPreservesFloatingPointNegative0(com.google.protobuf.util.JsonFormatTest)]
+display-name: testPreservesFloatingPointNegative0
+]]></system-out>
+</testcase>
+<testcase name="testConvertFromMillis" classname="com.google.protobuf.util.TimestampsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]/[runner:com.google.protobuf.util.TimestampsTest]/[test:testConvertFromMillis(com.google.protobuf.util.TimestampsTest)]
+display-name: testConvertFromMillis
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses": "com.google.protobuf.util.**"
+    }
+  ]
+}

--- a/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
+++ b/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.protobuf.util.**"
+      "includeClasses" : "com.google.protobuf.util.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #1653

This PR provides test fixes and new metadata for com.google.protobuf:protobuf-java-util:3.23.3, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 104502
- Cached input tokens: 855552
- Output tokens: 8231
- Metadata entries: 219
- Test-only metadata entries: 226
- Iterations: 2
- Library coverage percentage: 93.93
- Previous library version metadata entries: 609
- Previous library version coverage percentage: 94.29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.protobuf:protobuf-java-util:3.22.0: 0/0 covered calls (100.00%)
- com.google.protobuf:protobuf-java-util:3.23.3: 4/4 covered calls (100.00%)

**Reflection:**
- com.google.protobuf:protobuf-java-util:3.22.0: N/A
- com.google.protobuf:protobuf-java-util:3.23.3: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.google.protobuf:protobuf-java-util:3.22.0: 5966/6397 (93.26%)
- com.google.protobuf:protobuf-java-util:3.23.3: 6007/6451 (93.12%)

**Line:**
- com.google.protobuf:protobuf-java-util:3.22.0: 1320/1400 (94.29%)
- com.google.protobuf:protobuf-java-util:3.23.3: 1330/1416 (93.93%)

**Method:**
- com.google.protobuf:protobuf-java-util:3.22.0: 250/252 (99.21%)
- com.google.protobuf:protobuf-java-util:3.23.3: 252/254 (99.21%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/build.gradle 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
index 9d37373151..5d932b725e 100644
--- 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/build.gradle
+++ 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/build.gradle
@@ -10,6 +10,8 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+// 3.23.3 did not publish protoc executable artifacts. Runtime dependencies still use the tested version.
+String protocVersion = "3.23.4"
 
 dependencies {
     // Put well-known type .proto files on protoc include path only (do not generate code for them)
@@ -28,7 +30,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$libraryVersion"
+        artifact = "com.google.protobuf:protoc:$protocVersion"
     }
 }
 
diff --git 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/src/test/java/com/google/protobuf/util/TimestampsTest.java 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
index 7b66e64191..6374c9fc09 100644
--- 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/src/test/java/com/google/protobuf/util/TimestampsTest.java
+++ 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/src/test/java/com/google/protobuf/util/TimestampsTest.java
@@ -432,6 +432,17 @@ public class TimestampsTest {
         assertThat(Timestamps.toString(timestamp)).isEqualTo("1970-01-01T00:00:01.111Z");
     }
 
+    @Test
+    public void testNowReturnsValidCurrentTimestamp() {
+        long beforeMillis = System.currentTimeMillis();
+        Timestamp timestamp = Timestamps.now();
+        long afterMillis = System.currentTimeMillis();
+
+        assertThat(Timestamps.isValid(timestamp)).isTrue();
+        assertThat(Timestamps.toMillis(timestamp)).isAtLeast(beforeMillis);
+        assertThat(Timestamps.toMillis(timestamp)).isAtMost(afterMillis);
+    }
+
     @Test
     public void testTimeOperations() throws Exception {
         Timestamp start = Timestamps.parse("0001-01-01T00:00:00Z");
diff --git 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/user-code-filter.json 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
index 4c1dac6362..bb154f3d39 100644
--- 1/tests/src/com.google.protobuf/protobuf-java-util/3.22.0/user-code-filter.json
+++ 2/tests/src/com.google.protobuf/protobuf-java-util/3.23.3/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.protobuf.util.**"
+      "includeClasses" : "com.google.protobuf.util.**"
     }
   ]
 }

```
