### PR TITLE
[Automation] Generated metadata for org.apache.kafka:kafka-streams:3.7.0

### DIFF
--- a/metadata/org.apache.kafka/kafka-streams/3.7.0/reachability-metadata.json
+++ b/metadata/org.apache.kafka/kafka-streams/3.7.0/reachability-metadata.json
@@ -1,0 +1,517 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type" : "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
+      },
+      "type" : "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.clients.consumer.KafkaConsumer",
+      "fields" : [
+        {
+          "name" : "delegate"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.consumer.KafkaConsumer"
+      },
+      "type" : "org.apache.kafka.clients.consumer.RangeAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
+      },
+      "type" : "org.apache.kafka.clients.consumer.RangeAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer",
+      "fields" : [
+        {
+          "name" : "assignors"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.telemetry.internals.KafkaMetricsCollector"
+      },
+      "type" : "org.apache.kafka.common.metrics.KafkaMetric"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
+      },
+      "type" : "org.apache.kafka.common.resource.PatternType[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type" : "org.apache.kafka.common.serialization.IntegerSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.consumer.internals.Deserializers"
+      },
+      "type" : "org.apache.kafka.common.serialization.LongDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.KafkaStreams"
+      },
+      "type" : "org.apache.kafka.common.serialization.Serdes$StringSerde"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.StreamsConfig"
+      },
+      "type" : "org.apache.kafka.common.serialization.Serdes$StringSerde",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper"
+      },
+      "type" : "org.apache.kafka.common.serialization.Serdes$StringSerde"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.consumer.internals.Deserializers"
+      },
+      "type" : "org.apache.kafka.common.serialization.StringDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.clients.producer.KafkaProducer"
+      },
+      "type" : "org.apache.kafka.common.serialization.StringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.AbstractConfig"
+      },
+      "type" : "org.apache.kafka.coordinator.group.assignor.RangeAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.AbstractConfig"
+      },
+      "type" : "org.apache.kafka.coordinator.group.assignor.UniformAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistryFactory"
+      },
+      "type" : "org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.server.util.Json"
+      },
+      "type" : "org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler$Content",
+      "fields" : [
+        {
+          "name" : "brokerEpoch"
+        },
+        {
+          "name" : "version"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.KafkaStreams",
+      "fields" : [
+        {
+          "name" : "threads"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.KafkaStreams",
+      "fields" : [
+        {
+          "name" : "threads"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.IntegrationTestUtils"
+      },
+      "type" : "org.apache.kafka.streams.KafkaStreams",
+      "fields" : [
+        {
+          "name" : "stateListener"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.ConfigDef"
+      },
+      "type" : "org.apache.kafka.streams.errors.DefaultProductionExceptionHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.StreamsConfig"
+      },
+      "type" : "org.apache.kafka.streams.errors.DefaultProductionExceptionHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.ConfigDef"
+      },
+      "type" : "org.apache.kafka.streams.errors.LogAndFailExceptionHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.TopologyConfig"
+      },
+      "type" : "org.apache.kafka.streams.errors.LogAndFailExceptionHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest$MyTaskAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.kstream.internals.KStreamImpl"
+      },
+      "type" : "org.apache.kafka.streams.kstream.KStream[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.ConfigDef"
+      },
+      "type" : "org.apache.kafka.streams.processor.FailOnInvalidTimestamp"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.TopologyConfig"
+      },
+      "type" : "org.apache.kafka.streams.processor.FailOnInvalidTimestamp",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.config.ConfigDef"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.StreamsConfig"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.StateDirectory"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.StateDirectory$StateDirectoryProcessFile",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "processId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.StreamThread",
+      "fields" : [
+        {
+          "name" : "state"
+        },
+        {
+          "name" : "stateLock"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.StreamThread",
+      "fields" : [
+        {
+          "name" : "mainConsumer"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.TaskAssignorIntegrationTest"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor",
+      "fields" : [
+        {
+          "name" : "assignmentConfigs"
+        },
+        {
+          "name" : "assignmentListener"
+        },
+        {
+          "name" : "taskAssignorSupplier"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor"
+      },
+      "type" : "org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.utils.Utils"
+      },
+      "type" : "org.apache.kafka.streams.state.BuiltInDslStoreSuppliers$RocksDBDslStoreSuppliers",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.utils.ByteBufferUnmapper"
+      },
+      "type" : "sun.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "invokeCleaner",
+          "parameterTypes" : [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.rocksdb.RocksDB"
+      },
+      "type" : "org.rocksdb.RocksDBException",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true,
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.rocksdb.RocksDB"
+      },
+      "type" : "org.rocksdb.Status",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true,
+      "jniAccessible" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
+      },
+      "glob" : "META-INF/services/ch.qos.logback.classic.spi.Configurator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
+      },
+      "glob" : "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.internals.metrics.ClientMetrics"
+      },
+      "glob" : "kafka/kafka-streams-version.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.common.utils.AppInfoParser"
+      },
+      "glob" : "kafka/kafka-version.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.state.internals.RocksDBStore"
+      },
+      "glob" : "librocksdbjni-linux64.so"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster"
+      },
+      "glob" : "logback-test.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.kafka.streams.integration.IQv2IntegrationTest"
+      },
+      "module" : "jdk.jfr",
+      "glob" : "jdk/jfr/internal/query/view.ini"
+    }
+  ]
+}

--- a/metadata/org.apache.kafka/kafka-streams/index.json
+++ b/metadata/org.apache.kafka/kafka-streams/index.json
@@ -1,6 +1,24 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.7.0",
+    "test-version" : "3.6.0",
+    "tested-versions" : [
+      "3.7.0"
+    ],
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/kafka",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/$version$/kafka-streams-$version$-javadoc.jar",
+    "description" : "Apache Kafka Streams is a client library for building applications and microservices that process data stored in Kafka clusters. It lets Java applications define stream-processing topologies to transform, join, aggregate, and materialize event streams and tables.",
+    "allowed-packages" : [
+      "org.apache.kafka",
+      "org.rocksdb",
+      "org.mockito.internal.configuration.plugins",
+      "org.mockito.internal.runners.util"
+    ]
+  },
+  {
     "metadata-version" : "3.6.0",
     "tested-versions" : [
       "3.6.0",

--- a/stats/org.apache.kafka/kafka-streams/3.7.0/stats.json
+++ b/stats/org.apache.kafka/kafka-streams/3.7.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.7.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.454545,
+          "coveredCalls" : 15,
+          "totalCalls" : 33
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.470588,
+      "coveredCalls" : 16,
+      "totalCalls" : 34
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 39493,
+        "missed" : 635755,
+        "ratio" : 0.058487,
+        "total" : 675248
+      },
+      "line" : {
+        "covered" : 8776,
+        "missed" : 107782,
+        "ratio" : 0.075293,
+        "total" : 116558
+      },
+      "method" : {
+        "covered" : 1900,
+        "missed" : 18070,
+        "ratio" : 0.095143,
+        "total" : 19970
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#3347

This PR provides new metadata needed for the org.apache.kafka:kafka-streams:3.7.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.apache.kafka:kafka-streams:3.6.0`): 147
- Test-only metadata entries (previous `org.apache.kafka:kafka-streams:3.6.0`): 2
- Metadata entries (new `org.apache.kafka:kafka-streams:3.7.0`): 96
- Test-only metadata entries (new `org.apache.kafka:kafka-streams:3.7.0`): 2
- Library coverage (previous): 7.63%
- Library coverage (new): 7.53%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f268fb77d56dfb8f3e8faea498e8b02d822ed36d`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.kafka:kafka-streams:3.6.0: 15/31 covered calls (48.39%)
- org.apache.kafka:kafka-streams:3.7.0: 16/34 covered calls (47.06%)

**Reflection:**
- org.apache.kafka:kafka-streams:3.6.0: 14/30 covered calls (46.67%)
- org.apache.kafka:kafka-streams:3.7.0: 15/33 covered calls (45.45%)

**Resources:**
- org.apache.kafka:kafka-streams:3.6.0: 1/1 covered calls (100.00%)
- org.apache.kafka:kafka-streams:3.7.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.kafka:kafka-streams:3.6.0: 38652/651440 (5.93%)
- org.apache.kafka:kafka-streams:3.7.0: 39493/675248 (5.85%)

**Line:**
- org.apache.kafka:kafka-streams:3.6.0: 8571/112395 (7.63%)
- org.apache.kafka:kafka-streams:3.7.0: 8776/116558 (7.53%)

**Method:**
- org.apache.kafka:kafka-streams:3.6.0: 1855/19283 (9.62%)
- org.apache.kafka:kafka-streams:3.7.0: 1900/19970 (9.51%)
