### PR TITLE
[GenAI] Test fix for org.apache.camel:spi-annotations:3.2.0 using gpt-5.5

### DIFF
--- a/stats/org.apache.camel/spi-annotations/3.2.0/execution-metrics.json
+++ b/stats/org.apache.camel/spi-annotations/3.2.0/execution-metrics.json
@@ -43,5 +43,50 @@
       "test_file": "tests/src/org.apache.camel/spi-annotations/3.2.0/src/test/java/org_apache_camel/spi_annotations/Spi_annotationsTest.java",
       "metadata_file": "metadata/org.apache.camel/spi-annotations/3.2.0/reachability-metadata.json"
     }
+  },
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T16:03:59.283579Z",
+    "library": "org.apache.camel:spi-annotations:3.2.0",
+    "starting_commit": "f268fb77d56dfb8f3e8faea498e8b02d822ed36d",
+    "ending_commit": "7cc42cbecc0b0a91f0dd0a98a682f9a1b6227fa0",
+    "previous_library": "org.apache.camel:spi-annotations:3.2.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 22704,
+      "cached_input_tokens_used": 116736,
+      "output_tokens_used": 721,
+      "iterations": 1,
+      "cost_usd": 0.08,
+      "tested_library_loc": 0,
+      "metadata_entries": 0,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 100.0,
+      "previous_library_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.camel/spi-annotations/3.2.0/src/test/java/org_apache_camel/spi_annotations/Spi_annotationsTest.java",
+      "metadata_file": "metadata/org.apache.camel/spi-annotations/3.2.0/reachability-metadata.json"
+    }
   }
 }

--- a/tests/src/org.apache.camel/spi-annotations/3.2.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.camel/spi-annotations/3.2.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T18:02:24">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4059-c04fbf0a/tests/src/org.apache.camel/spi-annotations/3.2.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="uriParamsAndMetadataAnnotationsExposeTypeLevelValues()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:uriParamsAndMetadataAnnotationsExposeTypeLevelValues()]
+display-name: uriParamsAndMetadataAnnotationsExposeTypeLevelValues()
+]]></system-out>
+</testcase>
+<testcase name="uriParamsAnnotationSupportsNestedConfigurationTypes()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:uriParamsAnnotationSupportsNestedConfigurationTypes()]
+display-name: uriParamsAnnotationSupportsNestedConfigurationTypes()
+]]></system-out>
+</testcase>
+<testcase name="fieldAndMethodMetadataAnnotationsExposeValues()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:fieldAndMethodMetadataAnnotationsExposeValues()]
+display-name: fieldAndMethodMetadataAnnotationsExposeValues()
+]]></system-out>
+</testcase>
+<testcase name="endpointAnnotationCanDeclareConsumerOnlyEndpoint()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:endpointAnnotationCanDeclareConsumerOnlyEndpoint()]
+display-name: endpointAnnotationCanDeclareConsumerOnlyEndpoint()
+]]></system-out>
+</testcase>
+<testcase name="annotationTypesDeclareRuntimeRetentionAndSupportedTargets()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:annotationTypesDeclareRuntimeRetentionAndSupportedTargets()]
+display-name: annotationTypesDeclareRuntimeRetentionAndSupportedTargets()
+]]></system-out>
+</testcase>
+<testcase name="optionalAnnotationsReturnEmptyDefaults()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:optionalAnnotationsReturnEmptyDefaults()]
+display-name: optionalAnnotationsReturnEmptyDefaults()
+]]></system-out>
+</testcase>
+<testcase name="endpointAnnotationExposesConfiguredValues()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:endpointAnnotationExposesConfiguredValues()]
+display-name: endpointAnnotationExposesConfiguredValues()
+]]></system-out>
+</testcase>
+<testcase name="endpointAnnotationProvidesDocumentedDefaults()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:endpointAnnotationProvidesDocumentedDefaults()]
+display-name: endpointAnnotationProvidesDocumentedDefaults()
+]]></system-out>
+</testcase>
+<testcase name="uriPathAnnotationExposesPathMetadata()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:uriPathAnnotationExposesPathMetadata()]
+display-name: uriPathAnnotationExposesPathMetadata()
+]]></system-out>
+</testcase>
+<testcase name="uriParamAnnotationExposesParameterMetadata()" classname="org_apache_camel.spi_annotations.Spi_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_camel.spi_annotations.Spi_annotationsTest]/[method:uriParamAnnotationExposesParameterMetadata()]
+display-name: uriParamAnnotationExposesParameterMetadata()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.camel/spi-annotations/3.2.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.camel/spi-annotations/3.2.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:02:24">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4059-c04fbf0a/tests/src/org.apache.camel/spi-annotations/3.2.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>


### PR DESCRIPTION
## What does this PR do?

Fixes: #4059

This PR provides test fixes and new metadata for org.apache.camel:spi-annotations:3.2.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 22704
- Cached input tokens: 116736
- Output tokens: 721
- Metadata entries: 0
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 100.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f268fb77d56dfb8f3e8faea498e8b02d822ed36d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.camel:spi-annotations:3.2.0` and `org.apache.camel:spi-annotations:3.2.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```
