### PR TITLE
[GenAI] Mark io.netty.incubator:netty-incubator-codec-native-quic as not for Native Image

### DIFF
--- a/metadata/io.netty.incubator/netty-incubator-codec-native-quic/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-native-quic/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The default and platform classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.",
+    "replacement": "io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #1445

This PR records `io.netty.incubator:netty-incubator-codec-native-quic` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The default and platform classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.

Replacement guidance:
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8874a9649085e34940563d7174f9d4c519e2a745`
