### PR TITLE
[GenAI] Test fix for org.apache.commons:commons-fileupload2-core:2.0.0-M5 using gpt-5.5

### DIFF
--- a/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M5/execution-metrics.json
+++ b/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M5/execution-metrics.json
@@ -83,5 +83,90 @@
       "test_file": "tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java",
       "metadata_file": "metadata/org.apache.commons/commons-fileupload2-core/2.0.0-M5/reachability-metadata.json"
     }
+  },
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T16:04:21.341876Z",
+    "library": "org.apache.commons:commons-fileupload2-core:2.0.0-M5",
+    "starting_commit": "f268fb77d56dfb8f3e8faea498e8b02d822ed36d",
+    "ending_commit": "6c9950cd2c92eec9ac8366394ed6e25f9f697b12",
+    "previous_library": "org.apache.commons:commons-fileupload2-core:2.0.0-M5",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-M5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3375,
+          "missed": 1174,
+          "ratio": 0.741921,
+          "total": 4549
+        },
+        "line": {
+          "covered": 817,
+          "missed": 301,
+          "ratio": 0.730769,
+          "total": 1118
+        },
+        "method": {
+          "covered": 187,
+          "missed": 49,
+          "ratio": 0.792373,
+          "total": 236
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.0-M5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3375,
+          "missed": 1174,
+          "ratio": 0.741921,
+          "total": 4549
+        },
+        "line": {
+          "covered": 817,
+          "missed": 301,
+          "ratio": 0.730769,
+          "total": 1118
+        },
+        "method": {
+          "covered": 187,
+          "missed": 49,
+          "ratio": 0.792373,
+          "total": 236
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 53262,
+      "cached_input_tokens_used": 635904,
+      "output_tokens_used": 5151,
+      "iterations": 1,
+      "cost_usd": 0.4725,
+      "tested_library_loc": 817,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 73.08,
+      "previous_library_coverage_percent": 73.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java",
+      "metadata_file": "metadata/org.apache.commons/commons-fileupload2-core/2.0.0-M5/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M5/stats.json
+++ b/stats/org.apache.commons/commons-fileupload2-core/2.0.0-M5/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 3385,
-        "missed" : 1164,
-        "ratio" : 0.74412,
+        "covered" : 3375,
+        "missed" : 1174,
+        "ratio" : 0.741921,
         "total" : 4549
       },
       "line" : {
-        "covered" : 819,
-        "missed" : 299,
-        "ratio" : 0.732558,
+        "covered" : 817,
+        "missed" : 301,
+        "ratio" : 0.730769,
         "total" : 1118
       },
       "method" : {
-        "covered" : 188,
-        "missed" : 48,
-        "ratio" : 0.79661,
+        "covered" : 187,
+        "missed" : 49,
+        "ratio" : 0.792373,
         "total" : 236
       }
     }

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/src/test/java/org_apache_commons/commons_fileupload2_core/Commons_fileupload2_coreTest.java
@@ -82,7 +82,7 @@ public class Commons_fileupload2_coreTest {
         assertThat(description.getName()).isNull();
         assertThat(description.getContentType()).isEqualTo("text/plain; charset=UTF-8");
         assertThat(description.getCharset()).isEqualTo(StandardCharsets.UTF_8);
-        assertThat(description.getString()).isEqualTo(text);
+        assertThat(readUtf8(description.getInputStream())).isEqualTo(text);
         assertThat(description.getHeaders().getHeader("x-custom")).isEqualTo("first");
         assertThat(iteratorToList(description.getHeaders().getHeaders("X-Custom"))).containsExactly("first", "second");
 
@@ -116,7 +116,7 @@ public class Commons_fileupload2_coreTest {
             assertThat(item.isFormField()).isFalse();
             assertThat(item.getName()).isEqualTo("r\u00e9sum\u00e9.txt");
             assertThat(item.getContentType()).isEqualTo("text/plain; charset=UTF-8");
-            assertThat(item.getString()).isEqualTo("contents");
+            assertThat(item.getString(StandardCharsets.UTF_8)).isEqualTo("contents");
         });
     }
 
@@ -132,8 +132,8 @@ public class Commons_fileupload2_coreTest {
         Map<String, List<DiskFileItem>> parameterMap = upload.parseParameterMap(request(boundary, body));
 
         assertThat(parameterMap).containsOnlyKeys("tag", "single");
-        assertThat(parameterMap.get("tag")).extracting(item -> item.getString()).containsExactly("red", "blue");
-        assertThat(parameterMap.get("single")).singleElement().satisfies(item -> assertThat(item.getString()).isEqualTo("value"));
+        assertThat(parameterMap.get("tag")).extracting(item -> item.getString(StandardCharsets.UTF_8)).containsExactly("red", "blue");
+        assertThat(parameterMap.get("single")).singleElement().satisfies(item -> assertThat(item.getString(StandardCharsets.UTF_8)).isEqualTo("value"));
     }
 
     @Test
@@ -257,7 +257,7 @@ public class Commons_fileupload2_coreTest {
         headers.addHeader("Content-Language", "en");
         DiskFileItem inMemory = DiskFileItem.builder()
                 .setPath(tempDir)
-                .setBufferSize(64)
+                .setThreshold(64)
                 .setFieldName("comment")
                 .setFileName("comment.txt")
                 .setContentType("text/plain; charset=UTF-8")
@@ -270,8 +270,8 @@ public class Commons_fileupload2_coreTest {
 
         assertThat(inMemory.isInMemory()).isTrue();
         assertThat(inMemory.getPath()).isNull();
-        assertThat(inMemory.get()).containsExactly("hello".getBytes(StandardCharsets.UTF_8));
-        assertThat(inMemory.getString()).isEqualTo("hello");
+        assertThat(readBytes(inMemory)).containsExactly("hello".getBytes(StandardCharsets.UTF_8));
+        assertThat(readUtf8(inMemory.getInputStream())).isEqualTo("hello");
         assertThat(inMemory.getHeaders().getHeader("content-language")).isEqualTo("en");
         inMemory.setFieldName("renamed").setFormField(false);
         assertThat(inMemory.getFieldName()).isEqualTo("renamed");
@@ -282,7 +282,7 @@ public class Commons_fileupload2_coreTest {
 
         DiskFileItem onDisk = DiskFileItem.builder()
                 .setPath(tempDir)
-                .setBufferSize(4)
+                .setThreshold(4)
                 .setFieldName("upload")
                 .setFileName("large.txt")
                 .setContentType("application/octet-stream")
@@ -358,7 +358,7 @@ public class Commons_fileupload2_coreTest {
     private Upload newUpload(final int threshold) {
         DiskFileItemFactory factory = DiskFileItemFactory.builder()
                 .setPath(tempDir)
-                .setBufferSize(threshold)
+                .setThreshold(threshold)
                 .setCharset(StandardCharsets.ISO_8859_1)
                 .get();
         Upload upload = new Upload();
@@ -381,6 +381,12 @@ public class Commons_fileupload2_coreTest {
 
     private static String part(final String... lines) {
         return String.join(CRLF, lines);
+    }
+
+    private static byte[] readBytes(final DiskFileItem item) throws IOException {
+        try (InputStream stream = item.getInputStream()) {
+            return stream.readAllBytes();
+        }
     }
 
     private static String readUtf8(final InputStream inputStream) throws IOException {

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-02T18:02:53">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4060-c5d4158f/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="diskFileItemBuilderStoresSmallItemsInMemoryAndLargeItemsOnDisk()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:diskFileItemBuilderStoresSmallItemsInMemoryAndLargeItemsOnDisk()]
+display-name: diskFileItemBuilderStoresSmallItemsInMemoryAndLargeItemsOnDisk()
+]]></system-out>
+</testcase>
+<testcase name="multipartInputReadsBodiesAndDiscardsUnneededParts()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:multipartInputReadsBodiesAndDiscardsUnneededParts()]
+display-name: multipartInputReadsBodiesAndDiscardsUnneededParts()
+]]></system-out>
+</testcase>
+<testcase name="rejectsNonMultipartAndMultipartWithoutBoundary()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:rejectsNonMultipartAndMultipartWithoutBoundary()]
+display-name: rejectsNonMultipartAndMultipartWithoutBoundary()
+]]></system-out>
+</testcase>
+<testcase name="decodesRfc2231EncodedDispositionParameters()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:decodesRfc2231EncodedDispositionParameters()]
+display-name: decodesRfc2231EncodedDispositionParameters()
+]]></system-out>
+</testcase>
+<testcase name="parsesMultipartRequestIntoDiskFileItemsWithHeadersAndProgress()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:parsesMultipartRequestIntoDiskFileItemsWithHeadersAndProgress()]
+display-name: parsesMultipartRequestIntoDiskFileItemsWithHeadersAndProgress()
+]]></system-out>
+</testcase>
+<testcase name="enforcesRequestFileAndItemCountLimits()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:enforcesRequestFileAndItemCountLimits()]
+display-name: enforcesRequestFileAndItemCountLimits()
+]]></system-out>
+</testcase>
+<testcase name="validatesFileNamesAndParsesHeaderParameters()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:validatesFileNamesAndParsesHeaderParameters()]
+display-name: validatesFileNamesAndParsesHeaderParameters()
+]]></system-out>
+</testcase>
+<testcase name="streamingIteratorSkipsUnreadPartWhenAdvanced()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:streamingIteratorSkipsUnreadPartWhenAdvanced()]
+display-name: streamingIteratorSkipsUnreadPartWhenAdvanced()
+]]></system-out>
+</testcase>
+<testcase name="groupsRepeatedFormFieldsInParameterMap()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:groupsRepeatedFormFieldsInParameterMap()]
+display-name: groupsRepeatedFormFieldsInParameterMap()
+]]></system-out>
+</testcase>
+<testcase name="streamsNestedMultipartMixedFileItemsWithSharedFieldName()" classname="org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_commons.commons_fileupload2_core.Commons_fileupload2_coreTest]/[method:streamsNestedMultipartMixedFileItemsWithSharedFieldName()]
+display-name: streamsNestedMultipartMixedFileItemsWithSharedFieldName()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:02:53">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4060-c5d4158f/tests/src/org.apache.commons/commons-fileupload2-core/2.0.0-M5"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>


### PR DESCRIPTION
## What does this PR do?

Fixes: #4060

This PR provides test fixes and new metadata for org.apache.commons:commons-fileupload2-core:2.0.0-M5, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 53262
- Cached input tokens: 635904
- Output tokens: 5151
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 73.08
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 73.08

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f268fb77d56dfb8f3e8faea498e8b02d822ed36d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.commons:commons-fileupload2-core:2.0.0-M5` and `org.apache.commons:commons-fileupload2-core:2.0.0-M5`.

**Comparison between existing test version and AI-Generated update**

```diff

```
