### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-mqtt:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-mqtt/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-mqtt/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,63 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "methods": [
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.ByteBuf"
+          ]
+        },
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.CompositeByteBuf"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttCodecUtil"
+      },
+      "type": "io.netty.util.DefaultAttributeMap$DefaultAttribute"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.mqtt.MqttEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-mqtt/index.json
+++ b/metadata/io.netty/netty-codec-mqtt/index.json
@@ -1,16 +1,32 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-tests.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-javadoc.jar",
-    "description" : "Netty Codec MQTT provides MQTT protocol encoder, decoder, and message model classes for Netty pipelines. It lets Java applications implement MQTT clients or servers on top of Netty by translating MQTT wire frames to and from Netty message objects.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.1.79.Final",
+    "test-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/$version$/netty-codec-mqtt-$version$-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/$version$/netty-codec-mqtt-$version$-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/$version$/netty-codec-mqtt-$version$-javadoc.jar",
+    "description": "Netty Codec MQTT provides MQTT protocol encoder, decoder, and message model classes for Netty pipelines. It lets Java applications implement MQTT clients or servers on top of Netty by translating MQTT wire frames to and from Netty message objects.",
+    "tested-versions": [
+      "4.1.79.Final"
+    ],
+    "allowed-packages": [
+      "io.netty.handler.codec.mqtt",
+      "io.netty.buffer"
+    ]
+  },
+  {
+    "metadata-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-mqtt/4.1.74.Final/netty-codec-mqtt-4.1.74.Final-javadoc.jar",
+    "description": "Netty Codec MQTT provides MQTT protocol encoder, decoder, and message model classes for Netty pipelines. It lets Java applications implement MQTT clients or servers on top of Netty by translating MQTT wire frames to and from Netty message objects.",
+    "tested-versions": [
       "4.1.74.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.netty.handler.codec.mqtt"
     ]
   }

--- a/stats/io.netty/netty-codec-mqtt/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-codec-mqtt/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5741,
+        "missed" : 2398,
+        "ratio" : 0.705369,
+        "total" : 8139
+      },
+      "line" : {
+        "covered" : 1302,
+        "missed" : 488,
+        "ratio" : 0.727374,
+        "total" : 1790
+      },
+      "method" : {
+        "covered" : 301,
+        "missed" : 83,
+        "ratio" : 0.783854,
+        "total" : 384
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4307

This PR provides new metadata needed for the io.netty:netty-codec-mqtt:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-mqtt:4.1.74.Final`): 7
- Metadata entries (new `io.netty:netty-codec-mqtt:4.1.79.Final`): 10
- Library coverage (previous): 72.74%
- Library coverage (new): 72.74%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-mqtt:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 5741/8139 (70.54%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 5741/8139 (70.54%)

**Line:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 1302/1790 (72.74%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 1302/1790 (72.74%)

**Method:**
- io.netty:netty-codec-mqtt:4.1.74.Final: 301/384 (78.39%)
- io.netty:netty-codec-mqtt:4.1.79.Final: 301/384 (78.39%)
