### PR TITLE
[Automation] Generated metadata for io.jsonwebtoken:jjwt-impl:0.12.7

### DIFF
--- a/metadata/io.jsonwebtoken/jjwt-impl/0.12.7/reachability-metadata.json
+++ b/metadata/io.jsonwebtoken/jjwt-impl/0.12.7/reachability-metadata.json
@@ -1,0 +1,935 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.AbstractSecureDigestAlgorithm"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.AbstractSecureDigestAlgorithm"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "type": "com.sun.crypto.provider.KeyGeneratorCore$HmacKG$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultClaimsBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtHeaderBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts"
+      },
+      "type": "io.jsonwebtoken.impl.DefaultJwtParserBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ZIP"
+      },
+      "type": "io.jsonwebtoken.impl.io.StandardCompressionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.io.StandardCompressionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultDynamicJwkBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.KeyOperationConverter"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultJwkParserBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultJwkSetBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultJwkSetParserBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Keys"
+      },
+      "type": "io.jsonwebtoken.impl.security.KeysBridge",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": [
+            "javax.crypto.SecretKey"
+          ]
+        },
+        {
+          "name": "builder",
+          "parameterTypes": [
+            "java.security.PrivateKey"
+          ]
+        },
+        {
+          "name": "password",
+          "parameterTypes": [
+            "char[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks"
+      },
+      "type": "io.jsonwebtoken.impl.security.JwksBridge",
+      "methods": [
+        {
+          "name": "UNSAFE_JSON",
+          "parameterTypes": [
+            "io.jsonwebtoken.security.Jwk"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.KeyOperationConverter"
+      },
+      "type": "io.jsonwebtoken.impl.security.DefaultKeyOperationPolicyBuilder$Supplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$ENC"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardEncryptionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardEncryptionAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$KEY"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParserBuilder"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$OP"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyOperations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.Jwts$SIG"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardSecureDigestAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$CRV"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardCurves",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.security.Jwks$HASH"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardHashAlgorithms",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.KeyOperationConverter"
+      },
+      "type": "io.jsonwebtoken.impl.security.StandardKeyOperations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.io.Streams"
+      },
+      "type": "java.io.ByteArrayInputStream",
+      "fields": [
+        {
+          "name": "buf"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.ECPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.EdECKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.interfaces.XECKey"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "java.security.spec.NamedParameterSpec"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.Randoms"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.Randoms"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.DefaultMacAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$MessageDigestFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.lang.OptionalMethodInvoker"
+      },
+      "type": "sun.security.util.KeyUtil",
+      "methods": [
+        {
+          "name": "getKeySize",
+          "parameterTypes": [
+            "java.security.Key"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.KeysBridge"
+      },
+      "type": "sun.security.util.KeyUtil",
+      "methods": [
+        {
+          "name": "getKeySize",
+          "parameterTypes": [
+            "java.security.Key"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.AbstractSecureDigestAlgorithm"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.DefaultJwtParser"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.AbstractSecureDigestAlgorithm"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.EcSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$SignatureFactory"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "sun.security.rsa.RSAKeyPairGenerator$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate"
+      },
+      "type": "sun.security.rsa.RSAKeyPairGenerator$PSS",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA384withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$1"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.RsaSignatureAlgorithm$2"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA512withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.security.JcaTemplate$KeyGeneratorFactory"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.CompressionCodecLocator"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "io.jsonwebtoken.impl.CompressionCodecLocator"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/io.jsonwebtoken/jjwt-impl/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-impl/index.json
@@ -1,6 +1,23 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.12.7",
+    "test-version" : "0.12.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/$version$/jjwt-impl-$version$-sources.jar",
+    "repository-url" : "https://github.com/jwtk/jjwt",
+    "test-code-url" : "https://github.com/jwtk/jjwt/tree/$version$/impl/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/$version$/jjwt-impl-$version$-javadoc.jar",
+    "description" : "JJWT is a Java library for creating, parsing, and validating JSON Web Tokens on the JVM and Android. The jjwt-impl artifact provides the internal runtime implementation behind the public jjwt-api interfaces, including builders, parsers, signature algorithms, and compression support.",
+    "tested-versions" : [
+      "0.12.7"
+    ],
+    "allowed-packages" : [
+      "io.jsonwebtoken.impl",
+      "io.jsonwebtoken",
+      "io.jsonwebtoken.security"
+    ]
+  },
+  {
     "metadata-version" : "0.12.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-impl/$version$/jjwt-impl-$version$-sources.jar",
     "repository-url" : "https://github.com/jwtk/jjwt",

--- a/stats/io.jsonwebtoken/jjwt-impl/0.12.7/stats.json
+++ b/stats/io.jsonwebtoken/jjwt-impl/0.12.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "0.12.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.5,
+          "coveredCalls" : 1,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 0.5,
+      "coveredCalls" : 1,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11000,
+        "missed" : 20283,
+        "ratio" : 0.351629,
+        "total" : 31283
+      },
+      "line" : {
+        "covered" : 1978,
+        "missed" : 3798,
+        "ratio" : 0.342452,
+        "total" : 5776
+      },
+      "method" : {
+        "covered" : 656,
+        "missed" : 1055,
+        "ratio" : 0.383402,
+        "total" : 1711
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4171

This PR provides new metadata needed for the io.jsonwebtoken:jjwt-impl:0.12.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.jsonwebtoken:jjwt-impl:0.12.0`): 130
- Metadata entries (new `io.jsonwebtoken:jjwt-impl:0.12.7`): 153
- Library coverage (previous): 34.24%
- Library coverage (new): 34.25%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.jsonwebtoken:jjwt-impl:0.12.0: 2/2 covered calls (100.00%)
- io.jsonwebtoken:jjwt-impl:0.12.7: 1/2 covered calls (50.00%)

**Reflection:**
- io.jsonwebtoken:jjwt-impl:0.12.0: 2/2 covered calls (100.00%)
- io.jsonwebtoken:jjwt-impl:0.12.7: 1/2 covered calls (50.00%)

#### Library coverage

**Instruction:**
- io.jsonwebtoken:jjwt-impl:0.12.0: 10927/30841 (35.43%)
- io.jsonwebtoken:jjwt-impl:0.12.7: 11000/31283 (35.16%)

**Line:**
- io.jsonwebtoken:jjwt-impl:0.12.0: 1937/5657 (34.24%)
- io.jsonwebtoken:jjwt-impl:0.12.7: 1978/5776 (34.25%)

**Method:**
- io.jsonwebtoken:jjwt-impl:0.12.0: 642/1665 (38.56%)
- io.jsonwebtoken:jjwt-impl:0.12.7: 656/1711 (38.34%)
