### PR TITLE
[Automation] Generated metadata for org.slf4j:slf4j-nop:1.5.7

### DIFF
--- a/metadata/org.slf4j/slf4j-nop/1.5.7/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-nop/1.5.7/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMarkerBinder"
+      },
+      "type": "org.slf4j.helpers.BasicMarkerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMDCBinder"
+      },
+      "type": "org.slf4j.helpers.NOPMakerAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticLoggerBinder"
+      },
+      "type": "org.slf4j.impl.NOPLoggerFactory"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-nop/index.json
+++ b/metadata/org.slf4j/slf4j-nop/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.5.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-nop/$version$/slf4j-nop-$version$-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$_FINAL/slf4j-nop/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-site/$version$/slf4j-site-$version$-sources.jar",
+    "description" : "SLF4J NOP is a no-operation binding implementation for the SLF4J logging facade. It fulfills the required SLF4J backend dependency while intentionally discarding all log output.",
+    "test-version" : "1.5.6",
+    "tested-versions" : [
+      "1.5.7"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl"
+    ]
+  },
+  {
     "metadata-version" : "1.5.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/$version$/slf4j-nop-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/stats/org.slf4j/slf4j-nop/1.5.7/stats.json
+++ b/stats/org.slf4j/slf4j-nop/1.5.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.5.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 80,
+        "missed" : 2,
+        "ratio" : 0.97561,
+        "total" : 82
+      },
+      "line" : {
+        "covered" : 21,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 21
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 14
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3360

This PR provides new metadata needed for the org.slf4j:slf4j-nop:1.5.7, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.slf4j:slf4j-nop:1.5.6`): 3
- Metadata entries (new `org.slf4j:slf4j-nop:1.5.7`): 3
- Library coverage (previous): 100.00%
- Library coverage (new): 100.00%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f268fb77d56dfb8f3e8faea498e8b02d822ed36d`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-nop:1.5.6: 3/3 covered calls (100.00%)
- org.slf4j:slf4j-nop:1.5.7: 3/3 covered calls (100.00%)

**Reflection:**
- org.slf4j:slf4j-nop:1.5.6: 3/3 covered calls (100.00%)
- org.slf4j:slf4j-nop:1.5.7: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-nop:1.5.6: 80/82 (97.56%)
- org.slf4j:slf4j-nop:1.5.7: 80/82 (97.56%)

**Line:**
- org.slf4j:slf4j-nop:1.5.6: 21/21 (100.00%)
- org.slf4j:slf4j-nop:1.5.7: 21/21 (100.00%)

**Method:**
- org.slf4j:slf4j-nop:1.5.6: 14/14 (100.00%)
- org.slf4j:slf4j-nop:1.5.7: 14/14 (100.00%)
