### PR TITLE
[GenAI] Add support for com.tunnelvisionlabs:antlr4-annotations:4.5 using gpt-5.5

### DIFF
--- a/metadata/com.tunnelvisionlabs/antlr4-annotations/4.5/reachability-metadata.json
+++ b/metadata/com.tunnelvisionlabs/antlr4-annotations/4.5/reachability-metadata.json
@@ -1,0 +1,39 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.antlr.v4.runtime.misc.NullUsageProcessor"
+      },
+      "type": "jdk.internal.jrtfs.JrtFileSystemProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.antlr.v4.runtime.misc.NullUsageProcessor"
+      },
+      "module": "java.base",
+      "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.antlr.v4.runtime.misc.NullUsageProcessor"
+      },
+      "module": "jdk.compiler",
+      "bundle": "com.sun.tools.javac.resources.compiler"
+    },
+    {
+      "condition": {
+        "typeReached": "org.antlr.v4.runtime.misc.NullUsageProcessor"
+      },
+      "module": "jdk.compiler",
+      "bundle": "com.sun.tools.javac.resources.javac"
+    }
+  ]
+}

--- a/metadata/com.tunnelvisionlabs/antlr4-annotations/index.json
+++ b/metadata/com.tunnelvisionlabs/antlr4-annotations/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.5",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/tunnelvisionlabs/antlr4-annotations/$version$/antlr4-annotations-$version$-sources.jar",
+    "repository-url" : "https://github.com/antlr/antlr4",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/tunnelvisionlabs/antlr4-annotations/$version$/antlr4-annotations-$version$-javadoc.jar",
+    "description" : "ANTLR 4 Runtime Annotations provides the NotNull and Nullable annotations used by the ANTLR 4 Java runtime to describe nullability contracts. It also includes an annotation processor for checking nullability usage during Java compilation.",
+    "tested-versions" : [
+      "4.5"
+    ],
+    "allowed-packages" : [
+      "org.antlr.v4.runtime.misc"
+    ]
+  }
+]

--- a/stats/com.tunnelvisionlabs/antlr4-annotations/4.5/execution-metrics.json
+++ b/stats/com.tunnelvisionlabs/antlr4-annotations/4.5/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T19:04:21.695408Z",
+    "library": "com.tunnelvisionlabs:antlr4-annotations:4.5",
+    "starting_commit": "b343b0429b6670f8eebdbe154e1d307838d02961",
+    "ending_commit": "184d6b130b5bc882d07c12c2fcb0df24dae42a52",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.5",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 727,
+          "missed": 88,
+          "ratio": 0.892025,
+          "total": 815
+        },
+        "line": {
+          "covered": 125,
+          "missed": 10,
+          "ratio": 0.925926,
+          "total": 135
+        },
+        "method": {
+          "covered": 17,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 17
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 297244,
+      "cached_input_tokens_used": 4062720,
+      "output_tokens_used": 31889,
+      "iterations": 3,
+      "cost_usd": 2.9881,
+      "generated_loc": 740,
+      "tested_library_loc": 125,
+      "metadata_entries": 8,
+      "code_coverage_percent": 92.59
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java",
+      "metadata_file": "metadata/com.tunnelvisionlabs/antlr4-annotations/4.5/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.tunnelvisionlabs/antlr4-annotations/4.5/stats.json
+++ b/stats/com.tunnelvisionlabs/antlr4-annotations/4.5/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.5",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 727,
+        "missed" : 88,
+        "ratio" : 0.892025,
+        "total" : 815
+      },
+      "line" : {
+        "covered" : 125,
+        "missed" : 10,
+        "ratio" : 0.925926,
+        "total" : 135
+      },
+      "method" : {
+        "covered" : 17,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 17
+      }
+    }
+  } ]
+}

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/.gitignore
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/build.gradle
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/build.gradle
@@ -16,6 +16,13 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs("-H:+AllowJRTFileSystem")
+            runtimeArgs("-Djava.home=${System.getenv('JAVA_HOME')}")
+            runtimeArgs("-Djava.class.path=${sourceSets.test.runtimeClasspath.asPath}")
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/build.gradle
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.tunnelvisionlabs:antlr4-annotations:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/gradle.properties
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.tunnelvisionlabs:antlr4-annotations:4.5
+library.version = 4.5
+metadata.dir = com.tunnelvisionlabs/antlr4-annotations/4.5/

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/settings.gradle
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.tunnelvisionlabs.antlr4-annotations_tests'

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
@@ -9,12 +9,39 @@ package com_tunnelvisionlabs.antlr4_annotations;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.ServiceLoader;
 
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
@@ -138,6 +165,22 @@ public class Antlr4_annotationsTest {
         } catch (Error error) {
             verifyUnsupportedDynamicCompilationError(error);
         }
+    }
+
+    @Test
+    void processorReportsNotNullPrimitiveFieldsAsWarnings() {
+        TestElements elements = new TestElements();
+        CapturingMessager messager = new CapturingMessager();
+        NullUsageProcessor processor = new NullUsageProcessor();
+        processor.init(new TestProcessingEnvironment(elements, messager));
+
+        boolean processed = processor.process(Set.of(), new PrimitiveFieldRoundEnvironment(elements));
+
+        assertThat(processed).isTrue();
+        assertThat(messager.messages()).extracting(ProcessorMessage::kind)
+                .containsExactly(Diagnostic.Kind.WARNING);
+        assertThat(messager.messages()).extracting(ProcessorMessage::message)
+                .containsExactly("field with a primitive type should not be annotated with NotNull");
     }
 
     @Test
@@ -282,6 +325,528 @@ public class Antlr4_annotationsTest {
         @Override
         public CharSequence getCharContent(boolean ignoreEncodingErrors) {
             return this.content;
+        }
+
+    }
+
+    private static final class TestProcessingEnvironment implements ProcessingEnvironment {
+
+        private final Elements elements;
+
+        private final Messager messager;
+
+        private TestProcessingEnvironment(Elements elements, Messager messager) {
+            this.elements = elements;
+            this.messager = messager;
+        }
+
+        @Override
+        public Map<String, String> getOptions() {
+            return Map.of();
+        }
+
+        @Override
+        public Messager getMessager() {
+            return this.messager;
+        }
+
+        @Override
+        public Filer getFiler() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Elements getElementUtils() {
+            return this.elements;
+        }
+
+        @Override
+        public Types getTypeUtils() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SourceVersion getSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public Locale getLocale() {
+            return Locale.ROOT;
+        }
+
+    }
+
+    private static final class PrimitiveFieldRoundEnvironment implements RoundEnvironment {
+
+        private final TypeElement notNullType;
+
+        private final VariableElement notNullPrimitiveField;
+
+        private PrimitiveFieldRoundEnvironment(TestElements elements) {
+            this.notNullType = elements.notNullType();
+            this.notNullPrimitiveField = new TestVariableElement(this.notNullType);
+        }
+
+        @Override
+        public boolean processingOver() {
+            return false;
+        }
+
+        @Override
+        public boolean errorRaised() {
+            return false;
+        }
+
+        @Override
+        public Set<? extends Element> getRootElements() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<? extends Element> getElementsAnnotatedWith(TypeElement annotation) {
+            if (annotation == this.notNullType) {
+                return Set.of(this.notNullPrimitiveField);
+            }
+
+            return Set.of();
+        }
+
+        @Override
+        public Set<? extends Element> getElementsAnnotatedWith(Class<? extends java.lang.annotation.Annotation> annotation) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    private static final class CapturingMessager implements Messager {
+
+        private final List<ProcessorMessage> messages = new ArrayList<>();
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence message) {
+            this.messages.add(new ProcessorMessage(kind, message.toString()));
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence message, Element element) {
+            this.messages.add(new ProcessorMessage(kind, message.toString()));
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence message, Element element,
+                AnnotationMirror annotation) {
+            this.messages.add(new ProcessorMessage(kind, message.toString()));
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence message, Element element,
+                AnnotationMirror annotation, AnnotationValue value) {
+            this.messages.add(new ProcessorMessage(kind, message.toString()));
+        }
+
+        private List<ProcessorMessage> messages() {
+            return List.copyOf(this.messages);
+        }
+
+    }
+
+    private record ProcessorMessage(Diagnostic.Kind kind, String message) {
+    }
+
+    private static final class TestElements implements Elements {
+
+        private final TypeElement notNullType = new TestTypeElement(NullUsageProcessor.NotNullClassName);
+
+        private final TypeElement nullableType = new TestTypeElement(NullUsageProcessor.NullableClassName);
+
+        private TypeElement notNullType() {
+            return this.notNullType;
+        }
+
+        @Override
+        public TypeElement getTypeElement(CharSequence name) {
+            if (NullUsageProcessor.NotNullClassName.contentEquals(name)) {
+                return this.notNullType;
+            }
+            if (NullUsageProcessor.NullableClassName.contentEquals(name)) {
+                return this.nullableType;
+            }
+
+            return null;
+        }
+
+        @Override
+        public PackageElement getPackageElement(CharSequence name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValuesWithDefaults(
+                AnnotationMirror annotation) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getDocComment(Element element) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isDeprecated(Element element) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Name getBinaryName(TypeElement type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PackageElement getPackageOf(Element type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<? extends Element> getAllMembers(TypeElement type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element element) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hides(Element hider, Element hidden) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean overrides(ExecutableElement overrider, ExecutableElement overridden, TypeElement type) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getConstantExpression(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void printElements(java.io.Writer writer, Element... elements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Name getName(CharSequence cs) {
+            return new TestName(cs.toString());
+        }
+
+        @Override
+        public boolean isFunctionalInterface(TypeElement type) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    private static final class TestVariableElement implements VariableElement {
+
+        private final TypeElement annotationType;
+
+        private TestVariableElement(TypeElement annotationType) {
+            this.annotationType = annotationType;
+        }
+
+        @Override
+        public TypeMirror asType() {
+            return new TestPrimitiveType();
+        }
+
+        @Override
+        public Object getConstantValue() {
+            return 1;
+        }
+
+        @Override
+        public ElementKind getKind() {
+            return ElementKind.FIELD;
+        }
+
+        @Override
+        public Set<Modifier> getModifiers() {
+            return Set.of();
+        }
+
+        @Override
+        public Name getSimpleName() {
+            return new TestName("primitiveField");
+        }
+
+        @Override
+        public Element getEnclosingElement() {
+            return null;
+        }
+
+        @Override
+        public List<? extends Element> getEnclosedElements() {
+            return List.of();
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAnnotationMirrors() {
+            return List.of(new TestAnnotationMirror(this.annotationType));
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A getAnnotation(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R, P> R accept(ElementVisitor<R, P> visitor, P parameter) {
+            return visitor.visitVariable(this, parameter);
+        }
+
+    }
+
+    private static final class TestTypeElement implements TypeElement {
+
+        private final String qualifiedName;
+
+        private TestTypeElement(String qualifiedName) {
+            this.qualifiedName = qualifiedName;
+        }
+
+        @Override
+        public TypeMirror asType() {
+            return new TestDeclaredType(this);
+        }
+
+        @Override
+        public ElementKind getKind() {
+            return ElementKind.ANNOTATION_TYPE;
+        }
+
+        @Override
+        public Set<Modifier> getModifiers() {
+            return Set.of();
+        }
+
+        @Override
+        public Name getSimpleName() {
+            int lastDot = this.qualifiedName.lastIndexOf('.');
+            return new TestName(this.qualifiedName.substring(lastDot + 1));
+        }
+
+        @Override
+        public Element getEnclosingElement() {
+            return null;
+        }
+
+        @Override
+        public List<? extends Element> getEnclosedElements() {
+            return List.of();
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAnnotationMirrors() {
+            return List.of();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A getAnnotation(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R, P> R accept(ElementVisitor<R, P> visitor, P parameter) {
+            return visitor.visitType(this, parameter);
+        }
+
+        @Override
+        public NestingKind getNestingKind() {
+            return NestingKind.TOP_LEVEL;
+        }
+
+        @Override
+        public Name getQualifiedName() {
+            return new TestName(this.qualifiedName);
+        }
+
+        @Override
+        public TypeMirror getSuperclass() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<? extends TypeMirror> getInterfaces() {
+            return List.of();
+        }
+
+        @Override
+        public List<? extends TypeParameterElement> getTypeParameters() {
+            return List.of();
+        }
+
+    }
+
+    private static final class TestAnnotationMirror implements AnnotationMirror {
+
+        private final TypeElement annotationType;
+
+        private TestAnnotationMirror(TypeElement annotationType) {
+            this.annotationType = annotationType;
+        }
+
+        @Override
+        public DeclaredType getAnnotationType() {
+            return new TestDeclaredType(this.annotationType);
+        }
+
+        @Override
+        public Map<? extends ExecutableElement, ? extends AnnotationValue> getElementValues() {
+            return Map.of();
+        }
+
+    }
+
+    private static final class TestDeclaredType implements DeclaredType {
+
+        private final TypeElement element;
+
+        private TestDeclaredType(TypeElement element) {
+            this.element = element;
+        }
+
+        @Override
+        public Element asElement() {
+            return this.element;
+        }
+
+        @Override
+        public TypeMirror getEnclosingType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<? extends TypeMirror> getTypeArguments() {
+            return List.of();
+        }
+
+        @Override
+        public TypeKind getKind() {
+            return TypeKind.DECLARED;
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAnnotationMirrors() {
+            return List.of();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A getAnnotation(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R, P> R accept(TypeVisitor<R, P> visitor, P parameter) {
+            return visitor.visitDeclared(this, parameter);
+        }
+
+    }
+
+    private static final class TestPrimitiveType implements PrimitiveType {
+
+        @Override
+        public TypeKind getKind() {
+            return TypeKind.INT;
+        }
+
+        @Override
+        public List<? extends AnnotationMirror> getAnnotationMirrors() {
+            return List.of();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A getAnnotation(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <A extends java.lang.annotation.Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R, P> R accept(TypeVisitor<R, P> visitor, P parameter) {
+            return visitor.visitPrimitive(this, parameter);
+        }
+
+    }
+
+    private static final class TestName implements Name {
+
+        private final String value;
+
+        private TestName(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean contentEquals(CharSequence cs) {
+            return this.value.contentEquals(cs);
+        }
+
+        @Override
+        public int length() {
+            return this.value.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return this.value.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return this.value.subSequence(start, end);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof Name other)) {
+                return false;
+            }
+
+            return this.contentEquals(other);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
         }
 
     }

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_tunnelvisionlabs.antlr4_annotations;
+
+import org.junit.jupiter.api.Test;
+
+class Antlr4_annotationsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
@@ -184,6 +184,22 @@ public class Antlr4_annotationsTest {
     }
 
     @Test
+    void processorReportsNullablePrimitiveLocalVariablesAsErrors() {
+        TestElements elements = new TestElements();
+        CapturingMessager messager = new CapturingMessager();
+        NullUsageProcessor processor = new NullUsageProcessor();
+        processor.init(new TestProcessingEnvironment(elements, messager));
+
+        boolean processed = processor.process(Set.of(), new PrimitiveLocalVariableRoundEnvironment(elements));
+
+        assertThat(processed).isTrue();
+        assertThat(messager.messages()).extracting(ProcessorMessage::kind)
+                .containsExactly(Diagnostic.Kind.ERROR);
+        assertThat(messager.messages()).extracting(ProcessorMessage::message)
+                .containsExactly("local variable with a primitive type cannot be annotated with Nullable");
+    }
+
+    @Test
     void processorReportsInvalidNullabilityContracts() throws IOException {
         try {
             CompilationResult result = compileWithNullUsageProcessor("sample.InvalidSample", """
@@ -419,6 +435,49 @@ public class Antlr4_annotationsTest {
 
     }
 
+    private static final class PrimitiveLocalVariableRoundEnvironment implements RoundEnvironment {
+
+        private final TypeElement nullableType;
+
+        private final VariableElement nullablePrimitiveLocalVariable;
+
+        private PrimitiveLocalVariableRoundEnvironment(TestElements elements) {
+            this.nullableType = elements.nullableType();
+            this.nullablePrimitiveLocalVariable = new TestVariableElement(this.nullableType,
+                    ElementKind.LOCAL_VARIABLE, "primitiveLocal");
+        }
+
+        @Override
+        public boolean processingOver() {
+            return false;
+        }
+
+        @Override
+        public boolean errorRaised() {
+            return false;
+        }
+
+        @Override
+        public Set<? extends Element> getRootElements() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<? extends Element> getElementsAnnotatedWith(TypeElement annotation) {
+            if (annotation == this.nullableType) {
+                return Set.of(this.nullablePrimitiveLocalVariable);
+            }
+
+            return Set.of();
+        }
+
+        @Override
+        public Set<? extends Element> getElementsAnnotatedWith(Class<? extends java.lang.annotation.Annotation> annotation) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
     private static final class CapturingMessager implements Messager {
 
         private final List<ProcessorMessage> messages = new ArrayList<>();
@@ -462,6 +521,10 @@ public class Antlr4_annotationsTest {
 
         private TypeElement notNullType() {
             return this.notNullType;
+        }
+
+        private TypeElement nullableType() {
+            return this.nullableType;
         }
 
         @Override
@@ -553,8 +616,18 @@ public class Antlr4_annotationsTest {
 
         private final TypeElement annotationType;
 
+        private final ElementKind kind;
+
+        private final String name;
+
         private TestVariableElement(TypeElement annotationType) {
+            this(annotationType, ElementKind.FIELD, "primitiveField");
+        }
+
+        private TestVariableElement(TypeElement annotationType, ElementKind kind, String name) {
             this.annotationType = annotationType;
+            this.kind = kind;
+            this.name = name;
         }
 
         @Override
@@ -569,7 +642,7 @@ public class Antlr4_annotationsTest {
 
         @Override
         public ElementKind getKind() {
-            return ElementKind.FIELD;
+            return this.kind;
         }
 
         @Override
@@ -579,7 +652,7 @@ public class Antlr4_annotationsTest {
 
         @Override
         public Name getSimpleName() {
-            return new TestName("primitiveField");
+            return new TestName(this.name);
         }
 
         @Override

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
@@ -269,6 +269,7 @@ public class Antlr4_annotationsTest {
     }
 
     private CompilationResult compileWithNullUsageProcessor(String className, String source) throws IOException {
+        configureJavaHomeForDynamicCompilation();
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         assertThat(compiler).as("A JDK compiler is required to exercise the annotation processor").isNotNull();
 
@@ -283,6 +284,13 @@ public class Antlr4_annotationsTest {
 
             boolean success = task.call();
             return new CompilationResult(success, diagnostics.getDiagnostics());
+        }
+    }
+
+    private static void configureJavaHomeForDynamicCompilation() {
+        String environmentJavaHome = System.getenv("JAVA_HOME");
+        if (System.getProperty("java.home") == null && environmentJavaHome != null) {
+            System.setProperty("java.home", environmentJavaHome);
         }
     }
 

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/src/test/java/com_tunnelvisionlabs/antlr4_annotations/Antlr4_annotationsTest.java
@@ -6,11 +6,301 @@
  */
 package com_tunnelvisionlabs.antlr4_annotations;
 
-import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
 
-class Antlr4_annotationsTest {
+import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.misc.NullUsageProcessor;
+import org.antlr.v4.runtime.misc.Nullable;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Antlr4_annotationsTest {
+
+    private static final String NOT_NULL_SOURCE = """
+            package org.antlr.v4.runtime.misc;
+
+            import java.lang.annotation.Documented;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Documented
+            @Retention(RetentionPolicy.CLASS)
+            @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+            public @interface NotNull {
+            }
+            """;
+
+    private static final String NULLABLE_SOURCE = """
+            package org.antlr.v4.runtime.misc;
+
+            import java.lang.annotation.Documented;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            @Documented
+            @Retention(RetentionPolicy.CLASS)
+            @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+            public @interface Nullable {
+            }
+            """;
+
+    @TempDir
+    Path outputDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void annotationsCanBeUsedOnSupportedProgramElements() {
+        AnnotatedApiSurface sample = new AnnotatedApiSurface("antlr");
+
+        assertThat(sample.field).isEqualTo("antlr");
+        assertThat(sample.findValue("suffix")).isEqualTo("antlr-suffix");
+        assertThat(sample.findValue("")).isNull();
     }
+
+    @Test
+    void processorAdvertisesAnnotationNamesAndSupportedSourceVersion() {
+        NullUsageProcessor processor = new NullUsageProcessor();
+
+        assertThat(NullUsageProcessor.NotNullClassName).isEqualTo("org.antlr.v4.runtime.misc.NotNull");
+        assertThat(NullUsageProcessor.NullableClassName).isEqualTo("org.antlr.v4.runtime.misc.Nullable");
+        assertThat(processor.getSupportedAnnotationTypes())
+                .containsExactlyInAnyOrder(NullUsageProcessor.NotNullClassName, NullUsageProcessor.NullableClassName);
+        assertThat(processor.getSupportedSourceVersion()).isEqualTo(expectedSupportedSourceVersion());
+    }
+
+    @Test
+    void serviceLoaderDiscoversAnnotationProcessor() {
+        ServiceLoader<Processor> processors = ServiceLoader.load(Processor.class);
+
+        assertThat(processors).anySatisfy(processor -> assertThat(processor).isInstanceOf(NullUsageProcessor.class));
+    }
+
+    @Test
+    void processorAcceptsConsistentNullabilityContracts() throws IOException {
+        try {
+            CompilationResult result = compileWithNullUsageProcessor("sample.ValidSample", """
+                    package sample;
+
+                    import org.antlr.v4.runtime.misc.NotNull;
+                    import org.antlr.v4.runtime.misc.Nullable;
+
+                    interface ValidParent {
+                        @Nullable String find(@NotNull String query);
+
+                        void receive(@Nullable String value);
+                    }
+
+                    class ValidSample implements ValidParent {
+                        @NotNull String field = "antlr";
+
+                        @Override
+                        @Nullable
+                        public String find(@NotNull String query) {
+                            @Nullable String result = query.isEmpty() ? null : query;
+                            return result;
+                        }
+
+                        @Override
+                        public void receive(@Nullable String value) {
+                        }
+
+                        @NotNull
+                        String name() {
+                            return this.field;
+                        }
+                    }
+                    """);
+
+            assertThat(result.success()).as(result.formattedDiagnostics()).isTrue();
+            assertThat(result.diagnostics()).noneMatch(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR);
+        } catch (Error error) {
+            verifyUnsupportedDynamicCompilationError(error);
+        }
+    }
+
+    @Test
+    void processorReportsInvalidNullabilityContracts() throws IOException {
+        try {
+            CompilationResult result = compileWithNullUsageProcessor("sample.InvalidSample", """
+                    package sample;
+
+                    import org.antlr.v4.runtime.misc.NotNull;
+                    import org.antlr.v4.runtime.misc.Nullable;
+
+                    interface InvalidParent {
+                        @NotNull String value();
+
+                        void consume(@Nullable String value);
+
+                        String plain();
+                    }
+
+                    class InvalidSample implements InvalidParent {
+                        @NotNull @Nullable String both;
+
+                        @Nullable int primitiveField;
+
+                        @NotNull int primitiveMethod() {
+                            return 1;
+                        }
+
+                        @Nullable void voidMethod() {
+                        }
+
+                        @Override
+                        @Nullable
+                        public String value() {
+                            return null;
+                        }
+
+                        @Override
+                        public void consume(@NotNull String value) {
+                        }
+
+                        @Override
+                        @Nullable
+                        public String plain() {
+                            return null;
+                        }
+                    }
+                    """);
+
+            assertThat(result.success()).as(result.formattedDiagnostics()).isFalse();
+            assertThat(result.formattedDiagnostics())
+                    .contains("field cannot be annotated with both NotNull and Nullable")
+                    .contains("field with a primitive type cannot be annotated with Nullable")
+                    .contains("method with a primitive type should not be annotated with NotNull")
+                    .contains("void method cannot be annotated with Nullable")
+                    .contains("method annotated with Nullable cannot override or implement a method annotated "
+                            + "with NotNull")
+                    .contains("parameter value annotated with NotNull cannot override or implement a parameter "
+                            + "annotated with Nullable")
+                    .contains("method annotated with Nullable overrides a method that is not annotated");
+        } catch (Error error) {
+            verifyUnsupportedDynamicCompilationError(error);
+        }
+    }
+
+    private static void verifyUnsupportedDynamicCompilationError(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private CompilationResult compileWithNullUsageProcessor(String className, String source) throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).as("A JDK compiler is required to exercise the annotation processor").isNotNull();
+
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, Locale.ROOT, null)) {
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(this.outputDirectory));
+            JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, List.of("-proc:only"),
+                    null, List.of(new SourceFile("org.antlr.v4.runtime.misc.NotNull", NOT_NULL_SOURCE),
+                            new SourceFile("org.antlr.v4.runtime.misc.Nullable", NULLABLE_SOURCE),
+                            new SourceFile(className, source)));
+            task.setProcessors(List.of(new NullUsageProcessor()));
+
+            boolean success = task.call();
+            return new CompilationResult(success, diagnostics.getDiagnostics());
+        }
+    }
+
+    private static SourceVersion expectedSupportedSourceVersion() {
+        SourceVersion latest = SourceVersion.latestSupported();
+        if (latest.ordinal() <= SourceVersion.RELEASE_6.ordinal()) {
+            return SourceVersion.RELEASE_6;
+        }
+        if (latest.ordinal() <= SourceVersion.RELEASE_8.ordinal()) {
+            return latest;
+        }
+
+        return SourceVersion.RELEASE_8;
+    }
+
+    private static final class CompilationResult {
+
+        private final boolean success;
+
+        private final List<Diagnostic<? extends JavaFileObject>> diagnostics;
+
+        private CompilationResult(boolean success, List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+            this.success = success;
+            this.diagnostics = List.copyOf(diagnostics);
+        }
+
+        private boolean success() {
+            return this.success;
+        }
+
+        private List<Diagnostic<? extends JavaFileObject>> diagnostics() {
+            return this.diagnostics;
+        }
+
+        private String formattedDiagnostics() {
+            StringBuilder result = new StringBuilder("Compilation diagnostics");
+            for (Diagnostic<? extends JavaFileObject> diagnostic : this.diagnostics) {
+                result.append(System.lineSeparator()).append(diagnostic.getKind()).append(": ")
+                        .append(diagnostic.getMessage(Locale.ROOT));
+            }
+
+            return result.toString();
+        }
+
+    }
+
+    private static final class SourceFile extends SimpleJavaFileObject {
+
+        private final String content;
+
+        private SourceFile(String className, String content) {
+            super(URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+            this.content = content;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return this.content;
+        }
+
+    }
+
+    private static final class AnnotatedApiSurface {
+
+        @NotNull
+        private final String field;
+
+        private AnnotatedApiSurface(@NotNull String field) {
+            this.field = field;
+        }
+
+        @Nullable
+        private String findValue(@NotNull String suffix) {
+            @Nullable String local = suffix.isEmpty() ? null : this.field + "-" + suffix;
+            return local;
+        }
+
+    }
+
 }

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="2" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T20:39:00">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3685-771badd3/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="annotationsCanBeUsedOnSupportedProgramElements()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:annotationsCanBeUsedOnSupportedProgramElements()]
+display-name: annotationsCanBeUsedOnSupportedProgramElements()
+]]></system-out>
+</testcase>
+<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:serviceLoaderDiscoversAnnotationProcessor()]
+display-name: serviceLoaderDiscoversAnnotationProcessor()
+]]></system-out>
+</testcase>
+<testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<error message="Could not initialize class com.sun.tools.javac.file.Locations" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.tools.javac.file.Locations
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.<init>(BaseFileManager.java:82)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:217)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:146)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsInvalidNullabilityContracts()]
+display-name: processorReportsInvalidNullabilityContracts()
+]]></system-out>
+</testcase>
+<testcase name="processorAcceptsConsistentNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.<init>(BaseFileManager.java:82)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:217)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorAcceptsConsistentNullabilityContracts(Antlr4_annotationsTest.java:103)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.NullPointerException
+	at java.base@25.0.2/java.util.Objects.requireNonNull(Objects.java:220)
+	at java.base@25.0.2/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:257)
+	at jdk.compiler@25.0.2/com.sun.tools.javac.file.Locations.<clinit>(Locations.java:139)
+	... 19 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAcceptsConsistentNullabilityContracts()]
+display-name: processorAcceptsConsistentNullabilityContracts()
+]]></system-out>
+</testcase>
+<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAdvertisesAnnotationNamesAndSupportedSourceVersion()]
+display-name: processorAdvertisesAnnotationNamesAndSupportedSourceVersion()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="2" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-02T20:50:37">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="2" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-02T20:53:27">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,27 +58,27 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: annotationsCanBeUsedOnSupportedProgramElements()
 ]]></system-out>
 </testcase>
-<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
+<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:serviceLoaderDiscoversAnnotationProcessor()]
 display-name: serviceLoaderDiscoversAnnotationProcessor()
 ]]></system-out>
 </testcase>
-<testcase name="processorReportsNotNullPrimitiveFieldsAsWarnings()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
+<testcase name="processorReportsNotNullPrimitiveFieldsAsWarnings()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsNotNullPrimitiveFieldsAsWarnings()]
 display-name: processorReportsNotNullPrimitiveFieldsAsWarnings()
 ]]></system-out>
 </testcase>
-<testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.003">
 <error message="Could not initialize class com.sun.tools.javac.file.Locations" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.tools.javac.file.Locations
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.<init>(BaseFileManager.java:82)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:260)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:189)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:276)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:205)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -97,6 +97,12 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: processorReportsInvalidNullabilityContracts()
 ]]></system-out>
 </testcase>
+<testcase name="processorReportsNullablePrimitiveLocalVariablesAsErrors()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsNullablePrimitiveLocalVariablesAsErrors()]
+display-name: processorReportsNullablePrimitiveLocalVariablesAsErrors()
+]]></system-out>
+</testcase>
 <testcase name="processorAcceptsConsistentNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
 <error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
@@ -104,7 +110,7 @@ display-name: processorReportsInvalidNullabilityContracts()
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:260)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:276)
 	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorAcceptsConsistentNullabilityContracts(Antlr4_annotationsTest.java:130)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
@@ -129,7 +135,7 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: processorAcceptsConsistentNullabilityContracts()
 ]]></system-out>
 </testcase>
-<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
+<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAdvertisesAnnotationNamesAndSupportedSourceVersion()]
 display-name: processorAdvertisesAnnotationNamesAndSupportedSourceVersion()

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="2" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T20:39:00">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="2" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-02T20:50:37">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,10 +58,16 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: annotationsCanBeUsedOnSupportedProgramElements()
 ]]></system-out>
 </testcase>
-<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:serviceLoaderDiscoversAnnotationProcessor()]
 display-name: serviceLoaderDiscoversAnnotationProcessor()
+]]></system-out>
+</testcase>
+<testcase name="processorReportsNotNullPrimitiveFieldsAsWarnings()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsNotNullPrimitiveFieldsAsWarnings()]
+display-name: processorReportsNotNullPrimitiveFieldsAsWarnings()
 ]]></system-out>
 </testcase>
 <testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
@@ -71,8 +77,8 @@ display-name: serviceLoaderDiscoversAnnotationProcessor()
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:217)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:146)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:260)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:189)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -98,8 +104,8 @@ display-name: processorReportsInvalidNullabilityContracts()
 	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
 	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:217)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorAcceptsConsistentNullabilityContracts(Antlr4_annotationsTest.java:103)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:260)
+	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorAcceptsConsistentNullabilityContracts(Antlr4_annotationsTest.java:130)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -123,7 +129,7 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: processorAcceptsConsistentNullabilityContracts()
 ]]></system-out>
 </testcase>
-<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
+<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAdvertisesAnnotationNamesAndSupportedSourceVersion()]
 display-name: processorAdvertisesAnnotationNamesAndSupportedSourceVersion()

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="2" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-02T20:53:27">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.023" hostname="kung-fu-workstation" timestamp="2026-05-02T21:02:31">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.home" value="/home/vjovanov/bin/graalvm-jdk-25.0.3+9.1"/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3685-771badd3/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5"/>
@@ -58,40 +58,19 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: annotationsCanBeUsedOnSupportedProgramElements()
 ]]></system-out>
 </testcase>
-<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.004">
+<testcase name="serviceLoaderDiscoversAnnotationProcessor()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:serviceLoaderDiscoversAnnotationProcessor()]
 display-name: serviceLoaderDiscoversAnnotationProcessor()
 ]]></system-out>
 </testcase>
-<testcase name="processorReportsNotNullPrimitiveFieldsAsWarnings()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.002">
+<testcase name="processorReportsNotNullPrimitiveFieldsAsWarnings()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsNotNullPrimitiveFieldsAsWarnings()]
 display-name: processorReportsNotNullPrimitiveFieldsAsWarnings()
 ]]></system-out>
 </testcase>
-<testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.003">
-<error message="Could not initialize class com.sun.tools.javac.file.Locations" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.tools.javac.file.Locations
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.<init>(BaseFileManager.java:82)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:276)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorReportsInvalidNullabilityContracts(Antlr4_annotationsTest.java:205)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="processorReportsInvalidNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorReportsInvalidNullabilityContracts()]
 display-name: processorReportsInvalidNullabilityContracts()
@@ -103,39 +82,13 @@ unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations
 display-name: processorReportsNullablePrimitiveLocalVariablesAsErrors()
 ]]></system-out>
 </testcase>
-<testcase name="processorAcceptsConsistentNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
-<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.createLocations(BaseFileManager.java:126)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.BaseFileManager.<init>(BaseFileManager.java:82)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.JavacFileManager.<init>(JavacFileManager.java:161)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:108)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.api.JavacTool.getStandardFileManager(JavacTool.java:68)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.compileWithNullUsageProcessor(Antlr4_annotationsTest.java:276)
-	at com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest.processorAcceptsConsistentNullabilityContracts(Antlr4_annotationsTest.java:130)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.NullPointerException
-	at java.base@25.0.2/java.util.Objects.requireNonNull(Objects.java:220)
-	at java.base@25.0.2/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:257)
-	at jdk.compiler@25.0.2/com.sun.tools.javac.file.Locations.<clinit>(Locations.java:139)
-	... 19 more
-]]></error>
+<testcase name="processorAcceptsConsistentNullabilityContracts()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.014">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAcceptsConsistentNullabilityContracts()]
 display-name: processorAcceptsConsistentNullabilityContracts()
 ]]></system-out>
 </testcase>
-<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0.002">
+<testcase name="processorAdvertisesAnnotationNamesAndSupportedSourceVersion()" classname="com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_tunnelvisionlabs.antlr4_annotations.Antlr4_annotationsTest]/[method:processorAdvertisesAnnotationNamesAndSupportedSourceVersion()]
 display-name: processorAdvertisesAnnotationNamesAndSupportedSourceVersion()

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:39:00">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:50:37">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:39:00">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3685-771badd3/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:53:27">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:02:31">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3685-771badd3/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5"/>

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:50:37">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T20:53:27">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/user-code-filter.json
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.antlr.v4.runtime.misc.**"
+      "includeClasses" : "org.antlr.v4.runtime.misc.**"
     }
   ]
 }

--- a/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/user-code-filter.json
+++ b/tests/src/com.tunnelvisionlabs/antlr4-annotations/4.5/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.antlr.v4.runtime.misc.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3685

This PR introduces tests and metadata for com.tunnelvisionlabs:antlr4-annotations:4.5, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 297244
- Cached input tokens: 4062720
- Output tokens: 31889
- Metadata entries: 8
- Iterations: 3
- Library coverage percentage: 92.59
- Generated lines of code: 740
- Tested library lines of code: 125

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3827edb5771788b2dfda4e6f6c79d3ec878f16cf`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 727/815 (89.20%)
- Line: 125/135 (92.59%)
- Method: 17/17 (100.00%)
