### PR TITLE
[GenAI] Mark org.jboss.weld:weld-build-config as not for Native Image

### DIFF
--- a/metadata/org.jboss.weld/weld-build-config/index.json
+++ b/metadata/org.jboss.weld/weld-build-config/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.jboss.weld:weld-build-config:1.1.4.Final contains no JVM class files; it only packages Maven metadata, license files, and a Checkstyle XML resource."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2997

This PR records `org.jboss.weld:weld-build-config` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.jboss.weld:weld-build-config:1.1.4.Final contains no JVM class files; it only packages Maven metadata, license files, and a Checkstyle XML resource.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f7e19c10f73c3ed6cafadfc8bd28a9a01cb26412`
