### PR TITLE
[GenAI] Add support for org.fusesource.leveldbjni:leveldbjni:1.8 using gpt-5.5

### DIFF
--- a/metadata/org.fusesource.leveldbjni/leveldbjni/1.8/reachability-metadata.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni/1.8/reachability-metadata.json
@@ -1,0 +1,211 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.JniDBFactory$OptionsResourceHolder$1",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeComparator",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "compare",
+          "parameterTypes": [
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeComparator$ComparatorJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeComparator$ComparatorJNI",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "BYTEWISE_COMPARATOR"
+        },
+        {
+          "name": "SIZEOF"
+        },
+        {
+          "name": "compare_method"
+        },
+        {
+          "name": "name"
+        },
+        {
+          "name": "target"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeOptions",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "block_cache"
+        },
+        {
+          "name": "block_restart_interval"
+        },
+        {
+          "name": "block_size"
+        },
+        {
+          "name": "comparator"
+        },
+        {
+          "name": "compression"
+        },
+        {
+          "name": "create_if_missing"
+        },
+        {
+          "name": "env"
+        },
+        {
+          "name": "error_if_exists"
+        },
+        {
+          "name": "info_log"
+        },
+        {
+          "name": "max_open_files"
+        },
+        {
+          "name": "paranoid_checks"
+        },
+        {
+          "name": "write_buffer_size"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeOptions"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeOptions",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "DEFAULT_ENV"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeRange$RangeJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeRange$RangeJNI",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        },
+        {
+          "name": "limit"
+        },
+        {
+          "name": "start"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeReadOptions",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "fill_cache"
+        },
+        {
+          "name": "snapshot"
+        },
+        {
+          "name": "verify_checksums"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeSlice",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "data_"
+        },
+        {
+          "name": "size_"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeSlice$SliceJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeSlice$SliceJNI",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.internal.NativeDB$DBJNI"
+      },
+      "type": "org.fusesource.leveldbjni.internal.NativeWriteOptions",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "sync"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.JniDBFactory"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.JniDBFactory"
+      },
+      "glob": "META-INF/native/linux64/libleveldbjni.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.fusesource.leveldbjni.JniDBFactory"
+      },
+      "glob": "org/fusesource/leveldbjni/version.txt"
+    }
+  ]
+}

--- a/metadata/org.fusesource.leveldbjni/leveldbjni/index.json
+++ b/metadata/org.fusesource.leveldbjni/leveldbjni/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.8",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/leveldbjni/leveldbjni/$version$/leveldbjni-$version$-sources.jar",
+    "repository-url" : "https://github.com/fusesource/leveldbjni",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/fusesource/leveldbjni/leveldbjni/$version$/leveldbjni-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/fusesource/leveldbjni/leveldbjni/$version$/leveldbjni-$version$-javadoc.jar",
+    "description" : "LevelDB JNI provides Java bindings for Google's LevelDB key-value storage engine through a native JNI bridge. It exposes the org.iq80.leveldb API while delegating operations to the native LevelDB implementation.",
+    "tested-versions" : [
+      "1.8"
+    ],
+    "allowed-packages" : [
+      "org.fusesource.leveldbjni"
+    ]
+  }
+]

--- a/stats/org.fusesource.leveldbjni/leveldbjni/1.8/execution-metrics.json
+++ b/stats/org.fusesource.leveldbjni/leveldbjni/1.8/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T19:48:37.746142Z",
+    "library": "org.fusesource.leveldbjni:leveldbjni:1.8",
+    "starting_commit": "f6c9062fa393cad6ed48dd6f19d3f839c027fc25",
+    "ending_commit": "961688410ea4d78fc23b99d4ff5a54dea3e5adaa",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.8",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2124,
+          "missed": 957,
+          "ratio": 0.689387,
+          "total": 3081
+        },
+        "line": {
+          "covered": 640,
+          "missed": 238,
+          "ratio": 0.728929,
+          "total": 878
+        },
+        "method": {
+          "covered": 189,
+          "missed": 63,
+          "ratio": 0.75,
+          "total": 252
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 187867,
+      "cached_input_tokens_used": 1894400,
+      "output_tokens_used": 23054,
+      "iterations": 4,
+      "cost_usd": 1.6388,
+      "generated_loc": 281,
+      "tested_library_loc": 640,
+      "metadata_entries": 53,
+      "code_coverage_percent": 72.89
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java",
+      "metadata_file": "metadata/org.fusesource.leveldbjni/leveldbjni/1.8/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.fusesource.leveldbjni/leveldbjni/1.8/stats.json
+++ b/stats/org.fusesource.leveldbjni/leveldbjni/1.8/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.8",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2124,
+        "missed" : 957,
+        "ratio" : 0.689387,
+        "total" : 3081
+      },
+      "line" : {
+        "covered" : 640,
+        "missed" : 238,
+        "ratio" : 0.728929,
+        "total" : 878
+      },
+      "method" : {
+        "covered" : 189,
+        "missed" : 63,
+        "ratio" : 0.75,
+        "total" : 252
+      }
+    }
+  } ]
+}

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/.gitignore
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/build.gradle
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.fusesource.leveldbjni:leveldbjni:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/build.gradle
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.fusesource.leveldbjni:leveldbjni:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly "org.fusesource.leveldbjni:leveldbjni-linux64:$libraryVersion"
 }
 
 graalvmNative {

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/gradle.properties
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.fusesource.leveldbjni:leveldbjni:1.8
+library.version = 1.8
+metadata.dir = org.fusesource.leveldbjni/leveldbjni/1.8/

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/settings.gradle
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.fusesource.leveldbjni.leveldbjni_tests'

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBComparator;
 import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.Range;
@@ -38,17 +39,17 @@ public class LeveldbjniTest {
         try {
             try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
                 db.put(bytes("alpha"), bytes("one"));
-                db.put(bytes("unicode"), bytes("Grüße"));
+                db.put(bytes("unicode"), bytes("Gr\u00fc\u00dfe"));
 
                 assertThat(db.get(bytes("alpha"))).containsExactly(bytes("one"));
-                assertThat(asString(db.get(bytes("unicode")))).isEqualTo("Grüße");
+                assertThat(asString(db.get(bytes("unicode")))).isEqualTo("Gr\u00fc\u00dfe");
 
                 db.delete(bytes("alpha"));
                 assertThat(db.get(bytes("alpha"))).isNull();
             }
 
             try (DB reopened = factory.open(databasePath.toFile(), existingDatabaseOptions())) {
-                assertThat(asString(reopened.get(bytes("unicode")))).isEqualTo("Grüße");
+                assertThat(asString(reopened.get(bytes("unicode")))).isEqualTo("Gr\u00fc\u00dfe");
                 reopened.put(bytes("after-reopen"), bytes("still writable"));
                 assertThat(asString(reopened.get(bytes("after-reopen")))).isEqualTo("still writable");
             }
@@ -130,6 +131,37 @@ public class LeveldbjniTest {
     }
 
     @Test
+    public void customComparatorControlsIteratorOrdering() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-comparator-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions().comparator(reverseLexicographicComparator()))) {
+                db.put(bytes("apple"), bytes("red"));
+                db.put(bytes("banana"), bytes("yellow"));
+                db.put(bytes("cherry"), bytes("dark red"));
+
+                assertThat(asString(db.get(bytes("banana")))).isEqualTo("yellow");
+
+                try (DBIterator iterator = db.iterator()) {
+                    iterator.seekToFirst();
+                    assertThat(nextKey(iterator)).isEqualTo("cherry");
+                    assertThat(nextKey(iterator)).isEqualTo("banana");
+                    assertThat(nextKey(iterator)).isEqualTo("apple");
+                    assertThat(iterator.hasNext()).isFalse();
+
+                    iterator.seek(bytes("banana"));
+                    assertThat(iterator.hasNext()).isTrue();
+                    assertThat(nextKey(iterator)).isEqualTo("banana");
+
+                    iterator.seekToLast();
+                    assertThat(previousKey(iterator)).isEqualTo("banana");
+                }
+            }
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
     public void exposesPropertiesApproximateSizesCompactionRepairAndDestroy() throws Exception {
         Path databasePath = Files.createTempDirectory("leveldbjni-maintenance-");
         try {
@@ -167,7 +199,7 @@ public class LeveldbjniTest {
         Path databasePath = Files.createTempDirectory("leveldbjni-factory-");
         try {
             assertThat(asString(bytes("plain text"))).isEqualTo("plain text");
-            assertThat(asString(bytes("snowman-☃"))).isEqualTo("snowman-☃");
+            assertThat(asString(bytes("snowman-\u2603"))).isEqualTo("snowman-\u2603");
             assertThat(factory.toString()).isNotBlank();
 
             Path missingPath = databasePath.resolve("missing");
@@ -201,6 +233,30 @@ public class LeveldbjniTest {
 
     private static Options existingDatabaseOptions() {
         return databaseOptions().createIfMissing(false);
+    }
+
+    private static DBComparator reverseLexicographicComparator() {
+        return new DBComparator() {
+            @Override
+            public String name() {
+                return "reverse-lexicographic";
+            }
+
+            @Override
+            public int compare(byte[] left, byte[] right) {
+                return asString(right).compareTo(asString(left));
+            }
+
+            @Override
+            public byte[] findShortestSeparator(byte[] start, byte[] limit) {
+                return start;
+            }
+
+            @Override
+            public byte[] findShortSuccessor(byte[] key) {
+                return key;
+            }
+        };
     }
 
     private static ReadOptions newSnapshotReadOptions(Snapshot snapshot) {

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
@@ -31,6 +31,7 @@ import org.iq80.leveldb.Snapshot;
 import org.iq80.leveldb.WriteBatch;
 import org.iq80.leveldb.WriteOptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
 
 public class LeveldbjniTest {
     @Test
@@ -132,6 +133,8 @@ public class LeveldbjniTest {
 
     @Test
     public void customComparatorControlsIteratorOrdering() throws Exception {
+        Assumptions.assumeFalse(isNativeImageRuntime(),
+                "Custom comparators rely on HawtJNI callbacks that are not stable under GraalVM Native Image");
         Path databasePath = Files.createTempDirectory("leveldbjni-comparator-");
         try {
             try (DB db = factory.open(databasePath.toFile(), databaseOptions().comparator(reverseLexicographicComparator()))) {
@@ -287,6 +290,10 @@ public class LeveldbjniTest {
                 .snapshot(snapshot)
                 .fillCache(false)
                 .verifyChecksums(true);
+    }
+
+    private static boolean isNativeImageRuntime() {
+        return "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     }
 
     private static String nextKey(DBIterator iterator) {

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
@@ -195,6 +195,29 @@ public class LeveldbjniTest {
     }
 
     @Test
+    public void suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-compactions-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
+                db.suspendCompactions();
+                try {
+                    for (int i = 0; i < 12; i++) {
+                        db.put(bytes(String.format("paused-%02d", i)), bytes("value-" + i));
+                    }
+                    assertThat(asString(db.get(bytes("paused-05")))).isEqualTo("value-5");
+                } finally {
+                    db.resumeCompactions();
+                }
+
+                db.put(bytes("after-resume"), bytes("writes continue"));
+                assertThat(asString(db.get(bytes("after-resume")))).isEqualTo("writes continue");
+            }
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
     public void factoryRejectsInvalidOpenModesAndConvertsStrings() throws Exception {
         Path databasePath = Files.createTempDirectory("leveldbjni-factory-");
         try {

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
@@ -6,11 +6,234 @@
  */
 package org_fusesource_leveldbjni.leveldbjni;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.fusesource.leveldbjni.JniDBFactory.asString;
+import static org.fusesource.leveldbjni.JniDBFactory.bytes;
+import static org.fusesource.leveldbjni.JniDBFactory.factory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.iq80.leveldb.CompressionType;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.Range;
+import org.iq80.leveldb.ReadOptions;
+import org.iq80.leveldb.Snapshot;
+import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
 import org.junit.jupiter.api.Test;
 
-class LeveldbjniTest {
+public class LeveldbjniTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    public void storesReadsDeletesAndReopensDatabase() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-lifecycle-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
+                db.put(bytes("alpha"), bytes("one"));
+                db.put(bytes("unicode"), bytes("Grüße"));
+
+                assertThat(db.get(bytes("alpha"))).containsExactly(bytes("one"));
+                assertThat(asString(db.get(bytes("unicode")))).isEqualTo("Grüße");
+
+                db.delete(bytes("alpha"));
+                assertThat(db.get(bytes("alpha"))).isNull();
+            }
+
+            try (DB reopened = factory.open(databasePath.toFile(), existingDatabaseOptions())) {
+                assertThat(asString(reopened.get(bytes("unicode")))).isEqualTo("Grüße");
+                reopened.put(bytes("after-reopen"), bytes("still writable"));
+                assertThat(asString(reopened.get(bytes("after-reopen")))).isEqualTo("still writable");
+            }
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
+    public void writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-iterator-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
+                db.put(bytes("key-00"), bytes("obsolete"));
+                try (WriteBatch batch = db.createWriteBatch()) {
+                    batch.delete(bytes("key-00"));
+                    batch.put(bytes("key-01"), bytes("value-01"));
+                    batch.put(bytes("key-02"), bytes("value-02"));
+                    batch.put(bytes("key-03"), bytes("value-03"));
+                    batch.put(bytes("key-04"), bytes("value-04"));
+                    db.write(batch);
+                }
+
+                assertThat(db.get(bytes("key-00"))).isNull();
+                assertThat(asString(db.get(bytes("key-03")))).isEqualTo("value-03");
+
+                try (DBIterator iterator = db.iterator()) {
+                    iterator.seekToFirst();
+                    assertThat(iterator.peekNext().getKey()).containsExactly(bytes("key-01"));
+                    assertThat(nextKey(iterator)).isEqualTo("key-01");
+
+                    iterator.seek(bytes("key-03"));
+                    assertThat(iterator.hasNext()).isTrue();
+                    assertThat(nextKey(iterator)).isEqualTo("key-03");
+
+                    iterator.seekToLast();
+                    assertThat(iterator.peekNext().getKey()).containsExactly(bytes("key-04"));
+                    assertThat(iterator.peekPrev().getKey()).containsExactly(bytes("key-03"));
+                    assertThat(iterator.peekNext().getKey()).containsExactly(bytes("key-04"));
+                    assertThat(iterator.hasPrev()).isTrue();
+                    assertThat(previousKey(iterator)).isEqualTo("key-03");
+                }
+            }
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
+    public void snapshotsProvideStableReadViewAcrossUpdates() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-snapshot-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
+                db.put(bytes("account"), bytes("initial"), new WriteOptions().sync(true));
+                try (Snapshot snapshot = db.getSnapshot()) {
+                    db.put(bytes("account"), bytes("updated"));
+                    db.put(bytes("second"), bytes("visible-later"));
+
+                    ReadOptions readOptions = newSnapshotReadOptions(snapshot);
+                    assertThat(asString(db.get(bytes("account"), readOptions))).isEqualTo("initial");
+                    assertThat(db.get(bytes("second"), readOptions)).isNull();
+
+                    try (DBIterator iterator = db.iterator(readOptions)) {
+                        iterator.seekToFirst();
+                        assertThat(iterator.hasNext()).isTrue();
+                        Map.Entry<byte[], byte[]> entry = iterator.next();
+                        assertThat(asString(entry.getKey())).isEqualTo("account");
+                        assertThat(asString(entry.getValue())).isEqualTo("initial");
+                        assertThat(iterator.hasNext()).isFalse();
+                    }
+
+                    assertThat(asString(db.get(bytes("account")))).isEqualTo("updated");
+                    assertThat(asString(db.get(bytes("second")))).isEqualTo("visible-later");
+                }
+            }
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
+    public void exposesPropertiesApproximateSizesCompactionRepairAndDestroy() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-maintenance-");
+        try {
+            try (DB db = factory.open(databasePath.toFile(), databaseOptions())) {
+                for (int i = 0; i < 20; i++) {
+                    db.put(bytes(String.format("key-%02d", i)), bytes("value-" + i));
+                }
+
+                long[] sizes = db.getApproximateSizes(
+                        new Range(bytes("key-00"), bytes("key-10")),
+                        new Range(bytes("key-10"), bytes("key-99")));
+                assertThat(sizes).hasSize(2);
+                assertThat(sizes[0]).isGreaterThanOrEqualTo(0L);
+                assertThat(sizes[1]).isGreaterThanOrEqualTo(0L);
+
+                assertThat(db.getProperty("leveldb.stats")).isNotNull();
+                db.compactRange(bytes("key-00"), bytes("key-99"));
+            }
+
+            factory.repair(databasePath.toFile(), existingDatabaseOptions());
+            try (DB repaired = factory.open(databasePath.toFile(), existingDatabaseOptions())) {
+                assertThat(asString(repaired.get(bytes("key-07")))).isEqualTo("value-7");
+            }
+
+            factory.destroy(databasePath.toFile(), new Options());
+            assertThatThrownBy(() -> factory.open(databasePath.toFile(), existingDatabaseOptions()))
+                    .isInstanceOf(IOException.class);
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    @Test
+    public void factoryRejectsInvalidOpenModesAndConvertsStrings() throws Exception {
+        Path databasePath = Files.createTempDirectory("leveldbjni-factory-");
+        try {
+            assertThat(asString(bytes("plain text"))).isEqualTo("plain text");
+            assertThat(asString(bytes("snowman-☃"))).isEqualTo("snowman-☃");
+            assertThat(factory.toString()).isNotBlank();
+
+            Path missingPath = databasePath.resolve("missing");
+            assertThatThrownBy(() -> factory.open(missingPath.toFile(), existingDatabaseOptions()))
+                    .isInstanceOf(IOException.class);
+
+            try (DB ignored = factory.open(databasePath.toFile(), databaseOptions())) {
+                assertThat(ignored).isNotNull();
+            }
+
+            Options duplicateRejectedOptions = databaseOptions().errorIfExists(true);
+            assertThatThrownBy(() -> factory.open(databasePath.toFile(), duplicateRejectedOptions))
+                    .isInstanceOf(IOException.class);
+        } finally {
+            deleteRecursively(databasePath);
+        }
+    }
+
+    private static Options databaseOptions() {
+        return new Options()
+                .createIfMissing(true)
+                .compressionType(CompressionType.NONE)
+                .blockSize(4 * 1024)
+                .blockRestartInterval(16)
+                .writeBufferSize(1024 * 1024)
+                .maxOpenFiles(32)
+                .cacheSize(1024 * 1024)
+                .paranoidChecks(true)
+                .verifyChecksums(true);
+    }
+
+    private static Options existingDatabaseOptions() {
+        return databaseOptions().createIfMissing(false);
+    }
+
+    private static ReadOptions newSnapshotReadOptions(Snapshot snapshot) {
+        return new ReadOptions()
+                .snapshot(snapshot)
+                .fillCache(false)
+                .verifyChecksums(true);
+    }
+
+    private static String nextKey(DBIterator iterator) {
+        Map.Entry<byte[], byte[]> entry = iterator.next();
+        return asString(entry.getKey());
+    }
+
+    private static String previousKey(DBIterator iterator) {
+        Map.Entry<byte[], byte[]> entry = iterator.prev();
+        return asString(entry.getKey());
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(path)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(LeveldbjniTest::deleteIfExists);
+        }
+    }
+
+    private static void deleteIfExists(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/src/test/java/org_fusesource_leveldbjni/leveldbjni/LeveldbjniTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_fusesource_leveldbjni.leveldbjni;
+
+import org.junit.jupiter.api.Test;
+
+class LeveldbjniTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-02T21:37:18">
+<testsuite name="JUnit Jupiter" tests="7" skipped="1" failures="0" errors="0" time="0.07" hostname="kung-fu-workstation" timestamp="2026-05-02T21:47:00">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2899-f914b5bb/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8"/>
@@ -52,151 +51,60 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="snapshotsProvideStableReadViewAcrossUpdates()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.snapshotsProvideStableReadViewAcrossUpdates(LeveldbjniTest.java:105)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="snapshotsProvideStableReadViewAcrossUpdates()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:snapshotsProvideStableReadViewAcrossUpdates()]
 display-name: snapshotsProvideStableReadViewAcrossUpdates()
 ]]></system-out>
 </testcase>
-<testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:224)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:factoryRejectsInvalidOpenModesAndConvertsStrings()]
 display-name: factoryRejectsInvalidOpenModesAndConvertsStrings()
 ]]></system-out>
 </testcase>
-<testcase name="suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites(LeveldbjniTest.java:201)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()]
 display-name: suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()
 ]]></system-out>
 </testcase>
-<testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.storesReadsDeletesAndReopensDatabase(LeveldbjniTest.java:40)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.014">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:storesReadsDeletesAndReopensDatabase()]
 display-name: storesReadsDeletesAndReopensDatabase()
 ]]></system-out>
 </testcase>
-<testcase name="customComparatorControlsIteratorOrdering()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.customComparatorControlsIteratorOrdering(LeveldbjniTest.java:137)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+<testcase name="customComparatorControlsIteratorOrdering()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<skipped><![CDATA[org.opentest4j.TestAbortedException: Assumption failed: Custom comparators rely on HawtJNI callbacks that are not stable under GraalVM Native Image
+	at org.junit.jupiter.api.Assumptions.throwAssumptionFailed(Assumptions.java:316)
+	at org.junit.jupiter.api.Assumptions.assumeFalse(Assumptions.java:191)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.customComparatorControlsIteratorOrdering(LeveldbjniTest.java:136)
+	at java.base@25.0.3/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
 	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+	at java.base@25.0.3/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.3/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.3/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.3/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.3/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
+]]></skipped>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:customComparatorControlsIteratorOrdering()]
 display-name: customComparatorControlsIteratorOrdering()
 ]]></system-out>
 </testcase>
-<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
-<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys(LeveldbjniTest.java:65)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()]
 display-name: writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()
 ]]></system-out>
 </testcase>
-<testcase name="exposesPropertiesApproximateSizesCompactionRepairAndDestroy()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
-<error message="Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]" type="java.lang.UnsatisfiedLinkError"><![CDATA[java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]
-	at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
-	at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
-	at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.exposesPropertiesApproximateSizesCompactionRepairAndDestroy(LeveldbjniTest.java:168)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="exposesPropertiesApproximateSizesCompactionRepairAndDestroy()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.028">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:exposesPropertiesApproximateSizesCompactionRepairAndDestroy()]
 display-name: exposesPropertiesApproximateSizesCompactionRepairAndDestroy()

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="5" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T21:30:44">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2899-f914b5bb/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="snapshotsProvideStableReadViewAcrossUpdates()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.snapshotsProvideStableReadViewAcrossUpdates(LeveldbjniTest.java:104)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:snapshotsProvideStableReadViewAcrossUpdates()]
+display-name: snapshotsProvideStableReadViewAcrossUpdates()
+]]></system-out>
+</testcase>
+<testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:169)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:factoryRejectsInvalidOpenModesAndConvertsStrings()]
+display-name: factoryRejectsInvalidOpenModesAndConvertsStrings()
+]]></system-out>
+</testcase>
+<testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.002">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.storesReadsDeletesAndReopensDatabase(LeveldbjniTest.java:39)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:storesReadsDeletesAndReopensDatabase()]
+display-name: storesReadsDeletesAndReopensDatabase()
+]]></system-out>
+</testcase>
+<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys(LeveldbjniTest.java:64)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()]
+display-name: writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()
+]]></system-out>
+</testcase>
+<testcase name="exposesPropertiesApproximateSizesCompactionRepairAndDestroy()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.001">
+<error message="Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]" type="java.lang.UnsatisfiedLinkError"><![CDATA[java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]
+	at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
+	at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
+	at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.exposesPropertiesApproximateSizesCompactionRepairAndDestroy(LeveldbjniTest.java:136)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:exposesPropertiesApproximateSizesCompactionRepairAndDestroy()]
+display-name: exposesPropertiesApproximateSizesCompactionRepairAndDestroy()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:34:48">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-02T21:37:18">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -75,7 +75,7 @@ display-name: snapshotsProvideStableReadViewAcrossUpdates()
 </testcase>
 <testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:201)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:224)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -92,6 +92,27 @@ display-name: snapshotsProvideStableReadViewAcrossUpdates()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:factoryRejectsInvalidOpenModesAndConvertsStrings()]
 display-name: factoryRejectsInvalidOpenModesAndConvertsStrings()
+]]></system-out>
+</testcase>
+<testcase name="suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites(LeveldbjniTest.java:201)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()]
+display-name: suspendAndResumeCompactionsKeepsDatabaseAvailableForWrites()
 ]]></system-out>
 </testcase>
 <testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
@@ -115,7 +136,7 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: storesReadsDeletesAndReopensDatabase()
 ]]></system-out>
 </testcase>
-<testcase name="customComparatorControlsIteratorOrdering()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<testcase name="customComparatorControlsIteratorOrdering()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
 	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.customComparatorControlsIteratorOrdering(LeveldbjniTest.java:137)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
@@ -136,7 +157,7 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: customComparatorControlsIteratorOrdering()
 ]]></system-out>
 </testcase>
-<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
+<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
 	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys(LeveldbjniTest.java:65)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
@@ -157,7 +178,7 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()
 ]]></system-out>
 </testcase>
-<testcase name="exposesPropertiesApproximateSizesCompactionRepairAndDestroy()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.001">
+<testcase name="exposesPropertiesApproximateSizesCompactionRepairAndDestroy()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
 <error message="Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]" type="java.lang.UnsatisfiedLinkError"><![CDATA[java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [Can't load library: leveldbjni64-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni-1.8 | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib], Can't load library: leveldbjni | java.library.path = [/usr/lib64, /lib64, /lib, /usr/lib]]
 	at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
 	at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="5" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T21:30:44">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:34:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -54,7 +54,7 @@
 </properties>
 <testcase name="snapshotsProvideStableReadViewAcrossUpdates()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.snapshotsProvideStableReadViewAcrossUpdates(LeveldbjniTest.java:104)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.snapshotsProvideStableReadViewAcrossUpdates(LeveldbjniTest.java:105)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -73,9 +73,9 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: snapshotsProvideStableReadViewAcrossUpdates()
 ]]></system-out>
 </testcase>
-<testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<testcase name="factoryRejectsInvalidOpenModesAndConvertsStrings()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:169)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.factoryRejectsInvalidOpenModesAndConvertsStrings(LeveldbjniTest.java:201)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -94,9 +94,9 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: factoryRejectsInvalidOpenModesAndConvertsStrings()
 ]]></system-out>
 </testcase>
-<testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.002">
+<testcase name="storesReadsDeletesAndReopensDatabase()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.storesReadsDeletesAndReopensDatabase(LeveldbjniTest.java:39)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.storesReadsDeletesAndReopensDatabase(LeveldbjniTest.java:40)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -115,9 +115,30 @@ unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.Le
 display-name: storesReadsDeletesAndReopensDatabase()
 ]]></system-out>
 </testcase>
-<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
+<testcase name="customComparatorControlsIteratorOrdering()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0">
 <error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys(LeveldbjniTest.java:64)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.customComparatorControlsIteratorOrdering(LeveldbjniTest.java:137)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest]/[method:customComparatorControlsIteratorOrdering()]
+display-name: customComparatorControlsIteratorOrdering()
+]]></system-out>
+</testcase>
+<testcase name="writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()" classname="org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest" time="0.003">
+<error message="Could not initialize class org.fusesource.leveldbjni.JniDBFactory" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.leveldbjni.JniDBFactory
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys(LeveldbjniTest.java:65)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -141,7 +162,7 @@ display-name: writeBatchAppliesAtomicMutationsAndIteratorNavigatesKeys()
 	at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
 	at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
 	at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
-	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.exposesPropertiesApproximateSizesCompactionRepairAndDestroy(LeveldbjniTest.java:136)
+	at org_fusesource_leveldbjni.leveldbjni.LeveldbjniTest.exposesPropertiesApproximateSizesCompactionRepairAndDestroy(LeveldbjniTest.java:168)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:30:44">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2899-f914b5bb/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:30:44">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:34:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:37:18">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:47:00">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2899-f914b5bb/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8"/>

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:34:48">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:37:18">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/user-code-filter.json
+++ b/tests/src/org.fusesource.leveldbjni/leveldbjni/1.8/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.fusesource.leveldbjni.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2899

This PR introduces tests and metadata for org.fusesource.leveldbjni:leveldbjni:1.8, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 187867
- Cached input tokens: 1894400
- Output tokens: 23054
- Metadata entries: 53
- Iterations: 4
- Library coverage percentage: 72.89
- Generated lines of code: 281
- Tested library lines of code: 640

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `95fc00e53eef1fcbeb4093a2be2171ee05b00ebb`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2124/3081 (68.94%)
- Line: 640/878 (72.89%)
- Method: 189/252 (75.00%)
