### PR TITLE
[Automation] Generated metadata for com.google.protobuf:protobuf-java:2.6.0

### DIFF
--- a/metadata/com.google.protobuf/protobuf-java/2.6.0/reachability-metadata.json
+++ b/metadata/com.google.protobuf/protobuf-java/2.6.0/reachability-metadata.json
@@ -1,0 +1,158 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$DescriptorProto",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessage$FieldAccessorTable$RepeatedMessageFieldAccessor"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$DescriptorProto$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$DescriptorProto$ExtensionRange"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessage$FieldAccessorTable$RepeatedMessageFieldAccessor"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$EnumDescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessage$FieldAccessorTable$RepeatedMessageFieldAccessor"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldDescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileDescriptorProto",
+      "allDeclaredFields": true,
+      "allPublicMethods": true,
+      "methods": [
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileDescriptorProto",
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileDescriptorProto$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$DescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$OneofDescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceDescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$SourceCodeInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+      },
+      "type": "java.lang.String",
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.GeneratedMessage"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "com.google.protobuf.GeneratedMessageLite$SerializedForm"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.DescriptorProtos$FileDescriptorProto"
+      },
+      "type": "java.lang.String"
+    }
+  ]
+}

--- a/metadata/com.google.protobuf/protobuf-java/index.json
+++ b/metadata/com.google.protobuf/protobuf-java/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.6.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/$version$/protobuf-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/protocolbuffers/protobuf",
+    "test-code-url" : "https://github.com/protocolbuffers/protobuf/tree/v$version$/java/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/$version$/protobuf-java-$version$-javadoc.jar",
+    "description" : "Protocol Buffers are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data. The protobuf-java artifact provides the Java runtime API used by generated Java message classes to parse, serialize, and work with Protocol Buffer messages.",
+    "test-version" : "2.5.0",
+    "tested-versions" : [
+      "2.6.0"
+    ],
+    "allowed-packages" : [
+      "com.google.protobuf"
+    ]
+  },
+  {
     "metadata-version" : "2.5.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/$version$/protobuf-java-$version$-sources.jar",
     "repository-url" : "https://github.com/protocolbuffers/protobuf",

--- a/stats/com.google.protobuf/protobuf-java/2.6.0/stats.json
+++ b/stats/com.google.protobuf/protobuf-java/2.6.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.6.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.384615,
+          "coveredCalls" : 5,
+          "totalCalls" : 13
+        }
+      },
+      "coverageRatio" : 0.384615,
+      "coveredCalls" : 5,
+      "totalCalls" : 13
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8692,
+        "missed" : 57849,
+        "ratio" : 0.130626,
+        "total" : 66541
+      },
+      "line" : {
+        "covered" : 1849,
+        "missed" : 13413,
+        "ratio" : 0.121151,
+        "total" : 15262
+      },
+      "method" : {
+        "covered" : 441,
+        "missed" : 3274,
+        "ratio" : 0.118708,
+        "total" : 3715
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4304

This PR provides new metadata needed for the com.google.protobuf:protobuf-java:2.6.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `com.google.protobuf:protobuf-java:2.5.0`): 24
- Metadata entries (new `com.google.protobuf:protobuf-java:2.6.0`): 25
- Library coverage (previous): 12.83%
- Library coverage (new): 12.12%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.google.protobuf:protobuf-java:2.5.0: 5/5 covered calls (100.00%)
- com.google.protobuf:protobuf-java:2.6.0: 5/13 covered calls (38.46%)

**Reflection:**
- com.google.protobuf:protobuf-java:2.5.0: 5/5 covered calls (100.00%)
- com.google.protobuf:protobuf-java:2.6.0: 5/13 covered calls (38.46%)

#### Library coverage

**Instruction:**
- com.google.protobuf:protobuf-java:2.5.0: 8202/58393 (14.05%)
- com.google.protobuf:protobuf-java:2.6.0: 8692/66541 (13.06%)

**Line:**
- com.google.protobuf:protobuf-java:2.5.0: 1751/13644 (12.83%)
- com.google.protobuf:protobuf-java:2.6.0: 1849/15262 (12.12%)

**Method:**
- com.google.protobuf:protobuf-java:2.5.0: 428/3317 (12.90%)
- com.google.protobuf:protobuf-java:2.6.0: 441/3715 (11.87%)
