### PR TITLE
[GenAI] Add support for org.eclipse.microprofile.openapi:microprofile-openapi-api:4.1.1 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/reachability-metadata.json
+++ b/metadata/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.Components"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.ExternalDocumentation"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.OpenAPI"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.Operation"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.PathItem"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.Paths"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.callbacks.Callback"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.examples.Example"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.headers.Header"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.info.Contact"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.info.Info"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.info.License"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.links.Link"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Content"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Discriminator"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Encoding"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.MediaType"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Schema"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.XML"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.parameters.Parameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.parameters.RequestBody"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.responses.APIResponse"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.responses.APIResponses"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.security.OAuthFlow"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.security.OAuthFlows"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.security.SecurityRequirement"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.security.SecurityScheme"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.servers.Server"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.servers.ServerVariable"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.microprofile.openapi.OASFactory"
+      },
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.tags.Tag"
+        ]
+      }
+    }
+  ]
+}

--- a/metadata/org.eclipse.microprofile.openapi/microprofile-openapi-api/index.json
+++ b/metadata/org.eclipse.microprofile.openapi/microprofile-openapi-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/openapi/microprofile-openapi-api/$version$/microprofile-openapi-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/microprofile/microprofile-open-api",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/openapi/microprofile-openapi-tck/$version$/microprofile-openapi-tck-$version$-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/openapi/microprofile-openapi-api/$version$/microprofile-openapi-api-$version$-javadoc.jar",
+    "description" : "MicroProfile OpenAPI API defines annotations, models, and SPI contracts that Java applications use to describe REST endpoints as OpenAPI documents. It is a specification API artifact consumed by MicroProfile runtimes and tools rather than a standalone OpenAPI implementation.",
+    "tested-versions" : [
+      "4.1.1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.microprofile.openapi"
+    ]
+  }
+]

--- a/stats/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/execution-metrics.json
+++ b/stats/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T19:50:21.443786Z",
+    "library": "org.eclipse.microprofile.openapi:microprofile-openapi-api:4.1.1",
+    "starting_commit": "ca929cadca0d2286a3a7ff62942b18762408bec5",
+    "ending_commit": "5056380c2af97d97c3e06ac59bcb49a07c93d5ba",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 539,
+          "missed": 1518,
+          "ratio": 0.262032,
+          "total": 2057
+        },
+        "line": {
+          "covered": 94,
+          "missed": 510,
+          "ratio": 0.155629,
+          "total": 604
+        },
+        "method": {
+          "covered": 67,
+          "missed": 233,
+          "ratio": 0.223333,
+          "total": 300
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 307082,
+      "cached_input_tokens_used": 3572224,
+      "output_tokens_used": 35504,
+      "iterations": 6,
+      "cost_usd": 2.8512,
+      "generated_loc": 735,
+      "tested_library_loc": 94,
+      "metadata_entries": 30,
+      "code_coverage_percent": 15.56
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java",
+      "metadata_file": "metadata/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/stats.json
+++ b/stats/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 539,
+        "missed" : 1518,
+        "ratio" : 0.262032,
+        "total" : 2057
+      },
+      "line" : {
+        "covered" : 94,
+        "missed" : 510,
+        "ratio" : 0.155629,
+        "total" : 604
+      },
+      "method" : {
+        "covered" : 67,
+        "missed" : 233,
+        "ratio" : 0.223333,
+        "total" : 300
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/.gitignore
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/build.gradle
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.microprofile.openapi:microprofile-openapi-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/gradle.properties
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.microprofile.openapi:microprofile-openapi-api:4.1.1
+library.version = 4.1.1
+metadata.dir = org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/settings.gradle
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.microprofile.openapi.microprofile-openapi-api_tests'

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_microprofile_openapi.microprofile_openapi_api;
+
+import org.junit.jupiter.api.Test;
+
+class Microprofile_openapi_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
@@ -6,11 +6,674 @@
  */
 package org_eclipse_microprofile_openapi.microprofile_openapi_api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASConfig;
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.OASModelReader;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.models.Components;
+import org.eclipse.microprofile.openapi.models.ExternalDocumentation;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.callbacks.Callback;
+import org.eclipse.microprofile.openapi.models.examples.Example;
+import org.eclipse.microprofile.openapi.models.headers.Header;
+import org.eclipse.microprofile.openapi.models.info.Contact;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.eclipse.microprofile.openapi.models.info.License;
+import org.eclipse.microprofile.openapi.models.links.Link;
+import org.eclipse.microprofile.openapi.models.media.Discriminator;
+import org.eclipse.microprofile.openapi.models.media.Encoding;
+import org.eclipse.microprofile.openapi.models.media.MediaType;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.media.XML;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlow;
+import org.eclipse.microprofile.openapi.models.security.OAuthFlows;
+import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.tags.Tag;
+import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class Microprofile_openapi_apiTest {
+public class Microprofile_openapi_apiTest {
+    @BeforeEach
+    void installResolver() {
+        OASFactoryResolver.setInstance(new TestOASFactoryResolver());
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void createsAndLinksCompleteOpenAPIModel() {
+        Contact contact = OASFactory.createContact()
+                .name("OpenAPI Team")
+                .email("team@example.test")
+                .url("https://example.test/contact")
+                .addExtension("x-contact-kind", "support");
+        License license = OASFactory.createLicense()
+                .name("Apache-2.0")
+                .identifier("Apache-2.0")
+                .url("https://www.apache.org/licenses/LICENSE-2.0");
+        Info info = OASFactory.createInfo()
+                .title("Inventory")
+                .summary("Inventory summary")
+                .description("Inventory API")
+                .termsOfService("https://example.test/terms")
+                .version("1.0.0")
+                .contact(contact)
+                .license(license)
+                .addExtension("x-info", 7);
+        Server server = OASFactory.createServer()
+                .url("https://{tenant}.example.test/{basePath}")
+                .description("tenant server")
+                .addVariable("tenant", OASFactory.createServerVariable()
+                        .defaultValue("acme")
+                        .description("tenant subdomain")
+                        .addEnumeration("acme")
+                        .addEnumeration("contoso"))
+                .addVariable("basePath", OASFactory.createServerVariable().defaultValue("v1"));
+        SecurityRequirement requirement = OASFactory.createSecurityRequirement()
+                .addScheme("oauth2", Arrays.asList("inventory:read", "inventory:write"))
+                .addScheme("apiKey");
+        OpenAPI openAPI = OASFactory.createOpenAPI()
+                .openapi("3.1.1")
+                .jsonSchemaDialect("https://json-schema.org/draft/2020-12/schema")
+                .info(info)
+                .addServer(server)
+                .addSecurityRequirement(requirement)
+                .components(OASFactory.createComponents())
+                .paths(OASFactory.createPaths())
+                .addTag(OASFactory.createTag().name("inventory").description("Inventory operations"))
+                .addWebhook("stock-changed", OASFactory.createPathItem().summary("stock webhook"));
+
+        assertThat(openAPI.getOpenapi()).isEqualTo("3.1.1");
+        assertThat(openAPI.getJsonSchemaDialect()).contains("2020-12");
+        assertThat(openAPI.getInfo().getContact().getExtension("x-contact-kind")).isEqualTo("support");
+        assertThat(openAPI.getInfo().getLicense().getIdentifier()).isEqualTo("Apache-2.0");
+        assertThat(openAPI.getServers()).containsExactly(server);
+        assertThat(openAPI.getServers().get(0).getVariables()).containsKeys("tenant", "basePath");
+        assertThat(openAPI.getServers().get(0).getVariables().get("tenant").getEnumeration())
+                .containsExactly("acme", "contoso");
+        assertThat(openAPI.getSecurity().get(0).getScheme("oauth2"))
+                .containsExactly("inventory:read", "inventory:write");
+        assertThat(openAPI.getSecurity().get(0).getScheme("apiKey")).isEmpty();
+        assertThat(openAPI.getTags().get(0).getName()).isEqualTo("inventory");
+        assertThat(openAPI.getWebhooks()).containsKey("stock-changed");
+    }
+
+    @Test
+    void managesComponentsSchemasResponsesAndSecuritySchemes() {
+        Schema skuSchema = OASFactory.createSchema()
+                .title("Sku")
+                .type(Arrays.asList(Schema.SchemaType.STRING))
+                .minLength(3)
+                .maxLength(20)
+                .pattern("[A-Z0-9-]+")
+                .addExample("ABC-123")
+                .addEnumeration("ABC-123")
+                .addEnumeration("XYZ-987")
+                .addExtension("x-normalized", Boolean.TRUE);
+        Schema inventorySchema = OASFactory.createSchema()
+                .title("InventoryItem")
+                .description("An item available for sale")
+                .addType(Schema.SchemaType.OBJECT)
+                .addRequired("sku")
+                .addRequired("quantity")
+                .addProperty("sku", skuSchema)
+                .addProperty("quantity", OASFactory.createSchema()
+                        .addType(Schema.SchemaType.INTEGER)
+                        .minimum(BigDecimal.ZERO)
+                        .defaultValue(0))
+                .additionalPropertiesSchema(OASFactory.createSchema().booleanSchema(false));
+        APIResponse okResponse = OASFactory.createAPIResponse()
+                .description("item found")
+                .content(OASFactory.createContent().addMediaType("application/json",
+                        OASFactory.createMediaType().schema(inventorySchema)))
+                .addHeader("ETag", OASFactory.createHeader()
+                        .description("entity tag")
+                        .schema(OASFactory.createSchema().addType(Schema.SchemaType.STRING)));
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("JWT bearer token");
+        Components components = OASFactory.createComponents()
+                .addSchema("Sku", skuSchema)
+                .addSchema("InventoryItem", inventorySchema)
+                .addResponse("ItemResponse", okResponse)
+                .addParameter("SkuParameter", OASFactory.createParameter()
+                        .name("sku")
+                        .in(Parameter.In.PATH)
+                        .required(true)
+                        .schema(skuSchema))
+                .addExample("SampleItem", OASFactory.createExample().summary("sample").value("ABC-123"))
+                .addRequestBody("ItemBody", OASFactory.createRequestBody().required(true)
+                        .content(OASFactory.createContent().addMediaType("application/json",
+                                OASFactory.createMediaType().schema(inventorySchema))))
+                .addHeader("ETag", OASFactory.createHeader().description("entity tag"))
+                .addSecurityScheme("bearerAuth", securityScheme)
+                .addLink("findItem", OASFactory.createLink().operationId("getItem"))
+                .addCallback("stockCallback", OASFactory.createCallback().addPathItem("{$request.body#/callbackUrl}",
+                        OASFactory.createPathItem().POST(OASFactory.createOperation().summary("callback"))))
+                .addPathItem("ReusableItemPath", OASFactory.createPathItem().summary("reusable path"));
+
+        assertThat(components.getSchemas()).containsEntry("Sku", skuSchema).containsEntry("InventoryItem", inventorySchema);
+        assertThat(components.getSchemas().get("InventoryItem").getRequired()).containsExactly("sku", "quantity");
+        assertThat(components.getSchemas().get("InventoryItem").getProperties()).containsEntry("sku", skuSchema);
+        assertThat(components.getResponses().get("ItemResponse").getContent().hasMediaType("application/json")).isTrue();
+        assertThat(components.getResponses().get("ItemResponse").getHeaders()).containsKey("ETag");
+        assertThat(components.getParameters().get("SkuParameter").getIn()).isEqualTo(Parameter.In.PATH);
+        assertThat(components.getExamples().get("SampleItem").getValue()).isEqualTo("ABC-123");
+        assertThat(components.getRequestBodies().get("ItemBody").getContent().getMediaType("application/json").getSchema())
+                .isSameAs(inventorySchema);
+        assertThat(components.getSecuritySchemes().get("bearerAuth").getBearerFormat()).isEqualTo("JWT");
+        assertThat(components.getLinks().get("findItem").getOperationId()).isEqualTo("getItem");
+        assertThat(components.getCallbacks().get("stockCallback").hasPathItem("{$request.body#/callbackUrl}")).isTrue();
+        assertThat(components.getPathItems()).containsKey("ReusableItemPath");
+
+        components.removeSchema("Sku");
+        components.removeResponse("ItemResponse");
+        assertThat(components.getSchemas()).doesNotContainKey("Sku");
+        assertThat(components.getResponses()).doesNotContainKey("ItemResponse");
+    }
+
+    @Test
+    void managesPathsOperationsParametersRequestsAndResponses() {
+        Parameter skuParameter = OASFactory.createParameter()
+                .name("sku")
+                .in(Parameter.In.PATH)
+                .style(Parameter.Style.SIMPLE)
+                .required(true)
+                .description("stock keeping unit")
+                .schema(OASFactory.createSchema().addType(Schema.SchemaType.STRING));
+        RequestBody requestBody = OASFactory.createRequestBody()
+                .description("item update")
+                .required(true)
+                .content(OASFactory.createContent().addMediaType("application/json",
+                        OASFactory.createMediaType().schema(OASFactory.createSchema().addType(Schema.SchemaType.OBJECT))));
+        APIResponse created = OASFactory.createAPIResponse().description("created");
+        APIResponse notFound = OASFactory.createAPIResponse().description("not found");
+        APIResponses responses = OASFactory.createAPIResponses()
+                .addAPIResponse("201", created)
+                .addAPIResponse("404", notFound)
+                .defaultValue(OASFactory.createAPIResponse().description("unexpected error"))
+                .addExtension("x-rate-limit", 100);
+        Operation getItem = OASFactory.createOperation()
+                .operationId("getItem")
+                .summary("Fetch item")
+                .description("Fetches one inventory item")
+                .addTag("inventory")
+                .addParameter(skuParameter)
+                .requestBody(requestBody)
+                .responses(responses)
+                .deprecated(false)
+                .addSecurityRequirement(OASFactory.createSecurityRequirement().addScheme("bearerAuth", "inventory:read"))
+                .addServer(OASFactory.createServer().url("https://api.example.test"));
+        PathItem pathItem = OASFactory.createPathItem()
+                .summary("Inventory item")
+                .description("Single item resource")
+                .GET(getItem)
+                .addParameter(skuParameter)
+                .addServer(OASFactory.createServer().url("https://path.example.test"));
+        pathItem.setOperation(PathItem.HttpMethod.PATCH, OASFactory.createOperation().operationId("patchItem"));
+        Paths paths = OASFactory.createPaths().addPathItem("/items/{sku}", pathItem);
+
+        assertThat(paths.hasPathItem("/items/{sku}")).isTrue();
+        assertThat(paths.getPathItem("/items/{sku}").getGET().getOperationId()).isEqualTo("getItem");
+        assertThat(paths.getPathItem("/items/{sku}").getOperations())
+                .containsEntry(PathItem.HttpMethod.GET, getItem)
+                .containsKey(PathItem.HttpMethod.PATCH);
+        assertThat(getItem.getTags()).containsExactly("inventory");
+        assertThat(getItem.getParameters()).containsExactly(skuParameter);
+        assertThat(getItem.getRequestBody().getContent().getMediaType("application/json").getSchema().getType())
+                .containsExactly(Schema.SchemaType.OBJECT);
+        assertThat(getItem.getResponses().hasAPIResponse("201")).isTrue();
+        assertThat(getItem.getResponses().getAPIResponse("404").getDescription()).isEqualTo("not found");
+        assertThat(getItem.getResponses().getDefaultValue().getDescription()).contains("unexpected");
+        assertThat(getItem.getSecurity().get(0).getScheme("bearerAuth")).containsExactly("inventory:read");
+        assertThat(pathItem.getServers().get(0).getUrl()).isEqualTo("https://path.example.test");
+
+        responses.removeAPIResponse("404");
+        paths.removePathItem("/items/{sku}");
+        assertThat(responses.hasAPIResponse("404")).isFalse();
+        assertThat(paths.hasPathItem("/items/{sku}")).isFalse();
+    }
+
+    @Test
+    void supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties() {
+        Schema positiveInteger = OASFactory.createSchema()
+                .schemaDialect("https://json-schema.org/draft/2020-12/schema")
+                .addType(Schema.SchemaType.INTEGER)
+                .minimum(BigDecimal.ONE)
+                .exclusiveMaximum(new BigDecimal("1000"))
+                .multipleOf(BigDecimal.ONE)
+                .constValue(42)
+                .comment("business identifier")
+                .contentEncoding("base64")
+                .contentMediaType("text/plain")
+                .booleanSchema(true)
+                .addExample(1)
+                .addExample(42)
+                .set("x-ui-order", 10);
+        ExternalDocumentation docs = OASFactory.createExternalDocumentation()
+                .description("schema docs")
+                .url("https://example.test/schema-docs");
+        Discriminator discriminator = OASFactory.createDiscriminator()
+                .propertyName("kind")
+                .addMapping("physical", "#/components/schemas/PhysicalItem")
+                .addMapping("digital", "#/components/schemas/DigitalItem");
+        XML xml = OASFactory.createXML()
+                .name("inventoryItem")
+                .namespace("https://example.test/inventory")
+                .prefix("inv")
+                .attribute(false)
+                .wrapped(true);
+        Schema composed = OASFactory.createSchema()
+                .discriminator(discriminator)
+                .externalDocs(docs)
+                .xml(xml)
+                .format("int32")
+                .readOnly(true)
+                .writeOnly(false)
+                .deprecated(false)
+                .items(positiveInteger)
+                .not(OASFactory.createSchema().booleanSchema(false))
+                .addAllOf(OASFactory.createSchema().ref("#/components/schemas/BaseItem"))
+                .addAnyOf(OASFactory.createSchema().ref("#/components/schemas/PhysicalItem"))
+                .addOneOf(OASFactory.createSchema().ref("#/components/schemas/DigitalItem"));
+        Schema conditional = OASFactory.createSchema()
+                .ifSchema(OASFactory.createSchema().addProperty("kind", OASFactory.createSchema().constValue("physical")))
+                .thenSchema(OASFactory.createSchema().addRequired("weight"))
+                .elseSchema(OASFactory.createSchema().addRequired("downloadUrl"))
+                .addDependentSchema("billingAddress", OASFactory.createSchema().addRequired("paymentMethod"))
+                .addDependentRequired("creditCard", Arrays.asList("billingAddress", "cardholder"))
+                .addPrefixItem(OASFactory.createSchema().addType(Schema.SchemaType.STRING))
+                .contains(positiveInteger)
+                .minContains(1)
+                .maxContains(3)
+                .addPatternProperty("^x-", OASFactory.createSchema().addType(Schema.SchemaType.STRING))
+                .propertyNames(OASFactory.createSchema().pattern("^[a-zA-Z0-9-]+$"))
+                .unevaluatedItems(OASFactory.createSchema().booleanSchema(false))
+                .unevaluatedProperties(OASFactory.createSchema().booleanSchema(false))
+                .contentSchema(positiveInteger)
+                .additionalPropertiesSchema(OASFactory.createSchema().ref("#/components/schemas/Extra"));
+
+        assertThat(positiveInteger.getType()).containsExactly(Schema.SchemaType.INTEGER);
+        assertThat(positiveInteger.getExclusiveMaximum()).isEqualByComparingTo("1000");
+        assertThat(positiveInteger.getExamples()).containsExactly(1, 42);
+        assertThat(positiveInteger.get("x-ui-order")).isEqualTo(10);
+        assertThat(positiveInteger.getAll()).containsKey("x-ui-order");
+        assertThat(positiveInteger.getAll().get("x-ui-order")).isEqualTo(10);
+        assertThat(conditional.getIfSchema().getProperties()).containsKey("kind");
+        assertThat(conditional.getThenSchema().getRequired()).containsExactly("weight");
+        assertThat(conditional.getDependentSchemas()).containsKey("billingAddress");
+        assertThat(conditional.getDependentRequired()).containsEntry("creditCard", Arrays.asList("billingAddress", "cardholder"));
+        assertThat(conditional.getPrefixItems().get(0).getType()).containsExactly(Schema.SchemaType.STRING);
+        assertThat(conditional.getContains()).isSameAs(positiveInteger);
+        assertThat(conditional.getPatternProperties()).containsKey("^x-");
+        assertThat(conditional.getPropertyNames().getPattern()).contains("a-zA-Z");
+        assertThat(conditional.getAdditionalPropertiesSchema().getRef()).isEqualTo("#/components/schemas/Extra");
+        assertThat(composed.getDiscriminator().getMapping()).containsKeys("physical", "digital");
+        assertThat(composed.getExternalDocs().getUrl()).contains("schema-docs");
+        assertThat(composed.getXml().getPrefix()).isEqualTo("inv");
+        assertThat(composed.getItems()).isSameAs(positiveInteger);
+        assertThat(composed.getAllOf().get(0).getRef()).contains("BaseItem");
+        assertThat(composed.getAnyOf().get(0).getRef()).contains("PhysicalItem");
+        assertThat(composed.getOneOf().get(0).getRef()).contains("DigitalItem");
+
+        conditional.removeDependentSchema("billingAddress");
+        conditional.removePatternProperty("^x-");
+        positiveInteger.removeExample(1);
+        assertThat(conditional.getDependentSchemas()).doesNotContainKey("billingAddress");
+        assertThat(conditional.getPatternProperties()).doesNotContainKey("^x-");
+        assertThat(positiveInteger.getExamples()).containsExactly(42);
+    }
+
+    @Test
+    void supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows() {
+        Example successExample = OASFactory.createExample()
+                .summary("success")
+                .description("successful response")
+                .value(Map.of("status", "ok"))
+                .externalValue("https://example.test/examples/success.json")
+                .ref("#/components/examples/Success");
+        Encoding encoding = OASFactory.createEncoding()
+                .contentType("application/json")
+                .style(Encoding.Style.FORM)
+                .explode(true)
+                .allowReserved(false)
+                .addHeader("X-Trace", OASFactory.createHeader().description("trace header"));
+        MediaType mediaType = OASFactory.createMediaType()
+                .schema(OASFactory.createSchema().addType(Schema.SchemaType.OBJECT))
+                .example(Map.of("status", "ok"))
+                .addExample("success", successExample)
+                .addEncoding("payload", encoding);
+        Header header = OASFactory.createHeader()
+                .description("pagination cursor")
+                .required(false)
+                .deprecated(false)
+                .allowEmptyValue(false)
+                .style(Header.Style.SIMPLE)
+                .explode(false)
+                .schema(OASFactory.createSchema().addType(Schema.SchemaType.STRING))
+                .addExample("cursor", OASFactory.createExample().value("abc"));
+        Link link = OASFactory.createLink()
+                .operationRef("#/paths/~1items/get")
+                .operationId("listItems")
+                .requestBody("$request.body#/id")
+                .addParameter("sku", "$response.body#/sku")
+                .description("next item")
+                .server(OASFactory.createServer().url("https://links.example.test"));
+        Callback callback = OASFactory.createCallback()
+                .addPathItem("{$request.body#/callbackUrl}", OASFactory.createPathItem().POST(OASFactory.createOperation().summary("notify")))
+                .ref("#/components/callbacks/InventoryChanged");
+        OAuthFlow authorizationCode = OASFactory.createOAuthFlow()
+                .authorizationUrl("https://auth.example.test/authorize")
+                .tokenUrl("https://auth.example.test/token")
+                .refreshUrl("https://auth.example.test/refresh")
+                .addScope("inventory:read", "read inventory")
+                .addScope("inventory:write", "write inventory");
+        OAuthFlows flows = OASFactory.createOAuthFlows()
+                .authorizationCode(authorizationCode)
+                .clientCredentials(OASFactory.createOAuthFlow().tokenUrl("https://auth.example.test/client-token"));
+        SecurityScheme oauth = OASFactory.createSecurityScheme()
+                .type(SecurityScheme.Type.OAUTH2)
+                .flows(flows)
+                .openIdConnectUrl("https://auth.example.test/.well-known/openid-configuration");
+
+        assertThat(mediaType.getExamples()).containsEntry("success", successExample);
+        assertThat(mediaType.getEncoding().get("payload").getHeaders()).containsKey("X-Trace");
+        assertThat(header.getExamples().get("cursor").getValue()).isEqualTo("abc");
+        assertThat(link.getParameters()).containsEntry("sku", "$response.body#/sku");
+        assertThat(link.getServer().getUrl()).contains("links");
+        assertThat(callback.hasPathItem("{$request.body#/callbackUrl}")).isTrue();
+        assertThat(callback.getRef()).isEqualTo("#/components/callbacks/InventoryChanged");
+        assertThat(oauth.getFlows().getAuthorizationCode().getScopes())
+                .containsEntry("inventory:read", "read inventory")
+                .containsEntry("inventory:write", "write inventory");
+        assertThat(oauth.getFlows().getClientCredentials().getTokenUrl()).contains("client-token");
+    }
+
+    @Test
+    void exposesConfigurationConstantsEnumsAndDefaultFilterBehavior() {
+        assertThat(OASConfig.MODEL_READER).isEqualTo("mp.openapi.model.reader");
+        assertThat(OASConfig.FILTER).isEqualTo("mp.openapi.filter");
+        assertThat(OASConfig.SCAN_DISABLE).isEqualTo("mp.openapi.scan.disable");
+        assertThat(OASConfig.SERVERS_PATH_PREFIX).isEqualTo("mp.openapi.servers.path.");
+        assertThat(OASConfig.SERVERS_OPERATION_PREFIX).isEqualTo("mp.openapi.servers.operation.");
+        assertThat(OASConfig.SCHEMA_PREFIX).isEqualTo("mp.openapi.schema.");
+        assertThat(OASConfig.EXTENSIONS_PREFIX).isEqualTo("mp.openapi.extensions.");
+        assertThat(ParameterIn.PATH.toString()).isEqualTo("path");
+        assertThat(Parameter.In.COOKIE.toString()).isEqualTo("cookie");
+        assertThat(Parameter.Style.DEEPOBJECT.toString()).isEqualTo("deepObject");
+        assertThat(Schema.SchemaType.NULL.toString()).isEqualTo("null");
+        assertThat(SecurityScheme.Type.MUTUALTLS.toString()).isEqualTo("mutualTLS");
+
+        OASFilter filter = new OASFilter() {
+        };
+        OpenAPI openAPI = OASFactory.createOpenAPI();
+        OASModelReader reader = () -> openAPI;
+        Operation operation = OASFactory.createOperation();
+        Parameter parameter = OASFactory.createParameter();
+        Header header = OASFactory.createHeader();
+        RequestBody requestBody = OASFactory.createRequestBody();
+        APIResponse response = OASFactory.createAPIResponse();
+        Schema schema = OASFactory.createSchema();
+        SecurityScheme securityScheme = OASFactory.createSecurityScheme();
+        Server server = OASFactory.createServer();
+        Tag tag = OASFactory.createTag();
+        Link link = OASFactory.createLink();
+        Callback callback = OASFactory.createCallback();
+
+        assertThat(filter.filterOperation(operation)).isSameAs(operation);
+        assertThat(filter.filterParameter(parameter)).isSameAs(parameter);
+        assertThat(filter.filterHeader(header)).isSameAs(header);
+        assertThat(filter.filterRequestBody(requestBody)).isSameAs(requestBody);
+        assertThat(filter.filterAPIResponse(response)).isSameAs(response);
+        assertThat(filter.filterSchema(schema)).isSameAs(schema);
+        assertThat(filter.filterSecurityScheme(securityScheme)).isSameAs(securityScheme);
+        assertThat(filter.filterServer(server)).isSameAs(server);
+        assertThat(filter.filterTag(tag)).isSameAs(tag);
+        assertThat(filter.filterLink(link)).isSameAs(link);
+        assertThat(filter.filterCallback(callback)).isSameAs(callback);
+        filter.filterOpenAPI(openAPI);
+        assertThat(reader.buildModel()).isSameAs(openAPI);
+        assertThat(OASFactory.createObject(Schema.class)).isInstanceOf(Schema.class);
+    }
+
+    private static final class TestOASFactoryResolver extends OASFactoryResolver {
+        @Override
+        public <T extends org.eclipse.microprofile.openapi.models.Constructible> T createObject(Class<T> type) {
+            Object proxy = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type }, new ModelInvocationHandler(type));
+            return type.cast(proxy);
+        }
+    }
+
+    private static final class ModelInvocationHandler implements InvocationHandler {
+        private final Class<?> type;
+        private final Map<String, Object> values = new HashMap<>();
+        private final Map<String, Object> arbitraryValues = new LinkedHashMap<>();
+
+        private ModelInvocationHandler(Class<?> type) {
+            this.type = type;
+        }
+
+        @Override
+        public Object invoke(Object currentProxy, Method method, Object[] args) {
+            String name = method.getName();
+            if ("toString".equals(name)) {
+                return type.getSimpleName() + values;
+            }
+            if ("hashCode".equals(name)) {
+                return System.identityHashCode(currentProxy);
+            }
+            if ("equals".equals(name)) {
+                return currentProxy == args[0];
+            }
+            if ("setOperation".equals(name)) {
+                map("operations").put(args[0], args[1]);
+                setOperationAccessor(args[0], args[1]);
+                return null;
+            }
+            if ("getOperations".equals(name)) {
+                return map("operations");
+            }
+            if (isHttpAccessor(name) && args != null && args.length == 1) {
+                values.put(name, args[0]);
+                map("operations").put(PathItem.HttpMethod.valueOf(name), args[0]);
+                return currentProxy;
+            }
+            if ("set".equals(name)) {
+                arbitraryValues.put((String) args[0], args[1]);
+                return currentProxy;
+            }
+            if ("get".equals(name)) {
+                return arbitraryValues.get(args[0]);
+            }
+            if ("getAll".equals(name)) {
+                return arbitraryValues;
+            }
+            if ("setAll".equals(name)) {
+                arbitraryValues.clear();
+                arbitraryValues.putAll((Map<String, ?>) args[0]);
+                return null;
+            }
+            if (name.startsWith("get") && args == null) {
+                return values.get(propertyName(name.substring(3)));
+            }
+            if (name.startsWith("get") && args.length == 1) {
+                return map(collectionProperty(name.substring(3))).get(args[0]);
+            }
+            if (name.startsWith("set") && args.length == 1) {
+                values.put(propertyName(name.substring(3)), args[0]);
+                return null;
+            }
+            if (name.startsWith("has") && args.length == 1) {
+                return map(collectionProperty(name.substring(3))).containsKey(args[0]);
+            }
+            if ("additionalPropertiesSchema".equals(name)) {
+                values.put("additionalPropertiesSchema", args[0]);
+                return currentProxy;
+            }
+            if (name.startsWith("add") && args.length > 0) {
+                add(name.substring(3), args);
+                return currentProxy;
+            }
+            if (name.startsWith("remove") && args.length == 1) {
+                remove(name.substring(6), args[0]);
+                return null;
+            }
+            if (args != null && args.length == 1 && method.getReturnType().isInstance(currentProxy)) {
+                values.put(propertyName(name), args[0]);
+                return currentProxy;
+            }
+            return defaultValue(method.getReturnType());
+        }
+
+        private void add(String suffix, Object[] args) {
+            if ("Scheme".equals(suffix)) {
+                Object value = args.length == 1 ? List.of() : args[1] instanceof List ? args[1] : List.of(args[1]);
+                map("schemes").put(args[0], value);
+                return;
+            }
+            if (args.length == 2 && args[0] instanceof String) {
+                map(collectionProperty(suffix)).put(args[0], args[1]);
+                return;
+            }
+            list(collectionProperty(suffix)).add(args[0]);
+        }
+
+        private void remove(String suffix, Object keyOrValue) {
+            String property = collectionProperty(suffix);
+            Object current = values.get(property);
+            if (current instanceof Map<?, ?>) {
+                ((Map<?, ?>) current).remove(keyOrValue);
+                return;
+            }
+            if (current instanceof List<?>) {
+                ((List<?>) current).remove(keyOrValue);
+            }
+        }
+
+        private Map<Object, Object> map(String property) {
+            return (Map<Object, Object>) values.computeIfAbsent(property, ignored -> new LinkedHashMap<>());
+        }
+
+        private List<Object> list(String property) {
+            return (List<Object>) values.computeIfAbsent(property, ignored -> new ArrayList<>());
+        }
+
+        private boolean isHttpAccessor(String name) {
+            return "GET".equals(name) || "PUT".equals(name) || "POST".equals(name) || "DELETE".equals(name)
+                    || "OPTIONS".equals(name) || "HEAD".equals(name) || "PATCH".equals(name) || "TRACE".equals(name);
+        }
+
+        private void setOperationAccessor(Object method, Object operation) {
+            if (method == PathItem.HttpMethod.GET) {
+                values.put("GET", operation);
+            } else if (method == PathItem.HttpMethod.PUT) {
+                values.put("PUT", operation);
+            } else if (method == PathItem.HttpMethod.POST) {
+                values.put("POST", operation);
+            } else if (method == PathItem.HttpMethod.DELETE) {
+                values.put("DELETE", operation);
+            } else if (method == PathItem.HttpMethod.OPTIONS) {
+                values.put("OPTIONS", operation);
+            } else if (method == PathItem.HttpMethod.HEAD) {
+                values.put("HEAD", operation);
+            } else if (method == PathItem.HttpMethod.PATCH) {
+                values.put("PATCH", operation);
+            } else if (method == PathItem.HttpMethod.TRACE) {
+                values.put("TRACE", operation);
+            }
+        }
+
+        private String collectionProperty(String singular) {
+            if ("APIResponse".equals(singular)) {
+                return "APIResponses";
+            }
+            if ("PathItem".equals(singular)) {
+                return "pathItems";
+            }
+            if ("MediaType".equals(singular)) {
+                return "mediaTypes";
+            }
+            if ("RequestBody".equals(singular)) {
+                return "requestBodies";
+            }
+            if ("SecurityRequirement".equals(singular)) {
+                return "security";
+            }
+            if ("SecurityScheme".equals(singular)) {
+                return "securitySchemes";
+            }
+            if ("PrefixItem".equals(singular)) {
+                return "prefixItems";
+            }
+            if ("DependentSchema".equals(singular)) {
+                return "dependentSchemas";
+            }
+            if ("PatternProperty".equals(singular)) {
+                return "patternProperties";
+            }
+            if ("DependentRequired".equals(singular)) {
+                return "dependentRequired";
+            }
+            if ("Property".equals(singular)) {
+                return "properties";
+            }
+            if ("AllOf".equals(singular) || "AnyOf".equals(singular) || "OneOf".equals(singular)) {
+                return propertyName(singular);
+            }
+            if ("Type".equals(singular)) {
+                return "type";
+            }
+            if ("Enumeration".equals(singular)) {
+                return "enumeration";
+            }
+            if ("Required".equals(singular)) {
+                return "required";
+            }
+            if ("Encoding".equals(singular) || "Mapping".equals(singular)) {
+                return propertyName(singular);
+            }
+            return propertyName(singular) + "s";
+        }
+
+        private String propertyName(String suffix) {
+            if (suffix.length() > 1 && Character.isUpperCase(suffix.charAt(0)) && Character.isUpperCase(suffix.charAt(1))) {
+                return suffix;
+            }
+            return Character.toLowerCase(suffix.charAt(0)) + suffix.substring(1);
+        }
+
+        private Object defaultValue(Class<?> returnType) {
+            if (returnType == boolean.class || returnType == Boolean.class) {
+                return false;
+            }
+            if (returnType == int.class || returnType == Integer.class) {
+                return 0;
+            }
+            return null;
+        }
     }
 }

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
@@ -37,6 +37,7 @@ import org.eclipse.microprofile.openapi.models.info.Contact;
 import org.eclipse.microprofile.openapi.models.info.Info;
 import org.eclipse.microprofile.openapi.models.info.License;
 import org.eclipse.microprofile.openapi.models.links.Link;
+import org.eclipse.microprofile.openapi.models.media.Content;
 import org.eclipse.microprofile.openapi.models.media.Discriminator;
 import org.eclipse.microprofile.openapi.models.media.Encoding;
 import org.eclipse.microprofile.openapi.models.media.MediaType;
@@ -414,6 +415,53 @@ public class Microprofile_openapi_apiTest {
     }
 
     @Test
+    void supportsContentBasedParametersAndHeaders() {
+        Schema searchCriteria = OASFactory.createSchema()
+                .addType(Schema.SchemaType.OBJECT)
+                .addProperty("query", OASFactory.createSchema().addType(Schema.SchemaType.STRING))
+                .addProperty("limit", OASFactory.createSchema().addType(Schema.SchemaType.INTEGER));
+        MediaType jsonCriteria = OASFactory.createMediaType()
+                .schema(searchCriteria)
+                .example(Map.of("query", "boots", "limit", 10));
+        MediaType vendorCriteria = OASFactory.createMediaType()
+                .schema(searchCriteria)
+                .addExample("compact", OASFactory.createExample().value(Map.of("query", "boots")));
+        Content parameterContent = OASFactory.createContent()
+                .addMediaType("application/json", jsonCriteria)
+                .addMediaType("application/vnd.search+json", vendorCriteria);
+        Parameter filterParameter = OASFactory.createParameter()
+                .name("filter")
+                .in(Parameter.In.QUERY)
+                .description("structured search criteria")
+                .allowReserved(true)
+                .explode(false)
+                .content(parameterContent);
+        MediaType plainSignature = OASFactory.createMediaType()
+                .schema(OASFactory.createSchema().addType(Schema.SchemaType.STRING))
+                .example("sha256=abc123");
+        Content headerContent = OASFactory.createContent()
+                .addMediaType("text/plain", plainSignature);
+        Header signatureHeader = OASFactory.createHeader()
+                .description("request signature")
+                .required(true)
+                .content(headerContent);
+
+        assertThat(filterParameter.getContent()).isSameAs(parameterContent);
+        assertThat(filterParameter.getContent().hasMediaType("application/json")).isTrue();
+        assertThat(filterParameter.getContent().getMediaType("application/json").getSchema().getProperties())
+                .containsKeys("query", "limit");
+        assertThat(filterParameter.getContent().getMediaTypes())
+                .containsEntry("application/vnd.search+json", vendorCriteria);
+        assertThat(filterParameter.getAllowReserved()).isTrue();
+        assertThat(filterParameter.getExplode()).isFalse();
+        assertThat(signatureHeader.getContent().getMediaType("text/plain").getExample()).isEqualTo("sha256=abc123");
+        assertThat(signatureHeader.getRequired()).isTrue();
+
+        parameterContent.removeMediaType("application/vnd.search+json");
+        assertThat(parameterContent.hasMediaType("application/vnd.search+json")).isFalse();
+    }
+
+    @Test
     void exposesConfigurationConstantsEnumsAndDefaultFilterBehavior() {
         assertThat(OASConfig.MODEL_READER).isEqualTo("mp.openapi.model.reader");
         assertThat(OASConfig.FILTER).isEqualTo("mp.openapi.filter");
@@ -463,7 +511,7 @@ public class Microprofile_openapi_apiTest {
     private static final class TestOASFactoryResolver extends OASFactoryResolver {
         @Override
         public <T extends org.eclipse.microprofile.openapi.models.Constructible> T createObject(Class<T> type) {
-            Object proxy = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type }, new ModelInvocationHandler(type));
+            Object proxy = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, new ModelInvocationHandler(type));
             return type.cast(proxy);
         }
     }

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/src/test/java/org_eclipse_microprofile_openapi/microprofile_openapi_api/Microprofile_openapi_apiTest.java
@@ -462,6 +462,53 @@ public class Microprofile_openapi_apiTest {
     }
 
     @Test
+    void supportsOperationCallbacksExternalDocsAndExtensionMaps() {
+        ExternalDocumentation operationDocs = OASFactory.createExternalDocumentation()
+                .description("callback contract")
+                .url("https://example.test/docs/callbacks")
+                .extensions(new LinkedHashMap<>(Map.of("x-document-kind", "runbook")))
+                .addExtension("x-reviewed", Boolean.TRUE);
+        Operation notification = OASFactory.createOperation()
+                .operationId("receiveInventoryEvent")
+                .summary("Receive inventory event")
+                .externalDocs(operationDocs);
+        Callback initialCallback = OASFactory.createCallback()
+                .addPathItem("{$request.body#/subscriptions/initialUrl}",
+                        OASFactory.createPathItem().POST(OASFactory.createOperation().operationId("receiveInitialEvent")));
+        Callback updatedCallback = OASFactory.createCallback()
+                .addPathItem("{$request.body#/subscriptions/updateUrl}", OASFactory.createPathItem().POST(notification))
+                .addExtension("x-event-type", "inventory.updated");
+        Operation subscription = OASFactory.createOperation()
+                .operationId("subscribeToInventory")
+                .externalDocs(operationDocs)
+                .callbacks(new LinkedHashMap<>(Map.of("initial", initialCallback)))
+                .addCallback("updated", updatedCallback)
+                .addExtension("x-audience", "partners");
+        Tag subscriptionTag = OASFactory.createTag()
+                .name("subscriptions")
+                .externalDocs(operationDocs);
+
+        assertThat(subscription.getExternalDocs().getUrl()).contains("callbacks");
+        assertThat(subscription.getCallbacks())
+                .containsEntry("initial", initialCallback)
+                .containsEntry("updated", updatedCallback);
+        assertThat(subscription.getCallbacks().get("updated").getPathItem("{$request.body#/subscriptions/updateUrl}")
+                .getPOST().getOperationId()).isEqualTo("receiveInventoryEvent");
+        assertThat(operationDocs.hasExtension("x-document-kind")).isTrue();
+        assertThat(operationDocs.getExtensions()).containsEntry("x-reviewed", Boolean.TRUE);
+        assertThat(subscription.hasExtension("x-audience")).isTrue();
+        assertThat(updatedCallback.getExtension("x-event-type")).isEqualTo("inventory.updated");
+        assertThat(subscriptionTag.getExternalDocs()).isSameAs(operationDocs);
+
+        subscription.removeCallback("initial");
+        subscription.removeExtension("x-audience");
+        operationDocs.removeExtension("x-reviewed");
+        assertThat(subscription.getCallbacks()).doesNotContainKey("initial");
+        assertThat(subscription.hasExtension("x-audience")).isFalse();
+        assertThat(operationDocs.getExtensions()).doesNotContainKey("x-reviewed");
+    }
+
+    @Test
     void exposesConfigurationConstantsEnumsAndDefaultFilterBehavior() {
         assertThat(OASConfig.MODEL_READER).isEqualTo("mp.openapi.model.reader");
         assertThat(OASConfig.FILTER).isEqualTo("mp.openapi.filter");

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:39:28">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,289 +52,43 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.002">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.media.Schema&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.media.Schema"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createSchema(OASFactory.java:258)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties(Microprofile_openapi_apiTest.java:263)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()]
 display-name: supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()
 ]]></system-out>
 </testcase>
-<testcase name="managesPathsOperationsParametersRequestsAndResponses()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.001">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.parameters.Parameter']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.parameters.Parameter&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.parameters.Parameter']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.parameters.Parameter"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createParameter(OASFactory.java:276)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.managesPathsOperationsParametersRequestsAndResponses(Microprofile_openapi_apiTest.java:201)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="managesPathsOperationsParametersRequestsAndResponses()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:managesPathsOperationsParametersRequestsAndResponses()]
 display-name: managesPathsOperationsParametersRequestsAndResponses()
 ]]></system-out>
 </testcase>
-<testcase name="supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.001">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.examples.Example']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.examples.Example&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.examples.Example']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.examples.Example"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createExample(OASFactory.java:168)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows(Microprofile_openapi_apiTest.java:353)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="supportsContentBasedParametersAndHeaders()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsContentBasedParametersAndHeaders()]
+display-name: supportsContentBasedParametersAndHeaders()
+]]></system-out>
+</testcase>
+<testcase name="supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()]
 display-name: supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()
 ]]></system-out>
 </testcase>
-<testcase name="managesComponentsSchemasResponsesAndSecuritySchemes()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.002">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.media.Schema&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.media.Schema"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createSchema(OASFactory.java:258)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.managesComponentsSchemasResponsesAndSecuritySchemes(Microprofile_openapi_apiTest.java:125)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="managesComponentsSchemasResponsesAndSecuritySchemes()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:managesComponentsSchemasResponsesAndSecuritySchemes()]
 display-name: managesComponentsSchemasResponsesAndSecuritySchemes()
 ]]></system-out>
 </testcase>
-<testcase name="createsAndLinksCompleteOpenAPIModel()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.003">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.info.Contact']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.info.Contact&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.info.Contact']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.info.Contact"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createContact(OASFactory.java:186)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.createsAndLinksCompleteOpenAPIModel(Microprofile_openapi_apiTest.java:67)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="createsAndLinksCompleteOpenAPIModel()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:createsAndLinksCompleteOpenAPIModel()]
 display-name: createsAndLinksCompleteOpenAPIModel()
 ]]></system-out>
 </testcase>
 <testcase name="exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
-<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.OpenAPI']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: {
-        &quot;proxy&quot;: [
-          &quot;org.eclipse.microprofile.openapi.models.OpenAPI&quot;
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.OpenAPI']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": {
-        "proxy": [
-          "org.eclipse.microprofile.openapi.models.OpenAPI"
-        ]
-      }
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
-	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
-	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
-	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
-	at org.eclipse.microprofile.openapi.OASFactory.createOpenAPI(OASFactory.java:123)
-	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.exposesConfigurationConstantsEnumsAndDefaultFilterBehavior(Microprofile_openapi_apiTest.java:433)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()]
 display-name: exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T21:48:01">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T21:49:30">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3284-479fe21f/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1"/>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:39:28">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3284-479fe21f/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.002">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.media.Schema&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Schema"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createSchema(OASFactory.java:258)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties(Microprofile_openapi_apiTest.java:263)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()]
+display-name: supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties()
+]]></system-out>
+</testcase>
+<testcase name="managesPathsOperationsParametersRequestsAndResponses()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.001">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.parameters.Parameter']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.parameters.Parameter&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.parameters.Parameter']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.parameters.Parameter"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createParameter(OASFactory.java:276)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.managesPathsOperationsParametersRequestsAndResponses(Microprofile_openapi_apiTest.java:201)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:managesPathsOperationsParametersRequestsAndResponses()]
+display-name: managesPathsOperationsParametersRequestsAndResponses()
+]]></system-out>
+</testcase>
+<testcase name="supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.001">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.examples.Example']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.examples.Example&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.examples.Example']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.examples.Example"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createExample(OASFactory.java:168)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows(Microprofile_openapi_apiTest.java:353)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()]
+display-name: supportsMediaExamplesHeadersLinksCallbacksAndOAuthFlows()
+]]></system-out>
+</testcase>
+<testcase name="managesComponentsSchemasResponsesAndSecuritySchemes()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.002">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.media.Schema&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.media.Schema']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.media.Schema"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createSchema(OASFactory.java:258)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.managesComponentsSchemasResponsesAndSecuritySchemes(Microprofile_openapi_apiTest.java:125)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:managesComponentsSchemasResponsesAndSecuritySchemes()]
+display-name: managesComponentsSchemasResponsesAndSecuritySchemes()
+]]></system-out>
+</testcase>
+<testcase name="createsAndLinksCompleteOpenAPIModel()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0.003">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.info.Contact']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.info.Contact&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.info.Contact']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.info.Contact"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createContact(OASFactory.java:186)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.createsAndLinksCompleteOpenAPIModel(Microprofile_openapi_apiTest.java:67)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:createsAndLinksCompleteOpenAPIModel()]
+display-name: createsAndLinksCompleteOpenAPIModel()
+]]></system-out>
+</testcase>
+<testcase name="exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
+<error message="Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.OpenAPI']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: {
+        &quot;proxy&quot;: [
+          &quot;org.eclipse.microprofile.openapi.models.OpenAPI&quot;
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting ['org.eclipse.microprofile.openapi.models.OpenAPI']. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.microprofile.openapi.models.OpenAPI"
+        ]
+      }
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportProxyAccess(MissingReflectionRegistrationUtils.java:131)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.proxy.DynamicProxySupport.getProxyClass(DynamicProxySupport.java:253)
+	at java.base@25.0.2/java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:63)
+	at java.base@25.0.2/java.lang.reflect.Proxy.newProxyInstance(Proxy.java:924)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest$TestOASFactoryResolver.createObject(Microprofile_openapi_apiTest.java:466)
+	at org.eclipse.microprofile.openapi.OASFactory.createObject(OASFactory.java:96)
+	at org.eclipse.microprofile.openapi.OASFactory.createOpenAPI(OASFactory.java:123)
+	at org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest.exposesConfigurationConstantsEnumsAndDefaultFilterBehavior(Microprofile_openapi_apiTest.java:433)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()]
+display-name: exposesConfigurationConstantsEnumsAndDefaultFilterBehavior()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:15">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-02T21:48:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -62,6 +62,12 @@ display-name: supportsJsonSchema202012ModelFeaturesAndArbitrarySchemaProperties(
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:managesPathsOperationsParametersRequestsAndResponses()]
 display-name: managesPathsOperationsParametersRequestsAndResponses()
+]]></system-out>
+</testcase>
+<testcase name="supportsOperationCallbacksExternalDocsAndExtensionMaps()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest]/[method:supportsOperationCallbacksExternalDocsAndExtensionMaps()]
+display-name: supportsOperationCallbacksExternalDocsAndExtensionMaps()
 ]]></system-out>
 </testcase>
 <testcase name="supportsContentBasedParametersAndHeaders()" classname="org_eclipse_microprofile_openapi.microprofile_openapi_api.Microprofile_openapi_apiTest" time="0">

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:48:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:49:30">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3284-479fe21f/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1"/>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:39:28">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3284-479fe21f/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:15">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:48:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:39:28">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/user-code-filter.json
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.microprofile.openapi.**"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/user-code-filter.json
+++ b/tests/src/org.eclipse.microprofile.openapi/microprofile-openapi-api/4.1.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.microprofile.openapi.**"
+      "includeClasses" : "org.eclipse.microprofile.openapi.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3284

This PR introduces tests and metadata for org.eclipse.microprofile.openapi:microprofile-openapi-api:4.1.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 307082
- Cached input tokens: 3572224
- Output tokens: 35504
- Metadata entries: 30
- Iterations: 6
- Library coverage percentage: 15.56
- Generated lines of code: 735
- Tested library lines of code: 94

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `101d82d593cc1d1ed52c59a29cd82a574d6f038b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 539/2057 (26.20%)
- Line: 94/604 (15.56%)
- Method: 67/300 (22.33%)
