### PR TITLE
[GenAI] Test fix for com.google.errorprone:error_prone_annotations:2.6.0 using gpt-5.5

### DIFF
--- a/stats/com.google.errorprone/error_prone_annotations/2.6.0/execution-metrics.json
+++ b/stats/com.google.errorprone/error_prone_annotations/2.6.0/execution-metrics.json
@@ -1,10 +1,10 @@
 {
   "fix_javac_fail:2026-05-02": {
-    "timestamp": "2026-05-02T14:07:20.790864Z",
+    "timestamp": "2026-05-02T18:39:35.029583Z",
     "library": "com.google.errorprone:error_prone_annotations:2.6.0",
-    "starting_commit": "f5f4816f02f9ab462098bfa30355ba91e72b4a7f",
-    "ending_commit": "7614966b9b28ec5ddc8f46c740d8be5cce39aba1",
-    "previous_library": "com.google.errorprone:error_prone_annotations:2.4.0",
+    "starting_commit": "4ad45ed051185c8e462dfe26abd86a49d0c5c12d",
+    "ending_commit": "18f7616e50713c2ea67b5c692a92136cbf46c779",
+    "previous_library": "com.google.errorprone:error_prone_annotations:2.6.0",
     "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -19,7 +19,7 @@
       }
     },
     "previous_library_stats": {
-      "version": "2.4.0",
+      "version": "2.6.0",
       "dynamicAccess": {
         "breakdown": {},
         "coverageRatio": 1.0,
@@ -28,11 +28,11 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 15628,
-      "cached_input_tokens_used": 96768,
-      "output_tokens_used": 1299,
+      "input_tokens_used": 20077,
+      "cached_input_tokens_used": 113664,
+      "output_tokens_used": 1675,
       "iterations": 1,
-      "cost_usd": 0.0874,
+      "cost_usd": 0.1071,
       "tested_library_loc": 0,
       "metadata_entries": 0,
       "previous_library_metadata_entries": 0,

--- a/tests/src/com.google.errorprone/error_prone_annotations/2.6.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.errorprone/error_prone_annotations/2.6.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:06:06">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T20:38:32">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4303-8d2ab6bc/tests/src/com.google.errorprone/error_prone_annotations/2.6.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4370-2ba7db95/tests/src/com.google.errorprone/error_prone_annotations/2.6.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/com.google.errorprone/error_prone_annotations/2.6.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.errorprone/error_prone_annotations/2.6.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T16:06:06">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:38:32">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4303-8d2ab6bc/tests/src/com.google.errorprone/error_prone_annotations/2.6.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4370-2ba7db95/tests/src/com.google.errorprone/error_prone_annotations/2.6.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>


### PR DESCRIPTION
## What does this PR do?

Fixes: #4370

This PR provides test fixes and new metadata for com.google.errorprone:error_prone_annotations:2.6.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 20077
- Cached input tokens: 113664
- Output tokens: 1675
- Metadata entries: 0
- Iterations: 1
- Library coverage percentage: 100.0
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 100.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `com.google.errorprone:error_prone_annotations:2.6.0` and `com.google.errorprone:error_prone_annotations:2.6.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```
