### PR TITLE
[GenAI] Add support for com.google.guava:guava-bootstrap:11.0.2 using gpt-5.5

### DIFF
--- a/metadata/com.google.guava/guava-bootstrap/11.0.2/reachability-metadata.json
+++ b/metadata/com.google.guava/guava-bootstrap/11.0.2/reachability-metadata.json
@@ -1,0 +1,67 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.lang.Object[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.ArrayBlockingQueue"
+      },
+      "type" : "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.FutureTask"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.FutureTask"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/metadata/com.google.guava/guava-bootstrap/index.json
+++ b/metadata/com.google.guava/guava-bootstrap/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "11.0.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/guava/guava-bootstrap/$version$/guava-bootstrap-$version$-sources.jar",
+    "repository-url" : "https://github.com/google/guava",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/guava/guava-bootstrap/$version$/guava-bootstrap-$version$-javadoc.jar",
+    "description" : "Guava Bootstrap provides a JDK 6-like java.util.concurrent.ExecutorService interface compiled with JDK 5 settings for use during Guava's build. It is used on Guava's bootstrap class path so Guava can compile invokeAll and invokeAny signatures consistently across JDK 5 and JDK 6.",
+    "tested-versions" : [
+      "11.0.2"
+    ],
+    "allowed-packages" : [
+      "java.util.concurrent"
+    ]
+  }
+]

--- a/stats/com.google.guava/guava-bootstrap/11.0.2/execution-metrics.json
+++ b/stats/com.google.guava/guava-bootstrap/11.0.2/execution-metrics.json
@@ -1,0 +1,37 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T16:31:20.119700Z",
+    "library": "com.google.guava:guava-bootstrap:11.0.2",
+    "starting_commit": "76847db1822c731f9916f777d76e0cb7d4f35c0e",
+    "ending_commit": "c34d9f8cc67b6fa3271bb2320b86732ecaeb14f5",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 160112,
+      "cached_input_tokens_used": 1063936,
+      "output_tokens_used": 20605,
+      "iterations": 4,
+      "cost_usd": 1.1501,
+      "generated_loc": 285,
+      "tested_library_loc": 0,
+      "metadata_entries": 16,
+      "test_only_metadata_entries": 8,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java",
+      "metadata_file": "metadata/com.google.guava/guava-bootstrap/11.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.guava/guava-bootstrap/11.0.2/stats.json
+++ b/stats/com.google.guava/guava-bootstrap/11.0.2/stats.json
@@ -1,0 +1,16 @@
+{
+  "versions" : [ {
+    "version" : "11.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : "N/A",
+      "line" : "N/A",
+      "method" : "N/A"
+    }
+  } ]
+}

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/.gitignore
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/build.gradle
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('-H:+AllowDeprecatedBuilderClassesOnImageClasspath')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/build.gradle
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.guava:guava-bootstrap:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/gradle.properties
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.guava:guava-bootstrap:11.0.2
+library.version = 11.0.2
+metadata.dir = com.google.guava/guava-bootstrap/11.0.2/

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/settings.gradle
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.guava.guava-bootstrap_tests'

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
@@ -6,11 +6,128 @@
  */
 package com_google_guava.guava_bootstrap;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.jupiter.api.Test;
 
-class Guava_bootstrapTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Guava_bootstrapTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void submitVariantsReturnExpectedResults() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<String> callableResult = executor.submit(() -> "callable");
+            Future<String> runnableWithResult = executor.submit(() -> { }, "runnable-result");
+            Future<?> runnableResult = executor.submit(() -> { });
+
+            assertThat(callableResult.get(1, TimeUnit.SECONDS)).isEqualTo("callable");
+            assertThat(runnableWithResult.get(1, TimeUnit.SECONDS)).isEqualTo("runnable-result");
+            assertThat(runnableResult.get(1, TimeUnit.SECONDS)).isNull();
+        } finally {
+            shutdownAndAwait(executor);
+        }
+    }
+
+    @Test
+    void invokeAllAndInvokeAnyCompleteBoundedTaskSets() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<Callable<Integer>> tasks = Arrays.asList(() -> 1, () -> 2, () -> 3);
+            List<Future<Integer>> futures = executor.invokeAll(tasks, 1, TimeUnit.SECONDS);
+
+            assertThat(futures).hasSize(3);
+            assertThat(futures).allSatisfy(future -> {
+                assertThat(future.isDone()).isTrue();
+                assertThat(future.isCancelled()).isFalse();
+            });
+            assertThat(futures.get(0).get(1, TimeUnit.SECONDS)).isEqualTo(1);
+            assertThat(futures.get(1).get(1, TimeUnit.SECONDS)).isEqualTo(2);
+            assertThat(futures.get(2).get(1, TimeUnit.SECONDS)).isEqualTo(3);
+
+            String firstResult = executor.invokeAny(List.of(() -> "alpha", () -> "beta"), 1, TimeUnit.SECONDS);
+            assertThat(firstResult).isIn("alpha", "beta");
+        } finally {
+            shutdownAndAwait(executor);
+        }
+    }
+
+    @Test
+    void shutdownNowStopsRunningWorkAndReturnsQueuedWork() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch runningTaskStarted = new CountDownLatch(1);
+
+        Future<?> runningTask = executor.submit(() -> {
+            runningTaskStarted.countDown();
+            TimeUnit.SECONDS.sleep(5);
+            return null;
+        });
+        assertThat(runningTaskStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+        Future<String> queuedTask = executor.submit(() -> "never-run");
+        List<Runnable> queuedWork = executor.shutdownNow();
+
+        assertThat(executor.isShutdown()).isTrue();
+        assertThat(queuedWork).contains((Runnable) queuedTask);
+        assertThat(executor.awaitTermination(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(executor.isTerminated()).isTrue();
+        assertThatThrownBy(() -> runningTask.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(InterruptedException.class);
+    }
+
+    @Test
+    void invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline() {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch releaseTasks = new CountDownLatch(1);
+        Callable<String> blockedTask = () -> {
+            releaseTasks.await(5, TimeUnit.SECONDS);
+            return "finished";
+        };
+
+        try {
+            assertThatThrownBy(() -> executor.invokeAny(List.of(blockedTask, blockedTask), 100, TimeUnit.MILLISECONDS))
+                    .isInstanceOf(TimeoutException.class);
+        } finally {
+            releaseTasks.countDown();
+            shutdownAndAwait(executor);
+        }
+    }
+
+    @Test
+    void invokeAnyPropagatesFailureWhenEveryTaskFails() {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Callable<String> failingTask = () -> {
+                throw new IllegalStateException("controlled failure");
+            };
+
+            assertThatThrownBy(() -> executor.invokeAny(List.of(failingTask, failingTask), 1, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(IllegalStateException.class);
+        } finally {
+            shutdownAndAwait(executor);
+        }
+    }
+
+    private static void shutdownAndAwait(ExecutorService executor) {
+        executor.shutdownNow();
+        try {
+            assertThat(executor.awaitTermination(2, TimeUnit.SECONDS)).isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for executor termination", e);
+        }
     }
 }

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
@@ -137,6 +137,26 @@ public class Guava_bootstrapTest {
         assertThat(executor.isTerminated()).isTrue();
     }
 
+    @Test
+    void closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait() {
+        InterruptingExecutorService executor = new InterruptingExecutorService();
+        assertThat(Thread.interrupted()).isFalse();
+
+        try {
+            executor.close();
+
+            assertThat(executor.shutdownCalls).isEqualTo(1);
+            assertThat(executor.shutdownNowCalls).isEqualTo(1);
+            assertThat(executor.awaitTerminationCalls).isEqualTo(2);
+            assertThat(executor.lastAwaitTimeout).isEqualTo(1L);
+            assertThat(executor.lastAwaitTimeUnit).isEqualTo(TimeUnit.DAYS);
+            assertThat(executor.isTerminated()).isTrue();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
     private static void shutdownAndAwait(ExecutorService executor) {
         executor.shutdownNow();
         try {
@@ -144,6 +164,91 @@ public class Guava_bootstrapTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new AssertionError("Interrupted while waiting for executor termination", e);
+        }
+    }
+
+    private static final class InterruptingExecutorService implements ExecutorService {
+        private int shutdownCalls;
+        private int shutdownNowCalls;
+        private int awaitTerminationCalls;
+        private long lastAwaitTimeout;
+        private TimeUnit lastAwaitTimeUnit;
+        private boolean shutdown;
+        private boolean terminated;
+
+        @Override
+        public void shutdown() {
+            shutdownCalls++;
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdownNowCalls++;
+            shutdown = true;
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return terminated;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            awaitTerminationCalls++;
+            lastAwaitTimeout = timeout;
+            lastAwaitTimeUnit = unit;
+            if (awaitTerminationCalls == 1) {
+                throw new InterruptedException("controlled interruption");
+            }
+            terminated = true;
+            return true;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            throw new UnsupportedOperationException("execute is not used by this test");
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+            throw new UnsupportedOperationException("invokeAll is not used by this test");
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException("invokeAll is not used by this test");
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+            throw new UnsupportedOperationException("invokeAny is not used by this test");
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException("invokeAny is not used by this test");
         }
     }
 

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
@@ -7,6 +7,8 @@
 package com_google_guava.guava_bootstrap;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -121,6 +123,20 @@ public class Guava_bootstrapTest {
         }
     }
 
+    @Test
+    void closePerformsOrderlyShutdownAndWaitsUntilTerminated() {
+        RecordingExecutorService executor = new RecordingExecutorService();
+
+        executor.close();
+
+        assertThat(executor.shutdownCalls).isEqualTo(1);
+        assertThat(executor.shutdownNowCalls).isZero();
+        assertThat(executor.awaitTerminationCalls).isEqualTo(2);
+        assertThat(executor.lastAwaitTimeout).isEqualTo(1L);
+        assertThat(executor.lastAwaitTimeUnit).isEqualTo(TimeUnit.DAYS);
+        assertThat(executor.isTerminated()).isTrue();
+    }
+
     private static void shutdownAndAwait(ExecutorService executor) {
         executor.shutdownNow();
         try {
@@ -128,6 +144,89 @@ public class Guava_bootstrapTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new AssertionError("Interrupted while waiting for executor termination", e);
+        }
+    }
+
+    private static final class RecordingExecutorService implements ExecutorService {
+        private int shutdownCalls;
+        private int shutdownNowCalls;
+        private int awaitTerminationCalls;
+        private long lastAwaitTimeout;
+        private TimeUnit lastAwaitTimeUnit;
+        private boolean shutdown;
+        private boolean terminated;
+
+        @Override
+        public void shutdown() {
+            shutdownCalls++;
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdownNowCalls++;
+            shutdown = true;
+            terminated = true;
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return terminated;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            awaitTerminationCalls++;
+            lastAwaitTimeout = timeout;
+            lastAwaitTimeUnit = unit;
+            terminated = awaitTerminationCalls >= 2;
+            return terminated;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            throw new UnsupportedOperationException("execute is not used by this test");
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            throw new UnsupportedOperationException("submit is not used by this test");
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+            throw new UnsupportedOperationException("invokeAll is not used by this test");
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException("invokeAll is not used by this test");
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+            throw new UnsupportedOperationException("invokeAny is not used by this test");
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException("invokeAny is not used by this test");
         }
     }
 }

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/java/com_google_guava/guava_bootstrap/Guava_bootstrapTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_guava.guava_bootstrap;
+
+import org.junit.jupiter.api.Test;
+
+class Guava_bootstrapTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "java.util.concurrent.FutureTask"
+      },
+      "type" : "com_google_guava.guava_bootstrap.Guava_bootstrapTest",
+      "methods" : [
+        {
+          "name" : "closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "closePerformsOrderlyShutdownAndWaitsUntilTerminated",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "invokeAllAndInvokeAnyCompleteBoundedTaskSets",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "invokeAnyPropagatesFailureWhenEveryTaskFails",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "shutdownNowStopsRunningWorkAndReturnsQueuedWork",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "submitVariantsReturnExpectedResults",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.117" hostname="kung-fu-workstation" timestamp="2026-05-02T18:27:29">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.113" hostname="kung-fu-workstation" timestamp="2026-05-02T18:29:54">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2838-cd60ddfe/tests/src/com.google.guava/guava-bootstrap/11.0.2"/>
@@ -52,31 +51,31 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.102">
+<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.103">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()]
 display-name: invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()
 ]]></system-out>
 </testcase>
-<testcase name="closePerformsOrderlyShutdownAndWaitsUntilTerminated()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.003">
+<testcase name="closePerformsOrderlyShutdownAndWaitsUntilTerminated()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:closePerformsOrderlyShutdownAndWaitsUntilTerminated()]
 display-name: closePerformsOrderlyShutdownAndWaitsUntilTerminated()
 ]]></system-out>
 </testcase>
-<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
+<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:shutdownNowStopsRunningWorkAndReturnsQueuedWork()]
 display-name: shutdownNowStopsRunningWorkAndReturnsQueuedWork()
 ]]></system-out>
 </testcase>
-<testcase name="invokeAnyPropagatesFailureWhenEveryTaskFails()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<testcase name="invokeAnyPropagatesFailureWhenEveryTaskFails()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyPropagatesFailureWhenEveryTaskFails()]
 display-name: invokeAnyPropagatesFailureWhenEveryTaskFails()
 ]]></system-out>
 </testcase>
-<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.003">
+<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAllAndInvokeAnyCompleteBoundedTaskSets()]
 display-name: invokeAllAndInvokeAnyCompleteBoundedTaskSets()
@@ -88,7 +87,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_
 display-name: submitVariantsReturnExpectedResults()
 ]]></system-out>
 </testcase>
-<testcase name="closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
+<testcase name="closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()]
 display-name: closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.121" hostname="kung-fu-workstation" timestamp="2026-05-02T18:24:17">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2838-cd60ddfe/tests/src/com.google.guava/guava-bootstrap/11.0.2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.107">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()]
+display-name: invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()
+]]></system-out>
+</testcase>
+<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:shutdownNowStopsRunningWorkAndReturnsQueuedWork()]
+display-name: shutdownNowStopsRunningWorkAndReturnsQueuedWork()
+]]></system-out>
+</testcase>
+<testcase name="invokeAnyPropagatesFailureWhenEveryTaskFails()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyPropagatesFailureWhenEveryTaskFails()]
+display-name: invokeAnyPropagatesFailureWhenEveryTaskFails()
+]]></system-out>
+</testcase>
+<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAllAndInvokeAnyCompleteBoundedTaskSets()]
+display-name: invokeAllAndInvokeAnyCompleteBoundedTaskSets()
+]]></system-out>
+</testcase>
+<testcase name="submitVariantsReturnExpectedResults()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:submitVariantsReturnExpectedResults()]
+display-name: submitVariantsReturnExpectedResults()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.121" hostname="kung-fu-workstation" timestamp="2026-05-02T18:24:17">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.101" hostname="kung-fu-workstation" timestamp="2026-05-02T18:26:06">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,31 +52,37 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.107">
+<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.1">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()]
 display-name: invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()
 ]]></system-out>
 </testcase>
-<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
+<testcase name="closePerformsOrderlyShutdownAndWaitsUntilTerminated()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:closePerformsOrderlyShutdownAndWaitsUntilTerminated()]
+display-name: closePerformsOrderlyShutdownAndWaitsUntilTerminated()
+]]></system-out>
+</testcase>
+<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:shutdownNowStopsRunningWorkAndReturnsQueuedWork()]
 display-name: shutdownNowStopsRunningWorkAndReturnsQueuedWork()
 ]]></system-out>
 </testcase>
-<testcase name="invokeAnyPropagatesFailureWhenEveryTaskFails()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
+<testcase name="invokeAnyPropagatesFailureWhenEveryTaskFails()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyPropagatesFailureWhenEveryTaskFails()]
 display-name: invokeAnyPropagatesFailureWhenEveryTaskFails()
 ]]></system-out>
 </testcase>
-<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
+<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAllAndInvokeAnyCompleteBoundedTaskSets()]
 display-name: invokeAllAndInvokeAnyCompleteBoundedTaskSets()
 ]]></system-out>
 </testcase>
-<testcase name="submitVariantsReturnExpectedResults()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.006">
+<testcase name="submitVariantsReturnExpectedResults()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:submitVariantsReturnExpectedResults()]
 display-name: submitVariantsReturnExpectedResults()

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.101" hostname="kung-fu-workstation" timestamp="2026-05-02T18:26:06">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.117" hostname="kung-fu-workstation" timestamp="2026-05-02T18:27:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,19 +52,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.1">
+<testcase name="invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.102">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()]
 display-name: invokeAnyTimesOutWhenNoTaskCompletesBeforeDeadline()
 ]]></system-out>
 </testcase>
-<testcase name="closePerformsOrderlyShutdownAndWaitsUntilTerminated()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<testcase name="closePerformsOrderlyShutdownAndWaitsUntilTerminated()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:closePerformsOrderlyShutdownAndWaitsUntilTerminated()]
 display-name: closePerformsOrderlyShutdownAndWaitsUntilTerminated()
 ]]></system-out>
 </testcase>
-<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<testcase name="shutdownNowStopsRunningWorkAndReturnsQueuedWork()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:shutdownNowStopsRunningWorkAndReturnsQueuedWork()]
 display-name: shutdownNowStopsRunningWorkAndReturnsQueuedWork()
@@ -76,16 +76,22 @@ unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_
 display-name: invokeAnyPropagatesFailureWhenEveryTaskFails()
 ]]></system-out>
 </testcase>
-<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<testcase name="invokeAllAndInvokeAnyCompleteBoundedTaskSets()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:invokeAllAndInvokeAnyCompleteBoundedTaskSets()]
 display-name: invokeAllAndInvokeAnyCompleteBoundedTaskSets()
 ]]></system-out>
 </testcase>
-<testcase name="submitVariantsReturnExpectedResults()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0">
+<testcase name="submitVariantsReturnExpectedResults()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:submitVariantsReturnExpectedResults()]
 display-name: submitVariantsReturnExpectedResults()
+]]></system-out>
+</testcase>
+<testcase name="closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()" classname="com_google_guava.guava_bootstrap.Guava_bootstrapTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_guava.guava_bootstrap.Guava_bootstrapTest]/[method:closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()]
+display-name: closeForcesShutdownAndRestoresInterruptStatusAfterInterruptedWait()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:24:17">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:26:06">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:27:29">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:29:54">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2838-cd60ddfe/tests/src/com.google.guava/guava-bootstrap/11.0.2"/>

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:24:17">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2838-cd60ddfe/tests/src/com.google.guava/guava-bootstrap/11.0.2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:26:06">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:27:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/user-code-filter.json
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "java.util.concurrent.**"
+    }
+  ]
+}

--- a/tests/src/com.google.guava/guava-bootstrap/11.0.2/user-code-filter.json
+++ b/tests/src/com.google.guava/guava-bootstrap/11.0.2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "java.util.concurrent.**"
+      "includeClasses" : "java.util.concurrent.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2838

This PR introduces tests and metadata for com.google.guava:guava-bootstrap:11.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 160112
- Cached input tokens: 1063936
- Output tokens: 20605
- Metadata entries: 16
- Test-only metadata entries: 8
- Iterations: 4
- Library coverage percentage: 100.0
- Generated lines of code: 285
- Tested library lines of code: 0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f7e19c10f73c3ed6cafadfc8bd28a9a01cb26412`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: N/A
- Line: N/A
- Method: N/A
