### PR TITLE
[GenAI] Add support for tools.jackson.core:jackson-databind:3.0.0-rc2 using gpt-5.5

### DIFF
--- a/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
+++ b/metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json
@@ -1,0 +1,190 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.AnnotatedConstructor"
+      },
+      "type" : "char[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ObjectMapper"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.io.Serializable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.lang.Comparable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.lang.Iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.lang.Iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.math.BigDecimal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.AbstractCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.AbstractCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.AbstractMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.Collection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.Collection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableCollection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.ImmutableCollections$AbstractImmutableMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.ImmutableCollections$List12"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.ImmutableCollections$List12"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.ImmutableCollections$MapN"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.Map"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.SerializationContext"
+      },
+      "type" : "java.util.RandomAccess"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.SerializationContextExt"
+      },
+      "type" : "java.util.RandomAccess"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.cfg.DeserializerFactoryConfig"
+      },
+      "type" : "tools.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.cfg.SerializerFactoryConfig"
+      },
+      "type" : "tools.jackson.databind.ser.Serializers[]"
+    }
+  ]
+}

--- a/metadata/tools.jackson.core/jackson-databind/index.json
+++ b/metadata/tools.jackson.core/jackson-databind/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0.0-rc2",
+    "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/$version$/jackson-databind-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-databind",
+    "test-code-url" : "https://github.com/FasterXML/jackson-databind/tree/jackson-databind-$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/$version$/jackson-databind-$version$-javadoc.jar",
+    "description" : "Jackson Databind provides general-purpose data binding for Jackson, converting between Java objects and JSON or other content handled by Jackson's streaming core. It includes object mapping, serialization, deserialization, annotation handling, and type introspection support for JVM applications.",
+    "tested-versions" : [
+      "3.0.0-rc2"
+    ],
+    "allowed-packages" : [
+      "tools.jackson.databind"
+    ]
+  }
+]

--- a/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/execution-metrics.json
+++ b/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/execution-metrics.json
@@ -1,0 +1,63 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T15:49:42.098106Z",
+    "library": "tools.jackson.core:jackson-databind:3.0.0-rc2",
+    "starting_commit": "2db27e1e94704150dcd8bf27f20015547090b884",
+    "ending_commit": "655a11507c002cdfa36ede11beaed722248be0de",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0-rc2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.078125,
+            "coveredCalls": 5,
+            "totalCalls": 64
+          }
+        },
+        "coverageRatio": 0.078125,
+        "coveredCalls": 5,
+        "totalCalls": 64
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 25604,
+          "missed": 119861,
+          "ratio": 0.176015,
+          "total": 145465
+        },
+        "line": {
+          "covered": 6443,
+          "missed": 28023,
+          "ratio": 0.186938,
+          "total": 34466
+        },
+        "method": {
+          "covered": 1673,
+          "missed": 6270,
+          "ratio": 0.210626,
+          "total": 7943
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 194441,
+      "cached_input_tokens_used": 1676288,
+      "output_tokens_used": 20599,
+      "iterations": 5,
+      "cost_usd": 1.4561,
+      "generated_loc": 269,
+      "tested_library_loc": 6443,
+      "metadata_entries": 31,
+      "test_only_metadata_entries": 2,
+      "code_coverage_percent": 18.69
+    },
+    "artifacts": {
+      "test_file": "tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java",
+      "metadata_file": "metadata/tools.jackson.core/jackson-databind/3.0.0-rc2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
+++ b/stats/tools.jackson.core/jackson-databind/3.0.0-rc2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0-rc2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.078125,
+          "coveredCalls" : 5,
+          "totalCalls" : 64
+        }
+      },
+      "coverageRatio" : 0.078125,
+      "coveredCalls" : 5,
+      "totalCalls" : 64
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 25604,
+        "missed" : 119861,
+        "ratio" : 0.176015,
+        "total" : 145465
+      },
+      "line" : {
+        "covered" : 6443,
+        "missed" : 28023,
+        "ratio" : 0.186938,
+        "total" : 34466
+      },
+      "method" : {
+        "covered" : 1673,
+        "missed" : 6270,
+        "ratio" : 0.210626,
+        "total" : 7943
+      }
+    }
+  } ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/build.gradle
@@ -11,7 +11,10 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "tools.jackson.core:jackson-databind:$libraryVersion"
+    testImplementation("tools.jackson.core:jackson-databind:$libraryVersion") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+    }
+    testImplementation 'com.fasterxml.jackson.core:jackson-annotations:3.0-rc2@jar'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = tools.jackson.core:jackson-databind:3.0.0-rc2
+library.version = 3.0.0-rc2
+metadata.dir = tools.jackson.core/jackson-databind/3.0.0-rc2/

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'tools.jackson.core.jackson-databind_tests'

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tools_jackson_core.jackson_databind;
+
+import org.junit.jupiter.api.Test;
+
+class Jackson_databindTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -29,6 +29,7 @@ import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.databind.util.TokenBuffer;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
@@ -132,6 +133,42 @@ public class Jackson_databindTest {
 
         assertThat(json).isEqualTo("[3,1,4]");
         assertThat(values).containsExactly(3, 1, 4);
+    }
+
+    @Test
+    void buffersAndReplaysTokenStreams() throws JacksonException {
+        TokenBuffer tokenBuffer = TokenBuffer.forGeneration();
+        tokenBuffer.writeStartObject();
+        tokenBuffer.writeName("batch");
+        tokenBuffer.writeStartArray();
+        tokenBuffer.writeStartObject();
+        tokenBuffer.writeName("id");
+        tokenBuffer.writeNumber(1);
+        tokenBuffer.writeName("status");
+        tokenBuffer.writeString("queued");
+        tokenBuffer.writeEndObject();
+        tokenBuffer.writeStartObject();
+        tokenBuffer.writeName("id");
+        tokenBuffer.writeNumber(2);
+        tokenBuffer.writeName("status");
+        tokenBuffer.writeString("done");
+        tokenBuffer.writeEndObject();
+        tokenBuffer.writeEndArray();
+        tokenBuffer.writeEndObject();
+
+        JsonNode bufferedTree;
+        try (JsonParser parser = tokenBuffer.asParser()) {
+            bufferedTree = MAPPER.readTree(parser);
+        }
+
+        StringWriter output = new StringWriter();
+        try (JsonGenerator generator = MAPPER.createGenerator(output)) {
+            tokenBuffer.serialize(generator);
+        }
+
+        assertThat(bufferedTree.at("/batch/0/status").asString()).isEqualTo("queued");
+        assertThat(bufferedTree.at("/batch/1/id").asInt()).isEqualTo(2);
+        assertThat(MAPPER.readTree(output.toString())).isEqualTo(bufferedTree);
     }
 
     @Test

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -7,10 +7,258 @@
 package tools_jackson_core.jackson_databind;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.SequenceWriter;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ser.std.StdSerializer;
 
-class Jackson_databindTest {
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jackson_databindTest {
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void roundTripsNestedMapsWithTypedReaderWriter() throws JacksonException {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("name", "espresso");
+        payload.put("shots", 2);
+        payload.put("available", true);
+        payload.put("tags", List.of("hot", "small"));
+        payload.put("details", Map.of("origin", "Colombia", "ratio", BigDecimal.valueOf(18.5)));
+
+        ObjectWriter writer = MAPPER.writerFor(new TypeReference<Map<String, Object>>() { });
+        String json = writer.writeValueAsString(payload);
+
+        ObjectReader reader = MAPPER.readerFor(new TypeReference<Map<String, Object>>() { })
+                .with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        Map<String, Object> result = reader.readValue(json);
+
+        assertThat(result).containsEntry("name", "espresso");
+        assertThat(result).containsEntry("shots", 2);
+        assertThat(result).containsEntry("available", true);
+        assertThat(result.get("tags")).isEqualTo(List.of("hot", "small"));
+        assertThat(result.get("details")).isInstanceOf(Map.class);
+        Map<?, ?> details = (Map<?, ?>) result.get("details");
+        assertThat(details.get("origin")).isEqualTo("Colombia");
+        assertThat(details.get("ratio")).isEqualTo(BigDecimal.valueOf(18.5));
+    }
+
+    @Test
+    void buildsQueriesAndMutatesJsonTrees() throws JacksonException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("orderId", 17);
+        root.withObjectProperty("customer").put("name", "Ada");
+        ArrayNode items = root.withArrayProperty("items");
+        items.addObject().put("sku", "beans").put("quantity", 2);
+        items.addObject().put("sku", "grinder").put("quantity", 1);
+        items.insert(1, "gift-wrap");
+
+        assertThat(root.at("/customer/name").asString()).isEqualTo("Ada");
+        assertThat(root.path("items").path(0).path("quantity").asInt()).isEqualTo(2);
+        assertThat(root.path("items").path(9).isMissingNode()).isTrue();
+
+        items.remove(1);
+        root.withObjectProperty("shipping").put("expedited", true);
+        String json = MAPPER.writeValueAsString(root);
+        JsonNode reparsed = MAPPER.readTree(json);
+
+        assertThat(reparsed.at("/shipping/expedited").asBoolean()).isTrue();
+        assertThat(reparsed.at("/items/1/sku").asString()).isEqualTo("grinder");
+        assertThat(reparsed.has("orderId")).isTrue();
+    }
+
+    @Test
+    void convertsBetweenTreesAndParameterizedJavaTypes() throws JacksonException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.withArrayProperty("scores").add(9).add(10).add(8);
+        root.withObjectProperty("metadata").put("source", "integration-test");
+
+        JavaType mapType = MAPPER.getTypeFactory().constructMapType(
+                LinkedHashMap.class,
+                String.class,
+                Object.class);
+        Map<String, Object> asMap = MAPPER.treeToValue(root, mapType);
+
+        assertThat(asMap).containsKeys("scores", "metadata");
+        assertThat(asMap.get("scores")).isEqualTo(List.of(9, 10, 8));
+
+        JsonNode roundTripped = MAPPER.valueToTree(asMap);
+        assertThat(roundTripped.at("/metadata/source").asString()).isEqualTo("integration-test");
+        assertThat(roundTripped.at("/scores/2").asInt()).isEqualTo(8);
+    }
+
+    @Test
+    void streamsSequencesWithSequenceWriterAndMappingIterator() throws JacksonException {
+        StringWriter output = new StringWriter();
+        try (SequenceWriter sequenceWriter = MAPPER.writerFor(Integer.class).writeValuesAsArray(output)) {
+            sequenceWriter.write(3);
+            sequenceWriter.write(1);
+            sequenceWriter.write(4);
+        }
+
+        String json = output.toString();
+        List<Integer> values = new ArrayList<>();
+        try (MappingIterator<Integer> iterator = MAPPER.readerFor(Integer.class).readValues(json)) {
+            while (iterator.hasNextValue()) {
+                values.add(iterator.nextValue());
+            }
+        }
+
+        assertThat(json).isEqualTo("[3,1,4]");
+        assertThat(values).containsExactly(3, 1, 4);
+    }
+
+    @Test
+    void updatesExistingContainersWithoutReplacingUnchangedEntries() throws JacksonException {
+        Map<String, Object> target = new LinkedHashMap<>();
+        target.put("status", "new");
+        target.put("attempts", 1);
+        target.put("notes", new ArrayList<>(List.of("created")));
+
+        Map<String, Object> patched = MAPPER.readerForUpdating(target)
+                .readValue("{\"status\":\"processing\",\"owner\":\"worker-1\"}");
+
+        assertThat(patched).isSameAs(target);
+        assertThat(patched)
+                .containsEntry("status", "processing")
+                .containsEntry("attempts", 1)
+                .containsEntry("owner", "worker-1");
+        assertThat(patched.get("notes")).isEqualTo(List.of("created"));
+    }
+
+    @Test
+    void honorsPerReaderAndPerWriterFeatureConfiguration() throws JacksonException {
+        Map<String, Integer> unordered = new LinkedHashMap<>();
+        unordered.put("b", 2);
+        unordered.put("a", 1);
+
+        String sortedPrettyJson = MAPPER.writer()
+                .with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .with(SerializationFeature.INDENT_OUTPUT)
+                .writeValueAsString(unordered);
+
+        assertThat(sortedPrettyJson).contains("\n");
+        assertThat(sortedPrettyJson.indexOf("\"a\""))
+                .isLessThan(sortedPrettyJson.indexOf("\"b\""));
+
+        ObjectReader strictReader = MAPPER.readerFor(new TypeReference<Map<String, Integer>>() { })
+                .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+        assertThatThrownBy(() -> strictReader.readValue("{\"a\":1} {\"b\":2}"))
+                .isInstanceOf(JacksonException.class);
+    }
+
+    @Test
+    void registersCustomModuleForExplicitScalarType() throws JacksonException {
+        SimpleModule module = new SimpleModule("token-module");
+        module.addSerializer(Token.class, new TokenSerializer());
+        module.addDeserializer(Token.class, new TokenDeserializer());
+        ObjectMapper mapper = JsonMapper.builder().addModule(module).build();
+
+        Token token = new Token("coffee", 42);
+        String json = mapper.writeValueAsString(token);
+        Token result = mapper.readValue(json, Token.class);
+
+        assertThat(json).isEqualTo("\"coffee#42\"");
+        assertThat(result).isEqualTo(token);
+    }
+
+    @Test
+    void bindsArraysListsAndPrimitiveArraysByJavaType() throws JacksonException {
+        JavaType listOfStrings = MAPPER.getTypeFactory().constructCollectionType(List.class, String.class);
+        List<String> names = MAPPER.readValue("[\"alpha\",\"beta\"]", listOfStrings);
+
+        int[] numbers = MAPPER.readerFor(int[].class).readValue("[5,8,13]");
+        String encodedNames = MAPPER.writerFor(listOfStrings).writeValueAsString(names);
+
+        assertThat(names).containsExactly("alpha", "beta");
+        assertThat(numbers).containsExactly(5, 8, 13);
+        assertThat(encodedNames).isEqualTo("[\"alpha\",\"beta\"]");
+    }
+
+    public static final class Token {
+        private final String prefix;
+        private final int number;
+
+        public Token(String prefix, int number) {
+            this.prefix = prefix;
+            this.number = number;
+        }
+
+        String prefix() {
+            return prefix;
+        }
+
+        int number() {
+            return number;
+        }
+
+        static Token parse(String value) {
+            int separator = value.indexOf('#');
+            return new Token(value.substring(0, separator), Integer.parseInt(value.substring(separator + 1)));
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Token token)) {
+                return false;
+            }
+            return number == token.number && prefix.equals(token.prefix);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * prefix.hashCode() + number;
+        }
+    }
+
+    public static final class TokenSerializer extends StdSerializer<Token> {
+        public TokenSerializer() {
+            super(Token.class);
+        }
+
+        @Override
+        public void serialize(Token value, JsonGenerator generator, SerializationContext context)
+                throws JacksonException {
+            generator.writeString(value.prefix() + "#" + value.number());
+        }
+    }
+
+    public static final class TokenDeserializer extends StdDeserializer<Token> {
+        public TokenDeserializer() {
+            super(Token.class);
+        }
+
+        @Override
+        public Token deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            return Token.parse(parser.getValueAsString());
+        }
     }
 }

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/java/tools_jackson_core/jackson_databind/Jackson_databindTest.java
@@ -13,6 +13,7 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.EnumNamingStrategies;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.MappingIterator;
@@ -198,6 +199,24 @@ public class Jackson_databindTest {
         assertThat(names).containsExactly("alpha", "beta");
         assertThat(numbers).containsExactly(5, 8, 13);
         assertThat(encodedNames).isEqualTo("[\"alpha\",\"beta\"]");
+    }
+
+    @Test
+    void appliesEnumNamingStrategyForEnumValues() throws JacksonException {
+        ObjectMapper mapper = JsonMapper.builder().enumNamingStrategy(EnumNamingStrategies.KEBAB_CASE).build();
+        List<ReleaseStage> stages = List.of(ReleaseStage.RELEASE_CANDIDATE, ReleaseStage.GENERAL_AVAILABILITY);
+
+        String json = mapper.writeValueAsString(stages);
+        List<ReleaseStage> result = mapper.readerFor(new TypeReference<List<ReleaseStage>>() { }).readValue(json);
+
+        assertThat(json).isEqualTo("[\"release-candidate\",\"general-availability\"]");
+        assertThat(result).containsExactly(ReleaseStage.RELEASE_CANDIDATE, ReleaseStage.GENERAL_AVAILABILITY);
+    }
+
+    public enum ReleaseStage {
+        ALPHA_BUILD,
+        RELEASE_CANDIDATE,
+        GENERAL_AVAILABILITY
     }
 
     public static final class Token {

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.introspect.POJOPropertiesCollector"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ReleaseStage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tools.jackson.databind.ser.jdk.IndexedListSerializer"
+      },
+      "type" : "tools_jackson_core.jackson_databind.Jackson_databindTest$ReleaseStage"
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:43:08">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:45:27">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,6 +52,12 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
+<testcase name="appliesEnumNamingStrategyForEnumValues()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:appliesEnumNamingStrategyForEnumValues()]
+display-name: appliesEnumNamingStrategyForEnumValues()
+]]></system-out>
+</testcase>
 <testcase name="streamsSequencesWithSequenceWriterAndMappingIterator()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:streamsSequencesWithSequenceWriterAndMappingIterator()]

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:43:08">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2157-41589bdb/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="streamsSequencesWithSequenceWriterAndMappingIterator()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:streamsSequencesWithSequenceWriterAndMappingIterator()]
+display-name: streamsSequencesWithSequenceWriterAndMappingIterator()
+]]></system-out>
+</testcase>
+<testcase name="updatesExistingContainersWithoutReplacingUnchangedEntries()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:updatesExistingContainersWithoutReplacingUnchangedEntries()]
+display-name: updatesExistingContainersWithoutReplacingUnchangedEntries()
+]]></system-out>
+</testcase>
+<testcase name="buildsQueriesAndMutatesJsonTrees()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:buildsQueriesAndMutatesJsonTrees()]
+display-name: buildsQueriesAndMutatesJsonTrees()
+]]></system-out>
+</testcase>
+<testcase name="bindsArraysListsAndPrimitiveArraysByJavaType()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:bindsArraysListsAndPrimitiveArraysByJavaType()]
+display-name: bindsArraysListsAndPrimitiveArraysByJavaType()
+]]></system-out>
+</testcase>
+<testcase name="convertsBetweenTreesAndParameterizedJavaTypes()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:convertsBetweenTreesAndParameterizedJavaTypes()]
+display-name: convertsBetweenTreesAndParameterizedJavaTypes()
+]]></system-out>
+</testcase>
+<testcase name="roundTripsNestedMapsWithTypedReaderWriter()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:roundTripsNestedMapsWithTypedReaderWriter()]
+display-name: roundTripsNestedMapsWithTypedReaderWriter()
+]]></system-out>
+</testcase>
+<testcase name="registersCustomModuleForExplicitScalarType()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:registersCustomModuleForExplicitScalarType()]
+display-name: registersCustomModuleForExplicitScalarType()
+]]></system-out>
+</testcase>
+<testcase name="honorsPerReaderAndPerWriterFeatureConfiguration()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:honorsPerReaderAndPerWriterFeatureConfiguration()]
+display-name: honorsPerReaderAndPerWriterFeatureConfiguration()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:46:45">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T17:48:04">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2157-41589bdb/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2"/>
@@ -94,7 +93,7 @@ unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jac
 display-name: convertsBetweenTreesAndParameterizedJavaTypes()
 ]]></system-out>
 </testcase>
-<testcase name="roundTripsNestedMapsWithTypedReaderWriter()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<testcase name="roundTripsNestedMapsWithTypedReaderWriter()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:roundTripsNestedMapsWithTypedReaderWriter()]
 display-name: roundTripsNestedMapsWithTypedReaderWriter()

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:45:27">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T17:46:45">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,6 +52,12 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
+<testcase name="buffersAndReplaysTokenStreams()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:buffersAndReplaysTokenStreams()]
+display-name: buffersAndReplaysTokenStreams()
+]]></system-out>
+</testcase>
 <testcase name="appliesEnumNamingStrategyForEnumValues()" classname="tools_jackson_core.jackson_databind.Jackson_databindTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:tools_jackson_core.jackson_databind.Jackson_databindTest]/[method:appliesEnumNamingStrategyForEnumValues()]

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:46:45">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:48:04">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2157-41589bdb/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2"/>

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:45:27">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:46:45">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:43:08">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:45:27">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:43:08">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2157-41589bdb/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "tools.jackson.databind.**"
+    }
+  ]
+}

--- a/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
+++ b/tests/src/tools.jackson.core/jackson-databind/3.0.0-rc2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "tools.jackson.databind.**"
+      "includeClasses" : "tools.jackson.databind.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2157

This PR introduces tests and metadata for tools.jackson.core:jackson-databind:3.0.0-rc2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 194441
- Cached input tokens: 1676288
- Output tokens: 20599
- Metadata entries: 31
- Test-only metadata entries: 2
- Iterations: 5
- Library coverage percentage: 18.69
- Generated lines of code: 269
- Tested library lines of code: 6443

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cec4502ff46f042ec486c613e51dd2b022d85122`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 5/64 covered calls (7.81%)
- Reflection: 5/64 covered calls (7.81%)

Library coverage:
- Instruction: 25604/145465 (17.60%)
- Line: 6443/34466 (18.69%)
- Method: 1673/7943 (21.06%)
