### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
@@ -1,0 +1,56 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition",
+      "methods" : [
+        {
+          "name" : "getIgnorableNames",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getProperties",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getRecordComponents",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.reflect.RecordComponent",
+      "methods" : [
+        {
+          "name" : "getType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
+      },
+      "type" : "java.util.List[]"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.21.0",
+    "tested-versions" : [
+      "2.21.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
+    ]
+  },
+  {
     "metadata-version" : "2.17.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jr",

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.21.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-$version$/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrapper types, arrays, and Java beans, and for writing those values back as JSON. It builds on jackson-core with minimal dependencies and provides immutable JSON entry points plus builder-style composer APIs for direct JSON output.",
     "tested-versions" : [
       "2.21.0"
     ],

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T19:58:18.148019Z",
+    "library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0",
+    "starting_commit": "89a856ee1080dcc6377ddcf931f29ad38a77f5cc",
+    "ending_commit": "20f56ee953f4d1be03a6108d7bfd627c8346dc76",
+    "previous_library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.21.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5400,
+          "missed": 8310,
+          "ratio": 0.393873,
+          "total": 13710
+        },
+        "method": {
+          "covered": 288,
+          "missed": 417,
+          "ratio": 0.408511,
+          "total": 705
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4596,
+          "missed": 7891,
+          "ratio": 0.368063,
+          "total": 12487
+        },
+        "method": {
+          "covered": 255,
+          "missed": 411,
+          "ratio": 0.382883,
+          "total": 666
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 1135147,
+      "cached_input_tokens_used": 15081472,
+      "output_tokens_used": 131110,
+      "iterations": 22,
+      "cost_usd": 11.474,
+      "tested_library_loc": 0,
+      "metadata_entries": 9,
+      "test_only_metadata_entries": 137,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 47,
+      "code_coverage_percent": 39.39,
+      "previous_library_coverage_percent": 36.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
@@ -1,0 +1,32 @@
+{
+  "versions" : [ {
+    "version" : "2.21.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5400,
+        "missed" : 8310,
+        "ratio" : 0.393873,
+        "total" : 13710
+      },
+      "line" : "N/A",
+      "method" : {
+        "covered" : 288,
+        "missed" : 417,
+        "ratio" : 0.408511,
+        "total" : 705
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jr:jackson-jr-objects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0
+library.version = 2.21.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jr.jackson-jr-objects_tests'

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @BeforeEach
+    void resetConstructorCounters() {
+        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
+        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+
+        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+        constructors.forceAccess();
+
+        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        Object createBean() throws Exception {
+            return create();
+        }
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,11 +6,12 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +27,8 @@ public class BeanConstructorsDynamicAccessTest {
     }
 
     @Test
-    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
-        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
+    void createsBeansDirectlyThroughDefaultConstructorsDiscoveredByLibraryIntrospection() throws Exception {
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forNonRecord(PublicDefaultCtorBean.class);
 
         PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
 
@@ -39,15 +38,24 @@ public class BeanConstructorsDynamicAccessTest {
 
     @Test
     void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forNonRecord(PrivateDefaultCtorBean.class);
         constructors.forceAccess();
 
         PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
 
         assertThat(bean).isNotNull();
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsRecordsDirectlyThroughCanonicalConstructorsDiscoveredByLibraryIntrospection() throws Exception {
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forRecord(ArticleRecord.class);
+
+        ArticleRecord article = (ArticleRecord) constructors.createRecordBean("GraalVM", 42, true);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
     }
 
     @Test
@@ -67,13 +75,41 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        ArticleRecord article = JSON.std.beanFrom(ArticleRecord.class,
+                """
+                {"published":true,"pageCount":42,"title":"GraalVM"}
+                """);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
+    }
+
     static final class AccessibleBeanConstructors extends BeanConstructors {
-        AccessibleBeanConstructors(Class<?> valueType) {
+        private AccessibleBeanConstructors(Class<?> valueType) {
             super(valueType);
+        }
+
+        static AccessibleBeanConstructors forNonRecord(Class<?> valueType) {
+            AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(valueType);
+            BeanPropertyIntrospector.addNonRecordConstructors(valueType, constructors);
+            return constructors;
+        }
+
+        static AccessibleBeanConstructors forRecord(Class<?> valueType) {
+            AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(valueType);
+            constructors.addRecordConstructor(RecordsHelpers.findCanonicalConstructor(valueType));
+            return constructors;
         }
 
         Object createBean() throws Exception {
             return create();
+        }
+
+        Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
         }
     }
 
@@ -95,5 +131,8 @@ public class BeanConstructorsDynamicAccessTest {
         private PrivateDefaultCtorBean() {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
+    }
+
+    public record ArticleRecord(String title, int pageCount, boolean published) {
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyIntrospectorDynamicAccessTest {
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON_WITH_FORCE_ACCESS.with(
+            JSON.Feature.USE_FIELD_MATCHING_GETTERS);
+
+    @Test
+    void collectsDeclaredConstructorsForDeserialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
+
+        IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
+                "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
+        IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(objectBean.getName()).isEqualTo("Ada");
+        assertThat(objectBean.isActive()).isTrue();
+        assertThat(objectBean.visible).isEqualTo(7);
+        assertThat(stringBean.getName()).isEqualTo("Ada");
+        assertThat(longBean.visible).isEqualTo(7);
+    }
+
+    @Test
+    void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
+
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
+
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
+
+        assertThat(json).contains("\"title\":\"Ada\"");
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class BaseBean {
+        public int visible;
+    }
+
+    static final class IntrospectedBean extends BaseBean {
+        private String name;
+        private boolean active;
+
+        private IntrospectedBean() {
+        }
+
+        private IntrospectedBean(String name) {
+            this.name = name;
+        }
+
+        private IntrospectedBean(long visible) {
+            this.visible = (int) visible;
+        }
+
+        static IntrospectedBean create(String name, boolean active, int visible) {
+            IntrospectedBean bean = new IntrospectedBean();
+            bean.name = name;
+            bean.active = active;
+            bean.visible = visible;
+            return bean;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    static final class FieldNamedGetterBean {
+        private final String title;
+
+        FieldNamedGetterBean(String title) {
+            this.title = title;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -6,9 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
@@ -19,6 +21,7 @@ import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeanPropertyIntrospectorDynamicAccessTest {
     private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
@@ -80,6 +83,61 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(json).contains("\"title\":\"Ada\"");
     }
 
+    @Test
+    void publicJsonWriterIntrospectsDeclaredFieldsAndMethodsOnLibraryPojoDefinitions() throws Exception {
+        POJODefinition definition = new POJODefinition(POJODefinition.class, new POJODefinition.Prop[0],
+                new BeanConstructors(POJODefinition.class));
+
+        String json = JSON_WITH_FORCE_ACCESS.asString(definition);
+
+        assertThat(json).contains("\"ignorableNames\":[]", "\"properties\":[]");
+    }
+
+    @Test
+    void publicJsonReaderIntrospectsDeclaredConstructorsOnLibraryPojoDefinitions() {
+        assertThatThrownBy(() -> JSON_WITH_FORCE_ACCESS.beanFrom(POJODefinition.class, "{}"))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to create an instance of")
+                .hasMessageContaining(POJODefinition.class.getName());
+    }
+
+    @Test
+    void directIntrospectionCollectsEverySupportedConstructorShape() {
+        RecordingBeanConstructors constructors = new RecordingBeanConstructors(AllConstructorShapes.class);
+
+        BeanPropertyIntrospector.addNonRecordConstructors(AllConstructorShapes.class, constructors);
+
+        assertThat(constructors.noArgsConstructors).isEqualTo(1);
+        assertThat(constructors.stringConstructors).isEqualTo(1);
+        assertThat(constructors.intConstructors).isEqualTo(2);
+        assertThat(constructors.longConstructors).isEqualTo(2);
+    }
+
+    @Test
+    void directIntrospectionVisitsDeclaredFieldsAndMethods() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                StaticAndFluentBean.class);
+
+        assertThat(propertyNames(definition)).containsExactly("enabled", "name");
+        assertThat(property(definition, "enabled").isGetter).isNotNull();
+        assertThat(property(definition, "name").getter).isNotNull();
+    }
+
+    @Test
+    void publicJsonWriterIntrospectsStaticFieldsWhenEnabled() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.with(JSON.Feature.INCLUDE_STATIC_FIELDS)
+                .asString(new StaticAndFluentBean("Ada", true));
+
+        assertThat(json).contains("\"name\":\"Ada\"", "\"enabled\":true", "\"shared\":\"common\"");
+    }
+
+    @Test
+    void publicJsonWriterIntrospectsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new StaticAndFluentBean("Ada", true));
+
+        assertThat(json).contains("\"title\":\"Ada title\"");
+    }
+
     private static List<String> propertyNames(POJODefinition definition) {
         return definition.getProperties().stream().map(prop -> prop.name).toList();
     }
@@ -135,11 +193,91 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         }
     }
 
+    static final class RecordingBeanConstructors extends BeanConstructors {
+        private int noArgsConstructors;
+        private int stringConstructors;
+        private int intConstructors;
+        private int longConstructors;
+
+        RecordingBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public BeanConstructors addNoArgsConstructor(Constructor<?> constructor) {
+            noArgsConstructors++;
+            return super.addNoArgsConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addStringConstructor(Constructor<?> constructor) {
+            stringConstructors++;
+            return super.addStringConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addIntConstructor(Constructor<?> constructor) {
+            intConstructors++;
+            return super.addIntConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addLongConstructor(Constructor<?> constructor) {
+            longConstructors++;
+            return super.addLongConstructor(constructor);
+        }
+    }
+
+    static final class AllConstructorShapes {
+        AllConstructorShapes() {
+        }
+
+        AllConstructorShapes(String value) {
+        }
+
+        AllConstructorShapes(int value) {
+        }
+
+        AllConstructorShapes(Integer value) {
+        }
+
+        AllConstructorShapes(long value) {
+        }
+
+        AllConstructorShapes(Long value) {
+        }
+    }
+
     static final class FieldNamedGetterBean {
         private final String title;
 
         FieldNamedGetterBean(String title) {
             this.title = title;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
+
+    static final class StaticAndFluentBean {
+        public static String shared = "common";
+        private final String name;
+        private final String title;
+        private final boolean enabled;
+
+        StaticAndFluentBean(String name, boolean enabled) {
+            this.name = name;
+            this.title = name + " title";
+            this.enabled = enabled;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
 
         public String title() {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldBackedBeanProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
+    }
+
+    @Test
+    void populatesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFluentSetterBackedProperties() throws Exception {
+        FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class FieldBackedReaderBean {
+        private boolean constructed;
+        public int x;
+        public int y;
+
+        public FieldBackedReaderBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PublicSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public PublicSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class FluentSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public FluentSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public FluentSetterBackedReaderBean setName(String name) {
+            this.name = name;
+            setterCalls++;
+            return this;
+        }
+    }
+
+    public static final class SetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public SetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,7 +7,11 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.ValueIterator;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition.Prop;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,25 +20,24 @@ public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+    void assignsValuesWithDiscoveredFieldBackedPropertyReader() throws Exception {
+        BeanPropertyReader propertyReader = discoveredReaderFor(FieldBackedReaderBean.class, "x");
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[]{3});
+        propertyReader.setValueFor(bean, new Object[] {13});
 
         assertThat(bean.isConstructed()).isTrue();
-        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.x).isEqualTo(13);
     }
 
     @Test
-    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+    void assignsValuesWithDiscoveredSetterBackedPropertyReader() throws Exception {
+        BeanPropertyReader propertyReader = discoveredReaderFor(PublicSetterBackedReaderBean.class, "name");
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[]{"Ada"});
+        propertyReader.setValueFor(bean, new Object[] {"Katherine"});
 
-        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getName()).isEqualTo("Katherine");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
@@ -72,6 +75,46 @@ public class BeanPropertyReaderDynamicAccessTest {
 
         assertThat(bean.getName()).isEqualTo("Ada");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldBackedPropertiesFromBeanSequence() throws Exception {
+        try (ValueIterator<FieldBackedReaderBean> iterator = JSON_WITH_FORCE_ACCESS
+                .beanSequenceFrom(FieldBackedReaderBean.class, "[{\"x\":11,\"y\":12}]")) {
+            assertThat(iterator.hasNext()).isTrue();
+
+            FieldBackedReaderBean bean = iterator.next();
+
+            assertThat(bean.isConstructed()).isTrue();
+            assertThat(bean.x).isEqualTo(11);
+            assertThat(bean.y).isEqualTo(12);
+            assertThat(iterator.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void populatesSetterBackedPropertiesFromBeanSequence() throws Exception {
+        try (ValueIterator<PublicSetterBackedReaderBean> iterator = JSON_WITH_FORCE_ACCESS
+                .beanSequenceFrom(PublicSetterBackedReaderBean.class, "[{\"name\":\"Grace\"}]")) {
+            assertThat(iterator.hasNext()).isTrue();
+
+            PublicSetterBackedReaderBean bean = iterator.next();
+
+            assertThat(bean.getName()).isEqualTo("Grace");
+            assertThat(bean.getSetterCalls()).isEqualTo(1);
+            assertThat(iterator.hasNext()).isFalse();
+        }
+    }
+
+    private static BeanPropertyReader discoveredReaderFor(Class<?> beanType, String propertyName) {
+        JSONReader introspectionReader = JSON.builder().jsonReader();
+        for (Prop property : BeanPropertyIntrospector.instance()
+                .pojoDefinitionForDeserialization(introspectionReader, beanType).getProperties()) {
+            if (propertyName.equals(property.name)) {
+                return new BeanPropertyReader(property.name, property.field, property.setter);
+            }
+        }
+        throw new IllegalArgumentException("No property named " + propertyName + " on " + beanType.getName());
     }
 
     public static final class FieldBackedReaderBean {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyWriterDynamicAccessTest {
+    private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.USE_FIELDS);
+    private static final JSON JSON_WITH_GETTER_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.WRITE_READONLY_BEAN_PROPERTIES);
+
+    @Test
+    void serializesFieldBackedProperties() throws Exception {
+        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
+
+        assertThat(json).isEqualTo("{\"id\":3}");
+    }
+
+    @Test
+    void serializesGetterBackedProperties() throws Exception {
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+        String json = JSON_WITH_GETTER_ACCESS.asString(bean);
+
+        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+    }
+
+    public static final class GetterBackedWriterBean {
+        private int getterCalls;
+        private final String name;
+
+        public GetterBackedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            getterCalls++;
+            return name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -7,7 +7,11 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,18 +25,26 @@ public class BeanPropertyWriterDynamicAccessTest {
 
     @Test
     void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
+        FieldBackedWriterBean bean = new FieldBackedWriterBean();
+        String json = JSON_WITH_FIELD_ACCESS.asString(bean);
+        Field idField = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", idField, null);
 
         assertThat(json).isEqualTo("{\"id\":3}");
+        assertThat(writer.getValueFor(bean)).isEqualTo(3);
     }
 
     @Test
     void serializesGetterBackedProperties() throws Exception {
         GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
         String json = JSON_WITH_GETTER_ACCESS.asString(bean);
+        Method getName = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getName);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
         assertThat(bean.getterCalls).isEqualTo(1);
+        assertThat(writer.getValueFor(bean)).isEqualTo("Ada");
+        assertThat(bean.getterCalls).isEqualTo(2);
     }
 
     public static final class FieldBackedWriterBean {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionBuilderDynamicAccessTest {
+    @Test
+    void createsEmptyTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray(elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+
+        assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+
+        assertThat(values).containsExactly("solo");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
+        return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<String> runtimeStringType() throws Exception {
+        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    }
+
+    public static final class ArrayElement {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -6,6 +6,10 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
@@ -15,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CollectionBuilderDynamicAccessTest {
     @Test
     void createsEmptyTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.emptyArray(elementType);
@@ -26,7 +30,7 @@ public class CollectionBuilderDynamicAccessTest {
 
     @Test
     void createsSingletonTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
@@ -38,7 +42,7 @@ public class CollectionBuilderDynamicAccessTest {
 
     @Test
     void createsMultiValueTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.start()
@@ -53,36 +57,55 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
-    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsEmptyTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+        Object[] values = json.arrayOfFrom(elementType, "[]");
 
         assertThat(values).isEmpty();
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.emptyArrayCalls).isEqualTo(1);
     }
 
     @Test
-    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsSingletonTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+        Object[] values = json.arrayOfFrom(elementType, "[\"SOLO\"]");
 
-        assertThat(values).containsExactly("solo");
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).containsExactly(ArrayToken.SOLO);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.singletonArrayCalls).isEqualTo(1);
     }
 
     @Test
-    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsMultiValueTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+        Object[] values = json.arrayOfFrom(elementType, "[\"LEFT\",\"RIGHT\"]");
 
-        assertThat(values).containsExactly("left", "right");
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).containsExactly(ArrayToken.LEFT, ArrayToken.RIGHT);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.buildArrayCalls).isEqualTo(1);
+    }
+
+    private static JSON jsonWithBaseArrayMethodBuilder(CollectionBuilder builder) {
+        return JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+    }
+
+    private static BaseArrayMethodBuilder baseArrayMethodBuilder() {
+        return new BaseArrayMethodBuilder();
     }
 
     @SuppressWarnings("unchecked")
@@ -90,9 +113,77 @@ public class CollectionBuilderDynamicAccessTest {
         return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
     }
 
-    @SuppressWarnings("unchecked")
-    private static Class<String> runtimeStringType() throws Exception {
-        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    private static final class BaseArrayMethodBuilder extends CollectionBuilder {
+        private final InvocationCounts invocationCounts;
+        private List<Object> currentValues;
+
+        private BaseArrayMethodBuilder() {
+            this(0, null, new InvocationCounts());
+        }
+
+        private BaseArrayMethodBuilder(int features, Class<?> collectionType, InvocationCounts invocationCounts) {
+            super(features, collectionType);
+            this.invocationCounts = invocationCounts;
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new BaseArrayMethodBuilder(features, null, invocationCounts);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new BaseArrayMethodBuilder(_features, collectionType, invocationCounts);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            currentValues = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            currentValues.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> values = currentValues;
+            currentValues = null;
+            return values;
+        }
+
+        @Override
+        public <T> T[] buildArray(Class<T> type) {
+            invocationCounts.buildArrayCalls++;
+            return super.buildArray(type);
+        }
+
+        @Override
+        public <T> T[] emptyArray(Class<T> type) {
+            invocationCounts.emptyArrayCalls++;
+            return super.emptyArray(type);
+        }
+
+        @Override
+        public <T> T[] singletonArray(Class<?> type, T value) {
+            invocationCounts.singletonArrayCalls++;
+            return super.singletonArray(type, value);
+        }
+    }
+
+    private static final class InvocationCounts {
+        private int buildArrayCalls;
+        private int emptyArrayCalls;
+        private int singletonArrayCalls;
+    }
+
+    public enum ArrayToken {
+        LEFT,
+        RIGHT,
+        SOLO
     }
 
     public static final class ArrayElement {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBuilderDefaultDynamicAccessTest {
+    @BeforeEach
+    void resetConstructorCalls() {
+        ConstructorTrackingMap.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void readsMultiEntryJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"alpha\":1,\"beta\":2}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsEmptyJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsSingletonJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"only\":99}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
+        MapBuilder builder = configuredMapBuilder();
+
+        Map<String, Object> counts = builder.start()
+                .put("discarded", true)
+                .start()
+                .put("kept", true)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).hasSize(1);
+        assertThat(counts).containsEntry("kept", true);
+        assertThat(counts).doesNotContainKey("discarded");
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    private static JSON jsonWithConfiguredMaps() {
+        return JSON.builder()
+                .mapBuilder(configuredMapBuilder())
+                .build();
+    }
+
+    private static MapBuilder configuredMapBuilder() {
+        return MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
+    }
+
+    public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public ConstructorTrackingMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -12,10 +12,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -47,6 +49,45 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
         assertThat(counts).containsEntry("only", 99);
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationWhenStartingABuilderDirectly() {
+        Map<String, Object> counts = configuredMapBuilder().start()
+                .put("alpha", 1)
+                .put("beta", 2)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForEmptyMapsDirectly() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().emptyMap();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForSingletonMapsDirectly() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void reportsConfiguredTypeThatCannotBeUsedAsMap() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ClassKey.class);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(builder::emptyMap)
+                .withMessageContaining(ClassKey.class.getName())
+                .withMessageContaining(ClassCastException.class.getName());
     }
 
     @Test

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_RECORD_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+
+    @Test
+    void findsCanonicalConstructorFromRecordComponents() {
+        assertThat(RecordsHelpers.findCanonicalConstructor(ArticleRecord.class)).isNotNull();
+    }
+
+    @Test
+    void deserializesRecordUsingCanonicalConstructorComponents() throws Exception {
+        ArticleRecord article = JSON.std.beanFrom(ArticleRecord.class,
+                """
+                {"published":true,"pageCount":42,"title":"GraalVM"}
+                """);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
+    }
+
+    @Test
+    void serializesRecordInDeclarationOrderWhenFeatureIsEnabled() throws Exception {
+        String json = JSON_WITH_RECORD_DECLARATION_ORDER.asString(new ArticleRecord("Native Image", 7, false));
+
+        assertThat(json).isEqualTo("{\"title\":\"Native Image\",\"pageCount\":7,\"published\":false}");
+    }
+
+    public record ArticleRecord(String title, int pageCount, boolean published) {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void resolvesTopLevelClassesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+
+        assertThat(resolved).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
+                "{\"type\":\"" + className + "\"}");
+
+        assertThat(holder.type).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
+        String className = loadableClassName();
+
+        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
+                "{\"primary\":\"" + className + "\"}");
+        List<Class> classes = JSON.std.listOfFrom(Class.class,
+                "[\"" + className + "\"]");
+
+        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
+        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+    }
+
+    private static String loadableClassName() {
+        String propertyName = "simple.value.reader.class." + System.nanoTime();
+        System.setProperty(propertyName, LoadableType.class.getName());
+        return System.getProperty(propertyName);
+    }
+
+    public static final class TypeHolder {
+        public Class<?> type;
+    }
+
+    public static final class LoadableType {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -9,19 +9,38 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
+    void simpleReaderResolvesClassValuesDirectly() throws Exception {
+        JsonFactory jsonFactory = new JsonFactory();
+        SimpleValueReader reader = new SimpleValueReader(Class.class,
+                ValueLocatorBase.SER_CLASS);
+
+        try (JsonParser parser = jsonFactory.createParser("\"java.lang.String\"")) {
+            parser.nextToken();
+
+            Object resolved = reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(String.class);
+        }
+    }
+
+    @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
         String className = loadableClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved).isEqualTo(LoadableType.class);
+        assertThat(resolved.getName()).isEqualTo(className);
     }
 
     @Test
@@ -31,7 +50,7 @@ public class SimpleValueReaderDynamicAccessTest {
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type).isEqualTo(LoadableType.class);
+        assertThat(holder.type.getName()).isEqualTo(className);
     }
 
     @Test
@@ -43,14 +62,13 @@ public class SimpleValueReaderDynamicAccessTest {
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
-        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
+        assertThat(classes).singleElement().satisfies(resolved ->
+                assertThat(resolved.getName()).isEqualTo(className));
     }
 
     private static String loadableClassName() {
-        String propertyName = "simple.value.reader.class." + System.nanoTime();
-        System.setProperty(propertyName, LoadableType.class.getName());
-        return System.getProperty(propertyName);
+        return SimpleValueReaderDynamicAccessTest.class.getName() + "$LoadableType";
     }
 
     public static final class TypeHolder {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.type.ResolvedType;
+import com.fasterxml.jackson.jr.type.TypeBindings;
+import com.fasterxml.jackson.jr.type.TypeResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+        TypeResolver resolver = new TypeResolver();
+        Object runtimeComponentValue = runtimeComponentValue();
+        Class<?> componentClass = runtimeComponentValue.getClass();
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
+    }
+
+    @Test
+    void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType declaringType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                StringArrayContainer.class.getGenericSuperclass());
+        Type genericArrayType = GenericArrayContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
+    static class GenericArrayContainer<T> {
+        private T[] values;
+
+        public T[] getValues() {
+            return values;
+        }
+
+        public void setValues(T[] values) {
+            this.values = values;
+        }
+    }
+
+    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    private static Object runtimeComponentValue() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return Integer.valueOf(7);
+        }
+        return Thread.currentThread().getName();
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,10 +24,11 @@ public class TypeResolverDynamicAccessTest {
         Object runtimeComponentValue = runtimeComponentValue();
         Class<?> componentClass = runtimeComponentValue.getClass();
         ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
-        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentClass);
 
         ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
 
+        assertThat(componentClass).isEqualTo(ArrayComponentValue.class);
         assertThat(resolvedArrayType.isArray()).isTrue();
         assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
@@ -37,7 +39,7 @@ public class TypeResolverDynamicAccessTest {
         TypeResolver resolver = new TypeResolver();
         ResolvedType declaringType = resolver.resolve(
                 TypeBindings.emptyBindings(),
-                StringArrayContainer.class.getGenericSuperclass());
+                ArrayComponentValueContainer.class.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
                 .getDeclaredField("values")
                 .getGenericType();
@@ -45,8 +47,26 @@ public class TypeResolverDynamicAccessTest {
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(ArrayComponentValue[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(ArrayComponentValue.class);
+    }
+
+    @Test
+    void resolvesGenericArrayTypesWithParameterizedComponents() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type genericArrayType = ParameterizedComponentArrayContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(genericArrayType).isInstanceOf(GenericArrayType.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(List[].class);
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().typeParametersFor(List.class).get(0).erasedType())
+                .isEqualTo(Number.class);
     }
 
     static class GenericArrayContainer<T> {
@@ -61,14 +81,26 @@ public class TypeResolverDynamicAccessTest {
         }
     }
 
-    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    static final class ArrayComponentValueContainer extends GenericArrayContainer<ArrayComponentValue> {
+    }
+
+    static final class ParameterizedComponentArrayContainer {
+        private List<? extends Number>[] values;
+
+        public List<? extends Number>[] getValues() {
+            return values;
+        }
+
+        public void setValues(List<? extends Number>[] values) {
+            this.values = values;
+        }
     }
 
     private static Object runtimeComponentValue() {
-        if (Thread.currentThread().getName().isEmpty()) {
-            return Integer.valueOf(7);
-        }
-        return Thread.currentThread().getName();
+        return new ArrayComponentValue();
+    }
+
+    static final class ArrayComponentValue {
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueReaderLocatorDynamicAccessTest {
+    @Test
+    void readsEnumsFromModifierProvidedDefinitions() throws Exception {
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+
+        assertThat(direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+
+        assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitions() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
+
+        ValueReader reader = locator.findReader(Direction.class);
+
+        assertThat(reader).isNotNull();
+    }
+
+    private static JSON enumAwareJson(JSON.Feature... features) {
+        return JSON.builder()
+                .enable(features)
+                .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
+
+    public static class EnumDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class EnumDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != Direction.class) {
+                return null;
+            }
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+        }
+
+        private static POJODefinition.Prop[] enumProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp("go-north", "NORTH"),
+                    enumProp("go-south", "SOUTH")
+            };
+        }
+
+        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(String enumConstantName) {
+            try {
+                return Direction.class.getField(enumConstantName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
@@ -37,12 +38,36 @@ public class ValueReaderLocatorDynamicAccessTest {
     }
 
     @Test
+    void readsLibraryEnumValuesFromModifierProvidedDefinitions() throws Exception {
+        JSON.Feature feature = enumAwareJson().beanFrom(JSON.Feature.class, "\"field-access\"");
+
+        assertThat(feature).isEqualTo(JSON.Feature.USE_FIELDS);
+    }
+
+    @Test
     void createsEnumReadersFromModifierProvidedDefinitions() {
         ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
 
         ValueReader reader = locator.findReader(Direction.class);
 
         assertThat(reader).isNotNull();
+    }
+
+    @Test
+    void readsModifierNamedEnumValuesAsBeanProperties() throws Exception {
+        TravelPlan plan = enumAwareJson(JSON.Feature.USE_FIELDS)
+                .beanFrom(TravelPlan.class, "{\"direction\":\"go-north\"}");
+
+        assertThat(plan.direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsRecordPropertiesThroughBeanReader() throws Exception {
+        TripSummary summary = JSON.std.beanFrom(TripSummary.class,
+                "{\"destination\":\"Reykjavik\",\"travelers\":2}");
+
+        assertThat(summary.destination()).isEqualTo("Reykjavik");
+        assertThat(summary.travelers()).isEqualTo(2);
     }
 
     private static JSON enumAwareJson(JSON.Feature... features) {
@@ -57,6 +82,13 @@ public class ValueReaderLocatorDynamicAccessTest {
         SOUTH
     }
 
+    public static class TravelPlan {
+        public Direction direction;
+    }
+
+    public record TripSummary(String destination, int travelers) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -67,26 +99,36 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != Direction.class) {
-                return null;
+            if (pojoType == Direction.class) {
+                return new POJODefinition(Direction.class, directionProps(), new BeanConstructors(Direction.class));
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            if (pojoType == JSON.Feature.class) {
+                return new POJODefinition(JSON.Feature.class, featureProps(), new BeanConstructors(JSON.Feature.class));
+            }
+            return null;
         }
 
-        private static POJODefinition.Prop[] enumProps() {
+        private static POJODefinition.Prop[] directionProps() {
             return new POJODefinition.Prop[] {
-                    enumProp("go-north", "NORTH"),
-                    enumProp("go-south", "SOUTH")
+                    enumProp(Direction.class, "go-north", "NORTH"),
+                    enumProp(Direction.class, "go-south", "SOUTH")
             };
         }
 
-        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        private static POJODefinition.Prop[] featureProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp(JSON.Feature.class, "field-access", "USE_FIELDS")
+            };
         }
 
-        private static Field enumField(String enumConstantName) {
+        private static POJODefinition.Prop enumProp(Class<?> enumType, String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, externalName,
+                    enumField(enumType, enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(Class<?> enumType, String enumConstantName) {
             try {
-                return Direction.class.getField(enumConstantName);
+                return enumType.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,283 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$ConstructorTrackingMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "fields" : [
+        {
+          "name" : "NORTH"
+        },
+        {
+          "name" : "SOUTH"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -158,6 +158,11 @@
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
       "methods" : [
         {
           "name" : "<init>",
@@ -170,9 +175,43 @@
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
       "methods" : [
         {
           "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$ArticleRecord",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "title",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "pageCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "published",
           "parameterTypes" : [ ]
         }
       ]
@@ -217,6 +256,12 @@
         "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayToken[]"
     },
     {
       "condition" : {
@@ -278,6 +323,477 @@
           "name" : "SOUTH"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord",
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "title",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "pageCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "published",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$ArticleRecord",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$ArticleRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$ArticleRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$BaseBean",
+      "fields" : [
+        {
+          "name" : "visible"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$BaseBean",
+      "fields" : [
+        {
+          "name" : "visible"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldNamedGetterBean",
+      "methods" : [
+        {
+          "name" : "title",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$FieldNamedGetterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setActive",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isActive",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$StaticAndFluentBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$StaticAndFluentBean",
+      "fields" : [
+        {
+          "name" : "shared"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isEnabled",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "title",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.ValueIterator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "y"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.ValueIterator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord",
+      "methods" : [
+        {
+          "name" : "pageCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "published",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "title",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$ArticleRecord"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.CollectionReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.MapReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest$ArrayComponentValue[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.JSON"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TravelPlan",
+      "fields" : [
+        {
+          "name" : "direction"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TripSummary",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TripSummary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$TripSummary"
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="57" skipped="0" failures="0" errors="0" time="0.019" hostname="kung-fu-workstation" timestamp="2026-05-02T21:57:06">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-4793d491/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="instantiatesConfiguredMapImplementationForEmptyMapsDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:instantiatesConfiguredMapImplementationForEmptyMapsDirectly()]
+display-name: instantiatesConfiguredMapImplementationForEmptyMapsDirectly()
+]]></system-out>
+</testcase>
+<testcase name="reportsConfiguredTypeThatCannotBeUsedAsMap()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:reportsConfiguredTypeThatCannotBeUsedAsMap()]
+display-name: reportsConfiguredTypeThatCannotBeUsedAsMap()
+]]></system-out>
+</testcase>
+<testcase name="directIntrospectionCollectsEverySupportedConstructorShape()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:directIntrospectionCollectsEverySupportedConstructorShape()]
+display-name: directIntrospectionCollectsEverySupportedConstructorShape()
+]]></system-out>
+</testcase>
+<testcase name="resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes()]
+display-name: resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes()
+]]></system-out>
+</testcase>
+<testcase name="populatesSetterBackedPropertiesFromBeanSequence()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesSetterBackedPropertiesFromBeanSequence()]
+display-name: populatesSetterBackedPropertiesFromBeanSequence()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()]
+display-name: createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()
+]]></system-out>
+</testcase>
+<testcase name="readsSingletonTypedArraysThroughConfiguredJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsSingletonTypedArraysThroughConfiguredJsonApi()]
+display-name: readsSingletonTypedArraysThroughConfiguredJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="resolvesTopLevelClassesFromStringValues()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesTopLevelClassesFromStringValues()]
+display-name: resolvesTopLevelClassesFromStringValues()
+]]></system-out>
+</testcase>
+<testcase name="readsRecordPropertiesThroughBeanReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsRecordPropertiesThroughBeanReader()]
+display-name: readsRecordPropertiesThroughBeanReader()
+]]></system-out>
+</testcase>
+<testcase name="createsEmptyTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsEmptyTypedArraysDirectly()]
+display-name: createsEmptyTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="createsMultiValueTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsMultiValueTypedArraysDirectly()]
+display-name: createsMultiValueTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="populatesPublicSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPublicSetterBackedProperties()]
+display-name: populatesPublicSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="supportsFieldNamedGettersWhenEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:supportsFieldNamedGettersWhenEnabled()]
+display-name: supportsFieldNamedGettersWhenEnabled()
+]]></system-out>
+</testcase>
+<testcase name="resolvesGenericArrayTypesFromBoundTypeVariables()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesGenericArrayTypesFromBoundTypeVariables()]
+display-name: resolvesGenericArrayTypesFromBoundTypeVariables()
+]]></system-out>
+</testcase>
+<testcase name="findsCanonicalConstructorFromRecordComponents()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:findsCanonicalConstructorFromRecordComponents()]
+display-name: findsCanonicalConstructorFromRecordComponents()
+]]></system-out>
+</testcase>
+<testcase name="instantiatesConfiguredMapImplementationWhenStartingABuilderDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:instantiatesConfiguredMapImplementationWhenStartingABuilderDirectly()]
+display-name: instantiatesConfiguredMapImplementationWhenStartingABuilderDirectly()
+]]></system-out>
+</testcase>
+<testcase name="readsModifierProvidedEnumDefinitionsCaseInsensitively()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsModifierProvidedEnumDefinitionsCaseInsensitively()]
+display-name: readsModifierProvidedEnumDefinitionsCaseInsensitively()
+]]></system-out>
+</testcase>
+<testcase name="createsRecordsThroughCanonicalConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsThroughCanonicalConstructorsWhenReadingObjects()]
+display-name: createsRecordsThroughCanonicalConstructorsWhenReadingObjects()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="createsRecordsDirectlyThroughCanonicalConstructorsDiscoveredByLibraryIntrospection()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsDirectlyThroughCanonicalConstructorsDiscoveredByLibraryIntrospection()]
+display-name: createsRecordsDirectlyThroughCanonicalConstructorsDiscoveredByLibraryIntrospection()
+]]></system-out>
+</testcase>
+<testcase name="readsLibraryEnumValuesFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsLibraryEnumValuesFromModifierProvidedDefinitions()]
+display-name: readsLibraryEnumValuesFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="readsEmptyJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsEmptyJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsEmptyJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="populatesFieldBackedPropertiesFromBeanSequence()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFieldBackedPropertiesFromBeanSequence()]
+display-name: populatesFieldBackedPropertiesFromBeanSequence()
+]]></system-out>
+</testcase>
+<testcase name="serializesRecordInDeclarationOrderWhenFeatureIsEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:serializesRecordInDeclarationOrderWhenFeatureIsEnabled()]
+display-name: serializesRecordInDeclarationOrderWhenFeatureIsEnabled()
+]]></system-out>
+</testcase>
+<testcase name="simpleReaderResolvesClassValuesDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:simpleReaderResolvesClassValuesDirectly()]
+display-name: simpleReaderResolvesClassValuesDirectly()
+]]></system-out>
+</testcase>
+<testcase name="collectsDeclaredFieldsAndMethodsForSerialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsDeclaredFieldsAndMethodsForSerialization()]
+display-name: collectsDeclaredFieldsAndMethodsForSerialization()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructors()]
+display-name: createsBeansThroughPublicDefaultConstructors()
+]]></system-out>
+</testcase>
+<testcase name="resolvesClassesInsideTypedMapsAndLists()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesClassesInsideTypedMapsAndLists()]
+display-name: resolvesClassesInsideTypedMapsAndLists()
+]]></system-out>
+</testcase>
+<testcase name="readsEnumsFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsEnumsFromModifierProvidedDefinitions()]
+display-name: readsEnumsFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="publicJsonReaderIntrospectsDeclaredConstructorsOnLibraryPojoDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:publicJsonReaderIntrospectsDeclaredConstructorsOnLibraryPojoDefinitions()]
+display-name: publicJsonReaderIntrospectsDeclaredConstructorsOnLibraryPojoDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="readsMultiValueTypedArraysThroughConfiguredJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsMultiValueTypedArraysThroughConfiguredJsonApi()]
+display-name: readsMultiValueTypedArraysThroughConfiguredJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="publicJsonWriterIntrospectsFieldNamedGettersWhenEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:publicJsonWriterIntrospectsFieldNamedGettersWhenEnabled()]
+display-name: publicJsonWriterIntrospectsFieldNamedGettersWhenEnabled()
+]]></system-out>
+</testcase>
+<testcase name="directIntrospectionVisitsDeclaredFieldsAndMethods()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:directIntrospectionVisitsDeclaredFieldsAndMethods()]
+display-name: directIntrospectionVisitsDeclaredFieldsAndMethods()
+]]></system-out>
+</testcase>
+<testcase name="readsEmptyTypedArraysThroughConfiguredJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsEmptyTypedArraysThroughConfiguredJsonApi()]
+display-name: readsEmptyTypedArraysThroughConfiguredJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="publicJsonWriterIntrospectsDeclaredFieldsAndMethodsOnLibraryPojoDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:publicJsonWriterIntrospectsDeclaredFieldsAndMethodsOnLibraryPojoDefinitions()]
+display-name: publicJsonWriterIntrospectsDeclaredFieldsAndMethodsOnLibraryPojoDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="populatesFieldBackedBeanProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFieldBackedBeanProperties()]
+display-name: populatesFieldBackedBeanProperties()
+]]></system-out>
+</testcase>
+<testcase name="readsModifierNamedEnumValuesAsBeanProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsModifierNamedEnumValuesAsBeanProperties()]
+display-name: readsModifierNamedEnumValuesAsBeanProperties()
+]]></system-out>
+</testcase>
+<testcase name="createsSingletonTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsSingletonTypedArraysDirectly()]
+display-name: createsSingletonTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="deserializesRecordUsingCanonicalConstructorComponents()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:deserializesRecordUsingCanonicalConstructorComponents()]
+display-name: deserializesRecordUsingCanonicalConstructorComponents()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="assignsValuesWithDiscoveredSetterBackedPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:assignsValuesWithDiscoveredSetterBackedPropertyReader()]
+display-name: assignsValuesWithDiscoveredSetterBackedPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="retainsConfiguredMapImplementationWhenRestartingABusyBuilder()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:retainsConfiguredMapImplementationWhenRestartingABusyBuilder()]
+display-name: retainsConfiguredMapImplementationWhenRestartingABusyBuilder()
+]]></system-out>
+</testcase>
+<testcase name="readsMultiEntryJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsMultiEntryJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsMultiEntryJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="instantiatesConfiguredMapImplementationForSingletonMapsDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:instantiatesConfiguredMapImplementationForSingletonMapsDirectly()]
+display-name: instantiatesConfiguredMapImplementationForSingletonMapsDirectly()
+]]></system-out>
+</testcase>
+<testcase name="readsSingletonJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsSingletonJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsSingletonJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="serializesGetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesGetterBackedProperties()]
+display-name: serializesGetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="resolvesClassTypedBeanPropertiesFromStringValues()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesClassTypedBeanPropertiesFromStringValues()]
+display-name: resolvesClassTypedBeanPropertiesFromStringValues()
+]]></system-out>
+</testcase>
+<testcase name="publicJsonWriterIntrospectsStaticFieldsWhenEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:publicJsonWriterIntrospectsStaticFieldsWhenEnabled()]
+display-name: publicJsonWriterIntrospectsStaticFieldsWhenEnabled()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansDirectlyThroughDefaultConstructorsDiscoveredByLibraryIntrospection()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughDefaultConstructorsDiscoveredByLibraryIntrospection()]
+display-name: createsBeansDirectlyThroughDefaultConstructorsDiscoveredByLibraryIntrospection()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest]/[method:createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="resolvesGenericArrayTypesWithParameterizedComponents()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesGenericArrayTypesWithParameterizedComponents()]
+display-name: resolvesGenericArrayTypesWithParameterizedComponents()
+]]></system-out>
+</testcase>
+<testcase name="assignsValuesWithDiscoveredFieldBackedPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:assignsValuesWithDiscoveredFieldBackedPropertyReader()]
+display-name: assignsValuesWithDiscoveredFieldBackedPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="populatesPrivateSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPrivateSetterBackedProperties()]
+display-name: populatesPrivateSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="collectsDeclaredConstructorsForDeserialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsDeclaredConstructorsForDeserialization()]
+display-name: collectsDeclaredConstructorsForDeserialization()
+]]></system-out>
+</testcase>
+<testcase name="createsEnumReadersFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:createsEnumReadersFromModifierProvidedDefinitions()]
+display-name: createsEnumReadersFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="populatesFluentSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFluentSetterBackedProperties()]
+display-name: populatesFluentSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="serializesFieldBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesFieldBackedProperties()]
+display-name: serializesFieldBackedProperties()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:57:06">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-4793d491/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jr.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2564

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 1135147
- Cached input tokens: 15081472
- Output tokens: 131110
- Metadata entries: 9
- Test-only metadata entries: 137
- Iterations: 22
- Library coverage percentage: 39.39
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 47
- Previous library version coverage percentage: 36.81

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

**Reflection:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 4596/12487 (36.81%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 5400/13710 (39.39%)

**Line:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: N/A
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: N/A

**Method:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 255/666 (38.29%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 288/705 (40.85%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
index 4b9e6fc27b..137ed3edd9 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,11 +6,12 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +27,8 @@ public class BeanConstructorsDynamicAccessTest {
     }
 
     @Test
-    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
-        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
+    void createsBeansDirectlyThroughDefaultConstructorsDiscoveredByLibraryIntrospection() throws Exception {
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forNonRecord(PublicDefaultCtorBean.class);
 
         PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
 
@@ -39,9 +38,7 @@ public class BeanConstructorsDynamicAccessTest {
 
     @Test
     void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forNonRecord(PrivateDefaultCtorBean.class);
         constructors.forceAccess();
 
         PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
@@ -50,6 +47,17 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void createsRecordsDirectlyThroughCanonicalConstructorsDiscoveredByLibraryIntrospection() throws Exception {
+        AccessibleBeanConstructors constructors = AccessibleBeanConstructors.forRecord(ArticleRecord.class);
+
+        ArticleRecord article = (ArticleRecord) constructors.createRecordBean("GraalVM", 42, true);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
+    }
+
     @Test
     void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
         PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
@@ -67,14 +75,42 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        ArticleRecord article = JSON.std.beanFrom(ArticleRecord.class,
+                """
+                {"published":true,"pageCount":42,"title":"GraalVM"}
+                """);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
+    }
+
     static final class AccessibleBeanConstructors extends BeanConstructors {
-        AccessibleBeanConstructors(Class<?> valueType) {
+        private AccessibleBeanConstructors(Class<?> valueType) {
             super(valueType);
         }
 
+        static AccessibleBeanConstructors forNonRecord(Class<?> valueType) {
+            AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(valueType);
+            BeanPropertyIntrospector.addNonRecordConstructors(valueType, constructors);
+            return constructors;
+        }
+
+        static AccessibleBeanConstructors forRecord(Class<?> valueType) {
+            AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(valueType);
+            constructors.addRecordConstructor(RecordsHelpers.findCanonicalConstructor(valueType));
+            return constructors;
+        }
+
         Object createBean() throws Exception {
             return create();
         }
+
+        Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
+        }
     }
 
     public static final class PublicDefaultCtorBean {
@@ -96,4 +132,7 @@ public class BeanConstructorsDynamicAccessTest {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }
+
+    public record ArticleRecord(String title, int pageCount, boolean published) {
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
index bd54ecaf2c..fd4e0337ac 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -6,9 +6,11 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
@@ -19,6 +21,7 @@ import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeanPropertyIntrospectorDynamicAccessTest {
     private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
@@ -80,6 +83,61 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(json).contains("\"title\":\"Ada\"");
     }
 
+    @Test
+    void publicJsonWriterIntrospectsDeclaredFieldsAndMethodsOnLibraryPojoDefinitions() throws Exception {
+        POJODefinition definition = new POJODefinition(POJODefinition.class, new POJODefinition.Prop[0],
+                new BeanConstructors(POJODefinition.class));
+
+        String json = JSON_WITH_FORCE_ACCESS.asString(definition);
+
+        assertThat(json).contains("\"ignorableNames\":[]", "\"properties\":[]");
+    }
+
+    @Test
+    void publicJsonReaderIntrospectsDeclaredConstructorsOnLibraryPojoDefinitions() {
+        assertThatThrownBy(() -> JSON_WITH_FORCE_ACCESS.beanFrom(POJODefinition.class, "{}"))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to create an instance of")
+                .hasMessageContaining(POJODefinition.class.getName());
+    }
+
+    @Test
+    void directIntrospectionCollectsEverySupportedConstructorShape() {
+        RecordingBeanConstructors constructors = new RecordingBeanConstructors(AllConstructorShapes.class);
+
+        BeanPropertyIntrospector.addNonRecordConstructors(AllConstructorShapes.class, constructors);
+
+        assertThat(constructors.noArgsConstructors).isEqualTo(1);
+        assertThat(constructors.stringConstructors).isEqualTo(1);
+        assertThat(constructors.intConstructors).isEqualTo(2);
+        assertThat(constructors.longConstructors).isEqualTo(2);
+    }
+
+    @Test
+    void directIntrospectionVisitsDeclaredFieldsAndMethods() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                StaticAndFluentBean.class);
+
+        assertThat(propertyNames(definition)).containsExactly("enabled", "name");
+        assertThat(property(definition, "enabled").isGetter).isNotNull();
+        assertThat(property(definition, "name").getter).isNotNull();
+    }
+
+    @Test
+    void publicJsonWriterIntrospectsStaticFieldsWhenEnabled() throws Exception {
+        String json = JSON_WITH_FORCE_ACCESS.with(JSON.Feature.INCLUDE_STATIC_FIELDS)
+                .asString(new StaticAndFluentBean("Ada", true));
+
+        assertThat(json).contains("\"name\":\"Ada\"", "\"enabled\":true", "\"shared\":\"common\"");
+    }
+
+    @Test
+    void publicJsonWriterIntrospectsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new StaticAndFluentBean("Ada", true));
+
+        assertThat(json).contains("\"title\":\"Ada title\"");
+    }
+
     private static List<String> propertyNames(POJODefinition definition) {
         return definition.getProperties().stream().map(prop -> prop.name).toList();
     }
@@ -135,6 +193,61 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         }
     }
 
+    static final class RecordingBeanConstructors extends BeanConstructors {
+        private int noArgsConstructors;
+        private int stringConstructors;
+        private int intConstructors;
+        private int longConstructors;
+
+        RecordingBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public BeanConstructors addNoArgsConstructor(Constructor<?> constructor) {
+            noArgsConstructors++;
+            return super.addNoArgsConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addStringConstructor(Constructor<?> constructor) {
+            stringConstructors++;
+            return super.addStringConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addIntConstructor(Constructor<?> constructor) {
+            intConstructors++;
+            return super.addIntConstructor(constructor);
+        }
+
+        @Override
+        public BeanConstructors addLongConstructor(Constructor<?> constructor) {
+            longConstructors++;
+            return super.addLongConstructor(constructor);
+        }
+    }
+
+    static final class AllConstructorShapes {
+        AllConstructorShapes() {
+        }
+
+        AllConstructorShapes(String value) {
+        }
+
+        AllConstructorShapes(int value) {
+        }
+
+        AllConstructorShapes(Integer value) {
+        }
+
+        AllConstructorShapes(long value) {
+        }
+
+        AllConstructorShapes(Long value) {
+        }
+    }
+
     static final class FieldNamedGetterBean {
         private final String title;
 
@@ -146,4 +259,29 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
             return title;
         }
     }
+
+    static final class StaticAndFluentBean {
+        public static String shared = "common";
+        private final String name;
+        private final String title;
+        private final boolean enabled;
+
+        StaticAndFluentBean(String name, boolean enabled) {
+            this.name = name;
+            this.title = name + " title";
+            this.enabled = enabled;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
index ff55ef0382..7e15fa4904 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,7 +7,11 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.ValueIterator;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition.Prop;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,25 +20,24 @@ public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
 
     @Test
-    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+    void assignsValuesWithDiscoveredFieldBackedPropertyReader() throws Exception {
+        BeanPropertyReader propertyReader = discoveredReaderFor(FieldBackedReaderBean.class, "x");
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[]{3});
+        propertyReader.setValueFor(bean, new Object[] {13});
 
         assertThat(bean.isConstructed()).isTrue();
-        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.x).isEqualTo(13);
     }
 
     @Test
-    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+    void assignsValuesWithDiscoveredSetterBackedPropertyReader() throws Exception {
+        BeanPropertyReader propertyReader = discoveredReaderFor(PublicSetterBackedReaderBean.class, "name");
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
-        reader.setValueFor(bean, new Object[]{"Ada"});
+        propertyReader.setValueFor(bean, new Object[] {"Katherine"});
 
-        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getName()).isEqualTo("Katherine");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
@@ -74,6 +77,46 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
+    @Test
+    void populatesFieldBackedPropertiesFromBeanSequence() throws Exception {
+        try (ValueIterator<FieldBackedReaderBean> iterator = JSON_WITH_FORCE_ACCESS
+                .beanSequenceFrom(FieldBackedReaderBean.class, "[{\"x\":11,\"y\":12}]")) {
+            assertThat(iterator.hasNext()).isTrue();
+
+            FieldBackedReaderBean bean = iterator.next();
+
+            assertThat(bean.isConstructed()).isTrue();
+            assertThat(bean.x).isEqualTo(11);
+            assertThat(bean.y).isEqualTo(12);
+            assertThat(iterator.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void populatesSetterBackedPropertiesFromBeanSequence() throws Exception {
+        try (ValueIterator<PublicSetterBackedReaderBean> iterator = JSON_WITH_FORCE_ACCESS
+                .beanSequenceFrom(PublicSetterBackedReaderBean.class, "[{\"name\":\"Grace\"}]")) {
+            assertThat(iterator.hasNext()).isTrue();
+
+            PublicSetterBackedReaderBean bean = iterator.next();
+
+            assertThat(bean.getName()).isEqualTo("Grace");
+            assertThat(bean.getSetterCalls()).isEqualTo(1);
+            assertThat(iterator.hasNext()).isFalse();
+        }
+    }
+
+    private static BeanPropertyReader discoveredReaderFor(Class<?> beanType, String propertyName) {
+        JSONReader introspectionReader = JSON.builder().jsonReader();
+        for (Prop property : BeanPropertyIntrospector.instance()
+                .pojoDefinitionForDeserialization(introspectionReader, beanType).getProperties()) {
+            if (propertyName.equals(property.name)) {
+                return new BeanPropertyReader(property.name, property.field, property.setter);
+            }
+        }
+        throw new IllegalArgumentException("No property named " + propertyName + " on " + beanType.getName());
+    }
+
     public static final class FieldBackedReaderBean {
         private boolean constructed;
         public int x;
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
index dd41a65a32..fdd4abe552 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -7,8 +7,12 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPropertyWriterDynamicAccessTest {
@@ -21,18 +25,26 @@ public class BeanPropertyWriterDynamicAccessTest {
 
     @Test
     void serializesFieldBackedProperties() throws Exception {
-        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
+        FieldBackedWriterBean bean = new FieldBackedWriterBean();
+        String json = JSON_WITH_FIELD_ACCESS.asString(bean);
+        Field idField = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", idField, null);
 
         assertThat(json).isEqualTo("{\"id\":3}");
+        assertThat(writer.getValueFor(bean)).isEqualTo(3);
     }
 
     @Test
     void serializesGetterBackedProperties() throws Exception {
         GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
         String json = JSON_WITH_GETTER_ACCESS.asString(bean);
+        Method getName = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getName);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
         assertThat(bean.getterCalls).isEqualTo(1);
+        assertThat(writer.getValueFor(bean)).isEqualTo("Ada");
+        assertThat(bean.getterCalls).isEqualTo(2);
     }
 
     public static final class FieldBackedWriterBean {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
index 994dafe71d..f9da14dcc0 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -6,6 +6,10 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
@@ -15,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CollectionBuilderDynamicAccessTest {
     @Test
     void createsEmptyTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.emptyArray(elementType);
@@ -26,7 +30,7 @@ public class CollectionBuilderDynamicAccessTest {
 
     @Test
     void createsSingletonTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
@@ -38,7 +42,7 @@ public class CollectionBuilderDynamicAccessTest {
 
     @Test
     void createsMultiValueTypedArraysDirectly() throws Exception {
-        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        CollectionBuilder builder = baseArrayMethodBuilder();
         Class<ArrayElement> elementType = runtimeArrayElementType();
 
         Object[] values = builder.start()
@@ -53,36 +57,55 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
-    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsEmptyTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+        Object[] values = json.arrayOfFrom(elementType, "[]");
 
         assertThat(values).isEmpty();
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.emptyArrayCalls).isEqualTo(1);
     }
 
     @Test
-    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsSingletonTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+        Object[] values = json.arrayOfFrom(elementType, "[\"SOLO\"]");
 
-        assertThat(values).containsExactly("solo");
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).containsExactly(ArrayToken.SOLO);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.singletonArrayCalls).isEqualTo(1);
     }
 
     @Test
-    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
-        Class<String> elementType = runtimeStringType();
+    void readsMultiValueTypedArraysThroughConfiguredJsonApi() throws Exception {
+        BaseArrayMethodBuilder builder = baseArrayMethodBuilder();
+        JSON json = jsonWithBaseArrayMethodBuilder(builder);
+        Class<ArrayToken> elementType = ArrayToken.class;
 
-        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+        Object[] values = json.arrayOfFrom(elementType, "[\"LEFT\",\"RIGHT\"]");
 
-        assertThat(values).containsExactly("left", "right");
-        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values).containsExactly(ArrayToken.LEFT, ArrayToken.RIGHT);
+        assertThat(values).isInstanceOf(ArrayToken[].class);
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(builder.invocationCounts.buildArrayCalls).isEqualTo(1);
+    }
+
+    private static JSON jsonWithBaseArrayMethodBuilder(CollectionBuilder builder) {
+        return JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+    }
+
+    private static BaseArrayMethodBuilder baseArrayMethodBuilder() {
+        return new BaseArrayMethodBuilder();
     }
 
     @SuppressWarnings("unchecked")
@@ -90,9 +113,77 @@ public class CollectionBuilderDynamicAccessTest {
         return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
     }
 
-    @SuppressWarnings("unchecked")
-    private static Class<String> runtimeStringType() throws Exception {
-        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    private static final class BaseArrayMethodBuilder extends CollectionBuilder {
+        private final InvocationCounts invocationCounts;
+        private List<Object> currentValues;
+
+        private BaseArrayMethodBuilder() {
+            this(0, null, new InvocationCounts());
+        }
+
+        private BaseArrayMethodBuilder(int features, Class<?> collectionType, InvocationCounts invocationCounts) {
+            super(features, collectionType);
+            this.invocationCounts = invocationCounts;
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new BaseArrayMethodBuilder(features, null, invocationCounts);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new BaseArrayMethodBuilder(_features, collectionType, invocationCounts);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            currentValues = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            currentValues.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> values = currentValues;
+            currentValues = null;
+            return values;
+        }
+
+        @Override
+        public <T> T[] buildArray(Class<T> type) {
+            invocationCounts.buildArrayCalls++;
+            return super.buildArray(type);
+        }
+
+        @Override
+        public <T> T[] emptyArray(Class<T> type) {
+            invocationCounts.emptyArrayCalls++;
+            return super.emptyArray(type);
+        }
+
+        @Override
+        public <T> T[] singletonArray(Class<?> type, T value) {
+            invocationCounts.singletonArrayCalls++;
+            return super.singletonArray(type, value);
+        }
+    }
+
+    private static final class InvocationCounts {
+        private int buildArrayCalls;
+        private int emptyArrayCalls;
+        private int singletonArrayCalls;
+    }
+
+    public enum ArrayToken {
+        LEFT,
+        RIGHT,
+        SOLO
     }
 
     public static final class ArrayElement {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
index 2d801978bc..a3f5db7f38 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -12,10 +12,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.ClassKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -49,6 +51,45 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void instantiatesConfiguredMapImplementationWhenStartingABuilderDirectly() {
+        Map<String, Object> counts = configuredMapBuilder().start()
+                .put("alpha", 1)
+                .put("beta", 2)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForEmptyMapsDirectly() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().emptyMap();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void instantiatesConfiguredMapImplementationForSingletonMapsDirectly() throws Exception {
+        Map<String, Object> counts = configuredMapBuilder().singletonMap("only", 99);
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void reportsConfiguredTypeThatCannotBeUsedAsMap() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(ClassKey.class);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(builder::emptyMap)
+                .withMessageContaining(ClassKey.class.getName())
+                .withMessageContaining(ClassCastException.class.getName());
+    }
+
     @Test
     void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
         MapBuilder builder = configuredMapBuilder();
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
new file mode 100644
index 0000000000..47e5c8db5c
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -0,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_RECORD_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+
+    @Test
+    void findsCanonicalConstructorFromRecordComponents() {
+        assertThat(RecordsHelpers.findCanonicalConstructor(ArticleRecord.class)).isNotNull();
+    }
+
+    @Test
+    void deserializesRecordUsingCanonicalConstructorComponents() throws Exception {
+        ArticleRecord article = JSON.std.beanFrom(ArticleRecord.class,
+                """
+                {"published":true,"pageCount":42,"title":"GraalVM"}
+                """);
+
+        assertThat(article.title()).isEqualTo("GraalVM");
+        assertThat(article.pageCount()).isEqualTo(42);
+        assertThat(article.published()).isTrue();
+    }
+
+    @Test
+    void serializesRecordInDeclarationOrderWhenFeatureIsEnabled() throws Exception {
+        String json = JSON_WITH_RECORD_DECLARATION_ORDER.asString(new ArticleRecord("Native Image", 7, false));
+
+        assertThat(json).isEqualTo("{\"title\":\"Native Image\",\"pageCount\":7,\"published\":false}");
+    }
+
+    public record ArticleRecord(String title, int pageCount, boolean published) {
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
index 9cb0bb785b..0ff6d5d45f 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -9,19 +9,38 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
+import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void simpleReaderResolvesClassValuesDirectly() throws Exception {
+        JsonFactory jsonFactory = new JsonFactory();
+        SimpleValueReader reader = new SimpleValueReader(Class.class,
+                ValueLocatorBase.SER_CLASS);
+
+        try (JsonParser parser = jsonFactory.createParser("\"java.lang.String\"")) {
+            parser.nextToken();
+
+            Object resolved = reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(String.class);
+        }
+    }
+
     @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
         String className = loadableClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved).isEqualTo(LoadableType.class);
+        assertThat(resolved.getName()).isEqualTo(className);
     }
 
     @Test
@@ -31,7 +50,7 @@ public class SimpleValueReaderDynamicAccessTest {
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type).isEqualTo(LoadableType.class);
+        assertThat(holder.type.getName()).isEqualTo(className);
     }
 
     @Test
@@ -43,14 +62,13 @@ public class SimpleValueReaderDynamicAccessTest {
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
-        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
+        assertThat(classes).singleElement().satisfies(resolved ->
+                assertThat(resolved.getName()).isEqualTo(className));
     }
 
     private static String loadableClassName() {
-        String propertyName = "simple.value.reader.class." + System.nanoTime();
-        System.setProperty(propertyName, LoadableType.class.getName());
-        return System.getProperty(propertyName);
+        return SimpleValueReaderDynamicAccessTest.class.getName() + "$LoadableType";
     }
 
     public static final class TypeHolder {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
index 9e15382236..286ec34163 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,10 +24,11 @@ public class TypeResolverDynamicAccessTest {
         Object runtimeComponentValue = runtimeComponentValue();
         Class<?> componentClass = runtimeComponentValue.getClass();
         ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
-        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentClass);
 
         ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
 
+        assertThat(componentClass).isEqualTo(ArrayComponentValue.class);
         assertThat(resolvedArrayType.isArray()).isTrue();
         assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
@@ -37,7 +39,7 @@ public class TypeResolverDynamicAccessTest {
         TypeResolver resolver = new TypeResolver();
         ResolvedType declaringType = resolver.resolve(
                 TypeBindings.emptyBindings(),
-                StringArrayContainer.class.getGenericSuperclass());
+                ArrayComponentValueContainer.class.getGenericSuperclass());
         Type genericArrayType = GenericArrayContainer.class
                 .getDeclaredField("values")
                 .getGenericType();
@@ -45,8 +47,26 @@ public class TypeResolverDynamicAccessTest {
         ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
-        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(ArrayComponentValue[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(ArrayComponentValue.class);
+    }
+
+    @Test
+    void resolvesGenericArrayTypesWithParameterizedComponents() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type genericArrayType = ParameterizedComponentArrayContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(genericArrayType).isInstanceOf(GenericArrayType.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(List[].class);
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.elementType().typeParametersFor(List.class).get(0).erasedType())
+                .isEqualTo(Number.class);
     }
 
     static class GenericArrayContainer<T> {
@@ -61,14 +81,26 @@ public class TypeResolverDynamicAccessTest {
         }
     }
 
-    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    static final class ArrayComponentValueContainer extends GenericArrayContainer<ArrayComponentValue> {
     }
 
-    private static Object runtimeComponentValue() {
-        if (Thread.currentThread().getName().isEmpty()) {
-            return Integer.valueOf(7);
+    static final class ParameterizedComponentArrayContainer {
+        private List<? extends Number>[] values;
+
+        public List<? extends Number>[] getValues() {
+            return values;
+        }
+
+        public void setValues(List<? extends Number>[] values) {
+            this.values = values;
         }
-        return Thread.currentThread().getName();
+    }
+
+    private static Object runtimeComponentValue() {
+        return new ArrayComponentValue();
+    }
+
+    static final class ArrayComponentValue {
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
index 703886be9a..fcd489b00c 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
@@ -36,6 +37,13 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(direction).isEqualTo(Direction.SOUTH);
     }
 
+    @Test
+    void readsLibraryEnumValuesFromModifierProvidedDefinitions() throws Exception {
+        JSON.Feature feature = enumAwareJson().beanFrom(JSON.Feature.class, "\"field-access\"");
+
+        assertThat(feature).isEqualTo(JSON.Feature.USE_FIELDS);
+    }
+
     @Test
     void createsEnumReadersFromModifierProvidedDefinitions() {
         ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
@@ -45,6 +53,23 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader).isNotNull();
     }
 
+    @Test
+    void readsModifierNamedEnumValuesAsBeanProperties() throws Exception {
+        TravelPlan plan = enumAwareJson(JSON.Feature.USE_FIELDS)
+                .beanFrom(TravelPlan.class, "{\"direction\":\"go-north\"}");
+
+        assertThat(plan.direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsRecordPropertiesThroughBeanReader() throws Exception {
+        TripSummary summary = JSON.std.beanFrom(TripSummary.class,
+                "{\"destination\":\"Reykjavik\",\"travelers\":2}");
+
+        assertThat(summary.destination()).isEqualTo("Reykjavik");
+        assertThat(summary.travelers()).isEqualTo(2);
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -57,6 +82,13 @@ public class ValueReaderLocatorDynamicAccessTest {
         SOUTH
     }
 
+    public static class TravelPlan {
+        public Direction direction;
+    }
+
+    public record TripSummary(String destination, int travelers) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -67,26 +99,36 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != Direction.class) {
-                return null;
+            if (pojoType == Direction.class) {
+                return new POJODefinition(Direction.class, directionProps(), new BeanConstructors(Direction.class));
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            if (pojoType == JSON.Feature.class) {
+                return new POJODefinition(JSON.Feature.class, featureProps(), new BeanConstructors(JSON.Feature.class));
+            }
+            return null;
+        }
+
+        private static POJODefinition.Prop[] directionProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp(Direction.class, "go-north", "NORTH"),
+                    enumProp(Direction.class, "go-south", "SOUTH")
+            };
         }
 
-        private static POJODefinition.Prop[] enumProps() {
+        private static POJODefinition.Prop[] featureProps() {
             return new POJODefinition.Prop[] {
-                    enumProp("go-north", "NORTH"),
-                    enumProp("go-south", "SOUTH")
+                    enumProp(JSON.Feature.class, "field-access", "USE_FIELDS")
             };
         }
 
-        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        private static POJODefinition.Prop enumProp(Class<?> enumType, String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, externalName,
+                    enumField(enumType, enumConstantName), null, null, null, null);
         }
 
-        private static Field enumField(String enumConstantName) {
+        private static Field enumField(Class<?> enumType, String enumConstantName) {
             try {
-                return Direction.class.getField(enumConstantName);
+                return enumType.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }

```
