### PR TITLE
[GenAI] Add support for io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/reachability-metadata.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/reachability-metadata.json
@@ -1,0 +1,249 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.InsecureQuicTokenHandler"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLCertificateCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLCertificateVerifyCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLHandshakeCompleteCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.QuicheLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.BoringSSLCertificateVerifyCallback"
+      },
+      "type": "javax.net.ssl.X509ExtendedTrustManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.misc.VM"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.HmacSignQuicConnectionIdGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.SecureRandomQuicConnectionIdGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.HmacSignQuicConnectionIdGenerator"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "glob": "META-INF/native/libnetty_quiche_linux_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.0.34.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/incubator/netty-incubator-codec-classes-quic/$version$/netty-incubator-codec-classes-quic-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty-incubator-codec-quic",
+    "test-code-url" : "https://github.com/netty/netty-incubator-codec-quic/tree/netty-incubator-codec-parent-quic-$version$/codec-native-quic/src/test/java/io/netty/incubator/codec/quic",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/incubator/netty-incubator-codec-classes-quic/$version$/netty-incubator-codec-classes-quic-$version$-javadoc.jar",
+    "description" : "Netty incubator codec classes for QUIC provide the Java API and implementation classes for Netty's experimental QUIC codec built on Cloudflare quiche. The artifact is paired with platform-specific native QUIC artifacts to build asynchronous Netty clients and servers that speak QUIC streams and datagrams.",
+    "tested-versions" : [
+      "0.0.34.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.incubator.codec.quic"
+    ]
+  }
+]

--- a/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/execution-metrics.json
+++ b/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T15:11:48.357240Z",
+    "library": "io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final",
+    "starting_commit": "1561dcef688222db48e26ca336e382ec230a8b72",
+    "ending_commit": "eadb9ba2d5cdbb933ac2c997b7865585c65cfde7",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0.34.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 641,
+          "missed": 14404,
+          "ratio": 0.042606,
+          "total": 15045
+        },
+        "line": {
+          "covered": 134,
+          "missed": 3451,
+          "ratio": 0.037378,
+          "total": 3585
+        },
+        "method": {
+          "covered": 62,
+          "missed": 822,
+          "ratio": 0.070136,
+          "total": 884
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 241231,
+      "cached_input_tokens_used": 2101760,
+      "output_tokens_used": 23874,
+      "iterations": 5,
+      "cost_usd": 1.7671,
+      "generated_loc": 376,
+      "tested_library_loc": 134,
+      "metadata_entries": 44,
+      "code_coverage_percent": 3.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java",
+      "metadata_file": "metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/stats.json
+++ b/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.0.34.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 641,
+        "missed" : 14404,
+        "ratio" : 0.042606,
+        "total" : 15045
+      },
+      "line" : {
+        "covered" : 134,
+        "missed" : 3451,
+        "ratio" : 0.037378,
+        "total" : 3585
+      },
+      "method" : {
+        "covered" : 62,
+        "missed" : 822,
+        "ratio" : 0.070136,
+        "total" : 884
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/.gitignore
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/build.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty.incubator:netty-incubator-codec-classes-quic:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/gradle.properties
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final
+library.version = 0.0.34.Final
+metadata.dir = io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/settings.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.incubator.netty-incubator-codec-classes-quic_tests'

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty_incubator.netty_incubator_codec_classes_quic;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_incubator_codec_classes_quicTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -6,11 +6,362 @@
  */
 package io_netty_incubator.netty_incubator_codec_classes_quic;
 
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelOption;
+import io.netty.incubator.codec.quic.DefaultQuicStreamFrame;
+import io.netty.incubator.codec.quic.FlushStrategy;
+import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
+import io.netty.incubator.codec.quic.QLogConfiguration;
+import io.netty.incubator.codec.quic.Quic;
+import io.netty.incubator.codec.quic.QuicChannelOption;
+import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
+import io.netty.incubator.codec.quic.QuicCongestionControlAlgorithm;
+import io.netty.incubator.codec.quic.QuicConnectionAddress;
+import io.netty.incubator.codec.quic.QuicConnectionIdGenerator;
+import io.netty.incubator.codec.quic.QuicError;
+import io.netty.incubator.codec.quic.QuicPacketType;
+import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
+import io.netty.incubator.codec.quic.QuicStreamFrame;
+import io.netty.incubator.codec.quic.QuicStreamPriority;
+import io.netty.incubator.codec.quic.QuicStreamType;
+import io.netty.incubator.codec.quic.SegmentedDatagramPacketAllocator;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
-class Netty_incubator_codec_classes_quicTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_incubator_codec_classes_quicTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void quicAvailabilityContractIsSelfConsistent() {
+        boolean available = Quic.isAvailable();
+        Throwable cause = Quic.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(Quic::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(Quic.isVersionSupported(0)).isFalse();
+
+        Throwable thrown = catchThrowable(Quic::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void streamFrameBufferOperationsPreserveFinAndContentSemantics() {
+        QuicStreamFrame frame = new DefaultQuicStreamFrame(Unpooled.wrappedBuffer(new byte[] {1, 2, 3}), true);
+        QuicStreamFrame copy = frame.copy();
+        QuicStreamFrame duplicate = frame.duplicate();
+        QuicStreamFrame retainedDuplicate = frame.retainedDuplicate();
+        QuicStreamFrame replacement = frame.replace(Unpooled.wrappedBuffer(new byte[] {9, 8, 7}));
+
+        try {
+            assertThat(frame.hasFin()).isTrue();
+            assertThat(copy.hasFin()).isTrue();
+            assertThat(duplicate.hasFin()).isTrue();
+            assertThat(retainedDuplicate.hasFin()).isTrue();
+            assertThat(replacement.hasFin()).isTrue();
+
+            assertThat(frame.content().readableBytes()).isEqualTo(3);
+            assertThat(copy.content()).isNotSameAs(frame.content());
+            assertThat(duplicate.content()).isNotSameAs(frame.content());
+            assertThat(retainedDuplicate.content()).isNotSameAs(frame.content());
+
+            frame.content().setByte(0, 5);
+            assertThat(copy.content().getByte(0)).isEqualTo((byte) 1);
+            assertThat(duplicate.content().getByte(0)).isEqualTo((byte) 5);
+            assertThat(retainedDuplicate.content().getByte(0)).isEqualTo((byte) 5);
+            assertThat(replacement.content().getByte(0)).isEqualTo((byte) 9);
+
+            assertThat(frame.refCnt()).isEqualTo(2);
+            assertThat(frame.retain()).isSameAs(frame);
+            assertThat(frame.refCnt()).isEqualTo(3);
+            assertThat(frame.release()).isFalse();
+            assertThat(frame.refCnt()).isEqualTo(2);
+        } finally {
+            copy.release();
+            retainedDuplicate.release();
+            replacement.release();
+            frame.release();
+        }
+    }
+
+    @Test
+    void emptyFinFrameIsImmutableFinMarker() {
+        QuicStreamFrame emptyFin = QuicStreamFrame.EMPTY_FIN;
+
+        assertThat(emptyFin.hasFin()).isTrue();
+        assertThat(emptyFin.content().readableBytes()).isZero();
+        assertThat(emptyFin.copy().hasFin()).isTrue();
+        assertThat(emptyFin.duplicate().hasFin()).isTrue();
+        assertThat(emptyFin.retainedDuplicate().hasFin()).isTrue();
+        assertThatThrownBy(() -> emptyFin.content().writeByte(1)).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    void flushStrategiesApplyStrictPacketAndByteThresholds() {
+        FlushStrategy bytes = FlushStrategy.afterNumBytes(32);
+        FlushStrategy packets = FlushStrategy.afterNumPackets(3);
+
+        assertThat(bytes.shouldFlushNow(100, 31)).isFalse();
+        assertThat(bytes.shouldFlushNow(1, 32)).isFalse();
+        assertThat(bytes.shouldFlushNow(1, 33)).isTrue();
+
+        assertThat(packets.shouldFlushNow(3, 10_000)).isFalse();
+        assertThat(packets.shouldFlushNow(4, 0)).isTrue();
+
+        assertThat(FlushStrategy.DEFAULT.shouldFlushNow(1, 27_000)).isFalse();
+        assertThat(FlushStrategy.DEFAULT.shouldFlushNow(1, 27_001)).isTrue();
+
+        assertThatThrownBy(() -> FlushStrategy.afterNumBytes(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FlushStrategy.afterNumPackets(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void quicChannelOptionsAreRegisteredInNettyConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                QuicChannelOption.READ_FRAMES,
+                QuicChannelOption.QLOG,
+                QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void qlogConfigurationAndStreamPriorityExposeStableValueSemantics() {
+        QLogConfiguration qlog = new QLogConfiguration("/tmp/qlog", "integration", "quic test run");
+        assertThat(qlog.path()).isEqualTo("/tmp/qlog");
+        assertThat(qlog.logTitle()).isEqualTo("integration");
+        assertThat(qlog.logDescription()).isEqualTo("quic test run");
+
+        QuicStreamPriority priority = new QuicStreamPriority(7, true);
+        QuicStreamPriority samePriority = new QuicStreamPriority(7, true);
+        QuicStreamPriority differentPriority = new QuicStreamPriority(8, true);
+
+        assertThat(priority.urgency()).isEqualTo(7);
+        assertThat(priority.isIncremental()).isTrue();
+        assertThat(priority).isEqualTo(samePriority).hasSameHashCodeAs(samePriority);
+        assertThat(priority).isNotEqualTo(differentPriority);
+        assertThat(priority).hasToString("QuicStreamPriority{urgency=7, incremental=true}");
+        assertThatThrownBy(() -> new QuicStreamPriority(-1, false)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new QuicStreamPriority(128, false)).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new QLogConfiguration(null, "title", "description"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QLogConfiguration("path", null, "description"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QLogConfiguration("path", "title", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void segmentedDatagramAllocatorNoneRejectsPacketAllocation() {
+        ByteBuf content = Unpooled.wrappedBuffer(new byte[] {1, 2, 3, 4});
+        try {
+            assertThat(SegmentedDatagramPacketAllocator.NONE.maxNumSegments()).isZero();
+            assertThatThrownBy(() -> SegmentedDatagramPacketAllocator.NONE.newPacket(
+                    content,
+                    2,
+                    new InetSocketAddress("127.0.0.1", 9999)
+            )).isInstanceOf(UnsupportedOperationException.class);
+        } finally {
+            content.release();
+        }
+    }
+
+    @Test
+    void simpleEnumsExposeExpectedProtocolConstants() {
+        assertThat(QuicStreamType.values()).containsExactly(
+                QuicStreamType.UNIDIRECTIONAL,
+                QuicStreamType.BIDIRECTIONAL
+        );
+        assertThat(QuicStreamType.valueOf("UNIDIRECTIONAL")).isSameAs(QuicStreamType.UNIDIRECTIONAL);
+        assertThat(QuicStreamType.valueOf("BIDIRECTIONAL")).isSameAs(QuicStreamType.BIDIRECTIONAL);
+
+        assertThat(QuicPacketType.values()).containsExactly(
+                QuicPacketType.INITIAL,
+                QuicPacketType.RETRY,
+                QuicPacketType.HANDSHAKE,
+                QuicPacketType.ZERO_RTT,
+                QuicPacketType.SHORT,
+                QuicPacketType.VERSION_NEGOTIATION
+        );
+        assertThat(QuicPacketType.valueOf("SHORT")).isSameAs(QuicPacketType.SHORT);
+    }
+
+    @Test
+    void nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable() {
+        if (!Quic.isAvailable()) {
+            assertMayRequireNativeLibrary(() -> QuicError.values());
+            assertMayRequireNativeLibrary(() -> QuicCongestionControlAlgorithm.values());
+            return;
+        }
+
+        assertThat(QuicError.values()).containsExactly(
+                QuicError.BUFFER_TOO_SHORT,
+                QuicError.UNKNOWN_VERSION,
+                QuicError.INVALID_FRAME,
+                QuicError.INVALID_PACKET,
+                QuicError.INVALID_STATE,
+                QuicError.INVALID_STREAM_STATE,
+                QuicError.INVALID_TRANSPORT_PARAM,
+                QuicError.CRYPTO_FAIL,
+                QuicError.TLS_FAIL,
+                QuicError.FLOW_CONTROL,
+                QuicError.STREAM_LIMIT,
+                QuicError.FINAL_SIZE,
+                QuicError.CONGESTION_CONTROL,
+                QuicError.STREAM_RESET,
+                QuicError.STREAM_STOPPED
+        );
+        assertThat(QuicError.INVALID_PACKET.toString()).contains("INVALID_PACKET");
+        assertThat(QuicCongestionControlAlgorithm.values()).containsExactly(
+                QuicCongestionControlAlgorithm.RENO,
+                QuicCongestionControlAlgorithm.CUBIC
+        );
+    }
+
+    @Test
+    void nativeBackedAddressAndTokenTypesRespectTransportAvailability() {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(() -> QuicConnectionAddress.EPHEMERAL.toString());
+            assertNativeBackedTypeUnavailable(() -> InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
+            return;
+        }
+
+        byte[] id = new byte[] {1, 2, 3, 4};
+        QuicConnectionAddress address = new QuicConnectionAddress(id);
+        QuicConnectionAddress sameAddress = new QuicConnectionAddress(new byte[] {1, 2, 3, 4});
+        QuicConnectionAddress differentAddress = new QuicConnectionAddress(new byte[] {1, 2, 3, 5});
+        id[0] = 9;
+
+        assertThat(QuicConnectionAddress.EPHEMERAL).isSameAs(QuicConnectionAddress.EPHEMERAL);
+        assertThat(QuicConnectionAddress.EPHEMERAL).isNotEqualTo(address);
+        assertThat(QuicConnectionAddress.EPHEMERAL).hasToString("QuicConnectionAddress{EPHEMERAL}");
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address).hasToString("QuicConnectionAddress{connId=01020304}");
+
+        assertInsecureTokenHandlerRoundTrip();
+    }
+
+    @Test
+    void nativeBackedConnectionIdGeneratorsRespectTransportAvailability() {
+        QuicConnectionIdGenerator random = QuicConnectionIdGenerator.randomGenerator();
+        QuicConnectionIdGenerator signer = QuicConnectionIdGenerator.signGenerator();
+
+        assertThat(random.isIdempotent()).isFalse();
+        assertThat(signer.isIdempotent()).isTrue();
+
+        if (!Quic.isAvailable()) {
+            assertMayRequireNativeLibrary(random::maxConnectionIdLength);
+            assertMayRequireNativeLibrary(signer::maxConnectionIdLength);
+            return;
+        }
+
+        assertConnectionIdGeneratorsExposeNativeBackedState(random, signer);
+    }
+
+    @Test
+    void nativeBackedCodecBuildersRespectTransportAvailability() {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(QuicClientCodecBuilder::new);
+            assertNativeBackedTypeUnavailable(QuicServerCodecBuilder::new);
+            return;
+        }
+
+        QuicClientCodecBuilder clientBuilder = new QuicClientCodecBuilder()
+                .flushStrategy(FlushStrategy.afterNumPackets(2))
+                .grease(true)
+                .maxSendUdpPayloadSize(1_200)
+                .maxRecvUdpPayloadSize(1_200)
+                .initialMaxData(8_192)
+                .initialMaxStreamsBidirectional(4)
+                .initialMaxStreamsUnidirectional(2);
+        QuicServerCodecBuilder serverBuilder = new QuicServerCodecBuilder()
+                .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                .connectionIdAddressGenerator(QuicConnectionIdGenerator.signGenerator())
+                .option(QuicChannelOption.READ_FRAMES, true)
+                .streamOption(QuicChannelOption.READ_FRAMES, true);
+
+        assertThat(clientBuilder.clone()).isNotSameAs(clientBuilder).isInstanceOf(QuicClientCodecBuilder.class);
+        assertThat(serverBuilder.clone()).isNotSameAs(serverBuilder).isInstanceOf(QuicServerCodecBuilder.class);
+        assertThatThrownBy(() -> clientBuilder.localConnectionIdLength(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> serverBuilder.statelessResetToken(new byte[] {1, 2, 3}))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void assertConnectionIdGeneratorsExposeNativeBackedState(
+            QuicConnectionIdGenerator random,
+            QuicConnectionIdGenerator signer
+    ) {
+        int idLength = Math.min(8, random.maxConnectionIdLength());
+        ByteBuffer input = ByteBuffer.wrap(new byte[] {9, 8, 7, 6, 5, 4});
+
+        ByteBuffer randomId = random.newId(idLength);
+        ByteBuffer signedId = signer.newId(input.duplicate(), idLength);
+        ByteBuffer signedIdAgain = signer.newId(input.duplicate(), idLength);
+
+        assertThat(randomId.remaining()).isEqualTo(idLength);
+        assertThat(signedId.remaining()).isEqualTo(idLength);
+        assertThat(signedIdAgain).isEqualTo(signedId.duplicate());
+        assertThatThrownBy(() -> random.newId(random.maxConnectionIdLength() + 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> signer.newId(idLength)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> signer.newId(ByteBuffer.allocate(0), idLength))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void assertInsecureTokenHandlerRoundTrip() {
+        ByteBuf token = Unpooled.buffer(InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
+        ByteBuf destinationConnectionId = Unpooled.wrappedBuffer(new byte[] {10, 11, 12, 13});
+        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4433);
+        InetSocketAddress differentAddress = new InetSocketAddress("127.0.0.2", 4433);
+
+        try {
+            assertThat(InsecureQuicTokenHandler.INSTANCE.writeToken(token, destinationConnectionId, address)).isTrue();
+            assertThat(token.readableBytes()).isEqualTo("netty".length() + 4 + 4);
+            assertThat(destinationConnectionId.readerIndex()).isZero();
+            assertThat(InsecureQuicTokenHandler.INSTANCE.validateToken(token, address))
+                    .isEqualTo("netty".length() + 4);
+            assertThat(InsecureQuicTokenHandler.INSTANCE.validateToken(token, differentAddress)).isEqualTo(-1);
+        } finally {
+            destinationConnectionId.release();
+            token.release();
+        }
+    }
+
+    private static void assertMayRequireNativeLibrary(ThrowableAssert.ThrowingCallable callable) {
+        Throwable thrown = catchThrowable(callable);
+
+        if (thrown != null) {
+            assertThat(thrown).isInstanceOf(LinkageError.class);
+        }
+    }
+
+    private static void assertNativeBackedTypeUnavailable(ThrowableAssert.ThrowingCallable callable) {
+        Throwable thrown = catchThrowable(callable);
+
+        assertThat(thrown).isInstanceOf(LinkageError.class);
     }
 }

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -7,6 +7,7 @@
 package io_netty_incubator.netty_incubator_codec_classes_quic;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -28,6 +29,7 @@ import io.netty.incubator.codec.quic.QuicError;
 import io.netty.incubator.codec.quic.QuicHeaderParser;
 import io.netty.incubator.codec.quic.QuicPacketType;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
+import io.netty.incubator.codec.quic.QuicStreamAddress;
 import io.netty.incubator.codec.quic.QuicStreamFrame;
 import io.netty.incubator.codec.quic.QuicStreamPriority;
 import io.netty.incubator.codec.quic.QuicStreamType;
@@ -279,6 +281,23 @@ public class Netty_incubator_codec_classes_quicTest {
         }
 
         assertThat(processed[0]).isTrue();
+    }
+
+    @Test
+    void streamAddressIdentifiesStreamsByTheirNumericStreamId() {
+        long streamId = 1_234;
+        QuicStreamAddress address = new QuicStreamAddress(streamId);
+        QuicStreamAddress sameAddress = new QuicStreamAddress(streamId);
+        QuicStreamAddress differentAddress = new QuicStreamAddress(streamId + 1);
+        SocketAddress socketAddress = address;
+
+        assertThat(socketAddress).isSameAs(address);
+        assertThat(address.streamId()).isEqualTo(streamId);
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address).isNotEqualTo(new InetSocketAddress("127.0.0.1", 4433));
+        assertThat(address).hasToString("QuicStreamAddress{streamId=1234}");
+        assertThat(new QuicStreamAddress(Long.MAX_VALUE).streamId()).isEqualTo(Long.MAX_VALUE);
     }
 
     @Test

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -25,6 +25,7 @@ import io.netty.incubator.codec.quic.QuicCongestionControlAlgorithm;
 import io.netty.incubator.codec.quic.QuicConnectionAddress;
 import io.netty.incubator.codec.quic.QuicConnectionIdGenerator;
 import io.netty.incubator.codec.quic.QuicError;
+import io.netty.incubator.codec.quic.QuicHeaderParser;
 import io.netty.incubator.codec.quic.QuicPacketType;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
 import io.netty.incubator.codec.quic.QuicStreamFrame;
@@ -241,6 +242,46 @@ public class Netty_incubator_codec_classes_quicTest {
     }
 
     @Test
+    void quicHeaderParserExtractsVersionNegotiationHeader() throws Exception {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(() -> new QuicHeaderParser(0, 4));
+            return;
+        }
+
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 4433);
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 9443);
+        byte[] destinationConnectionId = new byte[] {1, 2, 3, 4};
+        byte[] sourceConnectionId = new byte[] {5, 6, 7};
+        boolean[] processed = {false};
+        ByteBuf packet = Unpooled.directBuffer();
+        packet.writeByte(0x80);
+        packet.writeInt(0);
+        packet.writeByte(destinationConnectionId.length);
+        packet.writeBytes(destinationConnectionId);
+        packet.writeByte(sourceConnectionId.length);
+        packet.writeBytes(sourceConnectionId);
+        packet.writeInt(1);
+
+        try (QuicHeaderParser parser = new QuicHeaderParser(0, destinationConnectionId.length)) {
+            parser.parse(sender, recipient, packet, (local, remote, payload, type, version, scid, dcid, token) -> {
+                assertThat(local).isSameAs(sender);
+                assertThat(remote).isSameAs(recipient);
+                assertThat(payload).isSameAs(packet);
+                assertThat(type).isSameAs(QuicPacketType.VERSION_NEGOTIATION);
+                assertThat(version).isZero();
+                assertThat(readBytes(dcid)).containsExactly(destinationConnectionId);
+                assertThat(readBytes(scid)).containsExactly(sourceConnectionId);
+                assertThat(token.readableBytes()).isZero();
+                processed[0] = true;
+            });
+        } finally {
+            packet.release();
+        }
+
+        assertThat(processed[0]).isTrue();
+    }
+
+    @Test
     void nativeBackedAddressAndTokenTypesRespectTransportAvailability() {
         if (!Quic.isAvailable()) {
             assertNativeBackedTypeUnavailable(() -> QuicConnectionAddress.EPHEMERAL.toString());
@@ -309,6 +350,12 @@ public class Netty_incubator_codec_classes_quicTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> serverBuilder.statelessResetToken(new byte[] {1, 2, 3}))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static byte[] readBytes(ByteBuf buffer) {
+        byte[] bytes = new byte[buffer.readableBytes()];
+        buffer.getBytes(buffer.readerIndex(), bytes);
+        return bytes;
     }
 
     private static void assertConnectionIdGeneratorsExposeNativeBackedState(

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="13" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:10">
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:08:59">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,13 +52,13 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:emptyFinFrameIsImmutableFinMarker()]
 display-name: emptyFinFrameIsImmutableFinMarker()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedAddressAndTokenTypesRespectTransportAvailability()]
 display-name: nativeBackedAddressAndTokenTypesRespectTransportAvailability()
@@ -76,43 +76,43 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
 ]]></system-out>
 </testcase>
-<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
 display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
 ]]></system-out>
 </testcase>
-<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicAvailabilityContractIsSelfConsistent()]
 display-name: quicAvailabilityContractIsSelfConsistent()
 ]]></system-out>
 </testcase>
-<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:qlogConfigurationAndStreamPriorityExposeStableValueSemantics()]
 display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
 display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
 ]]></system-out>
 </testcase>
-<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
 display-name: simpleEnumsExposeExpectedProtocolConstants()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
 display-name: nativeBackedCodecBuildersRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
 display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
@@ -124,10 +124,16 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:segmentedDatagramAllocatorNoneRejectsPacketAllocation()]
 display-name: segmentedDatagramAllocatorNoneRejectsPacketAllocation()
+]]></system-out>
+</testcase>
+<testcase name="streamAddressIdentifiesStreamsByTheirNumericStreamId()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamAddressIdentifiesStreamsByTheirNumericStreamId()]
+display-name: streamAddressIdentifiesStreamsByTheirNumericStreamId()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:24">
+<testsuite name="JUnit Jupiter" tests="13" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,40 +52,70 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:emptyFinFrameIsImmutableFinMarker()]
 display-name: emptyFinFrameIsImmutableFinMarker()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
-display-name: nativeBackedCodecBuildersRespectTransportAvailability()
-]]></system-out>
-</testcase>
-<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.005">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
-display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
-]]></system-out>
-</testcase>
-<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedAddressAndTokenTypesRespectTransportAvailability()]
 display-name: nativeBackedAddressAndTokenTypesRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<testcase name="quicHeaderParserExtractsVersionNegotiationHeader()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicHeaderParserExtractsVersionNegotiationHeader()]
+display-name: quicHeaderParserExtractsVersionNegotiationHeader()
+]]></system-out>
+</testcase>
+<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:flushStrategiesApplyStrictPacketAndByteThresholds()]
 display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
 ]]></system-out>
 </testcase>
-<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
 display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
+]]></system-out>
+</testcase>
+<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicAvailabilityContractIsSelfConsistent()]
+display-name: quicAvailabilityContractIsSelfConsistent()
+]]></system-out>
+</testcase>
+<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:qlogConfigurationAndStreamPriorityExposeStableValueSemantics()]
+display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
+display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
+]]></system-out>
+</testcase>
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
+display-name: simpleEnumsExposeExpectedProtocolConstants()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
+display-name: nativeBackedCodecBuildersRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
+display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
 ]]></system-out>
 </testcase>
 <testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
@@ -94,34 +124,10 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicAvailabilityContractIsSelfConsistent()]
-display-name: quicAvailabilityContractIsSelfConsistent()
-]]></system-out>
-</testcase>
-<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:qlogConfigurationAndStreamPriorityExposeStableValueSemantics()]
-display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
-]]></system-out>
-</testcase>
-<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:segmentedDatagramAllocatorNoneRejectsPacketAllocation()]
 display-name: segmentedDatagramAllocatorNoneRejectsPacketAllocation()
-]]></system-out>
-</testcase>
-<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
-display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
-]]></system-out>
-</testcase>
-<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
-display-name: simpleEnumsExposeExpectedProtocolConstants()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:24">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:emptyFinFrameIsImmutableFinMarker()]
+display-name: emptyFinFrameIsImmutableFinMarker()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
+display-name: nativeBackedCodecBuildersRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
+display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedAddressAndTokenTypesRespectTransportAvailability()]
+display-name: nativeBackedAddressAndTokenTypesRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:flushStrategiesApplyStrictPacketAndByteThresholds()]
+display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
+]]></system-out>
+</testcase>
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
+display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedConnectionIdGeneratorsRespectTransportAvailability()]
+display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicAvailabilityContractIsSelfConsistent()]
+display-name: quicAvailabilityContractIsSelfConsistent()
+]]></system-out>
+</testcase>
+<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:qlogConfigurationAndStreamPriorityExposeStableValueSemantics()]
+display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
+]]></system-out>
+</testcase>
+<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:segmentedDatagramAllocatorNoneRejectsPacketAllocation()]
+display-name: segmentedDatagramAllocatorNoneRejectsPacketAllocation()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
+display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
+]]></system-out>
+</testcase>
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
+display-name: simpleEnumsExposeExpectedProtocolConstants()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:08:59">
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
@@ -70,13 +69,13 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: quicHeaderParserExtractsVersionNegotiationHeader()
 ]]></system-out>
 </testcase>
-<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:flushStrategiesApplyStrictPacketAndByteThresholds()]
 display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
 ]]></system-out>
 </testcase>
-<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
 display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
@@ -100,25 +99,25 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
 ]]></system-out>
 </testcase>
-<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
 display-name: simpleEnumsExposeExpectedProtocolConstants()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
 display-name: nativeBackedCodecBuildersRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
 display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedConnectionIdGeneratorsRespectTransportAvailability()]
 display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:24">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:08:59">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:04:24">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:07:10">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:08:59">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/user-code-filter.json
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.incubator.codec.quic.**"
+      "includeClasses" : "io.netty.incubator.codec.quic.**"
     }
   ]
 }

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/user-code-filter.json
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.incubator.codec.quic.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #1443

This PR introduces tests and metadata for io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 241231
- Cached input tokens: 2101760
- Output tokens: 23874
- Metadata entries: 44
- Iterations: 5
- Library coverage percentage: 3.74
- Generated lines of code: 376
- Tested library lines of code: 134

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 641/15045 (4.26%)
- Line: 134/3585 (3.74%)
- Method: 62/884 (7.01%)
