### PR TITLE
[Automation] Generated metadata for io.netty:netty-handler-proxy:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-handler-proxy/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-handler-proxy/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,290 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ClientDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v4.Socks4ClientEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5ClientEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5InitialResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "io.netty.handler.codec.socksx.v5.Socks5PasswordAuthResponseDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.HttpProxyHandler"
+      },
+      "type": "io.netty.handler.proxy.HttpProxyHandler$HttpClientCodecWrapper"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.Recycler$DefaultHandle"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.ReferenceCountUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.ResourceLeakDetector$DefaultResourceLeak"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.HttpProxyHandler"
+      },
+      "type": "sun.misc.Unsafe",
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks5ProxyHandler"
+      },
+      "type": "sun.misc.VM"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/uprops.icu"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.Socks4ProxyHandler"
+      },
+      "module": "java.base",
+      "glob": "sun/net/idn/uidna.spp"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.proxy.ProxyHandler"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-handler-proxy/index.json
+++ b/metadata/io.netty/netty-handler-proxy/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.79.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/$version$/netty-handler-proxy-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/$version$/netty-handler-proxy-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/$version$/netty-handler-proxy-$version$-javadoc.jar",
+    "description" : "Netty Handler Proxy adds client-side support for connecting through proxy protocols such as SOCKS and HTTP CONNECT tunneling. It provides proxy channel handlers and connection events that integrate with Netty's asynchronous networking pipeline.",
+    "test-version" : "4.1.60.Final",
+    "tested-versions" : [
+      "4.1.79.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.proxy"
+    ]
+  },
+  {
     "metadata-version" : "4.1.60.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.60.Final/netty-handler-proxy-4.1.60.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/stats/io.netty/netty-handler-proxy/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-handler-proxy/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1255,
+        "missed" : 303,
+        "ratio" : 0.80552,
+        "total" : 1558
+      },
+      "line" : {
+        "covered" : 328,
+        "missed" : 82,
+        "ratio" : 0.8,
+        "total" : 410
+      },
+      "method" : {
+        "covered" : 90,
+        "missed" : 17,
+        "ratio" : 0.841121,
+        "total" : 107
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4310

This PR provides new metadata needed for the io.netty:netty-handler-proxy:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-handler-proxy:4.1.60.Final`): 55
- Metadata entries (new `io.netty:netty-handler-proxy:4.1.79.Final`): 56
- Library coverage (previous): 80.00%
- Library coverage (new): 80.00%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cd0e87255caed5c5f860fab8d9125f58f6d9018d`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-handler-proxy:4.1.60.Final: 0/0 covered calls (100.00%)
- io.netty:netty-handler-proxy:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-handler-proxy:4.1.60.Final: 1255/1558 (80.55%)
- io.netty:netty-handler-proxy:4.1.79.Final: 1255/1558 (80.55%)

**Line:**
- io.netty:netty-handler-proxy:4.1.60.Final: 328/410 (80.00%)
- io.netty:netty-handler-proxy:4.1.79.Final: 328/410 (80.00%)

**Method:**
- io.netty:netty-handler-proxy:4.1.60.Final: 90/107 (84.11%)
- io.netty:netty-handler-proxy:4.1.79.Final: 90/107 (84.11%)
