### PR TITLE
[GenAI] Test fix for org.jboss.weld:weld-spi:1.2.0.Beta1 using gpt-5.5

### DIFF
--- a/stats/org.jboss.weld/weld-spi/1.2.0.Beta1/execution-metrics.json
+++ b/stats/org.jboss.weld/weld-spi/1.2.0.Beta1/execution-metrics.json
@@ -1,10 +1,10 @@
 {
   "fix_javac_fail:2026-05-02": {
-    "timestamp": "2026-05-02T14:02:16.390788Z",
+    "timestamp": "2026-05-02T18:33:03.989753Z",
     "library": "org.jboss.weld:weld-spi:1.2.0.Beta1",
-    "starting_commit": "255911fe8a8f43892aa9427230643b7dfa2e42ff",
-    "ending_commit": "5250d2ed8072b3ee4c186e02e1b5877bff95fd9b",
-    "previous_library": "org.jboss.weld:weld-spi:1.1.Final",
+    "starting_commit": "4ad45ed051185c8e462dfe26abd86a49d0c5c12d",
+    "ending_commit": "7d675d35fae52088205cf0c8d8edea2ae82ae899",
+    "previous_library": "org.jboss.weld:weld-spi:1.2.0.Beta1",
     "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -45,7 +45,7 @@
       }
     },
     "previous_library_stats": {
-      "version": "1.1.Final",
+      "version": "1.2.0.Beta1",
       "dynamicAccess": {
         "breakdown": {
           "reflection": {
@@ -61,35 +61,35 @@
       "libraryCoverage": {
         "instruction": {
           "covered": 67,
-          "missed": 1066,
-          "ratio": 0.059135,
-          "total": 1133
+          "missed": 1127,
+          "ratio": 0.056114,
+          "total": 1194
         },
         "line": {
           "covered": 26,
-          "missed": 233,
-          "ratio": 0.100386,
-          "total": 259
+          "missed": 246,
+          "ratio": 0.095588,
+          "total": 272
         },
         "method": {
           "covered": 11,
-          "missed": 145,
-          "ratio": 0.070513,
-          "total": 156
+          "missed": 152,
+          "ratio": 0.067485,
+          "total": 163
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 86098,
-      "cached_input_tokens_used": 393216,
-      "output_tokens_used": 3465,
-      "iterations": 2,
-      "cost_usd": 0.3006,
+      "input_tokens_used": 25786,
+      "cached_input_tokens_used": 223232,
+      "output_tokens_used": 2065,
+      "iterations": 1,
+      "cost_usd": 0.1735,
       "tested_library_loc": 26,
       "metadata_entries": 2,
       "previous_library_metadata_entries": 2,
       "code_coverage_percent": 9.56,
-      "previous_library_coverage_percent": 10.04
+      "previous_library_coverage_percent": 9.56
     },
     "artifacts": {
       "test_file": "tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java",

--- a/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:01:37">
+<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T20:30:36">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,13 +45,13 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4315-ac6368d2/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4379-a4514a25/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="instanceInitializesDefaultIsolatedStaticProvider()" classname="org_jboss_weld.weld_spi.SingletonProviderTest" time="0">
+<testcase name="instanceInitializesDefaultIsolatedStaticProvider()" classname="org_jboss_weld.weld_spi.SingletonProviderTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jboss_weld.weld_spi.SingletonProviderTest]/[method:instanceInitializesDefaultIsolatedStaticProvider()]
 display-name: instanceInitializesDefaultIsolatedStaticProvider()

--- a/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:01:37">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:30:36">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4315-ac6368d2/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4379-a4514a25/tests/src/org.jboss.weld/weld-spi/1.2.0.Beta1"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>


### PR DESCRIPTION
## What does this PR do?

Fixes: #4379

This PR provides test fixes and new metadata for org.jboss.weld:weld-spi:1.2.0.Beta1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 25786
- Cached input tokens: 223232
- Output tokens: 2065
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 9.56
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 9.56

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.jboss.weld:weld-spi:1.2.0.Beta1` and `org.jboss.weld:weld-spi:1.2.0.Beta1`.

**Comparison between existing test version and AI-Generated update**

```diff

```
