### PR TITLE
[GenAI] Add support for org.springframework:spring-aspects:5.3.31 using gpt-5.5

### DIFF
--- a/metadata/org.springframework/spring-aspects/5.3.31/reachability-metadata.json
+++ b/metadata/org.springframework/spring-aspects/5.3.31/reachability-metadata.json
@@ -1,0 +1,336 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "beanConfigurerAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.AdviceModeImportSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.scheduling.annotation.AsyncConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.cache.annotation.CachingConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.annotation.TransactionManagementConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.scheduling.aspectj.AspectJAsyncConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "asyncAdvisor",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.cache.aspectj.AspectJCachingConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "cacheAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.annotation.AbstractTransactionManagementConfiguration",
+      "methods" : [
+        {
+          "name" : "transactionalEventListenerFactory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "transactionAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "io.vavr.control$Try"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "io.vavr.control.Try"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "javax.ejb$TransactionAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "javax.ejb.TransactionAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "javax.transaction$Transactional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "javax.transaction.Transactional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "org.reactivestreams$Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "org.reactivestreams.Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "org.springframework.transaction.TransactionDefinition",
+      "fields" : [
+        {
+          "name" : "$jacocoData"
+        },
+        {
+          "name" : "ISOLATION_DEFAULT"
+        },
+        {
+          "name" : "ISOLATION_READ_COMMITTED"
+        },
+        {
+          "name" : "ISOLATION_READ_UNCOMMITTED"
+        },
+        {
+          "name" : "ISOLATION_REPEATABLE_READ"
+        },
+        {
+          "name" : "ISOLATION_SERIALIZABLE"
+        },
+        {
+          "name" : "PROPAGATION_MANDATORY"
+        },
+        {
+          "name" : "PROPAGATION_NESTED"
+        },
+        {
+          "name" : "PROPAGATION_NEVER"
+        },
+        {
+          "name" : "PROPAGATION_NOT_SUPPORTED"
+        },
+        {
+          "name" : "PROPAGATION_REQUIRED"
+        },
+        {
+          "name" : "PROPAGATION_REQUIRES_NEW"
+        },
+        {
+          "name" : "PROPAGATION_SUPPORTS"
+        },
+        {
+          "name" : "TIMEOUT_DEFAULT"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AbstractTransactionAspect"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/beans/**/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/context/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/context/annotation/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/scheduling/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/scheduling/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/cache/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/cache/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/transaction/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/transaction/aspectj/*.class"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-aspects/index.json
+++ b/metadata/org.springframework/spring-aspects/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "5.3.31",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-framework",
-    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
-    "description" : "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "5.3.31",
+    "source-code-url": "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-framework",
+    "test-code-url": "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
+    "description": "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
+    "tested-versions": [
       "5.3.31"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.springframework.beans.factory.aspectj",
       "org.springframework.cache.aspectj",
       "org.springframework.context.annotation.aspectj",
       "org.springframework.scheduling.aspectj",
-      "org.springframework.transaction.aspectj"
+      "org.springframework.transaction.aspectj",
+      "org.springframework.context.annotation"
     ]
   }
 ]

--- a/metadata/org.springframework/spring-aspects/index.json
+++ b/metadata/org.springframework/spring-aspects/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.3.31",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
+    "description" : "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
+    "tested-versions" : [
+      "5.3.31"
+    ],
+    "allowed-packages" : [
+      "org.springframework.beans.factory.aspectj",
+      "org.springframework.cache.aspectj",
+      "org.springframework.context.annotation.aspectj",
+      "org.springframework.scheduling.aspectj",
+      "org.springframework.transaction.aspectj"
+    ]
+  }
+]

--- a/stats/org.springframework/spring-aspects/5.3.31/execution-metrics.json
+++ b/stats/org.springframework/spring-aspects/5.3.31/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T16:21:33.132483Z",
+    "library": "org.springframework:spring-aspects:5.3.31",
+    "starting_commit": "ab5995ab1a0749386c9d4f05d830eb3379da0dc9",
+    "ending_commit": "380a6b3f1f459f5034a405ce6a5cc7bc1dd6bf4c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.3.31",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 170,
+          "missed": 434,
+          "ratio": 0.281457,
+          "total": 604
+        },
+        "line": {
+          "covered": 53,
+          "missed": 77,
+          "ratio": 0.407692,
+          "total": 130
+        },
+        "method": {
+          "covered": 35,
+          "missed": 39,
+          "ratio": 0.472973,
+          "total": 74
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 327426,
+      "cached_input_tokens_used": 5226496,
+      "output_tokens_used": 30279,
+      "iterations": 4,
+      "cost_usd": 3.5216,
+      "generated_loc": 248,
+      "tested_library_loc": 53,
+      "metadata_entries": 63,
+      "test_only_metadata_entries": 8,
+      "code_coverage_percent": 40.77
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java",
+      "metadata_file": "metadata/org.springframework/spring-aspects/5.3.31/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework/spring-aspects/5.3.31/stats.json
+++ b/stats/org.springframework/spring-aspects/5.3.31/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.3.31",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 170,
+        "missed" : 434,
+        "ratio" : 0.281457,
+        "total" : 604
+      },
+      "line" : {
+        "covered" : 53,
+        "missed" : 77,
+        "ratio" : 0.407692,
+        "total" : 130
+      },
+      "method" : {
+        "covered" : 35,
+        "missed" : 39,
+        "ratio" : 0.472973,
+        "total" : 74
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-aspects/5.3.31/.gitignore
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework/spring-aspects/5.3.31/build.gradle
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework:spring-aspects:$libraryVersion"
+    testImplementation "org.springframework:spring-context:$libraryVersion"
+    testImplementation "org.springframework:spring-tx:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework/spring-aspects/5.3.31/build.gradle
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework:spring-aspects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework/spring-aspects/5.3.31/gradle.properties
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework:spring-aspects:5.3.31
+library.version = 5.3.31
+metadata.dir = org.springframework/spring-aspects/5.3.31/

--- a/tests/src/org.springframework/spring-aspects/5.3.31/settings.gradle
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.spring-aspects_tests'

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
@@ -7,10 +7,199 @@
 package org_springframework.spring_aspects;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.aspectj.AnnotationCacheAspect;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.config.CacheManagementConfigUtils;
+import org.springframework.context.annotation.AdviceMode;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
+import org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.aspectj.AnnotationAsyncExecutionAspect;
+import org.springframework.scheduling.config.TaskManagementConfigUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.aspectj.AnnotationTransactionAspect;
+import org.springframework.transaction.config.TransactionManagementConfigUtils;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
-class Spring_aspectsTest {
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_aspectsTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void springConfiguredRegistersTheSingletonBeanConfigurerAspect() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SpringConfiguredTestConfiguration.class)) {
+            BeanDefinition beanDefinition = context.getBeanFactory()
+                    .getBeanDefinition(SpringConfiguredConfiguration.BEAN_CONFIGURER_ASPECT_BEAN_NAME);
+            AnnotationBeanConfigurerAspect aspect = context.getBean(
+                    SpringConfiguredConfiguration.BEAN_CONFIGURER_ASPECT_BEAN_NAME,
+                    AnnotationBeanConfigurerAspect.class);
+
+            assertThat(beanDefinition.getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+            assertThat(aspect).isSameAs(AnnotationBeanConfigurerAspect.aspectOf());
+            assertThat(AnnotationBeanConfigurerAspect.hasAspect()).isTrue();
+        }
+    }
+
+    @Test
+    void beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("configurableService", BeanDefinitionBuilder
+                .genericBeanDefinition(ConfigurableService.class)
+                .setScope(BeanDefinition.SCOPE_PROTOTYPE)
+                .addPropertyValue("message", "configured by aspect")
+                .getBeanDefinition());
+        AnnotationBeanConfigurerAspect aspect = AnnotationBeanConfigurerAspect.aspectOf();
+        aspect.setBeanFactory(beanFactory);
+        aspect.afterPropertiesSet();
+
+        ConfigurableService service = new ConfigurableService();
+        aspect.configureBean(service);
+
+        assertThat(service.getMessage()).isEqualTo("configured by aspect");
+    }
+
+    @Test
+    void aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AspectJInfrastructureConfiguration.class)) {
+            AnnotationCacheAspect cacheAspect = context.getBean(
+                    CacheManagementConfigUtils.CACHE_ASPECT_BEAN_NAME,
+                    AnnotationCacheAspect.class);
+            AnnotationTransactionAspect transactionAspect = context.getBean(
+                    TransactionManagementConfigUtils.TRANSACTION_ASPECT_BEAN_NAME,
+                    AnnotationTransactionAspect.class);
+            AnnotationAsyncExecutionAspect asyncAspect = context.getBean(
+                    TaskManagementConfigUtils.ASYNC_EXECUTION_ASPECT_BEAN_NAME,
+                    AnnotationAsyncExecutionAspect.class);
+
+            assertThat(cacheAspect).isSameAs(AnnotationCacheAspect.aspectOf());
+            assertThat(transactionAspect).isSameAs(AnnotationTransactionAspect.aspectOf());
+            assertThat(asyncAspect).isSameAs(AnnotationAsyncExecutionAspect.aspectOf());
+            assertThat(context.getBeanFactory()
+                    .getBeanDefinition(CacheManagementConfigUtils.CACHE_ASPECT_BEAN_NAME)
+                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+            assertThat(context.getBeanFactory()
+                    .getBeanDefinition(TransactionManagementConfigUtils.TRANSACTION_ASPECT_BEAN_NAME)
+                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+            assertThat(context.getBeanFactory()
+                    .getBeanDefinition(TaskManagementConfigUtils.ASYNC_EXECUTION_ASPECT_BEAN_NAME)
+                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+        }
+    }
+
+    @Test
+    void transactionAspectAcceptsPublicTransactionConfiguration() {
+        AnnotationTransactionAspect aspect = AnnotationTransactionAspect.aspectOf();
+        RecordingTransactionManager transactionManager = new RecordingTransactionManager();
+        Properties attributes = new Properties();
+        attributes.setProperty("save*", "PROPAGATION_REQUIRES_NEW,readOnly,timeout_7");
+
+        aspect.setTransactionManager(transactionManager);
+        aspect.setTransactionAttributes(attributes);
+        aspect.afterPropertiesSet();
+
+        assertThat(aspect.getTransactionManager()).isSameAs(transactionManager);
+        assertThat(aspect.getTransactionAttributeSource()).isNotNull();
+    }
+
+    @Test
+    void cacheAspectAcceptsPublicCachingConfiguration() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager("books");
+        AnnotationCacheAspect aspect = AnnotationCacheAspect.aspectOf();
+        aspect.setCacheManager(cacheManager);
+        aspect.afterPropertiesSet();
+        Cache cache = cacheManager.getCache("books");
+
+        assertThat(aspect.getCacheOperationSource()).isNotNull();
+        assertThat(aspect.getCacheResolver()).isNotNull();
+        assertThat(aspect.getKeyGenerator()).isNotNull();
+        assertThat(cache).isNotNull();
+        cache.put("978-0134685991", "Effective Java");
+        assertThat(cache.get("978-0134685991", String.class)).isEqualTo("Effective Java");
+    }
+
+    @Test
+    void asyncAspectAcceptsBoundedExecutorConfiguration() {
+        AnnotationAsyncExecutionAspect aspect = AnnotationAsyncExecutionAspect.aspectOf();
+        SyncTaskExecutor executor = new SyncTaskExecutor();
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+        aspect.configure(() -> executor, () -> (throwable, method, parameters) -> {
+            throw new AssertionError("Unexpected asynchronous failure", throwable);
+        });
+        aspect.setBeanFactory(beanFactory);
+        aspect.setExecutor(executor);
+
+        assertThat(AnnotationAsyncExecutionAspect.hasAspect()).isTrue();
+    }
+
+    @EnableSpringConfigured
+    @Configuration(proxyBeanMethods = false)
+    static class SpringConfiguredTestConfiguration {
+    }
+
+    @EnableAsync(mode = AdviceMode.ASPECTJ)
+    @EnableCaching(mode = AdviceMode.ASPECTJ)
+    @EnableTransactionManagement(mode = AdviceMode.ASPECTJ)
+    @Configuration(proxyBeanMethods = false)
+    static class AspectJInfrastructureConfiguration {
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("books");
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager() {
+            return new RecordingTransactionManager();
+        }
+
+        @Bean
+        Executor taskExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
+
+    @Configurable("configurableService")
+    public static class ConfigurableService {
+        private String message;
+
+        public String getMessage() {
+            return this.message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    static class RecordingTransactionManager implements PlatformTransactionManager {
+        @Override
+        public TransactionStatus getTransaction(TransactionDefinition definition) {
+            return new SimpleTransactionStatus();
+        }
+
+        @Override
+        public void commit(TransactionStatus status) {
+        }
+
+        @Override
+        public void rollback(TransactionStatus status) {
+        }
     }
 }

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework.spring_aspects;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_aspectsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
@@ -9,6 +9,8 @@ package org_springframework.spring_aspects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect;
+import org.springframework.beans.factory.aspectj.ConfigurableObject;
+import org.springframework.beans.factory.aspectj.GenericInterfaceDrivenDependencyInjectionAspect;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -149,6 +151,17 @@ public class Spring_aspectsTest {
         assertThat(AnnotationAsyncExecutionAspect.hasAspect()).isTrue();
     }
 
+    @Test
+    void genericInterfaceDrivenAspectConfiguresConfigurableObjects() {
+        InterfaceDrivenConfigurableService service = new InterfaceDrivenConfigurableService();
+        InterfaceDrivenConfigurerAspect aspect = new InterfaceDrivenConfigurerAspect("configured through interface aspect");
+
+        aspect.configureBean(service);
+
+        assertThat(service.getMessage()).isEqualTo("configured through interface aspect");
+        assertThat(aspect.wasInvoked()).isTrue();
+    }
+
     @EnableSpringConfigured
     @Configuration(proxyBeanMethods = false)
     static class SpringConfiguredTestConfiguration {
@@ -185,6 +198,39 @@ public class Spring_aspectsTest {
 
         public void setMessage(String message) {
             this.message = message;
+        }
+    }
+
+    static class InterfaceDrivenConfigurableService implements ConfigurableObject {
+        private String message;
+
+        String getMessage() {
+            return this.message;
+        }
+
+        void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    static class InterfaceDrivenConfigurerAspect
+            extends GenericInterfaceDrivenDependencyInjectionAspect<InterfaceDrivenConfigurableService> {
+        private final String message;
+
+        private boolean invoked;
+
+        InterfaceDrivenConfigurerAspect(String message) {
+            this.message = message;
+        }
+
+        boolean wasInvoked() {
+            return this.invoked;
+        }
+
+        @Override
+        protected void configure(InterfaceDrivenConfigurableService service) {
+            this.invoked = true;
+            service.setMessage(this.message);
         }
     }
 

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
@@ -7,6 +7,7 @@
 package org_springframework.spring_aspects;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect;
 import org.springframework.beans.factory.aspectj.ConfigurableObject;
@@ -75,6 +76,22 @@ public class Spring_aspectsTest {
         aspect.configureBean(service);
 
         assertThat(service.getMessage()).isEqualTo("configured by aspect");
+    }
+
+    @Test
+    void beanConfigurerAspectAutowiresConfigurableObjectsByType() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        MessageProvider provider = new MessageProvider("autowired by type");
+        beanFactory.registerSingleton("messageProvider", provider);
+        AnnotationBeanConfigurerAspect aspect = AnnotationBeanConfigurerAspect.aspectOf();
+        aspect.setBeanFactory(beanFactory);
+        aspect.afterPropertiesSet();
+
+        AutowiredConfigurableService service = new AutowiredConfigurableService();
+        aspect.configureBean(service);
+
+        assertThat(service.getMessage()).isEqualTo("autowired by type");
+        assertThat(service.getMessageProvider()).isSameAs(provider);
     }
 
     @Test
@@ -198,6 +215,35 @@ public class Spring_aspectsTest {
 
         public void setMessage(String message) {
             this.message = message;
+        }
+    }
+
+    @Configurable(autowire = Autowire.BY_TYPE)
+    public static class AutowiredConfigurableService {
+        private MessageProvider messageProvider;
+
+        public MessageProvider getMessageProvider() {
+            return this.messageProvider;
+        }
+
+        public void setMessageProvider(MessageProvider messageProvider) {
+            this.messageProvider = messageProvider;
+        }
+
+        public String getMessage() {
+            return this.messageProvider.getMessage();
+        }
+    }
+
+    static class MessageProvider {
+        private final String message;
+
+        MessageProvider(String message) {
+            this.message = message;
+        }
+
+        String getMessage() {
+            return this.message;
         }
     }
 

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,56 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$AutowiredConfigurableService",
+      "methods" : [
+        {
+          "name" : "setMessageProvider",
+          "parameterTypes" : [
+            "org_springframework.spring_aspects.Spring_aspectsTest$MessageProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$AutowiredConfigurableServiceBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$AutowiredConfigurableServiceCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$ConfigurableService",
+      "methods" : [
+        {
+          "name" : "setMessage",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$ConfigurableServiceBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org_springframework.spring_aspects.Spring_aspectsTest$ConfigurableServiceCustomizer"
+    }
+  ]
+}

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.027" hostname="kung-fu-workstation" timestamp="2026-05-02T18:08:04">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T18:20:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2791-f398243e/tests/src/org.springframework/spring-aspects/5.3.31"/>
@@ -58,43 +57,43 @@ unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spri
 display-name: cacheAspectAcceptsPublicCachingConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.008">
+<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()]
 display-name: aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()
 ]]></system-out>
 </testcase>
-<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:asyncAspectAcceptsBoundedExecutorConfiguration()]
 display-name: asyncAspectAcceptsBoundedExecutorConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
+<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()]
 display-name: beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()
 ]]></system-out>
 </testcase>
-<testcase name="beanConfigurerAspectAutowiresConfigurableObjectsByType()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
+<testcase name="beanConfigurerAspectAutowiresConfigurableObjectsByType()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectAutowiresConfigurableObjectsByType()]
 display-name: beanConfigurerAspectAutowiresConfigurableObjectsByType()
 ]]></system-out>
 </testcase>
-<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
+<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:transactionAspectAcceptsPublicTransactionConfiguration()]
 display-name: transactionAspectAcceptsPublicTransactionConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="genericInterfaceDrivenAspectConfiguresConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
+<testcase name="genericInterfaceDrivenAspectConfiguresConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:genericInterfaceDrivenAspectConfiguresConfigurableObjects()]
 display-name: genericInterfaceDrivenAspectConfiguresConfigurableObjects()
 ]]></system-out>
 </testcase>
-<testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
+<testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:springConfiguredRegistersTheSingletonBeanConfigurerAspect()]
 display-name: springConfiguredRegistersTheSingletonBeanConfigurerAspect()

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T18:04:13">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.027" hostname="kung-fu-workstation" timestamp="2026-05-02T18:08:04">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,37 +58,43 @@ unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spri
 display-name: cacheAspectAcceptsPublicCachingConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
+<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.008">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()]
 display-name: aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()
 ]]></system-out>
 </testcase>
-<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:asyncAspectAcceptsBoundedExecutorConfiguration()]
 display-name: asyncAspectAcceptsBoundedExecutorConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()]
 display-name: beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()
 ]]></system-out>
 </testcase>
-<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<testcase name="beanConfigurerAspectAutowiresConfigurableObjectsByType()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectAutowiresConfigurableObjectsByType()]
+display-name: beanConfigurerAspectAutowiresConfigurableObjectsByType()
+]]></system-out>
+</testcase>
+<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:transactionAspectAcceptsPublicTransactionConfiguration()]
 display-name: transactionAspectAcceptsPublicTransactionConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="genericInterfaceDrivenAspectConfiguresConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<testcase name="genericInterfaceDrivenAspectConfiguresConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:genericInterfaceDrivenAspectConfiguresConfigurableObjects()]
 display-name: genericInterfaceDrivenAspectConfiguresConfigurableObjects()
 ]]></system-out>
 </testcase>
-<testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:springConfiguredRegistersTheSingletonBeanConfigurerAspect()]
 display-name: springConfiguredRegistersTheSingletonBeanConfigurerAspect()

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="3" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-02T17:54:35">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T18:04:13">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,132 +52,43 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="cacheAspectAcceptsPublicCachingConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<testcase name="cacheAspectAcceptsPublicCachingConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:cacheAspectAcceptsPublicCachingConfiguration()]
 display-name: cacheAspectAcceptsPublicCachingConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
-<error message="Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.&lt;init&gt;()" type="org.springframework.beans.factory.BeanCreationException"><![CDATA[org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
-	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
-	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:106)
-	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:756)
-	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572)
-	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
-	at org_springframework.spring_aspects.Spring_aspectsTest.aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects(Spring_aspectsTest.java:80)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:83)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326)
-	... 24 more
-Caused by: java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1652)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1860)
-	at java.base@25.0.2/java.lang.Class.getDeclaredConstructor(DynamicHub.java:2491)
-	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:78)
-	... 25 more
-]]></error>
+<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()]
 display-name: aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()
 ]]></system-out>
 </testcase>
-<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:asyncAspectAcceptsBoundedExecutorConfiguration()]
 display-name: asyncAspectAcceptsBoundedExecutorConfiguration()
 ]]></system-out>
 </testcase>
-<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()]
 display-name: beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()
 ]]></system-out>
 </testcase>
-<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
-<error message="Field 'PROPAGATION_REQUIRES_NEW' not found in class [org.springframework.transaction.TransactionDefinition]" type="org.springframework.core.Constants$ConstantException"><![CDATA[org.springframework.core.Constants$ConstantException: Field 'PROPAGATION_REQUIRES_NEW' not found in class [org.springframework.transaction.TransactionDefinition]
-	at org.springframework.core.Constants.asObject(Constants.java:145)
-	at org.springframework.core.Constants.asNumber(Constants.java:113)
-	at org.springframework.transaction.support.DefaultTransactionDefinition.setPropagationBehaviorName(DefaultTransactionDefinition.java:122)
-	at org.springframework.transaction.interceptor.TransactionAttributeEditor.setAsText(TransactionAttributeEditor.java:65)
-	at org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource.setProperties(NameMatchTransactionAttributeSource.java:87)
-	at org.springframework.transaction.interceptor.TransactionAspectSupport.setTransactionAttributes(TransactionAspectSupport.java:253)
-	at org_springframework.spring_aspects.Spring_aspectsTest.transactionAspectAcceptsPublicTransactionConfiguration(Spring_aspectsTest.java:114)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:transactionAspectAcceptsPublicTransactionConfiguration()]
 display-name: transactionAspectAcceptsPublicTransactionConfiguration()
 ]]></system-out>
 </testcase>
+<testcase name="genericInterfaceDrivenAspectConfiguresConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:genericInterfaceDrivenAspectConfiguresConfigurableObjects()]
+display-name: genericInterfaceDrivenAspectConfiguresConfigurableObjects()
+]]></system-out>
+</testcase>
 <testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
-<error message="Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.&lt;init&gt;()" type="org.springframework.beans.factory.BeanCreationException"><![CDATA[org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
-	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
-	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
-	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:106)
-	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:756)
-	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572)
-	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
-	at org_springframework.spring_aspects.Spring_aspectsTest.springConfiguredRegistersTheSingletonBeanConfigurerAspect(Spring_aspectsTest.java:47)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:83)
-	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326)
-	... 24 more
-Caused by: java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1652)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1860)
-	at java.base@25.0.2/java.lang.Class.getDeclaredConstructor(DynamicHub.java:2491)
-	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:78)
-	... 25 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:springConfiguredRegistersTheSingletonBeanConfigurerAspect()]
 display-name: springConfiguredRegistersTheSingletonBeanConfigurerAspect()

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="3" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-02T17:54:35">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2791-f398243e/tests/src/org.springframework/spring-aspects/5.3.31"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="cacheAspectAcceptsPublicCachingConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:cacheAspectAcceptsPublicCachingConfiguration()]
+display-name: cacheAspectAcceptsPublicCachingConfiguration()
+]]></system-out>
+</testcase>
+<testcase name="aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.003">
+<error message="Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.&lt;init&gt;()" type="org.springframework.beans.factory.BeanCreationException"><![CDATA[org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
+	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:106)
+	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:756)
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572)
+	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
+	at org_springframework.spring_aspects.Spring_aspectsTest.aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects(Spring_aspectsTest.java:80)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:83)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326)
+	... 24 more
+Caused by: java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1652)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1860)
+	at java.base@25.0.2/java.lang.Class.getDeclaredConstructor(DynamicHub.java:2491)
+	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:78)
+	... 25 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()]
+display-name: aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects()
+]]></system-out>
+</testcase>
+<testcase name="asyncAspectAcceptsBoundedExecutorConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:asyncAspectAcceptsBoundedExecutorConfiguration()]
+display-name: asyncAspectAcceptsBoundedExecutorConfiguration()
+]]></system-out>
+</testcase>
+<testcase name="beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()]
+display-name: beanConfigurerAspectInjectsDependenciesIntoConfigurableObjects()
+]]></system-out>
+</testcase>
+<testcase name="transactionAspectAcceptsPublicTransactionConfiguration()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0.001">
+<error message="Field 'PROPAGATION_REQUIRES_NEW' not found in class [org.springframework.transaction.TransactionDefinition]" type="org.springframework.core.Constants$ConstantException"><![CDATA[org.springframework.core.Constants$ConstantException: Field 'PROPAGATION_REQUIRES_NEW' not found in class [org.springframework.transaction.TransactionDefinition]
+	at org.springframework.core.Constants.asObject(Constants.java:145)
+	at org.springframework.core.Constants.asNumber(Constants.java:113)
+	at org.springframework.transaction.support.DefaultTransactionDefinition.setPropagationBehaviorName(DefaultTransactionDefinition.java:122)
+	at org.springframework.transaction.interceptor.TransactionAttributeEditor.setAsText(TransactionAttributeEditor.java:65)
+	at org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource.setProperties(NameMatchTransactionAttributeSource.java:87)
+	at org.springframework.transaction.interceptor.TransactionAspectSupport.setTransactionAttributes(TransactionAspectSupport.java:253)
+	at org_springframework.spring_aspects.Spring_aspectsTest.transactionAspectAcceptsPublicTransactionConfiguration(Spring_aspectsTest.java:114)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:transactionAspectAcceptsPublicTransactionConfiguration()]
+display-name: transactionAspectAcceptsPublicTransactionConfiguration()
+]]></system-out>
+</testcase>
+<testcase name="springConfiguredRegistersTheSingletonBeanConfigurerAspect()" classname="org_springframework.spring_aspects.Spring_aspectsTest" time="0">
+<error message="Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.&lt;init&gt;()" type="org.springframework.beans.factory.BeanCreationException"><![CDATA[org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.context.annotation.internalConfigurationAnnotationProcessor': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
+	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
+	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:213)
+	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:106)
+	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:756)
+	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:572)
+	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
+	at org_springframework.spring_aspects.Spring_aspectsTest.springConfiguredRegistersTheSingletonBeanConfigurerAspect(Spring_aspectsTest.java:47)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.context.annotation.ConfigurationClassPostProcessor]: No default constructor found; nested exception is java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:83)
+	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326)
+	... 24 more
+Caused by: java.lang.NoSuchMethodException: org.springframework.context.annotation.ConfigurationClassPostProcessor.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1652)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1860)
+	at java.base@25.0.2/java.lang.Class.getDeclaredConstructor(DynamicHub.java:2491)
+	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:78)
+	... 25 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_springframework.spring_aspects.Spring_aspectsTest]/[method:springConfiguredRegistersTheSingletonBeanConfigurerAspect()]
+display-name: springConfiguredRegistersTheSingletonBeanConfigurerAspect()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:54:35">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2791-f398243e/tests/src/org.springframework/spring-aspects/5.3.31"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:08:04">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:20:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2791-f398243e/tests/src/org.springframework/spring-aspects/5.3.31"/>

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:54:35">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:04:13">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:04:13">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:08:04">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.springframework/spring-aspects/5.3.31/user-code-filter.json
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/user-code-filter.json
@@ -1,22 +1,22 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.beans.factory.aspectj.**"
+      "includeClasses" : "org.springframework.beans.factory.aspectj.**"
     },
     {
-      "includeClasses": "org.springframework.cache.aspectj.**"
+      "includeClasses" : "org.springframework.cache.aspectj.**"
     },
     {
-      "includeClasses": "org.springframework.context.annotation.aspectj.**"
+      "includeClasses" : "org.springframework.context.annotation.aspectj.**"
     },
     {
-      "includeClasses": "org.springframework.scheduling.aspectj.**"
+      "includeClasses" : "org.springframework.scheduling.aspectj.**"
     },
     {
-      "includeClasses": "org.springframework.transaction.aspectj.**"
+      "includeClasses" : "org.springframework.transaction.aspectj.**"
     }
   ]
 }

--- a/tests/src/org.springframework/spring-aspects/5.3.31/user-code-filter.json
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/user-code-filter.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.beans.factory.aspectj.**"
+    },
+    {
+      "includeClasses": "org.springframework.cache.aspectj.**"
+    },
+    {
+      "includeClasses": "org.springframework.context.annotation.aspectj.**"
+    },
+    {
+      "includeClasses": "org.springframework.scheduling.aspectj.**"
+    },
+    {
+      "includeClasses": "org.springframework.transaction.aspectj.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2791

This PR introduces tests and metadata for org.springframework:spring-aspects:5.3.31, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 327426
- Cached input tokens: 5226496
- Output tokens: 30279
- Metadata entries: 63
- Test-only metadata entries: 8
- Iterations: 4
- Library coverage percentage: 40.77
- Generated lines of code: 248
- Tested library lines of code: 53

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f7e19c10f73c3ed6cafadfc8bd28a9a01cb26412`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 170/604 (28.15%)
- Line: 53/130 (40.77%)
- Method: 35/74 (47.30%)
