### PR TITLE
[Automation] Generated metadata for org.eclipse.jetty:jetty-http:10.0.0

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-http/10.0.0/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-http/10.0.0/reachability-metadata.json
@@ -1,0 +1,116 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Byte"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Double"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Float"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Long"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "java.lang.Short"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "type": "org.eclipse.jetty.util.TypeUtil",
+      "methods": [
+        {
+          "name": "getClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getCodeSourceLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getModuleLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getSystemClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.PreEncodedHttpField"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/encoding.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/eclipse/jetty/http/mime.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http.MimeTypes"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "10.0.0",
+    "test-version" : "9.4.1.v20170120",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/$version$/jetty-http-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-$version$/jetty-http/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/$version$/jetty-http-$version$-javadoc.jar",
+    "description" : "Jetty HTTP provides core HTTP utilities for Eclipse Jetty, including request and response metadata, headers, cookies, MIME types, and URI handling. It is used by Jetty server and client components to parse, represent, and generate HTTP protocol data.",
+    "tested-versions" : [
+      "10.0.0"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.http"
+    ]
+  },
+  {
     "metadata-version" : "9.4.1.v20170120",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/$version$/jetty-http-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse/jetty.project",

--- a/stats/org.eclipse.jetty/jetty-http/10.0.0/stats.json
+++ b/stats/org.eclipse.jetty/jetty-http/10.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "10.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2114,
+        "missed" : 22346,
+        "ratio" : 0.086427,
+        "total" : 24460
+      },
+      "line" : {
+        "covered" : 369,
+        "missed" : 4920,
+        "ratio" : 0.069767,
+        "total" : 5289
+      },
+      "method" : {
+        "covered" : 41,
+        "missed" : 805,
+        "ratio" : 0.048463,
+        "total" : 846
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4111

This PR provides new metadata needed for the org.eclipse.jetty:jetty-http:10.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.eclipse.jetty:jetty-http:9.4.1.v20170120`): 22
- Metadata entries (new `org.eclipse.jetty:jetty-http:10.0.0`): 18
- Library coverage (previous): 8.21%
- Library coverage (new): 6.98%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:10.0.0: 0/0 covered calls (100.00%)

**Resources:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2/2 covered calls (100.00%)
- org.eclipse.jetty:jetty-http:10.0.0: N/A

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 2123/20876 (10.17%)
- org.eclipse.jetty:jetty-http:10.0.0: 2114/24460 (8.64%)

**Line:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 343/4178 (8.21%)
- org.eclipse.jetty:jetty-http:10.0.0: 369/5289 (6.98%)

**Method:**
- org.eclipse.jetty:jetty-http:9.4.1.v20170120: 39/598 (6.52%)
- org.eclipse.jetty:jetty-http:10.0.0: 41/846 (4.85%)
