### PR TITLE
[GenAI] Test fix for io.r2dbc:r2dbc-spi:1.0.0.RELEASE using gpt-5.5

### DIFF
--- a/metadata/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/reachability-metadata.json
+++ b/metadata/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.r2dbc.spi.DefaultLob"
+      },
+      "type": "io.r2dbc.spi.DefaultLob"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.r2dbc.spi.ConnectionFactories"
+      },
+      "glob": "META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider"
+    }
+  ]
+}

--- a/metadata/io.r2dbc/r2dbc-spi/index.json
+++ b/metadata/io.r2dbc/r2dbc-spi/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.0.0.RELEASE",
+    "tested-versions" : [
+      "1.0.0.RELEASE"
+    ],
+    "allowed-packages" : [
+      "io.r2dbc.spi"
+    ]
+  },
+  {
     "metadata-version" : "0.9.1.RELEASE",
     "source-code-url" : "https://repo1.maven.org/maven2/io/r2dbc/r2dbc-spi/$version$/r2dbc-spi-$version$-sources.jar",
     "repository-url" : "https://github.com/r2dbc/r2dbc-spi",

--- a/metadata/io.r2dbc/r2dbc-spi/index.json
+++ b/metadata/io.r2dbc/r2dbc-spi/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.0.0.RELEASE",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/r2dbc/r2dbc-spi/$version$/r2dbc-spi-$version$-sources.jar",
+    "repository-url" : "https://github.com/r2dbc/r2dbc-spi",
+    "test-code-url" : "https://github.com/r2dbc/r2dbc-spi/tree/v$version$/r2dbc-spi/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/r2dbc/r2dbc-spi/$version$/r2dbc-spi-$version$-javadoc.jar",
+    "description" : "R2DBC SPI defines the service provider interfaces and core contracts for reactive relational database connectivity on the JVM. It lets database driver vendors expose non-blocking, Reactive Streams-based access to SQL databases while giving clients a common API to discover connections, execute statements, and consume results.",
     "tested-versions" : [
       "1.0.0.RELEASE"
     ],

--- a/stats/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/execution-metrics.json
+++ b/stats/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T16:39:19.622115Z",
+    "library": "io.r2dbc:r2dbc-spi:1.0.0.RELEASE",
+    "starting_commit": "eed8f668b437bad6da1c7e227d1049c117ddbe5e",
+    "ending_commit": "fec6ddce77396bb4905572e73d4cdfaef2dde04a",
+    "previous_library": "io.r2dbc:r2dbc-spi:0.9.1.RELEASE",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.0.RELEASE",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2110,
+          "missed": 1011,
+          "ratio": 0.676065,
+          "total": 3121
+        },
+        "line": {
+          "covered": 441,
+          "missed": 289,
+          "ratio": 0.60411,
+          "total": 730
+        },
+        "method": {
+          "covered": 135,
+          "missed": 116,
+          "ratio": 0.537849,
+          "total": 251
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.9.1.RELEASE",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2094,
+          "missed": 1011,
+          "ratio": 0.674396,
+          "total": 3105
+        },
+        "line": {
+          "covered": 437,
+          "missed": 289,
+          "ratio": 0.601928,
+          "total": 726
+        },
+        "method": {
+          "covered": 135,
+          "missed": 116,
+          "ratio": 0.537849,
+          "total": 251
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 30733,
+      "cached_input_tokens_used": 186368,
+      "output_tokens_used": 2264,
+      "iterations": 1,
+      "cost_usd": 0.1611,
+      "tested_library_loc": 441,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 60.41,
+      "previous_library_coverage_percent": 60.19
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java",
+      "metadata_file": "metadata/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/stats.json
+++ b/stats/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.0.RELEASE",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2110,
+        "missed" : 1011,
+        "ratio" : 0.676065,
+        "total" : 3121
+      },
+      "line" : {
+        "covered" : 441,
+        "missed" : 289,
+        "ratio" : 0.60411,
+        "total" : 730
+      },
+      "method" : {
+        "covered" : 135,
+        "missed" : 116,
+        "ratio" : 0.537849,
+        "total" : 251
+      }
+    }
+  } ]
+}

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/.gitignore
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/build.gradle
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.r2dbc:r2dbc-spi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/gradle.properties
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.r2dbc:r2dbc-spi:1.0.0.RELEASE
+library.version = 1.0.0.RELEASE
+metadata.dir = io.r2dbc/r2dbc-spi/1.0.0.RELEASE/

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/settings.gradle
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.r2dbc.r2dbc-spi_tests'

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_r2dbc.r2dbc_spi;
+
+import io.r2dbc.spi.Blob;
+import io.r2dbc.spi.Clob;
+import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.NoSuchOptionException;
+import io.r2dbc.spi.Nullability;
+import io.r2dbc.spi.Option;
+import io.r2dbc.spi.Parameter;
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.R2dbcBadGrammarException;
+import io.r2dbc.spi.R2dbcTimeoutException;
+import io.r2dbc.spi.R2dbcTransientException;
+import io.r2dbc.spi.R2dbcType;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import io.r2dbc.spi.TransactionDefinition;
+import io.r2dbc.spi.Type;
+import io.r2dbc.spi.ValidationDepth;
+import io.r2dbc.spi.Wrapped;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class R2dbc_spiTest {
+
+    @Test
+    void connectionFactoryOptionsBuilderMutationFilteringAndRedactionWork() {
+        Option<String> applicationName = Option.valueOf("applicationName");
+
+        ConnectionFactoryOptions original = ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "pool")
+                .option(ConnectionFactoryOptions.PROTOCOL, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "primary.internal")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .option(ConnectionFactoryOptions.USER, "forge")
+                .option(ConnectionFactoryOptions.PASSWORD, "s3cr3t")
+                .option(applicationName, "metadata-forge")
+                .build();
+
+        assertThat(original.getRequiredValue(ConnectionFactoryOptions.HOST)).isEqualTo("primary.internal");
+        assertThat(original.hasOption(ConnectionFactoryOptions.DATABASE)).isFalse();
+        assertThatThrownBy(() -> original.getRequiredValue(ConnectionFactoryOptions.DATABASE))
+                .isInstanceOfSatisfying(NoSuchOptionException.class, exception -> {
+                    assertThat(exception.getOption()).isEqualTo(ConnectionFactoryOptions.DATABASE);
+                    assertThat(exception).hasMessageContaining("database");
+                });
+        assertThat(original.toString())
+                .contains("host=primary.internal", "user=forge", "applicationName=metadata-forge")
+                .contains("password=REDACTED")
+                .doesNotContain("s3cr3t");
+
+        ConnectionFactoryOptions replica = original.mutate()
+                .option(ConnectionFactoryOptions.HOST, "replica.internal")
+                .build();
+
+        assertThat(replica.getValue(ConnectionFactoryOptions.HOST)).isEqualTo("replica.internal");
+        assertThat(original.getValue(ConnectionFactoryOptions.HOST)).isEqualTo("primary.internal");
+
+        ConnectionFactoryOptions withoutSensitiveOptions = ConnectionFactoryOptions.builder()
+                .from(original, option -> !option.equals(ConnectionFactoryOptions.PASSWORD))
+                .build();
+
+        assertThat(withoutSensitiveOptions.hasOption(ConnectionFactoryOptions.PASSWORD)).isFalse();
+        assertThat(withoutSensitiveOptions.getValue(applicationName)).isEqualTo("metadata-forge");
+    }
+
+    @Test
+    void parseConnectionUrlDecodesStructuredOptionsAndRejectsReservedQueryOptions() {
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(
+                "r2dbcs:pool:postgresql://user%20name:p%40ss+word@localhost:5432/sample%20db"
+                        + "?schema=tenant%2Bone&applicationName=my+app");
+
+        assertThat(options.getValue(ConnectionFactoryOptions.DRIVER)).isEqualTo("pool");
+        assertThat(options.getValue(ConnectionFactoryOptions.PROTOCOL)).isEqualTo("postgresql");
+        assertThat(options.getValue(ConnectionFactoryOptions.SSL)).isEqualTo(Boolean.TRUE);
+        assertThat(options.getValue(ConnectionFactoryOptions.HOST)).isEqualTo("localhost");
+        assertThat(options.getValue(ConnectionFactoryOptions.PORT)).isEqualTo(5432);
+        assertThat(options.getValue(ConnectionFactoryOptions.DATABASE)).isEqualTo("sample db");
+        assertThat(options.getValue(ConnectionFactoryOptions.USER)).isEqualTo("user name");
+        assertThat(options.getValue(ConnectionFactoryOptions.PASSWORD)).hasToString("p@ss word");
+        assertThat(options.getValue(Option.valueOf("schema"))).isEqualTo("tenant+one");
+        assertThat(options.getValue(Option.valueOf("applicationName"))).isEqualTo("my app");
+
+        assertThatThrownBy(() -> ConnectionFactoryOptions.parse("r2dbc:postgresql://localhost/test?user=alice"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not declare option user");
+    }
+
+    @Test
+    void optionsAndIsolationLevelsPreserveNamesSensitivityAndTransactionAttributes() {
+        Option<String> tenant = Option.valueOf("tenant");
+        Option<String> sameTenant = Option.valueOf("tenant");
+        Option<String> tenantDeclaredSensitiveLater = Option.sensitiveValueOf("tenant");
+        Option<String> sensitiveApiKey = Option.sensitiveValueOf("apiKey");
+        Option<String> sameSensitiveApiKey = Option.valueOf("apiKey");
+
+        assertThat(tenant).isEqualTo(sameTenant);
+        assertThat(tenant.hashCode()).isEqualTo(sameTenant.hashCode());
+        assertThat(tenant.cast("blue")).isEqualTo("blue");
+        assertThat(tenant.cast(null)).isNull();
+        assertThat(tenant.toString()).contains("tenant", "sensitive=false");
+        assertThat(tenantDeclaredSensitiveLater).isEqualTo(tenant);
+        assertThat(tenantDeclaredSensitiveLater.toString()).contains("tenant", "sensitive=false");
+        assertThat(sensitiveApiKey).isEqualTo(sameSensitiveApiKey);
+        assertThat(sensitiveApiKey.toString()).contains("apiKey", "sensitive=true");
+
+        IsolationLevel isolationLevel = IsolationLevel.valueOf("READ COMMITTED");
+
+        assertThat(isolationLevel).isEqualTo(IsolationLevel.READ_COMMITTED);
+        assertThat(isolationLevel.asSql()).isEqualTo("READ COMMITTED");
+        assertThat(isolationLevel.getAttribute(TransactionDefinition.ISOLATION_LEVEL)).isSameAs(isolationLevel);
+        assertThat(isolationLevel.getAttribute(TransactionDefinition.NAME)).isNull();
+        assertThat(isolationLevel.toString()).contains("READ COMMITTED");
+    }
+
+    @Test
+    void parametersRepresentDirectionsAndR2dbcTypesExposeMappedJavaTypes() {
+        Parameter in = Parameters.in(R2dbcType.VARCHAR, "alpha");
+        Parameter sameIn = Parameters.in(R2dbcType.VARCHAR, "alpha");
+        Parameter out = Parameters.out(Integer.class);
+        Parameter inOut = Parameters.inOut(R2dbcType.BOOLEAN, true);
+        Parameter inferred = Parameters.in(42);
+
+        assertThat(in).isInstanceOf(Parameter.In.class).isNotInstanceOf(Parameter.Out.class);
+        assertThat(in).isEqualTo(sameIn).isNotEqualTo(inOut);
+        assertThat(in.getType()).isEqualTo(R2dbcType.VARCHAR);
+        assertThat(in.getValue()).isEqualTo("alpha");
+        assertThat(in.toString()).isEqualTo("In{VARCHAR}");
+
+        assertThat(out).isInstanceOf(Parameter.Out.class).isNotInstanceOf(Parameter.In.class);
+        assertThat(out.getValue()).isNull();
+        assertThat(out.getType()).isInstanceOfSatisfying(Type.InferredType.class, type -> {
+            assertThat(type.getJavaType()).isEqualTo(Integer.class);
+            assertThat(type.getName()).isEqualTo("(inferred)");
+            assertThat(type.toString()).isEqualTo("Inferred: java.lang.Integer");
+        });
+        assertThat(out.toString()).isEqualTo("Out{Inferred: java.lang.Integer}");
+
+        assertThat(inOut).isInstanceOf(Parameter.In.class).isInstanceOf(Parameter.Out.class);
+        assertThat(inOut.getValue()).isEqualTo(true);
+        assertThat(inOut.toString()).isEqualTo("InOut{BOOLEAN}");
+
+        assertThat(inferred.getValue()).isEqualTo(42);
+        assertThat(inferred.getType()).isInstanceOfSatisfying(Type.InferredType.class,
+                type -> assertThat(type.getJavaType()).isEqualTo(Integer.class));
+
+        assertThat(R2dbcType.VARCHAR.getName()).isEqualTo("VARCHAR");
+        assertThat(R2dbcType.BLOB.getJavaType()).isEqualTo(ByteBuffer.class);
+        assertThat(R2dbcType.TIMESTAMP.getJavaType()).isEqualTo(LocalDateTime.class);
+        assertThat(ValidationDepth.values()).containsExactly(ValidationDepth.LOCAL, ValidationDepth.REMOTE);
+    }
+
+    @Test
+    void blobStreamsDataOnceAndRejectsReuse() {
+        RecordingPublisher<ByteBuffer> source = new RecordingPublisher<>(List.of(
+                StandardCharsets.UTF_8.encode("graal"),
+                StandardCharsets.UTF_8.encode("vm")));
+        Blob blob = Blob.from(source);
+
+        PublisherOutcome<ByteBuffer> firstRead = await(blob.stream());
+
+        assertThat(firstRead.completed).isTrue();
+        assertThat(firstRead.error).isNull();
+        assertThat(decodeUtf8(firstRead.items)).isEqualTo("graalvm");
+        assertThat(source.subscriptionCount()).isEqualTo(1);
+
+        PublisherOutcome<ByteBuffer> secondRead = await(blob.stream());
+
+        assertThat(secondRead.completed).isFalse();
+        assertThat(secondRead.items).isEmpty();
+        assertThat(secondRead.error)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already consumed");
+    }
+
+    @Test
+    void clobDiscardConsumesSourceAndPreventsStreamingAfterRelease() {
+        RecordingPublisher<CharSequence> source = new RecordingPublisher<>(List.of("metadata", "-forge"));
+        Clob clob = Clob.from(source);
+
+        PublisherOutcome<Void> discard = await(clob.discard());
+
+        assertThat(discard.completed).isTrue();
+        assertThat(discard.error).isNull();
+        assertThat(source.subscriptionCount()).isEqualTo(1);
+
+        PublisherOutcome<CharSequence> afterDiscard = await(clob.stream());
+
+        assertThat(afterDiscard.completed).isFalse();
+        assertThat(afterDiscard.items).isEmpty();
+        assertThat(afterDiscard.error)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already released");
+    }
+
+    @Test
+    void connectionFactoriesRejectUnsupportedDriversAndExceptionsRetainContext() {
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "definitely-missing")
+                .option(ConnectionFactoryOptions.HOST, "localhost")
+                .option(ConnectionFactoryOptions.DATABASE, "test")
+                .build();
+
+        assertThat(ConnectionFactories.find(options)).isNull();
+        assertThat(ConnectionFactories.supports(options)).isFalse();
+        assertThatThrownBy(() -> ConnectionFactories.get(options))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unable to create a ConnectionFactory")
+                .hasMessageContaining("definitely-missing");
+
+        IllegalArgumentException cause = new IllegalArgumentException("boom");
+        R2dbcBadGrammarException badGrammar = new R2dbcBadGrammarException(
+                "Bad SQL", "42000", 7, "SELECT * FROM broken", cause);
+
+        assertThat(badGrammar.getMessage()).isEqualTo("Bad SQL");
+        assertThat(badGrammar.getSqlState()).isEqualTo("42000");
+        assertThat(badGrammar.getErrorCode()).isEqualTo(7);
+        assertThat(badGrammar.getOffendingSql()).isEqualTo("SELECT * FROM broken");
+        assertThat(badGrammar.getCause()).isSameAs(cause);
+        assertThat(badGrammar.toString()).contains("Bad SQL", "[7]", "[42000]");
+
+        R2dbcTimeoutException timeout = new R2dbcTimeoutException("Timed out", "57014", 91);
+
+        assertThat(timeout).isInstanceOf(R2dbcTransientException.class);
+        assertThat(timeout.getSql()).isNull();
+        assertThat(timeout.toString()).contains("Timed out", "[91]", "[57014]");
+    }
+
+    @Test
+    void resultReadableAndMetadataDefaultMethodsDelegateToTypedAccessors() {
+        TestColumnMetadata nameColumn = new TestColumnMetadata("name", R2dbcType.VARCHAR);
+        TestColumnMetadata countColumn = new TestColumnMetadata("count", R2dbcType.INTEGER);
+        TestRowMetadata rowMetadata = new TestRowMetadata(List.of(nameColumn, countColumn));
+        TestRow row = new TestRow(
+                List.of("forge", 7),
+                Map.of("name", "forge", "count", 7),
+                rowMetadata);
+        TestResult result = new TestResult(row, rowMetadata);
+
+        assertThat(row.get(0)).isEqualTo("forge");
+        assertThat(row.get("count")).isEqualTo(7);
+        assertThat(row.lastIndexedType()).isEqualTo(Object.class);
+        assertThat(row.lastNamedType()).isEqualTo(Object.class);
+
+        PublisherOutcome<String> mapped = await(result.map(readable ->
+                readable.get("name", String.class) + ":" + readable.get(1, Integer.class)));
+
+        assertThat(mapped.completed).isTrue();
+        assertThat(mapped.error).isNull();
+        assertThat(mapped.items).containsExactly("forge:7");
+        assertThat(result.lastMappedRow()).isSameAs(row);
+        assertThat(result.lastMappedMetadata()).isSameAs(rowMetadata);
+
+        assertThat(rowMetadata.contains("name")).isTrue();
+        assertThat(rowMetadata.contains("missing")).isFalse();
+        assertThat(rowMetadata.getColumnMetadata("count")).isSameAs(countColumn);
+        assertThat(rowMetadata.getColumnMetadata(0)).isSameAs(nameColumn);
+
+        assertThat(nameColumn.getName()).isEqualTo("name");
+        assertThat(nameColumn.getType()).isEqualTo(R2dbcType.VARCHAR);
+        assertThat(nameColumn.getJavaType()).isNull();
+        assertThat(nameColumn.getNativeTypeMetadata()).isNull();
+        assertThat(nameColumn.getNullability()).isEqualTo(Nullability.UNKNOWN);
+        assertThat(nameColumn.getPrecision()).isNull();
+        assertThat(nameColumn.getScale()).isNull();
+    }
+
+    @Test
+    void wrappedDefaultMethodRecursivelyUnwrapsNestedWrappers() {
+        DriverSpecificHandle inner = new DriverSpecificHandle("postgresql");
+        TestWrapped<DriverSpecificHandle> nested = new TestWrapped<>(inner);
+
+        assertThat(nested.unwrap(TestWrapped.class)).isSameAs(nested);
+        assertThat(nested.unwrap(DriverFacade.class)).isSameAs(inner);
+        assertThat(nested.unwrap(CharSequence.class)).isNull();
+        assertThatThrownBy(() -> nested.unwrap((Class<Object>) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("targetClass must not be null");
+    }
+
+    private static <T> PublisherOutcome<T> await(Publisher<T> publisher) {
+        List<T> items = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<Boolean> completed = new AtomicReference<>(false);
+        CountDownLatch finished = new CountDownLatch(1);
+
+        publisher.subscribe(new Subscriber<>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(T item) {
+                items.add(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                error.set(throwable);
+                finished.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+                finished.countDown();
+            }
+        });
+
+        assertThat(finishedAwaited(finished)).isTrue();
+        return new PublisherOutcome<>(items, error.get(), completed.get());
+    }
+
+    private static boolean finishedAwaited(CountDownLatch finished) {
+        try {
+            return finished.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for publisher completion", exception);
+        }
+    }
+
+    private static String decodeUtf8(List<ByteBuffer> buffers) {
+        StringBuilder text = new StringBuilder();
+        for (ByteBuffer buffer : buffers) {
+            ByteBuffer copy = buffer.asReadOnlyBuffer();
+            byte[] bytes = new byte[copy.remaining()];
+            copy.get(bytes);
+            text.append(new String(bytes, StandardCharsets.UTF_8));
+        }
+        return text.toString();
+    }
+
+    private static final class TestResult implements Result {
+
+        private final Row row;
+
+        private final RowMetadata metadata;
+
+        private final AtomicReference<Row> lastMappedRow = new AtomicReference<>();
+
+        private final AtomicReference<RowMetadata> lastMappedMetadata = new AtomicReference<>();
+
+        private TestResult(Row row, RowMetadata metadata) {
+            this.row = row;
+            this.metadata = metadata;
+        }
+
+        @Override
+        public Publisher<Integer> getRowsUpdated() {
+            return new RecordingPublisher<>(List.of(1));
+        }
+
+        @Override
+        public <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction) {
+            lastMappedRow.set(row);
+            lastMappedMetadata.set(metadata);
+            return new RecordingPublisher<>(List.of(mappingFunction.apply(row, metadata)));
+        }
+
+        @Override
+        public Result filter(Predicate<Result.Segment> filter) {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public <T> Publisher<T> flatMap(Function<Result.Segment, ? extends Publisher<? extends T>> mappingFunction) {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        private Row lastMappedRow() {
+            return lastMappedRow.get();
+        }
+
+        private RowMetadata lastMappedMetadata() {
+            return lastMappedMetadata.get();
+        }
+    }
+
+    private static final class TestRow implements Row {
+
+        private final List<Object> indexedValues;
+
+        private final Map<String, Object> namedValues;
+
+        private final RowMetadata metadata;
+
+        private final AtomicReference<Class<?>> lastIndexedType = new AtomicReference<>();
+
+        private final AtomicReference<Class<?>> lastNamedType = new AtomicReference<>();
+
+        private TestRow(List<Object> indexedValues, Map<String, Object> namedValues, RowMetadata metadata) {
+            this.indexedValues = indexedValues;
+            this.namedValues = namedValues;
+            this.metadata = metadata;
+        }
+
+        @Override
+        public RowMetadata getMetadata() {
+            return metadata;
+        }
+
+        @Override
+        public <T> T get(int index, Class<T> type) {
+            lastIndexedType.set(type);
+            return type.cast(indexedValues.get(index));
+        }
+
+        @Override
+        public <T> T get(String name, Class<T> type) {
+            lastNamedType.set(type);
+            return type.cast(namedValues.get(name));
+        }
+
+        private Class<?> lastIndexedType() {
+            return lastIndexedType.get();
+        }
+
+        private Class<?> lastNamedType() {
+            return lastNamedType.get();
+        }
+    }
+
+    private static final class TestRowMetadata implements RowMetadata {
+
+        private final List<? extends ColumnMetadata> columns;
+
+        private final Map<String, ColumnMetadata> columnsByName;
+
+        private TestRowMetadata(List<? extends ColumnMetadata> columns) {
+            this.columns = columns;
+            this.columnsByName = new LinkedHashMap<>();
+            for (ColumnMetadata column : columns) {
+                columnsByName.put(column.getName(), column);
+            }
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(int index) {
+            return columns.get(index);
+        }
+
+        @Override
+        public ColumnMetadata getColumnMetadata(String name) {
+            return columnsByName.get(name);
+        }
+
+        @Override
+        public List<? extends ColumnMetadata> getColumnMetadatas() {
+            return columns;
+        }
+
+        @Override
+        public Collection<String> getColumnNames() {
+            return columnsByName.keySet();
+        }
+    }
+
+    private static final class TestColumnMetadata implements ColumnMetadata {
+
+        private final String name;
+
+        private final Type type;
+
+        private TestColumnMetadata(String name, Type type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        @Override
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static final class PublisherOutcome<T> {
+
+        private final List<T> items;
+
+        private final Throwable error;
+
+        private final boolean completed;
+
+        private PublisherOutcome(List<T> items, Throwable error, boolean completed) {
+            this.items = items;
+            this.error = error;
+            this.completed = completed;
+        }
+    }
+
+    private interface DriverFacade {
+
+        String backend();
+    }
+
+    private static final class DriverSpecificHandle implements DriverFacade, Wrapped<Object> {
+
+        private final String backend;
+
+        private DriverSpecificHandle(String backend) {
+            this.backend = backend;
+        }
+
+        @Override
+        public String backend() {
+            return backend;
+        }
+
+        @Override
+        public Object unwrap() {
+            return backend;
+        }
+    }
+
+    private static final class TestWrapped<T> implements Wrapped<T> {
+
+        private final T delegate;
+
+        private TestWrapped(T delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T unwrap() {
+            return delegate;
+        }
+    }
+
+    private static final class RecordingPublisher<T> implements Publisher<T> {
+
+        private final List<T> elements;
+
+        private final AtomicInteger subscriptions = new AtomicInteger();
+
+        private RecordingPublisher(List<T> elements) {
+            this.elements = elements;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber) {
+            subscriptions.incrementAndGet();
+            subscriber.onSubscribe(new Subscription() {
+
+                private boolean finished;
+
+                @Override
+                public void request(long requested) {
+                    if (finished) {
+                        return;
+                    }
+                    finished = true;
+                    if (requested <= 0) {
+                        subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                        return;
+                    }
+                    for (T element : elements) {
+                        subscriber.onNext(element);
+                    }
+                    subscriber.onComplete();
+                }
+
+                @Override
+                public void cancel() {
+                    finished = true;
+                }
+            });
+        }
+
+        private int subscriptionCount() {
+            return subscriptions.get();
+        }
+    }
+}

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
@@ -37,7 +37,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -379,8 +378,8 @@ public class R2dbc_spiTest {
         }
 
         @Override
-        public Publisher<Integer> getRowsUpdated() {
-            return new RecordingPublisher<>(List.of(1));
+        public Publisher<Long> getRowsUpdated() {
+            return new RecordingPublisher<>(List.of(1L));
         }
 
         @Override
@@ -480,11 +479,6 @@ public class R2dbc_spiTest {
         @Override
         public List<? extends ColumnMetadata> getColumnMetadatas() {
             return columns;
-        }
-
-        @Override
-        public Collection<String> getColumnNames() {
-            return columnsByName.keySet();
         }
     }
 

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-02T18:38:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2567-641edf30/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="parseConnectionUrlDecodesStructuredOptionsAndRejectsReservedQueryOptions()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:parseConnectionUrlDecodesStructuredOptionsAndRejectsReservedQueryOptions()]
+display-name: parseConnectionUrlDecodesStructuredOptionsAndRejectsReservedQueryOptions()
+]]></system-out>
+</testcase>
+<testcase name="wrappedDefaultMethodRecursivelyUnwrapsNestedWrappers()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:wrappedDefaultMethodRecursivelyUnwrapsNestedWrappers()]
+display-name: wrappedDefaultMethodRecursivelyUnwrapsNestedWrappers()
+]]></system-out>
+</testcase>
+<testcase name="connectionFactoriesRejectUnsupportedDriversAndExceptionsRetainContext()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:connectionFactoriesRejectUnsupportedDriversAndExceptionsRetainContext()]
+display-name: connectionFactoriesRejectUnsupportedDriversAndExceptionsRetainContext()
+]]></system-out>
+</testcase>
+<testcase name="optionsAndIsolationLevelsPreserveNamesSensitivityAndTransactionAttributes()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:optionsAndIsolationLevelsPreserveNamesSensitivityAndTransactionAttributes()]
+display-name: optionsAndIsolationLevelsPreserveNamesSensitivityAndTransactionAttributes()
+]]></system-out>
+</testcase>
+<testcase name="clobDiscardConsumesSourceAndPreventsStreamingAfterRelease()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:clobDiscardConsumesSourceAndPreventsStreamingAfterRelease()]
+display-name: clobDiscardConsumesSourceAndPreventsStreamingAfterRelease()
+]]></system-out>
+</testcase>
+<testcase name="blobStreamsDataOnceAndRejectsReuse()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:blobStreamsDataOnceAndRejectsReuse()]
+display-name: blobStreamsDataOnceAndRejectsReuse()
+]]></system-out>
+</testcase>
+<testcase name="connectionFactoryOptionsBuilderMutationFilteringAndRedactionWork()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:connectionFactoryOptionsBuilderMutationFilteringAndRedactionWork()]
+display-name: connectionFactoryOptionsBuilderMutationFilteringAndRedactionWork()
+]]></system-out>
+</testcase>
+<testcase name="parametersRepresentDirectionsAndR2dbcTypesExposeMappedJavaTypes()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:parametersRepresentDirectionsAndR2dbcTypesExposeMappedJavaTypes()]
+display-name: parametersRepresentDirectionsAndR2dbcTypesExposeMappedJavaTypes()
+]]></system-out>
+</testcase>
+<testcase name="resultReadableAndMetadataDefaultMethodsDelegateToTypedAccessors()" classname="io_r2dbc.r2dbc_spi.R2dbc_spiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_r2dbc.r2dbc_spi.R2dbc_spiTest]/[method:resultReadableAndMetadataDefaultMethodsDelegateToTypedAccessors()]
+display-name: resultReadableAndMetadataDefaultMethodsDelegateToTypedAccessors()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T18:38:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2567-641edf30/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/user-code-filter.json
+++ b/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.r2dbc.spi.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2567

This PR provides test fixes and new metadata for io.r2dbc:r2dbc-spi:1.0.0.RELEASE, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 30733
- Cached input tokens: 186368
- Output tokens: 2264
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 60.41
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 60.19

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3827edb5771788b2dfda4e6f6c79d3ec878f16cf`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.r2dbc:r2dbc-spi:0.9.1.RELEASE: 0/0 covered calls (100.00%)
- io.r2dbc:r2dbc-spi:1.0.0.RELEASE: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.r2dbc:r2dbc-spi:0.9.1.RELEASE: 2094/3105 (67.44%)
- io.r2dbc:r2dbc-spi:1.0.0.RELEASE: 2110/3121 (67.61%)

**Line:**
- io.r2dbc:r2dbc-spi:0.9.1.RELEASE: 437/726 (60.19%)
- io.r2dbc:r2dbc-spi:1.0.0.RELEASE: 441/730 (60.41%)

**Method:**
- io.r2dbc:r2dbc-spi:0.9.1.RELEASE: 135/251 (53.78%)
- io.r2dbc:r2dbc-spi:1.0.0.RELEASE: 135/251 (53.78%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.r2dbc/r2dbc-spi/0.9.1.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java 2/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
index 6367143e4e..f73be84049 100644
--- 1/tests/src/io.r2dbc/r2dbc-spi/0.9.1.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
+++ 2/tests/src/io.r2dbc/r2dbc-spi/1.0.0.RELEASE/src/test/java/io_r2dbc/r2dbc_spi/R2dbc_spiTest.java
@@ -37,7 +37,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -379,8 +378,8 @@ public class R2dbc_spiTest {
         }
 
         @Override
-        public Publisher<Integer> getRowsUpdated() {
-            return new RecordingPublisher<>(List.of(1));
+        public Publisher<Long> getRowsUpdated() {
+            return new RecordingPublisher<>(List.of(1L));
         }
 
         @Override
@@ -481,11 +480,6 @@ public class R2dbc_spiTest {
         public List<? extends ColumnMetadata> getColumnMetadatas() {
             return columns;
         }
-
-        @Override
-        public Collection<String> getColumnNames() {
-            return columnsByName.keySet();
-        }
     }
 
     private static final class TestColumnMetadata implements ColumnMetadata {

```
