### PR TITLE
[GenAI] Test fix for io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/reachability-metadata.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/reachability-metadata.json
@@ -1,0 +1,223 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.InsecureQuicTokenHandler"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLCertificateCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLCertificateVerifyCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.BoringSSLHandshakeCompleteCallback"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.incubator.codec.quic.QuicheLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.ByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.BoringSSLCertificateVerifyCallback"
+      },
+      "type": "javax.net.ssl.X509ExtendedTrustManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.QuicStreamFrame$1"
+      },
+      "type": "sun.misc.VM"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.SecureRandomQuicConnectionIdGenerator"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.codec.quic.Quiche"
+      },
+      "glob": "META-INF/native/libnetty_quiche_linux_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.0.63.Final",
+    "tested-versions" : [
+      "0.0.63.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.incubator.codec.quic"
+    ]
+  },
+  {
     "metadata-version" : "0.0.34.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/incubator/netty-incubator-codec-classes-quic/$version$/netty-incubator-codec-classes-quic-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty-incubator-codec-quic",

--- a/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-codec-classes-quic/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.0.63.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/incubator/netty-incubator-codec-classes-quic/$version$/netty-incubator-codec-classes-quic-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty-incubator-codec-quic",
+    "test-code-url" : "https://github.com/netty/netty-incubator-codec-quic/tree/netty-incubator-codec-parent-quic-$version$/codec-native-quic/src/test/java/io/netty/incubator/codec/quic",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/incubator/netty-incubator-codec-classes-quic/$version$/netty-incubator-codec-classes-quic-$version$-javadoc.jar",
+    "description" : "Netty incubator codec classes for QUIC provide the Java API and implementation classes for Netty's experimental QUIC codec built on Cloudflare quiche. The artifact is paired with platform-specific native QUIC artifacts to build asynchronous Netty clients and servers that speak QUIC streams and datagrams.",
     "tested-versions" : [
       "0.0.63.Final"
     ],

--- a/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/execution-metrics.json
+++ b/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T18:37:30.493438Z",
+    "library": "io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final",
+    "starting_commit": "51cab12979cd5c94834bb36bbe7ff76cd44ff8b7",
+    "ending_commit": "2c1e2a53954a4d3b7602ab5948534785c9702a50",
+    "previous_library": "io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0.63.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 915,
+          "missed": 17534,
+          "ratio": 0.049596,
+          "total": 18449
+        },
+        "line": {
+          "covered": 184,
+          "missed": 4191,
+          "ratio": 0.042057,
+          "total": 4375
+        },
+        "method": {
+          "covered": 69,
+          "missed": 969,
+          "ratio": 0.066474,
+          "total": 1038
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.0.34.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 641,
+          "missed": 14404,
+          "ratio": 0.042606,
+          "total": 15045
+        },
+        "line": {
+          "covered": 134,
+          "missed": 3451,
+          "ratio": 0.037378,
+          "total": 3585
+        },
+        "method": {
+          "covered": 62,
+          "missed": 822,
+          "ratio": 0.070136,
+          "total": 884
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 66914,
+      "cached_input_tokens_used": 339968,
+      "output_tokens_used": 3196,
+      "iterations": 1,
+      "cost_usd": 0.2659,
+      "tested_library_loc": 184,
+      "metadata_entries": 40,
+      "previous_library_metadata_entries": 44,
+      "code_coverage_percent": 4.21,
+      "previous_library_coverage_percent": 3.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java",
+      "metadata_file": "metadata/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/stats.json
+++ b/stats/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.0.63.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 915,
+        "missed" : 17534,
+        "ratio" : 0.049596,
+        "total" : 18449
+      },
+      "line" : {
+        "covered" : 184,
+        "missed" : 4191,
+        "ratio" : 0.042057,
+        "total" : 4375
+      },
+      "method" : {
+        "covered" : 69,
+        "missed" : 969,
+        "ratio" : 0.066474,
+        "total" : 1038
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/.gitignore
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/build.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty.incubator:netty-incubator-codec-classes-quic:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/gradle.properties
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final
+library.version = 0.0.63.Final
+metadata.dir = io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/settings.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.incubator.netty-incubator-codec-classes-quic_tests'

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty_incubator.netty_incubator_codec_classes_quic;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelOption;
+import io.netty.incubator.codec.quic.DefaultQuicStreamFrame;
+import io.netty.incubator.codec.quic.FlushStrategy;
+import io.netty.incubator.codec.quic.InsecureQuicTokenHandler;
+import io.netty.incubator.codec.quic.QLogConfiguration;
+import io.netty.incubator.codec.quic.Quic;
+import io.netty.incubator.codec.quic.QuicChannelOption;
+import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
+import io.netty.incubator.codec.quic.QuicCongestionControlAlgorithm;
+import io.netty.incubator.codec.quic.QuicConnectionAddress;
+import io.netty.incubator.codec.quic.QuicConnectionIdGenerator;
+import io.netty.incubator.codec.quic.QuicError;
+import io.netty.incubator.codec.quic.QuicHeaderParser;
+import io.netty.incubator.codec.quic.QuicPacketType;
+import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
+import io.netty.incubator.codec.quic.QuicStreamAddress;
+import io.netty.incubator.codec.quic.QuicStreamFrame;
+import io.netty.incubator.codec.quic.QuicStreamPriority;
+import io.netty.incubator.codec.quic.QuicStreamType;
+import io.netty.incubator.codec.quic.SegmentedDatagramPacketAllocator;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_incubator_codec_classes_quicTest {
+    @Test
+    void quicAvailabilityContractIsSelfConsistent() {
+        boolean available = Quic.isAvailable();
+        Throwable cause = Quic.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(Quic::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(Quic.isVersionSupported(0)).isFalse();
+
+        Throwable thrown = catchThrowable(Quic::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void streamFrameBufferOperationsPreserveFinAndContentSemantics() {
+        QuicStreamFrame frame = new DefaultQuicStreamFrame(Unpooled.wrappedBuffer(new byte[] {1, 2, 3}), true);
+        QuicStreamFrame copy = frame.copy();
+        QuicStreamFrame duplicate = frame.duplicate();
+        QuicStreamFrame retainedDuplicate = frame.retainedDuplicate();
+        QuicStreamFrame replacement = frame.replace(Unpooled.wrappedBuffer(new byte[] {9, 8, 7}));
+
+        try {
+            assertThat(frame.hasFin()).isTrue();
+            assertThat(copy.hasFin()).isTrue();
+            assertThat(duplicate.hasFin()).isTrue();
+            assertThat(retainedDuplicate.hasFin()).isTrue();
+            assertThat(replacement.hasFin()).isTrue();
+
+            assertThat(frame.content().readableBytes()).isEqualTo(3);
+            assertThat(copy.content()).isNotSameAs(frame.content());
+            assertThat(duplicate.content()).isNotSameAs(frame.content());
+            assertThat(retainedDuplicate.content()).isNotSameAs(frame.content());
+
+            frame.content().setByte(0, 5);
+            assertThat(copy.content().getByte(0)).isEqualTo((byte) 1);
+            assertThat(duplicate.content().getByte(0)).isEqualTo((byte) 5);
+            assertThat(retainedDuplicate.content().getByte(0)).isEqualTo((byte) 5);
+            assertThat(replacement.content().getByte(0)).isEqualTo((byte) 9);
+
+            assertThat(frame.refCnt()).isEqualTo(2);
+            assertThat(frame.retain()).isSameAs(frame);
+            assertThat(frame.refCnt()).isEqualTo(3);
+            assertThat(frame.release()).isFalse();
+            assertThat(frame.refCnt()).isEqualTo(2);
+        } finally {
+            copy.release();
+            retainedDuplicate.release();
+            replacement.release();
+            frame.release();
+        }
+    }
+
+    @Test
+    void emptyFinFrameIsImmutableFinMarker() {
+        QuicStreamFrame emptyFin = QuicStreamFrame.EMPTY_FIN;
+
+        assertThat(emptyFin.hasFin()).isTrue();
+        assertThat(emptyFin.content().readableBytes()).isZero();
+        assertThat(emptyFin.copy().hasFin()).isTrue();
+        assertThat(emptyFin.duplicate().hasFin()).isTrue();
+        assertThat(emptyFin.retainedDuplicate().hasFin()).isTrue();
+        assertThatThrownBy(() -> emptyFin.content().writeByte(1)).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    void flushStrategiesApplyStrictPacketAndByteThresholds() {
+        FlushStrategy bytes = FlushStrategy.afterNumBytes(32);
+        FlushStrategy packets = FlushStrategy.afterNumPackets(3);
+
+        assertThat(bytes.shouldFlushNow(100, 31)).isFalse();
+        assertThat(bytes.shouldFlushNow(1, 32)).isFalse();
+        assertThat(bytes.shouldFlushNow(1, 33)).isTrue();
+
+        assertThat(packets.shouldFlushNow(3, 10_000)).isFalse();
+        assertThat(packets.shouldFlushNow(4, 0)).isTrue();
+
+        assertThat(FlushStrategy.DEFAULT.shouldFlushNow(1, 27_000)).isFalse();
+        assertThat(FlushStrategy.DEFAULT.shouldFlushNow(1, 27_001)).isTrue();
+
+        assertThatThrownBy(() -> FlushStrategy.afterNumBytes(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FlushStrategy.afterNumPackets(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void quicChannelOptionsAreRegisteredInNettyConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                QuicChannelOption.READ_FRAMES,
+                QuicChannelOption.QLOG,
+                QuicChannelOption.SEGMENTED_DATAGRAM_PACKET_ALLOCATOR
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void qlogConfigurationAndStreamPriorityExposeStableValueSemantics() {
+        QLogConfiguration qlog = new QLogConfiguration("/tmp/qlog", "integration", "quic test run");
+        assertThat(qlog.path()).isEqualTo("/tmp/qlog");
+        assertThat(qlog.logTitle()).isEqualTo("integration");
+        assertThat(qlog.logDescription()).isEqualTo("quic test run");
+
+        QuicStreamPriority priority = new QuicStreamPriority(7, true);
+        QuicStreamPriority samePriority = new QuicStreamPriority(7, true);
+        QuicStreamPriority differentPriority = new QuicStreamPriority(8, true);
+
+        assertThat(priority.urgency()).isEqualTo(7);
+        assertThat(priority.isIncremental()).isTrue();
+        assertThat(priority).isEqualTo(samePriority).hasSameHashCodeAs(samePriority);
+        assertThat(priority).isNotEqualTo(differentPriority);
+        assertThat(priority).hasToString("QuicStreamPriority{urgency=7, incremental=true}");
+        assertThatThrownBy(() -> new QuicStreamPriority(-1, false)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new QuicStreamPriority(128, false)).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new QLogConfiguration(null, "title", "description"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QLogConfiguration("path", null, "description"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new QLogConfiguration("path", "title", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void segmentedDatagramAllocatorNoneRejectsPacketAllocation() {
+        ByteBuf content = Unpooled.wrappedBuffer(new byte[] {1, 2, 3, 4});
+        try {
+            assertThat(SegmentedDatagramPacketAllocator.NONE.maxNumSegments()).isZero();
+            assertThatThrownBy(() -> SegmentedDatagramPacketAllocator.NONE.newPacket(
+                    content,
+                    2,
+                    new InetSocketAddress("127.0.0.1", 9999)
+            )).isInstanceOf(UnsupportedOperationException.class);
+        } finally {
+            content.release();
+        }
+    }
+
+    @Test
+    void simpleEnumsExposeExpectedProtocolConstants() {
+        assertThat(QuicStreamType.values()).containsExactly(
+                QuicStreamType.UNIDIRECTIONAL,
+                QuicStreamType.BIDIRECTIONAL
+        );
+        assertThat(QuicStreamType.valueOf("UNIDIRECTIONAL")).isSameAs(QuicStreamType.UNIDIRECTIONAL);
+        assertThat(QuicStreamType.valueOf("BIDIRECTIONAL")).isSameAs(QuicStreamType.BIDIRECTIONAL);
+
+        assertThat(QuicPacketType.values()).containsExactly(
+                QuicPacketType.INITIAL,
+                QuicPacketType.RETRY,
+                QuicPacketType.HANDSHAKE,
+                QuicPacketType.ZERO_RTT,
+                QuicPacketType.SHORT,
+                QuicPacketType.VERSION_NEGOTIATION
+        );
+        assertThat(QuicPacketType.valueOf("SHORT")).isSameAs(QuicPacketType.SHORT);
+    }
+
+    @Test
+    void nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable() {
+        if (!Quic.isAvailable()) {
+            assertMayRequireNativeLibrary(() -> QuicError.values());
+            assertMayRequireNativeLibrary(() -> QuicCongestionControlAlgorithm.values());
+            return;
+        }
+
+        assertThat(QuicError.values()).containsExactly(
+                QuicError.BUFFER_TOO_SHORT,
+                QuicError.UNKNOWN_VERSION,
+                QuicError.INVALID_FRAME,
+                QuicError.INVALID_PACKET,
+                QuicError.INVALID_STATE,
+                QuicError.INVALID_STREAM_STATE,
+                QuicError.INVALID_TRANSPORT_PARAM,
+                QuicError.CRYPTO_FAIL,
+                QuicError.TLS_FAIL,
+                QuicError.FLOW_CONTROL,
+                QuicError.STREAM_LIMIT,
+                QuicError.FINAL_SIZE,
+                QuicError.CONGESTION_CONTROL,
+                QuicError.STREAM_RESET,
+                QuicError.STREAM_STOPPED
+        );
+        assertThat(QuicError.INVALID_PACKET.toString()).contains("INVALID_PACKET");
+        assertThat(QuicCongestionControlAlgorithm.values()).containsExactly(
+                QuicCongestionControlAlgorithm.RENO,
+                QuicCongestionControlAlgorithm.CUBIC
+        );
+    }
+
+    @Test
+    void quicHeaderParserExtractsVersionNegotiationHeader() throws Exception {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(() -> new QuicHeaderParser(0, 4));
+            return;
+        }
+
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 4433);
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 9443);
+        byte[] destinationConnectionId = new byte[] {1, 2, 3, 4};
+        byte[] sourceConnectionId = new byte[] {5, 6, 7};
+        boolean[] processed = {false};
+        ByteBuf packet = Unpooled.directBuffer();
+        packet.writeByte(0x80);
+        packet.writeInt(0);
+        packet.writeByte(destinationConnectionId.length);
+        packet.writeBytes(destinationConnectionId);
+        packet.writeByte(sourceConnectionId.length);
+        packet.writeBytes(sourceConnectionId);
+        packet.writeInt(1);
+
+        try (QuicHeaderParser parser = new QuicHeaderParser(0, destinationConnectionId.length)) {
+            parser.parse(sender, recipient, packet, (local, remote, payload, type, version, scid, dcid, token) -> {
+                assertThat(local).isSameAs(sender);
+                assertThat(remote).isSameAs(recipient);
+                assertThat(payload).isSameAs(packet);
+                assertThat(type).isSameAs(QuicPacketType.VERSION_NEGOTIATION);
+                assertThat(version).isZero();
+                assertThat(readBytes(dcid)).containsExactly(destinationConnectionId);
+                assertThat(readBytes(scid)).containsExactly(sourceConnectionId);
+                assertThat(token.readableBytes()).isZero();
+                processed[0] = true;
+            });
+        } finally {
+            packet.release();
+        }
+
+        assertThat(processed[0]).isTrue();
+    }
+
+    @Test
+    void streamAddressIdentifiesStreamsByTheirNumericStreamId() {
+        long streamId = 1_234;
+        QuicStreamAddress address = new QuicStreamAddress(streamId);
+        QuicStreamAddress sameAddress = new QuicStreamAddress(streamId);
+        QuicStreamAddress differentAddress = new QuicStreamAddress(streamId + 1);
+        SocketAddress socketAddress = address;
+
+        assertThat(socketAddress).isSameAs(address);
+        assertThat(address.streamId()).isEqualTo(streamId);
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address).isNotEqualTo(new InetSocketAddress("127.0.0.1", 4433));
+        assertThat(address).hasToString("QuicStreamAddress{streamId=1234}");
+        assertThat(new QuicStreamAddress(Long.MAX_VALUE).streamId()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void nativeBackedAddressAndTokenTypesRespectTransportAvailability() {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(() -> QuicConnectionAddress.EPHEMERAL.toString());
+            assertNativeBackedTypeUnavailable(() -> InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
+            return;
+        }
+
+        byte[] id = new byte[] {1, 2, 3, 4};
+        QuicConnectionAddress address = new QuicConnectionAddress(id);
+        QuicConnectionAddress sameAddress = new QuicConnectionAddress(new byte[] {1, 2, 3, 4});
+        QuicConnectionAddress differentAddress = new QuicConnectionAddress(new byte[] {1, 2, 3, 5});
+        id[0] = 9;
+
+        assertThat(QuicConnectionAddress.EPHEMERAL).isSameAs(QuicConnectionAddress.EPHEMERAL);
+        assertThat(QuicConnectionAddress.EPHEMERAL).isNotEqualTo(address);
+        assertThat(QuicConnectionAddress.EPHEMERAL).hasToString("QuicConnectionAddress{EPHEMERAL}");
+        assertThat(address).isEqualTo(sameAddress).hasSameHashCodeAs(sameAddress);
+        assertThat(address).isNotEqualTo(differentAddress);
+        assertThat(address).hasToString("QuicConnectionAddress{connId=01020304}");
+
+        assertInsecureTokenHandlerRoundTrip();
+    }
+
+    @Test
+    void nativeBackedConnectionIdGeneratorsRespectTransportAvailability() {
+        QuicConnectionIdGenerator random = QuicConnectionIdGenerator.randomGenerator();
+        QuicConnectionIdGenerator signer = QuicConnectionIdGenerator.signGenerator();
+
+        assertThat(random.isIdempotent()).isFalse();
+        assertThat(signer.isIdempotent()).isTrue();
+
+        if (!Quic.isAvailable()) {
+            assertMayRequireNativeLibrary(random::maxConnectionIdLength);
+            assertMayRequireNativeLibrary(signer::maxConnectionIdLength);
+            return;
+        }
+
+        assertConnectionIdGeneratorsExposeNativeBackedState(random, signer);
+    }
+
+    @Test
+    void nativeBackedCodecBuildersRespectTransportAvailability() {
+        if (!Quic.isAvailable()) {
+            assertNativeBackedTypeUnavailable(QuicClientCodecBuilder::new);
+            assertNativeBackedTypeUnavailable(QuicServerCodecBuilder::new);
+            return;
+        }
+
+        QuicClientCodecBuilder clientBuilder = new QuicClientCodecBuilder()
+                .flushStrategy(FlushStrategy.afterNumPackets(2))
+                .grease(true)
+                .maxSendUdpPayloadSize(1_200)
+                .maxRecvUdpPayloadSize(1_200)
+                .initialMaxData(8_192)
+                .initialMaxStreamsBidirectional(4)
+                .initialMaxStreamsUnidirectional(2);
+        QuicServerCodecBuilder serverBuilder = new QuicServerCodecBuilder()
+                .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                .connectionIdAddressGenerator(QuicConnectionIdGenerator.signGenerator())
+                .option(QuicChannelOption.READ_FRAMES, true)
+                .streamOption(QuicChannelOption.READ_FRAMES, true);
+
+        assertThat(clientBuilder.clone()).isNotSameAs(clientBuilder).isInstanceOf(QuicClientCodecBuilder.class);
+        assertThat(serverBuilder.clone()).isNotSameAs(serverBuilder).isInstanceOf(QuicServerCodecBuilder.class);
+        assertThatThrownBy(() -> clientBuilder.localConnectionIdLength(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> serverBuilder.statelessResetToken(new byte[] {1, 2, 3}))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static byte[] readBytes(ByteBuf buffer) {
+        byte[] bytes = new byte[buffer.readableBytes()];
+        buffer.getBytes(buffer.readerIndex(), bytes);
+        return bytes;
+    }
+
+    private static void assertConnectionIdGeneratorsExposeNativeBackedState(
+            QuicConnectionIdGenerator random,
+            QuicConnectionIdGenerator signer
+    ) {
+        int idLength = Math.min(8, random.maxConnectionIdLength());
+        ByteBuffer input = ByteBuffer.wrap(new byte[] {9, 8, 7, 6, 5, 4});
+
+        ByteBuffer randomId = random.newId(idLength);
+        ByteBuffer signedId = signer.newId(input.duplicate(), idLength);
+        ByteBuffer signedIdAgain = signer.newId(input.duplicate(), idLength);
+
+        assertThat(randomId.remaining()).isEqualTo(idLength);
+        assertThat(signedId.remaining()).isEqualTo(idLength);
+        assertThat(signedIdAgain).isEqualTo(signedId.duplicate());
+        assertThatThrownBy(() -> random.newId(random.maxConnectionIdLength() + 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> signer.newId(idLength)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> signer.newId(ByteBuffer.allocate(0), idLength))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static void assertInsecureTokenHandlerRoundTrip() {
+        ByteBuf token = Unpooled.buffer(InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
+        ByteBuf destinationConnectionId = Unpooled.wrappedBuffer(new byte[] {10, 11, 12, 13});
+        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4433);
+        InetSocketAddress differentAddress = new InetSocketAddress("127.0.0.2", 4433);
+
+        try {
+            assertThat(InsecureQuicTokenHandler.INSTANCE.writeToken(token, destinationConnectionId, address)).isTrue();
+            assertThat(token.readableBytes()).isEqualTo("netty".length() + 4 + 4);
+            assertThat(destinationConnectionId.readerIndex()).isZero();
+            assertThat(InsecureQuicTokenHandler.INSTANCE.validateToken(token, address))
+                    .isEqualTo("netty".length() + 4);
+            assertThat(InsecureQuicTokenHandler.INSTANCE.validateToken(token, differentAddress)).isEqualTo(-1);
+        } finally {
+            destinationConnectionId.release();
+            token.release();
+        }
+    }
+
+    private static void assertMayRequireNativeLibrary(ThrowableAssert.ThrowingCallable callable) {
+        Throwable thrown = catchThrowable(callable);
+
+        if (thrown != null) {
+            assertThat(thrown).isInstanceOf(LinkageError.class);
+        }
+    }
+
+    private static void assertNativeBackedTypeUnavailable(ThrowableAssert.ThrowingCallable callable) {
+        Throwable thrown = catchThrowable(callable);
+
+        assertThat(thrown).isInstanceOf(LinkageError.class);
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -25,7 +25,7 @@ import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
 import io.netty.incubator.codec.quic.QuicCongestionControlAlgorithm;
 import io.netty.incubator.codec.quic.QuicConnectionAddress;
 import io.netty.incubator.codec.quic.QuicConnectionIdGenerator;
-import io.netty.incubator.codec.quic.QuicError;
+import io.netty.incubator.codec.quic.QuicTransportError;
 import io.netty.incubator.codec.quic.QuicHeaderParser;
 import io.netty.incubator.codec.quic.QuicPacketType;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
@@ -212,31 +212,59 @@ public class Netty_incubator_codec_classes_quicTest {
     }
 
     @Test
-    void nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable() {
+    void transportErrorsExposeMappingsAndNativeBackedEnumsRespectAvailability() {
+        List<QuicTransportError> errors = List.of(
+                QuicTransportError.NO_ERROR,
+                QuicTransportError.INTERNAL_ERROR,
+                QuicTransportError.CONNECTION_REFUSED,
+                QuicTransportError.FLOW_CONTROL_ERROR,
+                QuicTransportError.STREAM_LIMIT_ERROR,
+                QuicTransportError.STREAM_STATE_ERROR,
+                QuicTransportError.FINAL_SIZE_ERROR,
+                QuicTransportError.FRAME_ENCODING_ERROR,
+                QuicTransportError.TRANSPORT_PARAMETER_ERROR,
+                QuicTransportError.CONNECTION_ID_LIMIT_ERROR,
+                QuicTransportError.PROTOCOL_VIOLATION,
+                QuicTransportError.INVALID_TOKEN,
+                QuicTransportError.APPLICATION_ERROR,
+                QuicTransportError.CRYPTO_BUFFER_EXCEEDED,
+                QuicTransportError.KEY_UPDATE_ERROR,
+                QuicTransportError.AEAD_LIMIT_REACHED,
+                QuicTransportError.NO_VIABLE_PATH
+        );
+
+        assertThat(errors).extracting(QuicTransportError::code)
+                .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L);
+        assertThat(errors).extracting(QuicTransportError::name)
+                .containsExactly(
+                        "NO_ERROR",
+                        "INTERNAL_ERROR",
+                        "CONNECTION_REFUSED",
+                        "FLOW_CONTROL_ERROR",
+                        "STREAM_LIMIT_ERROR",
+                        "STREAM_STATE_ERROR",
+                        "FINAL_SIZE_ERROR",
+                        "FRAME_ENCODING_ERROR",
+                        "TRANSPORT_PARAMETER_ERROR",
+                        "CONNECTION_ID_LIMIT_ERROR",
+                        "PROTOCOL_VIOLATION",
+                        "INVALID_TOKEN",
+                        "APPLICATION_ERROR",
+                        "CRYPTO_BUFFER_EXCEEDED",
+                        "KEY_UPDATE_ERROR",
+                        "AEAD_LIMIT_REACHED",
+                        "NO_VIABLE_PATH"
+                );
+        assertThat(QuicTransportError.valueOf(0x3)).isSameAs(QuicTransportError.FLOW_CONTROL_ERROR);
+        assertThat(QuicTransportError.valueOf(0x10)).isSameAs(QuicTransportError.NO_VIABLE_PATH);
+        assertThat(QuicTransportError.NO_ERROR.isCryptoError()).isFalse();
+        assertThat(QuicTransportError.NO_VIABLE_PATH.toString()).contains("NO_VIABLE_PATH");
+
         if (!Quic.isAvailable()) {
-            assertMayRequireNativeLibrary(() -> QuicError.values());
             assertMayRequireNativeLibrary(() -> QuicCongestionControlAlgorithm.values());
             return;
         }
 
-        assertThat(QuicError.values()).containsExactly(
-                QuicError.BUFFER_TOO_SHORT,
-                QuicError.UNKNOWN_VERSION,
-                QuicError.INVALID_FRAME,
-                QuicError.INVALID_PACKET,
-                QuicError.INVALID_STATE,
-                QuicError.INVALID_STREAM_STATE,
-                QuicError.INVALID_TRANSPORT_PARAM,
-                QuicError.CRYPTO_FAIL,
-                QuicError.TLS_FAIL,
-                QuicError.FLOW_CONTROL,
-                QuicError.STREAM_LIMIT,
-                QuicError.FINAL_SIZE,
-                QuicError.CONGESTION_CONTROL,
-                QuicError.STREAM_RESET,
-                QuicError.STREAM_STOPPED
-        );
-        assertThat(QuicError.INVALID_PACKET.toString()).contains("INVALID_PACKET");
         assertThat(QuicCongestionControlAlgorithm.values()).containsExactly(
                 QuicCongestionControlAlgorithm.RENO,
                 QuicCongestionControlAlgorithm.CUBIC

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="emptyFinFrameIsImmutableFinMarker()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:emptyFinFrameIsImmutableFinMarker()]
+display-name: emptyFinFrameIsImmutableFinMarker()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedAddressAndTokenTypesRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedAddressAndTokenTypesRespectTransportAvailability()]
+display-name: nativeBackedAddressAndTokenTypesRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="quicHeaderParserExtractsVersionNegotiationHeader()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicHeaderParserExtractsVersionNegotiationHeader()]
+display-name: quicHeaderParserExtractsVersionNegotiationHeader()
+]]></system-out>
+</testcase>
+<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:flushStrategiesApplyStrictPacketAndByteThresholds()]
+display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
+]]></system-out>
+</testcase>
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
+display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
+]]></system-out>
+</testcase>
+<testcase name="quicAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicAvailabilityContractIsSelfConsistent()]
+display-name: quicAvailabilityContractIsSelfConsistent()
+]]></system-out>
+</testcase>
+<testcase name="qlogConfigurationAndStreamPriorityExposeStableValueSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:qlogConfigurationAndStreamPriorityExposeStableValueSemantics()]
+display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
+display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
+]]></system-out>
+</testcase>
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
+display-name: simpleEnumsExposeExpectedProtocolConstants()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
+display-name: nativeBackedCodecBuildersRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
+display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
+]]></system-out>
+</testcase>
+<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedConnectionIdGeneratorsRespectTransportAvailability()]
+display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="segmentedDatagramAllocatorNoneRejectsPacketAllocation()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:segmentedDatagramAllocatorNoneRejectsPacketAllocation()]
+display-name: segmentedDatagramAllocatorNoneRejectsPacketAllocation()
+]]></system-out>
+</testcase>
+<testcase name="streamAddressIdentifiesStreamsByTheirNumericStreamId()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamAddressIdentifiesStreamsByTheirNumericStreamId()]
+display-name: streamAddressIdentifiesStreamsByTheirNumericStreamId()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.02" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
+<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T20:36:08">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4373-9851716f/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
@@ -69,13 +69,13 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: quicHeaderParserExtractsVersionNegotiationHeader()
 ]]></system-out>
 </testcase>
-<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="flushStrategiesApplyStrictPacketAndByteThresholds()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:flushStrategiesApplyStrictPacketAndByteThresholds()]
 display-name: flushStrategiesApplyStrictPacketAndByteThresholds()
 ]]></system-out>
 </testcase>
-<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.002">
+<testcase name="quicChannelOptionsAreRegisteredInNettyConstantPool()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:quicChannelOptionsAreRegisteredInNettyConstantPool()]
 display-name: quicChannelOptionsAreRegisteredInNettyConstantPool()
@@ -93,31 +93,31 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_code
 display-name: qlogConfigurationAndStreamPriorityExposeStableValueSemantics()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
+<testcase name="transportErrorsExposeMappingsAndNativeBackedEnumsRespectAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()]
-display-name: nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable()
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:transportErrorsExposeMappingsAndNativeBackedEnumsRespectAvailability()]
+display-name: transportErrorsExposeMappingsAndNativeBackedEnumsRespectAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.001">
+<testcase name="simpleEnumsExposeExpectedProtocolConstants()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:simpleEnumsExposeExpectedProtocolConstants()]
 display-name: simpleEnumsExposeExpectedProtocolConstants()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<testcase name="nativeBackedCodecBuildersRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedCodecBuildersRespectTransportAvailability()]
 display-name: nativeBackedCodecBuildersRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<testcase name="streamFrameBufferOperationsPreserveFinAndContentSemantics()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:streamFrameBufferOperationsPreserveFinAndContentSemantics()]
 display-name: streamFrameBufferOperationsPreserveFinAndContentSemantics()
 ]]></system-out>
 </testcase>
-<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0.003">
+<testcase name="nativeBackedConnectionIdGeneratorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_codec_classes_quic.Netty_incubator_codec_classes_quicTest]/[method:nativeBackedConnectionIdGeneratorsRespectTransportAvailability()]
 display-name: nativeBackedConnectionIdGeneratorsRespectTransportAvailability()

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T17:10:42">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:36:08">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/1443-17dfe475/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4373-9851716f/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/user-code-filter.json
+++ b/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.netty.incubator.codec.quic.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4373

This PR provides test fixes and new metadata for io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 66914
- Cached input tokens: 339968
- Output tokens: 3196
- Metadata entries: 40
- Iterations: 1
- Library coverage percentage: 4.21
- Previous library version metadata entries: 44
- Previous library version coverage percentage: 3.74

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final: 0/0 covered calls (100.00%)
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final: 641/15045 (4.26%)
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final: 915/18449 (4.96%)

**Line:**
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final: 134/3585 (3.74%)
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final: 184/4375 (4.21%)

**Method:**
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.34.Final: 62/884 (7.01%)
- io.netty.incubator:netty-incubator-codec-classes-quic:0.0.63.Final: 69/1038 (6.65%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java 2/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
index 0cb7c59aae..cce1bd29f2 100644
--- 1/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.34.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
+++ 2/tests/src/io.netty.incubator/netty-incubator-codec-classes-quic/0.0.63.Final/src/test/java/io_netty_incubator/netty_incubator_codec_classes_quic/Netty_incubator_codec_classes_quicTest.java
@@ -25,7 +25,7 @@ import io.netty.incubator.codec.quic.QuicClientCodecBuilder;
 import io.netty.incubator.codec.quic.QuicCongestionControlAlgorithm;
 import io.netty.incubator.codec.quic.QuicConnectionAddress;
 import io.netty.incubator.codec.quic.QuicConnectionIdGenerator;
-import io.netty.incubator.codec.quic.QuicError;
+import io.netty.incubator.codec.quic.QuicTransportError;
 import io.netty.incubator.codec.quic.QuicHeaderParser;
 import io.netty.incubator.codec.quic.QuicPacketType;
 import io.netty.incubator.codec.quic.QuicServerCodecBuilder;
@@ -212,31 +212,59 @@ public class Netty_incubator_codec_classes_quicTest {
     }
 
     @Test
-    void nativeBackedEnumsExposeMappingsWhenNativeLibraryIsAvailable() {
+    void transportErrorsExposeMappingsAndNativeBackedEnumsRespectAvailability() {
+        List<QuicTransportError> errors = List.of(
+                QuicTransportError.NO_ERROR,
+                QuicTransportError.INTERNAL_ERROR,
+                QuicTransportError.CONNECTION_REFUSED,
+                QuicTransportError.FLOW_CONTROL_ERROR,
+                QuicTransportError.STREAM_LIMIT_ERROR,
+                QuicTransportError.STREAM_STATE_ERROR,
+                QuicTransportError.FINAL_SIZE_ERROR,
+                QuicTransportError.FRAME_ENCODING_ERROR,
+                QuicTransportError.TRANSPORT_PARAMETER_ERROR,
+                QuicTransportError.CONNECTION_ID_LIMIT_ERROR,
+                QuicTransportError.PROTOCOL_VIOLATION,
+                QuicTransportError.INVALID_TOKEN,
+                QuicTransportError.APPLICATION_ERROR,
+                QuicTransportError.CRYPTO_BUFFER_EXCEEDED,
+                QuicTransportError.KEY_UPDATE_ERROR,
+                QuicTransportError.AEAD_LIMIT_REACHED,
+                QuicTransportError.NO_VIABLE_PATH
+        );
+
+        assertThat(errors).extracting(QuicTransportError::code)
+                .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L);
+        assertThat(errors).extracting(QuicTransportError::name)
+                .containsExactly(
+                        "NO_ERROR",
+                        "INTERNAL_ERROR",
+                        "CONNECTION_REFUSED",
+                        "FLOW_CONTROL_ERROR",
+                        "STREAM_LIMIT_ERROR",
+                        "STREAM_STATE_ERROR",
+                        "FINAL_SIZE_ERROR",
+                        "FRAME_ENCODING_ERROR",
+                        "TRANSPORT_PARAMETER_ERROR",
+                        "CONNECTION_ID_LIMIT_ERROR",
+                        "PROTOCOL_VIOLATION",
+                        "INVALID_TOKEN",
+                        "APPLICATION_ERROR",
+                        "CRYPTO_BUFFER_EXCEEDED",
+                        "KEY_UPDATE_ERROR",
+                        "AEAD_LIMIT_REACHED",
+                        "NO_VIABLE_PATH"
+                );
+        assertThat(QuicTransportError.valueOf(0x3)).isSameAs(QuicTransportError.FLOW_CONTROL_ERROR);
+        assertThat(QuicTransportError.valueOf(0x10)).isSameAs(QuicTransportError.NO_VIABLE_PATH);
+        assertThat(QuicTransportError.NO_ERROR.isCryptoError()).isFalse();
+        assertThat(QuicTransportError.NO_VIABLE_PATH.toString()).contains("NO_VIABLE_PATH");
+
         if (!Quic.isAvailable()) {
-            assertMayRequireNativeLibrary(() -> QuicError.values());
             assertMayRequireNativeLibrary(() -> QuicCongestionControlAlgorithm.values());
             return;
         }
 
-        assertThat(QuicError.values()).containsExactly(
-                QuicError.BUFFER_TOO_SHORT,
-                QuicError.UNKNOWN_VERSION,
-                QuicError.INVALID_FRAME,
-                QuicError.INVALID_PACKET,
-                QuicError.INVALID_STATE,
-                QuicError.INVALID_STREAM_STATE,
-                QuicError.INVALID_TRANSPORT_PARAM,
-                QuicError.CRYPTO_FAIL,
-                QuicError.TLS_FAIL,
-                QuicError.FLOW_CONTROL,
-                QuicError.STREAM_LIMIT,
-                QuicError.FINAL_SIZE,
-                QuicError.CONGESTION_CONTROL,
-                QuicError.STREAM_RESET,
-                QuicError.STREAM_STOPPED
-        );
-        assertThat(QuicError.INVALID_PACKET.toString()).contains("INVALID_PACKET");
         assertThat(QuicCongestionControlAlgorithm.values()).containsExactly(
                 QuicCongestionControlAlgorithm.RENO,
                 QuicCongestionControlAlgorithm.CUBIC

```
