### PR TITLE
[GenAI] Test fix for org.apache.xbean:xbean-asm9-shaded:4.26 using gpt-5.5

### DIFF
--- a/metadata/org.apache.xbean/xbean-asm9-shaded/4.26/reachability-metadata.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/4.26/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.LinkedList"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.List"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassWriter"
+      },
+      "type": "java.util.Set"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.ClassReader"
+      },
+      "glob": "org/apache/xbean/asm9/ClassReader.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.asm9.Constants"
+      },
+      "glob": "org/apache/xbean/asm9/tree/ClassNode.class"
+    }
+  ]
+}

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.26",
+    "tested-versions" : [
+      "4.26"
+    ],
+    "allowed-packages" : [
+      "org.apache.xbean.asm9"
+    ]
+  },
+  {
     "metadata-version" : "4.22",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/4.22/xbean-asm9-shaded-4.22-sources.jar",
     "repository-url" : "https://github.com/apache/geronimo-xbean",

--- a/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
+++ b/metadata/org.apache.xbean/xbean-asm9-shaded/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "4.26"
     ],
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/xbean/xbean-asm9-shaded/$version$/xbean-asm9-shaded-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/geronimo-xbean",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "Apache XBean xbean-asm9-shaded repackages and shades ASM 9 classes under the org.apache.xbean.asm9 namespace. It provides an isolated bytecode manipulation dependency for XBean and consumers that need ASM without package conflicts.",
     "allowed-packages" : [
       "org.apache.xbean.asm9"
     ]

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.26/execution-metrics.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.26/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T19:23:34.036680Z",
+    "library": "org.apache.xbean:xbean-asm9-shaded:4.26",
+    "starting_commit": "bfee087df8c5cc9df029370e86d5cd80a0075f8b",
+    "ending_commit": "4ef6eaa4af200bf43527199de6444c3446f34872",
+    "previous_library": "org.apache.xbean:xbean-asm9-shaded:4.22",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.26",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5379,
+          "missed": 35889,
+          "ratio": 0.130343,
+          "total": 41268
+        },
+        "line": {
+          "covered": 1172,
+          "missed": 8617,
+          "ratio": 0.119726,
+          "total": 9789
+        },
+        "method": {
+          "covered": 164,
+          "missed": 1201,
+          "ratio": 0.120147,
+          "total": 1365
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.22",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5390,
+          "missed": 35735,
+          "ratio": 0.131064,
+          "total": 41125
+        },
+        "line": {
+          "covered": 1166,
+          "missed": 8537,
+          "ratio": 0.120169,
+          "total": 9703
+        },
+        "method": {
+          "covered": 161,
+          "missed": 1189,
+          "ratio": 0.119259,
+          "total": 1350
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 22893,
+      "cached_input_tokens_used": 120320,
+      "output_tokens_used": 1422,
+      "iterations": 1,
+      "cost_usd": 0.1029,
+      "tested_library_loc": 1172,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 11.97,
+      "previous_library_coverage_percent": 12.02
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java",
+      "metadata_file": "metadata/org.apache.xbean/xbean-asm9-shaded/4.26/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.xbean/xbean-asm9-shaded/4.26/stats.json
+++ b/stats/org.apache.xbean/xbean-asm9-shaded/4.26/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.26",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5379,
+        "missed" : 35889,
+        "ratio" : 0.130343,
+        "total" : 41268
+      },
+      "line" : {
+        "covered" : 1172,
+        "missed" : 8617,
+        "ratio" : 0.119726,
+        "total" : 9789
+      },
+      "method" : {
+        "covered" : 164,
+        "missed" : 1201,
+        "ratio" : 0.120147,
+        "total" : 1365
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/.gitignore
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/build.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.xbean:xbean-asm9-shaded:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/gradle.properties
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.xbean:xbean-asm9-shaded:4.26
+library.version = 4.26
+metadata.dir = org.apache.xbean/xbean-asm9-shaded/4.26/

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/settings.gradle
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.xbean.xbean-asm9-shaded_tests'

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassReaderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.io.IOException;
+
+import org.apache.xbean.asm9.ClassReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassReaderTest {
+    @Test
+    void readsClassBytesFromTheSystemClassLoader() throws IOException {
+        ClassReader classReader = new ClassReader(ClassReader.class.getName());
+
+        assertThat(classReader.getClassName()).isEqualTo("org/apache/xbean/asm9/ClassReader");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+        assertThat(classReader.getInterfaces()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ClassWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import org.apache.xbean.asm9.ClassWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassWriterTest {
+    @Test
+    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+
+        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+    }
+
+    @Test
+    void returnsObjectWhenEitherLoadedTypeIsAnInterface() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/List", "java/util/Set");
+
+        assertThat(commonSuperClass).isEqualTo("java/lang/Object");
+    }
+
+    private static final class TestableClassWriter extends ClassWriter {
+        private TestableClassWriter() {
+            super(0);
+        }
+
+        private String commonSuperClass(String firstType, String secondType) {
+            return super.getCommonSuperClass(firstType, secondType);
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.xbean.asm9.ClassVisitor;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+public class ConstantsTest {
+    private static final String EXPERIMENTAL_API_REJECTION_MESSAGE =
+            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+    private static final String GENERATED_VISITOR_NAME =
+            "org_apache_xbean.xbean_asm9_shaded.ConstantsPreviewVisitor";
+    private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');
+    private static final String GENERATED_VISITOR_RESOURCE = GENERATED_VISITOR_INTERNAL_NAME + ".class";
+    private static final byte[] PREVIEW_CLASS_HEADER = {
+            (byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE, (byte) 0xFF, (byte) 0xFF
+    };
+
+    @Test
+    void experimentalClassNodeChecksTheShadedTreeClassResource() {
+        assertThatIllegalStateException()
+                .isThrownBy(() -> createExperimentalClassNode())
+                .withMessage(EXPERIMENTAL_API_REJECTION_MESSAGE);
+    }
+
+    @Test
+    void experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader() throws Exception {
+        try {
+            PreviewResourceClassLoader classLoader = new PreviewResourceClassLoader();
+            Class<? extends ClassVisitor> visitorClass = classLoader.definePreviewVisitor();
+            ClassVisitor visitor = visitorClass.getConstructor().newInstance();
+
+            assertThat(visitor.getClass().getName()).isEqualTo(GENERATED_VISITOR_NAME);
+        } catch (InvocationTargetException exception) {
+            rethrowUnlessUnsupportedFeatureError(exception.getCause());
+        } catch (Error error) {
+            rethrowUnlessUnsupportedFeatureError(error);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ClassNode createExperimentalClassNode() {
+        return new ClassNode(Opcodes.ASM10_EXPERIMENTAL);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] createPreviewVisitorClassBytes() throws IOException {
+        ByteArrayOutputStream classBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(classBytes)) {
+            output.writeInt(0xCAFEBABE);
+            output.writeShort(0);
+            output.writeShort(52);
+            output.writeShort(14);
+            writeUtf8(output, GENERATED_VISITOR_INTERNAL_NAME);
+            output.writeByte(7);
+            output.writeShort(1);
+            writeUtf8(output, "org/apache/xbean/asm9/ClassVisitor");
+            output.writeByte(7);
+            output.writeShort(3);
+            writeUtf8(output, "<init>");
+            writeUtf8(output, "(I)V");
+            output.writeByte(12);
+            output.writeShort(5);
+            output.writeShort(6);
+            output.writeByte(10);
+            output.writeShort(4);
+            output.writeShort(7);
+            output.writeByte(3);
+            output.writeInt(Opcodes.ASM10_EXPERIMENTAL);
+            writeUtf8(output, "Code");
+            writeUtf8(output, "()V");
+            writeUtf8(output, "SourceFile");
+            writeUtf8(output, "ConstantsPreviewVisitor.java");
+            output.writeShort(0x0021);
+            output.writeShort(2);
+            output.writeShort(4);
+            output.writeShort(0);
+            output.writeShort(0);
+            output.writeShort(1);
+            writeDefaultConstructor(output);
+            output.writeShort(1);
+            output.writeShort(12);
+            output.writeInt(2);
+            output.writeShort(13);
+        }
+        return classBytes.toByteArray();
+    }
+
+    private static void writeDefaultConstructor(DataOutputStream output) throws IOException {
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(11);
+        output.writeShort(1);
+        output.writeShort(10);
+        output.writeInt(19);
+        output.writeShort(2);
+        output.writeShort(1);
+        output.writeInt(7);
+        output.writeByte(0x2A);
+        output.writeByte(0x12);
+        output.writeByte(9);
+        output.writeByte(0xB7);
+        output.writeShort(8);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+    }
+
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static void rethrowUnlessUnsupportedFeatureError(Throwable throwable) {
+        if (throwable instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+            return;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new IllegalStateException(throwable);
+    }
+
+    private static final class PreviewResourceClassLoader extends ClassLoader {
+        private PreviewResourceClassLoader() {
+            super(ConstantsTest.class.getClassLoader());
+        }
+
+        private Class<? extends ClassVisitor> definePreviewVisitor() throws IOException {
+            byte[] classBytes = createPreviewVisitorClassBytes();
+            Class<?> visitorClass = defineClass(GENERATED_VISITOR_NAME, classBytes, 0, classBytes.length);
+            return visitorClass.asSubclass(ClassVisitor.class);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (GENERATED_VISITOR_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(PREVIEW_CLASS_HEADER);
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
     private static final String EXPERIMENTAL_API_REJECTION_MESSAGE =
-            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+            "ASM10_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
     private static final String GENERATED_VISITOR_NAME =
             "org_apache_xbean.xbean_asm9_shaded.ConstantsPreviewVisitor";
     private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/SimpleVerifierTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_asm9_shaded;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.xbean.asm9.ClassReader;
+import org.apache.xbean.asm9.ClassWriter;
+import org.apache.xbean.asm9.Opcodes;
+import org.apache.xbean.asm9.tree.AbstractInsnNode;
+import org.apache.xbean.asm9.tree.ClassNode;
+import org.apache.xbean.asm9.tree.InsnList;
+import org.apache.xbean.asm9.tree.InsnNode;
+import org.apache.xbean.asm9.tree.LdcInsnNode;
+import org.apache.xbean.asm9.tree.MethodInsnNode;
+import org.apache.xbean.asm9.tree.MethodNode;
+import org.apache.xbean.asm9.tree.VarInsnNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleVerifierTest {
+    @Test
+    void writesAndReadsClassNodeWithGeneratedMethods() {
+        ClassNode generatedClass = createGeneratedClassNode();
+
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        generatedClass.accept(classWriter);
+
+        ClassNode parsedClass = new ClassNode();
+        new ClassReader(classWriter.toByteArray()).accept(parsedClass, 0);
+
+        assertThat(parsedClass.name).isEqualTo("org/apache/xbean/generated/Greeter");
+        assertThat(parsedClass.superName).isEqualTo("java/lang/Object");
+        assertThat(parsedClass.methods)
+                .extracting(methodNode -> methodNode.name + methodNode.desc)
+                .containsExactly("<init>()V", "message()Ljava/lang/String;");
+        assertThat(instructionOpcodes(method(parsedClass, "message")))
+                .containsExactly(Opcodes.LDC, Opcodes.ARETURN);
+    }
+
+    private static ClassNode createGeneratedClassNode() {
+        ClassNode classNode = new ClassNode();
+        classNode.version = Opcodes.V17;
+        classNode.access = Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL;
+        classNode.name = "org/apache/xbean/generated/Greeter";
+        classNode.superName = "java/lang/Object";
+        classNode.methods.add(createConstructor());
+        classNode.methods.add(createMessageMethod());
+        return classNode;
+    }
+
+    private static MethodNode createConstructor() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        instructions.add(new MethodInsnNode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false));
+        instructions.add(new InsnNode(Opcodes.RETURN));
+        return methodNode;
+    }
+
+    private static MethodNode createMessageMethod() {
+        MethodNode methodNode = new MethodNode(Opcodes.ACC_PUBLIC, "message", "()Ljava/lang/String;", null, null);
+        InsnList instructions = methodNode.instructions;
+        instructions.add(new LdcInsnNode("xbean-asm9-shaded"));
+        instructions.add(new InsnNode(Opcodes.ARETURN));
+        return methodNode;
+    }
+
+    private static MethodNode method(ClassNode classNode, String name) {
+        return classNode.methods.stream()
+                .filter(methodNode -> methodNode.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static List<Integer> instructionOpcodes(MethodNode methodNode) {
+        List<Integer> opcodes = new ArrayList<>();
+        for (int index = 0; index < methodNode.instructions.size(); index++) {
+            AbstractInsnNode instruction = methodNode.instructions.get(index);
+            int opcode = instruction.getOpcode();
+            if (opcode >= 0) {
+                opcodes.add(opcode);
+            }
+        }
+        return opcodes;
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:40">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4375-a976a518/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="writesAndReadsClassNodeWithGeneratedMethods()" classname="org_apache_xbean.xbean_asm9_shaded.SimpleVerifierTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.SimpleVerifierTest]/[method:writesAndReadsClassNodeWithGeneratedMethods()]
+display-name: writesAndReadsClassNodeWithGeneratedMethods()
+]]></system-out>
+</testcase>
+<testcase name="returnsSharedAbstractSuperclassForConcreteCollectionTypes()" classname="org_apache_xbean.xbean_asm9_shaded.ClassWriterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.ClassWriterTest]/[method:returnsSharedAbstractSuperclassForConcreteCollectionTypes()]
+display-name: returnsSharedAbstractSuperclassForConcreteCollectionTypes()
+]]></system-out>
+</testcase>
+<testcase name="returnsObjectWhenEitherLoadedTypeIsAnInterface()" classname="org_apache_xbean.xbean_asm9_shaded.ClassWriterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.ClassWriterTest]/[method:returnsObjectWhenEitherLoadedTypeIsAnInterface()]
+display-name: returnsObjectWhenEitherLoadedTypeIsAnInterface()
+]]></system-out>
+</testcase>
+<testcase name="readsClassBytesFromTheSystemClassLoader()" classname="org_apache_xbean.xbean_asm9_shaded.ClassReaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.ClassReaderTest]/[method:readsClassBytesFromTheSystemClassLoader()]
+display-name: readsClassBytesFromTheSystemClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="experimentalClassNodeChecksTheShadedTreeClassResource()" classname="org_apache_xbean.xbean_asm9_shaded.ConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.ConstantsTest]/[method:experimentalClassNodeChecksTheShadedTreeClassResource()]
+display-name: experimentalClassNodeChecksTheShadedTreeClassResource()
+]]></system-out>
+</testcase>
+<testcase name="experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader()" classname="org_apache_xbean.xbean_asm9_shaded.ConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_asm9_shaded.ConstantsTest]/[method:experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader()]
+display-name: experimentalVisitorAcceptsPreviewBytecodeResourceFromCallerClassLoader()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:40">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4375-a976a518/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/user-code-filter.json
+++ b/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.xbean.asm9.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4375

This PR provides test fixes and new metadata for org.apache.xbean:xbean-asm9-shaded:4.26, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 22893
- Cached input tokens: 120320
- Output tokens: 1422
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 11.97
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 12.02

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `503d35864c35771e206a929fb2e5be20456d0bf7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.xbean:xbean-asm9-shaded:4.22: 4/4 covered calls (100.00%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 4/4 covered calls (100.00%)

**Reflection:**
- org.apache.xbean:xbean-asm9-shaded:4.22: 2/2 covered calls (100.00%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 2/2 covered calls (100.00%)

**Resources:**
- org.apache.xbean:xbean-asm9-shaded:4.22: 2/2 covered calls (100.00%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.xbean:xbean-asm9-shaded:4.22: 5390/41125 (13.11%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 5379/41268 (13.03%)

**Line:**
- org.apache.xbean:xbean-asm9-shaded:4.22: 1166/9703 (12.02%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 1172/9789 (11.97%)

**Method:**
- org.apache.xbean:xbean-asm9-shaded:4.22: 161/1350 (11.93%)
- org.apache.xbean:xbean-asm9-shaded:4.26: 164/1365 (12.01%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
index 7ba6a91c01..62dd93837b 100644
--- 1/tests/src/org.apache.xbean/xbean-asm9-shaded/4.22/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
+++ 2/tests/src/org.apache.xbean/xbean-asm9-shaded/4.26/src/test/java/org_apache_xbean/xbean_asm9_shaded/ConstantsTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class ConstantsTest {
     private static final String EXPERIMENTAL_API_REJECTION_MESSAGE =
-            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+            "ASM10_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
     private static final String GENERATED_VISITOR_NAME =
             "org_apache_xbean.xbean_asm9_shaded.ConstantsPreviewVisitor";
     private static final String GENERATED_VISITOR_INTERNAL_NAME = GENERATED_VISITOR_NAME.replace('.', '/');

```
