### PR TITLE
[GenAI] Test fix for org.junit.platform:junit-platform-commons:1.11.0 using gpt-5.5

### DIFF
--- a/metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json
@@ -1,0 +1,118 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceClassScanner"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "java.util.UUID"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "java.util.UUID[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.RuntimeUtils"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ClasspathScanner"
+      },
+      "glob" : "org_junit_platform/junit_platform_commons"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ClassLoaderUtils"
+      },
+      "glob" : "org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest$LocationSubject.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "glob" : "sun/text/resources/LineBreakIteratorData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ModuleUtils$ModuleReferenceResourceScanner"
+      },
+      "module" : "java.base",
+      "glob" : "sun/text/resources/LineBreakIteratorData"
+    }
+  ]
+}

--- a/metadata/org.junit.platform/junit-platform-commons/index.json
+++ b/metadata/org.junit.platform/junit-platform-commons/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.11.0",
+    "tested-versions" : [
+      "1.11.0"
+    ],
+    "allowed-packages" : [
+      "org.junit.platform.commons"
+    ]
+  },
+  {
     "metadata-version" : "1.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/$version$/junit-platform-commons-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit5",

--- a/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T15:14:23.097526Z",
+    "library": "org.junit.platform:junit-platform-commons:1.11.0",
+    "starting_commit": "a555279c677936a88e21ef50ccbe2c041f5baef2",
+    "ending_commit": "ec89e17c721c6af276cbf29023f9fe744a930e94",
+    "previous_library": "org.junit.platform:junit-platform-commons:1.8.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.11.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 0.666667,
+            "coveredCalls": 2,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.964286,
+        "coveredCalls": 27,
+        "totalCalls": 28
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2992,
+          "missed": 5038,
+          "ratio": 0.372603,
+          "total": 8030
+        },
+        "line": {
+          "covered": 634,
+          "missed": 1022,
+          "ratio": 0.38285,
+          "total": 1656
+        },
+        "method": {
+          "covered": 201,
+          "missed": 387,
+          "ratio": 0.341837,
+          "total": 588
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.8.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 26,
+            "totalCalls": 26
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 28,
+        "totalCalls": 28
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2763,
+          "missed": 3435,
+          "ratio": 0.445789,
+          "total": 6198
+        },
+        "line": {
+          "covered": 582,
+          "missed": 703,
+          "ratio": 0.452918,
+          "total": 1285
+        },
+        "method": {
+          "covered": 184,
+          "missed": 261,
+          "ratio": 0.413483,
+          "total": 445
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 132678,
+      "cached_input_tokens_used": 1010688,
+      "output_tokens_used": 15656,
+      "iterations": 6,
+      "cost_usd": 0.975,
+      "tested_library_loc": 634,
+      "metadata_entries": 24,
+      "test_only_metadata_entries": 62,
+      "previous_library_metadata_entries": 25,
+      "previous_library_test_only_metadata_entries": 47,
+      "code_coverage_percent": 38.29,
+      "previous_library_coverage_percent": 45.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java",
+      "metadata_file": "metadata/org.junit.platform/junit-platform-commons/1.11.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.junit.platform/junit-platform-commons/1.11.0/stats.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.11.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.11.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 0.666667,
+          "coveredCalls" : 2,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 0.964286,
+      "coveredCalls" : 27,
+      "totalCalls" : 28
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2992,
+        "missed" : 5038,
+        "ratio" : 0.372603,
+        "total" : 8030
+      },
+      "line" : {
+        "covered" : 634,
+        "missed" : 1022,
+        "ratio" : 0.38285,
+        "total" : 1656
+      },
+      "method" : {
+        "covered" : 201,
+        "missed" : 387,
+        "ratio" : 0.341837,
+        "total" : 588
+      }
+    }
+  } ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/.gitignore
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.platform:junit-platform-commons:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            buildArgs("-H:+AllowJRTFileSystem")
+            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
+            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
@@ -4,6 +4,14 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 plugins {
     id "org.graalvm.internal.tck"
 }
@@ -19,8 +27,6 @@ graalvmNative {
     binaries {
         test {
             buildArgs("-H:+AllowJRTFileSystem")
-            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
-            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
         }
     }
     agent {
@@ -31,4 +37,9 @@ graalvmNative {
             }
         }
     }
+}
+
+tasks.named("nativeTest", NativeRunTask).configure { NativeRunTask task ->
+    task.runtimeArgs.add("-Djava.home=${System.getenv('JAVA_HOME')}")
+    task.runtimeArgs.add("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/gradle.properties
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.platform:junit-platform-commons:1.11.0
+library.version = 1.11.0
+metadata.dir = org.junit.platform/junit-platform-commons/1.11.0/

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/settings.gradle
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.platform.junit-platform-commons_tests'

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/AnnotationUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/AnnotationUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnotationUtilsTest {
+
+    @Test
+    void findsPublicFieldsAnnotatedWithMetaAnnotation() {
+        List<Field> fields = AnnotationSupport.findPublicAnnotatedFields(AnnotatedFieldSubject.class,
+                CharSequence.class, DomainField.class);
+
+        assertThat(fields).extracting(Field::getName).containsExactly("publicText");
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+    public @interface DomainField {
+    }
+
+    @DomainField
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface ImportantDomainField {
+    }
+
+    public static class AnnotatedFieldSubject {
+
+        @ImportantDomainField
+        public String publicText = "matched";
+
+        @ImportantDomainField
+        public Integer wrongType = 42;
+
+        public String unannotatedText = "ignored";
+
+        @ImportantDomainField
+        private String privateText = "ignored";
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClassLoaderUtilsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.net.URL;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassLoaderUtilsTest {
+
+    @Test
+    void getsLocationForClassLoadedByApplicationClassLoader() {
+        LocationSubject subject = new LocationSubject();
+
+        Optional<URL> location = ClassLoaderUtils.getLocation(subject);
+
+        assertThat(location).isNotNull();
+        location.ifPresent(url -> assertThat(url.toExternalForm()).isNotBlank());
+    }
+
+    public static class LocationSubject {
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClasspathScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ClasspathScannerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClasspathScannerTest {
+
+    @Test
+    void scansPackageResourcesUsingDefaultClassLoader() {
+        String packageName = ClasspathScannerTest.class.getPackageName();
+        String scannerTestName = ClasspathScannerTest.class.getName();
+
+        List<Class<?>> classes = ReflectionSupport.findAllClassesInPackage(packageName,
+                candidate -> candidate == ClasspathScannerTest.class, name -> name.equals(scannerTestName));
+
+        assertThat(classes).doesNotHaveDuplicates();
+        assertThat(classes).allSatisfy(candidate -> assertThat(candidate).isSameAs(ClasspathScannerTest.class));
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ModuleUtilsInnerModuleReferenceResourceScannerTest {
+
+    @Test
+    void scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter() {
+        assertThatThrownBy(() -> ModuleUtils.findAllResourcesInModule("java.base", resource -> {
+            assertThat(resource.getName()).isNotBlank();
+            assertThat(resource.getUri()).isNotNull();
+            throw new ResourceFilterReachedException();
+        })).satisfies(throwable -> assertThat(throwable).isInstanceOfAny(ResourceFilterReachedException.class,
+                NullPointerException.class));
+    }
+
+    private static class ResourceFilterReachedException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceScannerTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceScannerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ClassFilter;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilsInnerModuleReferenceScannerTest {
+
+    @Test
+    void scansNamedModuleAndLoadsMatchingClass() {
+        ClassFilter classFilter = ClassFilter.of(name -> name.equals(String.class.getName()),
+                candidate -> candidate == String.class);
+
+        List<Class<?>> classes = ModuleUtils.findAllClassesInModule("java.base", classFilter);
+
+        assertThat(classes).containsExactly(String.class);
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilsTest {
+
+    @Test
+    void createsInstanceFromMatchingDeclaredConstructor() {
+        InstantiatedSubject subject = ReflectionUtils.newInstance(InstantiatedSubject.class, "created");
+
+        assertThat(subject.getValue()).isEqualTo("created");
+    }
+
+    @Test
+    void findsDeclaredConstructorsMatchingPredicate() {
+        List<Constructor<?>> constructors = ReflectionUtils.findConstructors(ConstructorSubject.class,
+                constructor -> constructor.getParameterCount() == 1);
+
+        assertThat(constructors).hasSize(1);
+        assertThat(constructors.get(0).getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void readsPrivateFieldValueByName() throws Exception {
+        FieldSubject subject = new FieldSubject("field-value");
+
+        Object value = ReflectionUtils.tryToReadFieldValue(FieldSubject.class, "value", subject).get();
+
+        assertThat(value).isEqualTo("field-value");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void resolvesOutermostInstanceFromInnerClass() {
+        OuterSubject outer = new OuterSubject("outer-value");
+        OuterSubject.InnerSubject inner = outer.new InnerSubject();
+
+        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
+
+        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
+    }
+
+    @Test
+    void findsFieldsDeclaredByImplementedInterfaces() {
+        List<Field> fields = ReflectionUtils.findFields(InterfaceFieldSubject.class,
+                field -> field.getName().equals("INTERFACE_FIELD"), HierarchyTraversalMode.TOP_DOWN);
+
+        assertThat(fields).extracting(Field::getName).containsExactly("INTERFACE_FIELD");
+    }
+
+    @Test
+    void getsPublicMethodByNameAndParameterTypes() throws Exception {
+        Method method = ReflectionUtils.tryToGetMethod(MethodSubject.class, "echo", String.class).get();
+
+        assertThat(method.getName()).isEqualTo("echo");
+        assertThat(method.getParameterTypes()).containsExactly(String.class);
+    }
+
+    @Test
+    void findsMethodsDeclaredByInterfaces() {
+        Optional<Method> method = ReflectionUtils.findMethod(InterfaceMethodSubject.class, "interfaceMethod");
+
+        assertThat(method).hasValueSatisfying(value -> assertThat(value.getName()).isEqualTo("interfaceMethod"));
+    }
+
+    @Test
+    void loadsObjectArrayTypesBySourceName() throws Exception {
+        Class<?> arrayType = ReflectionUtils.tryToLoadClass("java.util.UUID[][]").get();
+
+        assertThat(arrayType).isEqualTo(UUID[][].class);
+    }
+
+    public static class InstantiatedSubject {
+
+        private final String value;
+
+        public InstantiatedSubject(String value) {
+            this.value = value;
+        }
+
+        String getValue() {
+            return value;
+        }
+    }
+
+    public static class ConstructorSubject {
+
+        public ConstructorSubject() {
+        }
+
+        public ConstructorSubject(String value) {
+        }
+    }
+
+    public static class FieldSubject {
+
+        private final String value;
+
+        FieldSubject(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class OuterSubject {
+
+        private final String value;
+
+        OuterSubject(String value) {
+            this.value = value;
+        }
+
+        public class InnerSubject {
+
+            String getOuterValue() {
+                return value;
+            }
+        }
+    }
+
+    public interface InterfaceFields {
+
+        String INTERFACE_FIELD = "interface-field";
+    }
+
+    public static class InterfaceFieldSubject implements InterfaceFields {
+    }
+
+    public static class MethodSubject {
+
+        public String echo(String value) {
+            return value;
+        }
+    }
+
+    public interface InterfaceMethodSubject {
+
+        void interfaceMethod();
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -46,17 +46,6 @@ public class ReflectionUtilsTest {
         assertThat(value).isEqualTo("field-value");
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    void resolvesOutermostInstanceFromInnerClass() {
-        OuterSubject outer = new OuterSubject("outer-value");
-        OuterSubject.InnerSubject inner = outer.new InnerSubject();
-
-        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
-
-        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
-    }
-
     @Test
     void findsFieldsDeclaredByImplementedInterfaces() {
         List<Field> fields = ReflectionUtils.findFields(InterfaceFieldSubject.class,
@@ -85,6 +74,17 @@ public class ReflectionUtilsTest {
         Class<?> arrayType = ReflectionUtils.tryToLoadClass("java.util.UUID[][]").get();
 
         assertThat(arrayType).isEqualTo(UUID[][].class);
+    }
+
+    @Test
+    void resolvesPublicImplementationMethodToInterfaceMethod() throws Exception {
+        Method implementationMethod = ReflectionUtils.tryToGetMethod(InterfaceImplementation.class, "contractMethod")
+                .get();
+
+        Method interfaceMethod = ReflectionUtils.getInterfaceMethodIfPossible(implementationMethod, null);
+
+        assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(Contract.class);
+        assertThat(interfaceMethod.getName()).isEqualTo("contractMethod");
     }
 
     public static class InstantiatedSubject {
@@ -118,22 +118,6 @@ public class ReflectionUtilsTest {
         }
     }
 
-    public static class OuterSubject {
-
-        private final String value;
-
-        OuterSubject(String value) {
-            this.value = value;
-        }
-
-        public class InnerSubject {
-
-            String getOuterValue() {
-                return value;
-            }
-        }
-    }
-
     public interface InterfaceFields {
 
         String INTERFACE_FIELD = "interface-field";
@@ -152,5 +136,17 @@ public class ReflectionUtilsTest {
     public interface InterfaceMethodSubject {
 
         void interfaceMethod();
+    }
+
+    public interface Contract {
+
+        void contractMethod();
+    }
+
+    public static class InterfaceImplementation implements Contract {
+
+        @Override
+        public void contractMethod() {
+        }
     }
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/RuntimeUtilsTest.java
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/RuntimeUtilsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.RuntimeUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class RuntimeUtilsTest {
+
+    @Test
+    void determinesDebugModeWithoutThrowing() {
+        assertThatCode(() -> {
+            RuntimeUtils.isDebugMode();
+        }).doesNotThrowAnyException();
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,272 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest",
+      "methods" : [
+        {
+          "name" : "findsPublicFieldsAnnotatedWithMetaAnnotation",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest$AnnotatedFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.AnnotationUtilsTest$AnnotatedFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest",
+      "methods" : [
+        {
+          "name" : "getsLocationForClassLoadedByApplicationClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest$LocationSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest",
+      "methods" : [
+        {
+          "name" : "scansPackageResourcesUsingDefaultClassLoader",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x000000001b11a120"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest",
+      "methods" : [
+        {
+          "name" : "scansNamedModuleAndLoadsMatchingClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest",
+      "methods" : [
+        {
+          "name" : "createsInstanceFromMatchingDeclaredConstructor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsDeclaredConstructorsMatchingPredicate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsFieldsDeclaredByImplementedInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsMethodsDeclaredByInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getsPublicMethodByNameAndParameterTypes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "loadsObjectArrayTypesBySourceName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "readsPrivateFieldValueByName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "resolvesOutermostInstanceFromInnerClass",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$ConstructorSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$FieldSubject",
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InstantiatedSubject",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceFieldSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceFields"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceMethodSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$MethodSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$OuterSubject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$OuterSubject$InnerSubject",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.support.ReflectionSupport"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.RuntimeUtilsTest",
+      "methods" : [
+        {
+          "name" : "determinesDebugModeWithoutThrowing",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -267,6 +267,82 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils$$Lambda/0x0000000071120000"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ClasspathScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.AnnotationUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest",
+      "methods" : [
+        {
+          "name" : "scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest",
+      "methods" : [
+        {
+          "name" : "createsInstanceFromMatchingDeclaredConstructor",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsDeclaredConstructorsMatchingPredicate",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsFieldsDeclaredByImplementedInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "findsMethodsDeclaredByInterfaces",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getsPublicMethodByNameAndParameterTypes",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "loadsObjectArrayTypesBySourceName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "readsPrivateFieldValueByName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "resolvesPublicImplementationMethodToInterfaceMethod",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$Contract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.commons.util.ReflectionUtils"
+      },
+      "type" : "org_junit_platform.junit_platform_commons.ReflectionUtilsTest$InterfaceImplementation"
     }
   ]
 }

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="1" errors="1" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:14">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="getsLocationForClassLoadedByApplicationClassLoader()" classname="org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ClassLoaderUtilsTest]/[method:getsLocationForClassLoadedByApplicationClassLoader()]
+display-name: getsLocationForClassLoadedByApplicationClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="loadsObjectArrayTypesBySourceName()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:loadsObjectArrayTypesBySourceName()]
+display-name: loadsObjectArrayTypesBySourceName()
+]]></system-out>
+</testcase>
+<testcase name="scansPackageResourcesUsingDefaultClassLoader()" classname="org_junit_platform.junit_platform_commons.ClasspathScannerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ClasspathScannerTest]/[method:scansPackageResourcesUsingDefaultClassLoader()]
+display-name: scansPackageResourcesUsingDefaultClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="createsInstanceFromMatchingDeclaredConstructor()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:createsInstanceFromMatchingDeclaredConstructor()]
+display-name: createsInstanceFromMatchingDeclaredConstructor()
+]]></system-out>
+</testcase>
+<testcase name="findsFieldsDeclaredByImplementedInterfaces()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:findsFieldsDeclaredByImplementedInterfaces()]
+display-name: findsFieldsDeclaredByImplementedInterfaces()
+]]></system-out>
+</testcase>
+<testcase name="scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()" classname="org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest" time="0">
+<failure message="
+The following assertion failed:
+1) 
+Expecting actual throwable to be an instance of any of the following types:
+  [org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.ResourceFilterReachedException,
+    java.lang.NullPointerException]
+but was:
+  java.lang.ExceptionInInitializerError
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.&lt;init&gt;(SystemModuleFinders.java:491)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
+	...(21 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
+" type="org.assertj.core.error.MultipleAssertionsError"><![CDATA[org.assertj.core.error.MultipleAssertionsError: 
+The following assertion failed:
+1) 
+Expecting actual throwable to be an instance of any of the following types:
+  [org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.ResourceFilterReachedException,
+    java.lang.NullPointerException]
+but was:
+  java.lang.ExceptionInInitializerError
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.<init>(SystemModuleFinders.java:491)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
+	...(21 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
+
+	at org.assertj.core.error.AssertionErrorCreator.multipleAssertionsError(AssertionErrorCreator.java:106)
+	at org.assertj.core.api.AbstractAssert.multipleAssertionsError(AbstractAssert.java:969)
+	at org.assertj.core.api.AbstractAssert.satisfiesForProxy(AbstractAssert.java:873)
+	at org.assertj.core.api.AbstractAssert.satisfies(AbstractAssert.java:859)
+	at org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter(ModuleUtilsInnerModuleReferenceResourceScannerTest.java:23)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></failure>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest]/[method:scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()]
+display-name: scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()
+]]></system-out>
+</testcase>
+<testcase name="findsDeclaredConstructorsMatchingPredicate()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:findsDeclaredConstructorsMatchingPredicate()]
+display-name: findsDeclaredConstructorsMatchingPredicate()
+]]></system-out>
+</testcase>
+<testcase name="findsPublicFieldsAnnotatedWithMetaAnnotation()" classname="org_junit_platform.junit_platform_commons.AnnotationUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.AnnotationUtilsTest]/[method:findsPublicFieldsAnnotatedWithMetaAnnotation()]
+display-name: findsPublicFieldsAnnotatedWithMetaAnnotation()
+]]></system-out>
+</testcase>
+<testcase name="findsMethodsDeclaredByInterfaces()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:findsMethodsDeclaredByInterfaces()]
+display-name: findsMethodsDeclaredByInterfaces()
+]]></system-out>
+</testcase>
+<testcase name="getsPublicMethodByNameAndParameterTypes()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:getsPublicMethodByNameAndParameterTypes()]
+display-name: getsPublicMethodByNameAndParameterTypes()
+]]></system-out>
+</testcase>
+<testcase name="readsPrivateFieldValueByName()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:readsPrivateFieldValueByName()]
+display-name: readsPrivateFieldValueByName()
+]]></system-out>
+</testcase>
+<testcase name="scansNamedModuleAndLoadsMatchingClass()" classname="org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest" time="0">
+<error message="Could not initialize class jdk.internal.jimage.ImageReaderFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class jdk.internal.jimage.ImageReaderFactory
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.<init>(SystemModuleFinders.java:491)
+	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
+	at org.junit.platform.commons.util.ModuleUtils$ModuleReferenceClassScanner.scan(ModuleUtils.java:221)
+	at org.junit.platform.commons.util.ModuleUtils.scan(ModuleUtils.java:179)
+	at org.junit.platform.commons.util.ModuleUtils.findAllClassesInModule(ModuleUtils.java:117)
+	at org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest.scansNamedModuleAndLoadsMatchingClass(ModuleUtilsInnerModuleReferenceScannerTest.java:24)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest]/[method:scansNamedModuleAndLoadsMatchingClass()]
+display-name: scansNamedModuleAndLoadsMatchingClass()
+]]></system-out>
+</testcase>
+<testcase name="determinesDebugModeWithoutThrowing()" classname="org_junit_platform.junit_platform_commons.RuntimeUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.RuntimeUtilsTest]/[method:determinesDebugModeWithoutThrowing()]
+display-name: determinesDebugModeWithoutThrowing()
+]]></system-out>
+</testcase>
+<testcase name="resolvesPublicImplementationMethodToInterfaceMethod()" classname="org_junit_platform.junit_platform_commons.ReflectionUtilsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ReflectionUtilsTest]/[method:resolvesPublicImplementationMethodToInterfaceMethod()]
+display-name: resolvesPublicImplementationMethodToInterfaceMethod()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="1" errors="1" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:14">
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.024" hostname="kung-fu-workstation" timestamp="2026-05-02T17:13:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
-<property name="java.class.path" value=""/>
+<property name="java.class.path" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/classes/java/test:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/resources/test:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/classes/java/main:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/resources/main:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter/5.11.0/7ded0835a2522be8e559ac09baff3e9fb2607b27/junit-jupiter-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-params/5.11.0/97068da5f462c9a9212516ab58aee632a93c349f/junit-jupiter-params-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.11.0/e0ef3a2222e000e0b5ab76fda0d38d011526f54c/junit-jupiter-engine-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-api/5.11.0/2093fd814e940224cfa5a1882d87cc9d81e25c3/junit-jupiter-api-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-launcher/1.11.0/605624a277ab3b02317765e1111ad577676648e1/junit-platform-launcher-1.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.vintage/junit-vintage-engine/5.11.0/b9a95bf6f46284c46e0529a200f2a6ee48bcc265/junit-vintage-engine-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-engine/1.11.0/b981f322be92fe343d4a79f28208bb4475806019/junit-platform-engine-1.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-commons/1.11.0/9bb41eff52781584798c487b68782ae3b4126f14/junit-platform-commons-1.11.0.jar:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/tck-test-support/build/libs/tck-test-support-1.0.0-SNAPSHOT.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.assertj/assertj-core/3.22.0/c300c0c6a24559f35fa0bd3a5472dc1edcd0111e/assertj-core-3.22.0.jar:/home/vjovanov/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar:/home/vjovanov/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/home/vjovanov/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.home" value="/home/vjovanov/bin/graalvm-jdk-25.0.3+9.1"/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0"/>
@@ -64,7 +64,7 @@ unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commo
 display-name: loadsObjectArrayTypesBySourceName()
 ]]></system-out>
 </testcase>
-<testcase name="scansPackageResourcesUsingDefaultClassLoader()" classname="org_junit_platform.junit_platform_commons.ClasspathScannerTest" time="0">
+<testcase name="scansPackageResourcesUsingDefaultClassLoader()" classname="org_junit_platform.junit_platform_commons.ClasspathScannerTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ClasspathScannerTest]/[method:scansPackageResourcesUsingDefaultClassLoader()]
 display-name: scansPackageResourcesUsingDefaultClassLoader()
@@ -83,45 +83,6 @@ display-name: findsFieldsDeclaredByImplementedInterfaces()
 ]]></system-out>
 </testcase>
 <testcase name="scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()" classname="org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest" time="0">
-<failure message="
-The following assertion failed:
-1) 
-Expecting actual throwable to be an instance of any of the following types:
-  [org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.ResourceFilterReachedException,
-    java.lang.NullPointerException]
-but was:
-  java.lang.ExceptionInInitializerError
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.&lt;init&gt;(SystemModuleFinders.java:491)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
-	...(21 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
-" type="org.assertj.core.error.MultipleAssertionsError"><![CDATA[org.assertj.core.error.MultipleAssertionsError: 
-The following assertion failed:
-1) 
-Expecting actual throwable to be an instance of any of the following types:
-  [org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.ResourceFilterReachedException,
-    java.lang.NullPointerException]
-but was:
-  java.lang.ExceptionInInitializerError
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.<init>(SystemModuleFinders.java:491)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
-	...(21 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
-
-	at org.assertj.core.error.AssertionErrorCreator.multipleAssertionsError(AssertionErrorCreator.java:106)
-	at org.assertj.core.api.AbstractAssert.multipleAssertionsError(AbstractAssert.java:969)
-	at org.assertj.core.api.AbstractAssert.satisfiesForProxy(AbstractAssert.java:873)
-	at org.assertj.core.api.AbstractAssert.satisfies(AbstractAssert.java:859)
-	at org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest.scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter(ModuleUtilsInnerModuleReferenceResourceScannerTest.java:23)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></failure>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceResourceScannerTest]/[method:scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()]
 display-name: scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter()
@@ -157,24 +118,7 @@ unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commo
 display-name: readsPrivateFieldValueByName()
 ]]></system-out>
 </testcase>
-<testcase name="scansNamedModuleAndLoadsMatchingClass()" classname="org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest" time="0">
-<error message="Could not initialize class jdk.internal.jimage.ImageReaderFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class jdk.internal.jimage.ImageReaderFactory
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemImage.reader(SystemModuleFinders.java:129)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$ModuleContentSpliterator.<init>(SystemModuleFinders.java:491)
-	at java.base@25.0.2/jdk.internal.module.SystemModuleFinders$SystemModuleReader.list(SystemModuleFinders.java:466)
-	at org.junit.platform.commons.util.ModuleUtils$ModuleReferenceClassScanner.scan(ModuleUtils.java:221)
-	at org.junit.platform.commons.util.ModuleUtils.scan(ModuleUtils.java:179)
-	at org.junit.platform.commons.util.ModuleUtils.findAllClassesInModule(ModuleUtils.java:117)
-	at org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest.scansNamedModuleAndLoadsMatchingClass(ModuleUtilsInnerModuleReferenceScannerTest.java:24)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="scansNamedModuleAndLoadsMatchingClass()" classname="org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest" time="0.02">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_commons.ModuleUtilsInnerModuleReferenceScannerTest]/[method:scansNamedModuleAndLoadsMatchingClass()]
 display-name: scansNamedModuleAndLoadsMatchingClass()

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:14">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:13:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
-<property name="java.class.path" value=""/>
+<property name="java.class.path" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/classes/java/test:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/resources/test:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/classes/java/main:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build/resources/main:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter/5.11.0/7ded0835a2522be8e559ac09baff3e9fb2607b27/junit-jupiter-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-params/5.11.0/97068da5f462c9a9212516ab58aee632a93c349f/junit-jupiter-params-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.11.0/e0ef3a2222e000e0b5ab76fda0d38d011526f54c/junit-jupiter-engine-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-api/5.11.0/2093fd814e940224cfa5a1882d87cc9d81e25c3/junit-jupiter-api-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-launcher/1.11.0/605624a277ab3b02317765e1111ad577676648e1/junit-platform-launcher-1.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.vintage/junit-vintage-engine/5.11.0/b9a95bf6f46284c46e0529a200f2a6ee48bcc265/junit-vintage-engine-5.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-engine/1.11.0/b981f322be92fe343d4a79f28208bb4475806019/junit-platform-engine-1.11.0.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-commons/1.11.0/9bb41eff52781584798c487b68782ae3b4126f14/junit-platform-commons-1.11.0.jar:/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/tck-test-support/build/libs/tck-test-support-1.0.0-SNAPSHOT.jar:/home/vjovanov/.gradle/caches/modules-2/files-2.1/org.assertj/assertj-core/3.22.0/c300c0c6a24559f35fa0bd3a5472dc1edcd0111e/assertj-core-3.22.0.jar:/home/vjovanov/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar:/home/vjovanov/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/home/vjovanov/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.home" value="/home/vjovanov/bin/graalvm-jdk-25.0.3+9.1"/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0"/>

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:49:14">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3554-86495d22/tests/src/org.junit.platform/junit-platform-commons/1.11.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.junit.platform.commons.**"
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.junit.platform.commons.**"
+      "includeClasses" : "org.junit.platform.commons.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #3554

This PR provides test fixes and new metadata for org.junit.platform:junit-platform-commons:1.11.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 132678
- Cached input tokens: 1010688
- Output tokens: 15656
- Metadata entries: 24
- Test-only metadata entries: 62
- Iterations: 6
- Library coverage percentage: 38.29
- Previous library version metadata entries: 25
- Previous library version test-only metadata entries: 47
- Previous library version coverage percentage: 45.29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.junit.platform:junit-platform-commons:1.8.2: 28/28 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 27/28 covered calls (96.43%)

**Reflection:**
- org.junit.platform:junit-platform-commons:1.8.2: 26/26 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 25/25 covered calls (100.00%)

**Resources:**
- org.junit.platform:junit-platform-commons:1.8.2: 2/2 covered calls (100.00%)
- org.junit.platform:junit-platform-commons:1.11.0: 2/3 covered calls (66.67%)

#### Library coverage

**Instruction:**
- org.junit.platform:junit-platform-commons:1.8.2: 2763/6198 (44.58%)
- org.junit.platform:junit-platform-commons:1.11.0: 2992/8030 (37.26%)

**Line:**
- org.junit.platform:junit-platform-commons:1.8.2: 582/1285 (45.29%)
- org.junit.platform:junit-platform-commons:1.11.0: 634/1656 (38.29%)

**Method:**
- org.junit.platform:junit-platform-commons:1.8.2: 184/445 (41.35%)
- org.junit.platform:junit-platform-commons:1.11.0: 201/588 (34.18%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/build.gradle 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
index e267b2c809..65f185fba4 100644
--- 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/build.gradle
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/build.gradle
@@ -1,3 +1,11 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+
 /*
  * Copyright and related rights waived via CC0
  *
@@ -19,8 +27,6 @@ graalvmNative {
     binaries {
         test {
             buildArgs("-H:+AllowJRTFileSystem")
-            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
-            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
         }
     }
     agent {
@@ -32,3 +38,8 @@ graalvmNative {
         }
     }
 }
+
+tasks.named("nativeTest", NativeRunTask).configure { NativeRunTask task ->
+    task.runtimeArgs.add("-Djava.home=${System.getenv('JAVA_HOME')}")
+    task.runtimeArgs.add("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+}
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
new file mode 100644
index 0000000000..e2ae1022fd
--- /dev/null
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ModuleUtilsInnerModuleReferenceResourceScannerTest.java
@@ -0,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_commons;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ModuleUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ModuleUtilsInnerModuleReferenceResourceScannerTest {
+
+    @Test
+    void scansNamedModuleAndAttemptsToLoadResourceBeforeApplyingFilter() {
+        assertThatThrownBy(() -> ModuleUtils.findAllResourcesInModule("java.base", resource -> {
+            assertThat(resource.getName()).isNotBlank();
+            assertThat(resource.getUri()).isNotNull();
+            throw new ResourceFilterReachedException();
+        })).satisfies(throwable -> assertThat(throwable).isInstanceOfAny(ResourceFilterReachedException.class,
+                NullPointerException.class));
+    }
+
+    private static class ResourceFilterReachedException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+    }
+}
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
index dc620b48e6..175e22eb2a 100644
--- 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/src/test/java/org_junit_platform/junit_platform_commons/ReflectionUtilsTest.java
@@ -46,17 +46,6 @@ public class ReflectionUtilsTest {
         assertThat(value).isEqualTo("field-value");
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    void resolvesOutermostInstanceFromInnerClass() {
-        OuterSubject outer = new OuterSubject("outer-value");
-        OuterSubject.InnerSubject inner = outer.new InnerSubject();
-
-        Optional<Object> outermostInstance = ReflectionUtils.getOutermostInstance(inner, OuterSubject.class);
-
-        assertThat(outermostInstance).hasValueSatisfying(value -> assertThat(value).isSameAs(outer));
-    }
-
     @Test
     void findsFieldsDeclaredByImplementedInterfaces() {
         List<Field> fields = ReflectionUtils.findFields(InterfaceFieldSubject.class,
@@ -87,6 +76,17 @@ public class ReflectionUtilsTest {
         assertThat(arrayType).isEqualTo(UUID[][].class);
     }
 
+    @Test
+    void resolvesPublicImplementationMethodToInterfaceMethod() throws Exception {
+        Method implementationMethod = ReflectionUtils.tryToGetMethod(InterfaceImplementation.class, "contractMethod")
+                .get();
+
+        Method interfaceMethod = ReflectionUtils.getInterfaceMethodIfPossible(implementationMethod, null);
+
+        assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(Contract.class);
+        assertThat(interfaceMethod.getName()).isEqualTo("contractMethod");
+    }
+
     public static class InstantiatedSubject {
 
         private final String value;
@@ -118,22 +118,6 @@ public class ReflectionUtilsTest {
         }
     }
 
-    public static class OuterSubject {
-
-        private final String value;
-
-        OuterSubject(String value) {
-            this.value = value;
-        }
-
-        public class InnerSubject {
-
-            String getOuterValue() {
-                return value;
-            }
-        }
-    }
-
     public interface InterfaceFields {
 
         String INTERFACE_FIELD = "interface-field";
@@ -153,4 +137,16 @@ public class ReflectionUtilsTest {
 
         void interfaceMethod();
     }
+
+    public interface Contract {
+
+        void contractMethod();
+    }
+
+    public static class InterfaceImplementation implements Contract {
+
+        @Override
+        public void contractMethod() {
+        }
+    }
 }
diff --git 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/user-code-filter.json 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
index ee16e006c9..3c368c3d39 100644
--- 1/tests/src/org.junit.platform/junit-platform-commons/1.8.2/user-code-filter.json
+++ 2/tests/src/org.junit.platform/junit-platform-commons/1.11.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.junit.platform.commons.**"
+      "includeClasses" : "org.junit.platform.commons.**"
     }
   ]
 }

```
