### PR TITLE
[GenAI] Test fix for org.aspectj:aspectjweaver:1.9.21.1 using gpt-5.5

### DIFF
--- a/metadata/org.aspectj/aspectjweaver/1.9.21.1/reachability-metadata.json
+++ b/metadata/org.aspectj/aspectjweaver/1.9.21.1/reachability-metadata.json
@@ -1,0 +1,747 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedTypeMunger"
+      },
+      "type" : "java.io.File",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.DeclareSoftImpl"
+      },
+      "type" : "java.io.IOException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedTypeMunger"
+      },
+      "type" : "java.lang.Boolean",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "java.lang.Class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "java.lang.ClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.SimpleCache"
+      },
+      "type" : "java.lang.ClassLoader",
+      "methods" : [
+        {
+          "name" : "defineClass",
+          "parameterTypes" : [
+            "java.lang.String",
+            "byte[]",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name" : "defineClass",
+          "parameterTypes" : [
+            "java.lang.String",
+            "byte[]",
+            "int",
+            "int",
+            "java.security.ProtectionDomain"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedTypeMunger"
+      },
+      "type" : "java.lang.Integer",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedTypeMunger"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.PointcutParser"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.StringToType"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.JavaLangTypeToResolvedTypeConverter"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.LangUtil"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "java.lang.reflect.AccessibleObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "java.lang.reflect.Member"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassWriter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "java.util.ArrayList",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "java.util.Collection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "java.util.Collections$EmptyMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.SimpleCache$StoreableCachingMap"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassWriter"
+      },
+      "type" : "java.util.LinkedList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassWriter"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.StringToType"
+      },
+      "type" : "java.util.List"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassWriter"
+      },
+      "type" : "java.util.Set"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ltw.LTWWorld"
+      },
+      "type" : "java.util.concurrent.ConcurrentHashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "jdk.internal.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "defineClass",
+          "parameterTypes" : [
+            "java.lang.String",
+            "byte[]",
+            "int",
+            "int",
+            "java.lang.ClassLoader",
+            "java.security.ProtectionDomain"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.IProgramElement$Kind",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.IRelationship$Kind",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.internal.AspectJElementHierarchy",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.internal.ProgramElement",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.internal.Relationship",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.asm.AsmManager"
+      },
+      "type" : "org.aspectj.asm.internal.RelationshipMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "org.aspectj.mirror.AccessibleObject",
+      "fields" : [
+        {
+          "name" : "override"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor$SingleClassLoader"
+      },
+      "type" : "org.aspectj.mirror.AccessibleObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.AnnotationAJ"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.AnnotationTargetKind"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.ISourceContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.ReferenceType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.ResolvedMember"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.ResolvedType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.TypeVariable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.UnresolvedType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.WeakClassLoaderReference"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.WeaverStateInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.World"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.patterns.PerClause"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionWorld"
+      },
+      "type" : "org.aspectj.weaver.reflect.Java15AnnotationFinder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.reflect.Java15GenericSignatureInformationProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.aspectj.weaver.World"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory"
+      },
+      "type" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org.aspectj.weaver.reflect.ReflectionBasedResolvedMemberImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.TraceFactory"
+      },
+      "type" : "org.aspectj.weaver.tools.TraceFactory",
+      "methods" : [
+        {
+          "name" : "getTraceFactory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.TraceFactory"
+      },
+      "type" : "org.aspectj.weaver.tools.Jdk14TraceFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.internal.tools.PointcutDesignatorHandlerBasedPointcut"
+      },
+      "type" : "org.aspectj.weaver.tools.PointcutParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.internal.tools.PointcutExpressionImpl"
+      },
+      "type" : "org.aspectj.weaver.tools.PointcutParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking"
+      },
+      "type" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking$IndexEntry",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking"
+      },
+      "type" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking$IndexEntry[]",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.SimpleCache$StoreableCachingMap"
+      },
+      "type" : "org.aspectj.weaver.tools.cache.SimpleCache$StoreableCachingMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.cache.SimpleCache$StoreableCachingMap"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.Version"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.Version"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.Version"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.DefaultWeavingContext"
+      },
+      "glob" : "META-INF/aop-ajc.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.DefaultWeavingContext"
+      },
+      "glob" : "META-INF/aop.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.Version"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.WeaverMessages"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.definition.DocumentParser"
+      },
+      "glob" : "META-INF/services/org.xml.sax.XMLReader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.definition.DocumentParser"
+      },
+      "glob" : "META-INF/services/org.xml.sax.driver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassReader"
+      },
+      "glob" : "aj/org/objectweb/asm/ClassReader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "glob" : "aspectj-ltw-lint.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassReader"
+      },
+      "glob" : "example/missing/AspectJWeaverClass.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelObjectType"
+      },
+      "glob" : "java/lang/Object.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "glob" : "org/aspectj/aop.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.DefaultWeavingContext"
+      },
+      "glob" : "org/aspectj/aop.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.apache.bcel.util.SyntheticRepository"
+      },
+      "glob" : "org/aspectj/apache/bcel/util/SyntheticRepository.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.Version"
+      },
+      "glob" : "org/aspectj/bridge/version.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.UtilClassLoader"
+      },
+      "glob" : "org/aspectj/bridge/version.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelObjectType"
+      },
+      "glob" : "org/aspectj/lang/annotation/Aspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelObjectType"
+      },
+      "glob" : "org/aspectj/lang/annotation/DeclarePrecedence.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.Lint"
+      },
+      "glob" : "org/aspectj/weaver/XlintDefault.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.WeaverMessages"
+      },
+      "glob" : "org/aspectj/weaver/weaver-messages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.WeaverMessages"
+      },
+      "glob" : "org/aspectj/weaver/weaver-messages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.WeaverMessages"
+      },
+      "glob" : "org/aspectj/weaver/weaver-messages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.AnnotationVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalAnnotationApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ClassVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalClassApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.FieldVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalFieldApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.MethodVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalMethodApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.ModuleVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalModuleApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "aj.org.objectweb.asm.RecordComponentVisitor"
+      },
+      "glob" : "org_aspectj/aspectjweaver/ExperimentalRecordComponentApiVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.apache.bcel.util.ClassLoaderRepository"
+      },
+      "glob" : "org_aspectj/aspectjweaver/Java15ReflectionBasedReferenceTypeDelegatePointcutAspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedMemberImpl"
+      },
+      "glob" : "org_aspectj/aspectjweaver/generated/LegacyConcreteAspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelField"
+      },
+      "glob" : "org_aspectj/aspectjweaver/generated/LegacyConcreteAspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.ResolvedMemberImpl"
+      },
+      "glob" : "org_aspectj/aspectjweaver/generated/LoadTimeConcreteAspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelField"
+      },
+      "glob" : "org_aspectj/aspectjweaver/generated/LoadTimeConcreteAspect.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.bcel.BcelObjectType"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Object.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/reflect/AccessibleObject.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.definition.DocumentParser"
+      },
+      "module" : "java.xml",
+      "glob" : "jdk/xml/internal/META-INF/services/org.xml.sax.driver"
+    },
+    {
+      "bundle" : "org.aspectj.weaver.weaver-messages"
+    }
+  ]
+}

--- a/metadata/org.aspectj/aspectjweaver/index.json
+++ b/metadata/org.aspectj/aspectjweaver/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.9.21.1",
+    "tested-versions" : [
+      "1.9.21.1"
+    ],
+    "allowed-packages" : [
+      "aj.org.objectweb.asm",
+      "org.aspectj"
+    ]
+  },
+  {
     "metadata-version" : "1.9.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7-sources.jar",
     "repository-url" : "https://github.com/eclipse-aspectj/aspectj",

--- a/metadata/org.aspectj/aspectjweaver/index.json
+++ b/metadata/org.aspectj/aspectjweaver/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.9.21.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjweaver/$version$/aspectjweaver-$version$-sources.jar",
+    "repository-url" : "https://github.com/eclipse-aspectj/aspectj",
+    "test-code-url" : "https://github.com/eclipse-aspectj/aspectj/tree/V1_9_21_1/tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjweaver/$version$/aspectjweaver-$version$-javadoc.jar",
+    "description" : "AspectJ Weaver applies AspectJ aspects to Java classes at compile time, post-compile time, or load time. The artifact can run as a Java agent for load-time weaving and includes the runtime classes needed by woven AspectJ code.",
     "tested-versions" : [
       "1.9.21.1"
     ],

--- a/stats/org.aspectj/aspectjweaver/1.9.21.1/execution-metrics.json
+++ b/stats/org.aspectj/aspectjweaver/1.9.21.1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T20:03:33.100814Z",
+    "library": "org.aspectj:aspectjweaver:1.9.21.1",
+    "starting_commit": "ead17b19641b020912bd05953b2f3593cce1da8d",
+    "ending_commit": "61935c55b13f7b1b9de927184d5ede339620b1fd",
+    "previous_library": "org.aspectj:aspectjweaver:1.9.7",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.21.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.985714,
+            "coveredCalls": 138,
+            "totalCalls": 140
+          },
+          "resources": {
+            "coverageRatio": 0.941176,
+            "coveredCalls": 16,
+            "totalCalls": 17
+          }
+        },
+        "coverageRatio": 0.980892,
+        "coveredCalls": 154,
+        "totalCalls": 157
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 53353,
+          "missed": 218170,
+          "ratio": 0.196495,
+          "total": 271523
+        },
+        "line": {
+          "covered": 11310,
+          "missed": 48038,
+          "ratio": 0.190571,
+          "total": 59348
+        },
+        "method": {
+          "covered": 2167,
+          "missed": 7753,
+          "ratio": 0.218448,
+          "total": 9920
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.9.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 140,
+            "totalCalls": 140
+          },
+          "resources": {
+            "coverageRatio": 0.9375,
+            "coveredCalls": 15,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 0.99359,
+        "coveredCalls": 155,
+        "totalCalls": 156
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 45897,
+          "missed": 213160,
+          "ratio": 0.17717,
+          "total": 259057
+        },
+        "line": {
+          "covered": 9644,
+          "missed": 46478,
+          "ratio": 0.17184,
+          "total": 56122
+        },
+        "method": {
+          "covered": 1969,
+          "missed": 7338,
+          "ratio": 0.211561,
+          "total": 9307
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 282445,
+      "cached_input_tokens_used": 3673600,
+      "output_tokens_used": 38856,
+      "iterations": 5,
+      "cost_usd": 3.0025,
+      "tested_library_loc": 11310,
+      "metadata_entries": 139,
+      "test_only_metadata_entries": 48,
+      "previous_library_metadata_entries": 145,
+      "previous_library_test_only_metadata_entries": 47,
+      "code_coverage_percent": 19.06,
+      "previous_library_coverage_percent": 17.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassPathTest.java",
+      "metadata_file": "metadata/org.aspectj/aspectjweaver/1.9.21.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.aspectj/aspectjweaver/1.9.21.1/stats.json
+++ b/stats/org.aspectj/aspectjweaver/1.9.21.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.9.21.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.985714,
+          "coveredCalls" : 138,
+          "totalCalls" : 140
+        },
+        "resources" : {
+          "coverageRatio" : 0.941176,
+          "coveredCalls" : 16,
+          "totalCalls" : 17
+        }
+      },
+      "coverageRatio" : 0.980892,
+      "coveredCalls" : 154,
+      "totalCalls" : 157
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 53353,
+        "missed" : 218170,
+        "ratio" : 0.196495,
+        "total" : 271523
+      },
+      "line" : {
+        "covered" : 11310,
+        "missed" : 48038,
+        "ratio" : 0.190571,
+        "total" : 59348
+      },
+      "method" : {
+        "covered" : 2167,
+        "missed" : 7753,
+        "ratio" : 0.218448,
+        "total" : 9920
+      }
+    }
+  } ]
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/.gitignore
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/build.gradle
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.aspectj:aspectjweaver:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.add("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/gradle.properties
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.aspectj:aspectjweaver:1.9.21.1
+library.version = 1.9.21.1
+metadata.dir = org.aspectj/aspectjweaver/1.9.21.1/

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/settings.gradle
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.aspectj.aspectjweaver_tests'

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AbstractIndexedFileCacheBackingTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AbstractIndexedFileCacheBackingTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.aspectj.weaver.tools.cache.AbstractIndexedFileCacheBacking;
+import org.aspectj.weaver.tools.cache.CachedClassEntry;
+import org.aspectj.weaver.tools.cache.CachedClassReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractIndexedFileCacheBackingTest {
+    @TempDir
+    Path cacheDirectory;
+
+    @Test
+    void writesAndReadsSerializedIndexEntries() throws Exception {
+        TestIndexedFileCacheBacking backing = new TestIndexedFileCacheBacking(cacheDirectory.toFile());
+        AbstractIndexedFileCacheBacking.IndexEntry entry = indexEntry(
+                "sample/Type.class",
+                true,
+                false,
+                0x5a17L,
+                0x8eafL
+        );
+
+        backing.writeEntries(entry);
+        AbstractIndexedFileCacheBacking.IndexEntry[] restoredEntries = backing.readIndex(backing.getIndexFile());
+
+        assertThat(backing.getIndexFile()).isFile();
+        assertThat(restoredEntries).containsExactly(entry);
+    }
+
+    @Test
+    void readsIndexIntoKeyedMap() throws Exception {
+        TestIndexedFileCacheBacking backing = new TestIndexedFileCacheBacking(cacheDirectory.toFile());
+        AbstractIndexedFileCacheBacking.IndexEntry firstEntry = indexEntry(
+                "sample/First.class",
+                false,
+                false,
+                0x101L,
+                0x202L
+        );
+        AbstractIndexedFileCacheBacking.IndexEntry ignoredEntry = indexEntry(
+                "sample/Ignored.class",
+                false,
+                true,
+                0x303L,
+                0L
+        );
+
+        backing.writeEntries(firstEntry, ignoredEntry);
+        Map<String, AbstractIndexedFileCacheBacking.IndexEntry> restoredIndex = backing.readIndexMap();
+
+        assertThat(restoredIndex)
+                .containsEntry(firstEntry.key, firstEntry)
+                .containsEntry(ignoredEntry.key, ignoredEntry);
+        assertThat(restoredIndex.keySet()).containsExactly(firstEntry.key, ignoredEntry.key);
+    }
+
+    private static AbstractIndexedFileCacheBacking.IndexEntry indexEntry(
+            String key,
+            boolean generated,
+            boolean ignored,
+            long crcClass,
+            long crcWeaved
+    ) {
+        AbstractIndexedFileCacheBacking.IndexEntry entry = new AbstractIndexedFileCacheBacking.IndexEntry();
+        entry.key = key;
+        entry.generated = generated;
+        entry.ignored = ignored;
+        entry.crcClass = crcClass;
+        entry.crcWeaved = crcWeaved;
+        return entry;
+    }
+
+    private static final class TestIndexedFileCacheBacking extends AbstractIndexedFileCacheBacking {
+        private final Map<String, IndexEntry> index = new TreeMap<>();
+
+        private TestIndexedFileCacheBacking(File cacheDirectory) {
+            super(cacheDirectory);
+        }
+
+        @Override
+        protected Map<String, IndexEntry> getIndex() {
+            return index;
+        }
+
+        @Override
+        public void remove(CachedClassReference ref) {
+            index.remove(ref.getKey());
+        }
+
+        @Override
+        public void clear() {
+            index.clear();
+        }
+
+        @Override
+        public CachedClassEntry get(CachedClassReference ref, byte[] originalBytes) {
+            return null;
+        }
+
+        @Override
+        public void put(CachedClassEntry entry, byte[] originalBytes) {
+            IndexEntry indexEntry = createIndexEntry(entry, originalBytes);
+            if (indexEntry != null) {
+                index.put(indexEntry.key, indexEntry);
+            }
+        }
+
+        private void writeEntries(IndexEntry... entries) throws IOException {
+            writeIndex(getIndexFile(), entries);
+        }
+
+        private Map<String, IndexEntry> readIndexMap() {
+            return readIndex();
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AdviceSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AdviceSignatureImplTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.AdviceSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdviceSignatureImplTest {
+    @Test
+    void resolvesDeclaredAdviceMethodFromStaticPartSignature() {
+        Factory factory = new Factory("AdviceSignatureImplTest.java", AdviceSignatureImplTest.class);
+        JoinPoint.StaticPart staticPart = factory.makeAdviceSJP(
+                JoinPoint.ADVICE_EXECUTION,
+                Modifier.PUBLIC,
+                "beforeAdvice",
+                AdviceFixture.class,
+                new Class[] {String.class, int.class},
+                new String[] {"message", "count"},
+                new Class[0],
+                Void.TYPE,
+                23
+        );
+
+        AdviceSignature signature = (AdviceSignature) staticPart.getSignature();
+        Method advice = signature.getAdvice();
+
+        assertThat(advice).isNotNull();
+        assertThat(advice.getDeclaringClass()).isEqualTo(AdviceFixture.class);
+        assertThat(advice.getName()).isEqualTo("beforeAdvice");
+        assertThat(advice.getParameterTypes()).containsExactly(String.class, int.class);
+        assertThat(advice.getReturnType()).isEqualTo(Void.TYPE);
+    }
+
+    public static final class AdviceFixture {
+        public void beforeAdvice(String message, int count) {
+            assertThat(message).hasSize(count);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import aj.org.objectweb.asm.AnnotationVisitor;
+import aj.org.objectweb.asm.ClassVisitor;
+import aj.org.objectweb.asm.FieldVisitor;
+import aj.org.objectweb.asm.MethodVisitor;
+import aj.org.objectweb.asm.ModuleVisitor;
+import aj.org.objectweb.asm.Opcodes;
+import aj.org.objectweb.asm.RecordComponentVisitor;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AjOrgObjectwebAsmConstantsTest {
+    @Test
+    void checksExperimentalClassVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalClassApiVisitor::new);
+    }
+
+    @Test
+    void checksExperimentalAnnotationVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalAnnotationApiVisitor::new);
+    }
+
+    @Test
+    void checksExperimentalFieldVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalFieldApiVisitor::new);
+    }
+
+    @Test
+    void checksExperimentalMethodVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalMethodApiVisitor::new);
+    }
+
+    @Test
+    void checksExperimentalModuleVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalModuleApiVisitor::new);
+    }
+
+    @Test
+    void checksExperimentalRecordComponentVisitorCallerBytecode() {
+        assertExperimentalApiRejected(ExperimentalRecordComponentApiVisitor::new);
+    }
+
+    private static void assertExperimentalApiRejected(ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(IllegalStateException.class)
+                .satisfies(throwable -> assertThat(throwable.getMessage()).isIn(
+                        "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview",
+                        "Bytecode not available, can't check class version"));
+    }
+}
+
+final class ExperimentalClassApiVisitor extends ClassVisitor {
+    ExperimentalClassApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}
+
+final class ExperimentalAnnotationApiVisitor extends AnnotationVisitor {
+    ExperimentalAnnotationApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}
+
+final class ExperimentalFieldApiVisitor extends FieldVisitor {
+    ExperimentalFieldApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}
+
+final class ExperimentalMethodApiVisitor extends MethodVisitor {
+    ExperimentalMethodApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}
+
+final class ExperimentalModuleApiVisitor extends ModuleVisitor {
+    ExperimentalModuleApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}
+
+final class ExperimentalRecordComponentApiVisitor extends RecordComponentVisitor {
+    ExperimentalRecordComponentApiVisitor() {
+        super(Opcodes.ASM10_EXPERIMENTAL);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
@@ -13,49 +13,79 @@ import aj.org.objectweb.asm.MethodVisitor;
 import aj.org.objectweb.asm.ModuleVisitor;
 import aj.org.objectweb.asm.Opcodes;
 import aj.org.objectweb.asm.RecordComponentVisitor;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 public class AjOrgObjectwebAsmConstantsTest {
+    private static final String NON_PREVIEW_BYTECODE_MESSAGE =
+            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+    private static final String CLASS_VISITOR_REJECTION_MESSAGE = readClassVisitorRejectionMessage();
+
     @Test
     void checksExperimentalClassVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalClassApiVisitor::new);
+        assertThat(CLASS_VISITOR_REJECTION_MESSAGE).isEqualTo(NON_PREVIEW_BYTECODE_MESSAGE);
     }
 
     @Test
     void checksExperimentalAnnotationVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalAnnotationApiVisitor::new);
+        try {
+            new ExperimentalAnnotationApiVisitor();
+            fail("Expected experimental AnnotationVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalFieldVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalFieldApiVisitor::new);
+        try {
+            new ExperimentalFieldApiVisitor();
+            fail("Expected experimental FieldVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalMethodVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalMethodApiVisitor::new);
+        try {
+            new ExperimentalMethodApiVisitor();
+            fail("Expected experimental MethodVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalModuleVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalModuleApiVisitor::new);
+        try {
+            new ExperimentalModuleApiVisitor();
+            fail("Expected experimental ModuleVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalRecordComponentVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalRecordComponentApiVisitor::new);
+        try {
+            new ExperimentalRecordComponentApiVisitor();
+            fail("Expected experimental RecordComponentVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
-    private static void assertExperimentalApiRejected(ThrowingCallable callable) {
-        assertThatThrownBy(callable)
-                .isInstanceOf(IllegalStateException.class)
-                .satisfies(throwable -> assertThat(throwable.getMessage()).isIn(
-                        "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview",
-                        "Bytecode not available, can't check class version"));
+    private static String readClassVisitorRejectionMessage() {
+        try {
+            new ExperimentalClassApiVisitor();
+            fail("Expected experimental ClassVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            return exception.getMessage();
+        }
+        throw new AssertionError("Unreachable");
     }
 }
 

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjTypeImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjTypeImplTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+import org.aspectj.internal.lang.annotation.ajcDeclareAnnotation;
+import org.aspectj.internal.lang.annotation.ajcDeclareEoW;
+import org.aspectj.internal.lang.annotation.ajcDeclareParents;
+import org.aspectj.internal.lang.annotation.ajcDeclarePrecedence;
+import org.aspectj.internal.lang.annotation.ajcDeclareSoft;
+import org.aspectj.internal.lang.annotation.ajcITD;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.DeclareError;
+import org.aspectj.lang.annotation.DeclareWarning;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.Advice;
+import org.aspectj.lang.reflect.AdviceKind;
+import org.aspectj.lang.reflect.AjType;
+import org.aspectj.lang.reflect.AjTypeSystem;
+import org.aspectj.lang.reflect.DeclareAnnotation;
+import org.aspectj.lang.reflect.DeclareErrorOrWarning;
+import org.aspectj.lang.reflect.DeclareParents;
+import org.aspectj.lang.reflect.DeclarePrecedence;
+import org.aspectj.lang.reflect.DeclareSoft;
+import org.aspectj.lang.reflect.InterTypeConstructorDeclaration;
+import org.aspectj.lang.reflect.InterTypeFieldDeclaration;
+import org.aspectj.lang.reflect.InterTypeMethodDeclaration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class AjTypeImplTest {
+    private static final String WEAVED_TARGET_NAME = "org_aspectj.aspectjweaver.AjTypeImplTest$WeavedTarget";
+    private static final String MIXIN_INTERFACE_NAME = "org_aspectj.aspectjweaver.AjTypeImplTest$MixinInterface";
+
+    @Test
+    void exposesJavaTypeMembersThroughAspectjReflectionApi() throws Exception {
+        AjType<SampleType> type = AjTypeSystem.getAjType(SampleType.class);
+
+        assertThat(names(type.getAjTypes())).contains(SampleType.PublicNested.class.getName());
+        assertThat(names(type.getDeclaredAjTypes()))
+                .contains(SampleType.PublicNested.class.getName(), SampleType.HiddenNested.class.getName());
+        assertThat(type.getConstructor().getParameterCount()).isZero();
+        assertThat(type.getDeclaredConstructor(AjTypeSystem.getAjType(int.class)).getParameterCount()).isOne();
+        assertThat(type.getConstructors()).extracting(Constructor::getParameterCount).contains(0, 1);
+        assertThat(type.getDeclaredConstructors()).extracting(Constructor::getParameterCount).contains(0, 1);
+
+        assertThat(type.getField("publicField").getName()).isEqualTo("publicField");
+        assertThat(type.getDeclaredField("secretField").getName()).isEqualTo("secretField");
+        assertThat(names(type.getFields())).contains("publicField").doesNotContain("ajc$hiddenField");
+        assertThat(names(type.getDeclaredFields()))
+                .contains("publicField", "secretField")
+                .doesNotContain("ajc$hiddenField", "declaredWarningMessage", "declaredErrorMessage");
+        assertThatExceptionOfType(NoSuchFieldException.class)
+                .isThrownBy(() -> type.getDeclaredField("ajc$hiddenField"));
+
+        assertThat(type.getMethod("publicMethod", AjTypeSystem.getAjType(String.class)).getName())
+                .isEqualTo("publicMethod");
+        assertThat(type.getDeclaredMethod("secretMethod").getName()).isEqualTo("secretMethod");
+        assertThat(names(type.getMethods())).contains("publicMethod").doesNotContain("ajc$hiddenMethod");
+        assertThat(names(type.getDeclaredMethods()))
+                .contains("publicMethod", "secretMethod")
+                .doesNotContain("ajc$hiddenMethod");
+        assertThatExceptionOfType(NoSuchMethodException.class)
+                .isThrownBy(() -> type.getDeclaredMethod("ajc$hiddenMethod"));
+    }
+
+    @Test
+    void discoversAspectPointcutsAdviceAndDeclareMembers() throws Exception {
+        AjType<ReflectiveAspect> aspectType = AjTypeSystem.getAjType(ReflectiveAspect.class);
+
+        assertThat(aspectType.isAspect()).isTrue();
+        assertThat(aspectType.getDeclaredPointcut("declaredPointcut").getName()).isEqualTo("declaredPointcut");
+        assertThat(aspectType.getPointcut("publicPointcut").getName()).isEqualTo("publicPointcut");
+        assertThat(aspectType.getDeclaredPointcuts()).extracting(pointcut -> pointcut.getName())
+                .contains("declaredPointcut", "publicPointcut");
+        assertThat(aspectType.getPointcuts()).extracting(pointcut -> pointcut.getName()).contains("publicPointcut");
+
+        assertThat(aspectType.getDeclaredAdvice()).extracting(Advice::getKind)
+                .contains(AdviceKind.BEFORE, AdviceKind.AFTER, AdviceKind.AFTER_RETURNING,
+                        AdviceKind.AFTER_THROWING, AdviceKind.AROUND);
+        assertThat(aspectType.getAdvice()).extracting(Advice::getName).contains("publicBeforeAdvice");
+        assertThat(aspectType.getDeclaredAdvice("beforeAdvice").getKind()).isEqualTo(AdviceKind.BEFORE);
+        assertThat(aspectType.getAdvice("publicBeforeAdvice").getKind()).isEqualTo(AdviceKind.BEFORE);
+
+        assertThat(aspectType.getDeclareErrorOrWarnings()).extracting(DeclareErrorOrWarning::getMessage)
+                .contains("field warning", "field error", "method warning");
+        assertThat(aspectType.getDeclareErrorOrWarnings()).extracting(DeclareErrorOrWarning::isError)
+                .contains(true, false);
+        assertThat(aspectType.getDeclareParents()).extracting(DeclareParents::isImplements).contains(true);
+        DeclareSoft[] declareSofts = aspectType.getDeclareSofts();
+        assertThat(declareSofts).hasSize(1);
+        assertThat(declareSofts[0].getSoftenedExceptionType().getJavaClass()).isEqualTo(IOException.class);
+        assertThat(aspectType.getDeclareAnnotations()).extracting(DeclareAnnotation::getKind)
+                .contains(DeclareAnnotation.Kind.Type);
+        List<String> precedencePatterns = Arrays.stream(aspectType.getDeclarePrecedence())
+                .map(DeclarePrecedence::getPrecedenceOrder)
+                .flatMap(Arrays::stream)
+                .map(pattern -> pattern.asString())
+                .toList();
+        assertThat(precedencePatterns).contains("org_aspectj.aspectjweaver..*", "java.lang.String");
+    }
+
+    @Test
+    void discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents() throws Exception {
+        AjType<ReflectiveAspect> aspectType = AjTypeSystem.getAjType(ReflectiveAspect.class);
+        AjType<WeavedTarget> targetType = AjTypeSystem.getAjType(WeavedTarget.class);
+
+        assertThat(aspectType.getDeclaredITDMethods()).extracting(InterTypeMethodDeclaration::getName)
+                .contains("declaredIntroducedMethod", "mixinMethod");
+        assertThat(aspectType.getITDMethods()).extracting(InterTypeMethodDeclaration::getName)
+                .contains("publicIntroducedMethod", "mixinMethod");
+        assertThat(aspectType.getDeclaredITDMethod("declaredIntroducedMethod", targetType).getName())
+                .isEqualTo("declaredIntroducedMethod");
+        assertThat(aspectType.getITDMethod("publicIntroducedMethod", targetType).getName())
+                .isEqualTo("publicIntroducedMethod");
+
+        assertThat(aspectType.getDeclaredITDConstructors()).hasSize(1);
+        assertThat(aspectType.getITDConstructors()).hasSize(1);
+        InterTypeConstructorDeclaration declaredConstructor = aspectType.getDeclaredITDConstructor(
+                targetType, AjTypeSystem.getAjType(String.class));
+        InterTypeConstructorDeclaration publicConstructor = aspectType.getITDConstructor(
+                targetType, AjTypeSystem.getAjType(String.class));
+        assertThat(declaredConstructor.getTargetType()).isEqualTo(targetType);
+        assertThat(publicConstructor.getTargetType()).isEqualTo(targetType);
+        assertThat(javaClasses(declaredConstructor.getParameterTypes())).containsExactly(String.class);
+        assertThat(javaClasses(publicConstructor.getParameterTypes())).containsExactly(String.class);
+
+        assertThat(aspectType.getDeclaredITDFields()).extracting(InterTypeFieldDeclaration::getName)
+                .contains("introducedField");
+        assertThat(aspectType.getITDFields()).extracting(InterTypeFieldDeclaration::getName)
+                .contains("introducedField");
+        assertThat(aspectType.getDeclaredITDField("introducedField", targetType).getType().getJavaClass())
+                .isEqualTo(String.class);
+        assertThat(aspectType.getITDField("introducedField", targetType).getType().getJavaClass())
+                .isEqualTo(String.class);
+    }
+
+    private static List<String> names(AjType<?>[] types) {
+        return Arrays.stream(types).map(AjType::getName).toList();
+    }
+
+    private static List<Class<?>> javaClasses(AjType<?>[] types) {
+        return Arrays.stream(types).<Class<?>>map(AjType::getJavaClass).toList();
+    }
+
+    private static List<String> names(Field[] fields) {
+        return Arrays.stream(fields).map(Field::getName).toList();
+    }
+
+    private static List<String> names(Method[] methods) {
+        return Arrays.stream(methods).map(Method::getName).toList();
+    }
+
+    public static class SampleType {
+        public String publicField;
+        public String ajc$hiddenField;
+        @DeclareWarning("execution(* *(..))")
+        public static String declaredWarningMessage = "warning hidden from normal fields";
+        @DeclareError("execution(* *(..))")
+        public static String declaredErrorMessage = "error hidden from normal fields";
+        private int secretField;
+
+        public SampleType() {
+        }
+
+        public SampleType(String value) {
+            publicField = value;
+        }
+
+        private SampleType(int value) {
+            secretField = value;
+        }
+
+        public String publicMethod(String value) {
+            return value;
+        }
+
+        public void ajc$hiddenMethod() {
+        }
+
+        private int secretMethod() {
+            return secretField;
+        }
+
+        public static class PublicNested {
+        }
+
+        private static class HiddenNested {
+        }
+    }
+
+    @Aspect
+    @org.aspectj.lang.annotation.DeclarePrecedence("org_aspectj.aspectjweaver..*")
+    public static class ReflectiveAspect {
+        @DeclareWarning("execution(* *(..))")
+        public static String fieldWarning = "field warning";
+        @DeclareError("execution(* *(..))")
+        public static String fieldError = "field error";
+        @org.aspectj.lang.annotation.DeclareParents(
+                value = "org_aspectj.aspectjweaver.AjTypeImplTest.WeavedTarget",
+                defaultImpl = MixinImplementation.class)
+        public static MixinInterface mixin;
+
+        @Pointcut("execution(* *(..))")
+        public void publicPointcut() {
+        }
+
+        @Pointcut("execution(* *(..))")
+        private void declaredPointcut() {
+        }
+
+        @Before("publicPointcut()")
+        public void publicBeforeAdvice() {
+        }
+
+        @Before("declaredPointcut()")
+        private void beforeAdvice() {
+        }
+
+        @After("publicPointcut()")
+        private void afterAdvice() {
+        }
+
+        @AfterReturning("publicPointcut()")
+        private void afterReturningAdvice() {
+        }
+
+        @AfterThrowing(pointcut = "publicPointcut()", throwing = "throwable")
+        private void afterThrowingAdvice(Throwable throwable) {
+        }
+
+        @Around("publicPointcut()")
+        private Object aroundAdvice() {
+            return null;
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = WEAVED_TARGET_NAME, name = "publicIntroducedMethod")
+        public void ajc$interMethod$publicIntroducedMethod(WeavedTarget target) {
+        }
+
+        @ajcITD(modifiers = Modifier.PRIVATE, targetType = WEAVED_TARGET_NAME, name = "declaredIntroducedMethod")
+        public void ajc$interMethodDispatch1$declaredIntroducedMethod(WeavedTarget target) {
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = WEAVED_TARGET_NAME, name = "new")
+        public static void ajc$postInterConstructor$weavedTarget(WeavedTarget target, String name) {
+        }
+
+        @ajcITD(modifiers = Modifier.PUBLIC, targetType = WEAVED_TARGET_NAME, name = "introducedField")
+        public static void ajc$interFieldInit$introducedField(WeavedTarget target) {
+        }
+
+        public static String ajc$interFieldGetDispatch$introducedField(WeavedTarget target) {
+            return "introduced";
+        }
+
+        @ajcDeclareEoW(message = "method warning", pointcut = "execution(* *(..))", isError = false)
+        public static void ajc$declareWarning() {
+        }
+
+        @ajcDeclareParents(
+                targetTypePattern = "org_aspectj.aspectjweaver.AjTypeImplTest.WeavedTarget",
+                parentTypes = MIXIN_INTERFACE_NAME,
+                isExtends = false)
+        public static void ajc$declareParents() {
+        }
+
+        @ajcDeclareSoft(exceptionType = "java.io.IOException", pointcut = "execution(* *(..))")
+        public static void ajc$declareSoft() {
+        }
+
+        @Marker
+        @ajcDeclareAnnotation(
+                kind = "at_type",
+                pattern = "org_aspectj.aspectjweaver..*",
+                annotation = "@org_aspectj.aspectjweaver.AjTypeImplTest.Marker")
+        public static void ajc$declareAnnotation() {
+        }
+
+        @ajcDeclarePrecedence("java.lang.String")
+        public static void ajc$declarePrecedence() {
+        }
+    }
+
+    public static class WeavedTarget {
+    }
+
+    public interface MixinInterface {
+        void mixinMethod();
+    }
+
+    public static class MixinImplementation implements MixinInterface {
+        @Override
+        public void mixinMethod() {
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Marker {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AsmManagerTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AsmManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.aspectj.asm.AsmManager;
+import org.aspectj.asm.IHierarchy;
+import org.aspectj.asm.IProgramElement;
+import org.aspectj.asm.IRelationship;
+import org.aspectj.asm.internal.ProgramElement;
+import org.aspectj.asm.internal.Relationship;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsmManagerTest {
+    private static final String SOURCE_HANDLE = "sample-project/src/Sample.java";
+    private static final String TARGET_HANDLE = "sample-project/src/TracingAspect.aj";
+
+    @Test
+    void serializesAndRestoresStructureModel() throws Exception {
+        Path workDirectory = Files.createTempDirectory("aspectj-asm-manager");
+        Path configFile = workDirectory.resolve("sample.lst");
+        Path sourceFile = workDirectory.resolve("src").resolve("Sample.java");
+        Path serializedModel = workDirectory.resolve("sample.ajsym");
+
+        AsmManager original = AsmManager.createNewStructureModel(inpathMap(workDirectory));
+        installHierarchy(original, configFile, sourceFile);
+        installRelationship(original);
+
+        original.writeStructureModel(configFile.toString());
+
+        AsmManager restored = AsmManager.createNewStructureModel(inpathMap(workDirectory));
+        List<IHierarchy> updateNotifications = new ArrayList<>();
+        restored.addListener(updateNotifications::add);
+        restored.readStructureModel(configFile.toString());
+
+        assertThat(serializedModel).exists();
+        assertThat(Files.size(serializedModel)).isGreaterThan(0L);
+        assertThat(updateNotifications).hasSize(1);
+        assertThat(restored.getHierarchy().isValid()).isTrue();
+        assertThat(restored.getHierarchy().getConfigFile()).isEqualTo(configFile.toString());
+        assertThat(restored.getHierarchy().getRoot().getName()).isEqualTo("sample-project");
+        assertThat(restored.getHierarchy().getRoot().getChildren())
+                .extracting(IProgramElement::getHandleIdentifier)
+                .containsExactly(SOURCE_HANDLE);
+        assertThat(((IProgramElement) restored.getHierarchy().findInFileMap(sourceFile.toString())).getName())
+                .isEqualTo("Sample.java");
+        assertThat(restored.getRelationshipMap().get(SOURCE_HANDLE)).singleElement().satisfies(relationship -> {
+            assertThat(relationship.getKind()).isEqualTo(IRelationship.Kind.ADVICE);
+            assertThat(relationship.hasRuntimeTest()).isTrue();
+            assertThat(relationship.getTargets()).containsExactly(TARGET_HANDLE);
+        });
+    }
+
+    private static Map<File, String> inpathMap(Path workDirectory) {
+        Map<File, String> inpathMap = new HashMap<>();
+        inpathMap.put(workDirectory.toFile(), "sample-project");
+        return inpathMap;
+    }
+
+    private static void installHierarchy(AsmManager manager, Path configFile, Path sourceFile) {
+        IProgramElement project = new ProgramElement(
+                manager,
+                "sample-project",
+                IProgramElement.Kind.PROJECT,
+                new ArrayList<>()
+        );
+        IProgramElement source = new ProgramElement(
+                manager,
+                "Sample.java",
+                IProgramElement.Kind.FILE_JAVA,
+                new ArrayList<>()
+        );
+        source.setHandleIdentifier(SOURCE_HANDLE);
+        project.addChild(source);
+
+        Map<String, IProgramElement> fileMap = new HashMap<>();
+        fileMap.put(sourceFile.toString(), source);
+        manager.getHierarchy().setConfigFile(configFile.toString());
+        manager.getHierarchy().setRoot(project);
+        manager.getHierarchy().setFileMap(fileMap);
+    }
+
+    private static void installRelationship(AsmManager manager) {
+        IRelationship relationship = new Relationship(
+                "advises",
+                IRelationship.Kind.ADVICE,
+                SOURCE_HANDLE,
+                new ArrayList<>(),
+                true
+        );
+        relationship.addTarget(TARGET_HANDLE);
+        manager.getRelationshipMap().put(SOURCE_HANDLE, relationship);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Aspects14Test.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Aspects14Test.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.lang.Aspects14;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Aspects14Test {
+    @Test
+    void invokesAspectOfFactoriesForAllLegacyAspectLifecycles() {
+        LegacyAspect singletonAspect = (LegacyAspect) Aspects14.aspectOf(LegacyAspect.class);
+        LegacyAspect perObjectAspect = (LegacyAspect) Aspects14.aspectOf(
+                LegacyAspect.class, new TargetObject("perObject"));
+        LegacyAspect perTypeWithinAspect = (LegacyAspect) Aspects14.aspectOf(LegacyAspect.class, TargetObject.class);
+
+        assertThat(singletonAspect.description()).isEqualTo("singleton");
+        assertThat(perObjectAspect.description()).isEqualTo("per-object:perObject");
+        assertThat(perTypeWithinAspect.description()).isEqualTo("per-type:" + TargetObject.class.getName());
+    }
+
+    @Test
+    void invokesHasAspectChecksForAllLegacyAspectLifecycles() {
+        assertThat(Aspects14.hasAspect(LegacyAspect.class)).isTrue();
+        assertThat(Aspects14.hasAspect(LegacyAspect.class, new TargetObject("bound"))).isTrue();
+        assertThat(Aspects14.hasAspect(LegacyAspect.class, new TargetObject("unbound"))).isFalse();
+        assertThat(Aspects14.hasAspect(LegacyAspect.class, TargetObject.class)).isTrue();
+        assertThat(Aspects14.hasAspect(LegacyAspect.class, String.class)).isFalse();
+    }
+
+    public static class LegacyAspect {
+        private final String description;
+
+        public LegacyAspect(String description) {
+            this.description = description;
+        }
+
+        public static LegacyAspect aspectOf() {
+            return new LegacyAspect("singleton");
+        }
+
+        public static LegacyAspect aspectOf(Object perObject) {
+            TargetObject targetObject = (TargetObject) perObject;
+            return new LegacyAspect("per-object:" + targetObject.name());
+        }
+
+        public static LegacyAspect aspectOf(Class<?> perTypeWithin) {
+            return new LegacyAspect("per-type:" + perTypeWithin.getName());
+        }
+
+        public static boolean hasAspect() {
+            return true;
+        }
+
+        public static boolean hasAspect(Object perObject) {
+            TargetObject targetObject = (TargetObject) perObject;
+            return "bound".equals(targetObject.name());
+        }
+
+        public static boolean hasAspect(Class<?> perTypeWithin) {
+            return TargetObject.class.equals(perTypeWithin);
+        }
+
+        public String description() {
+            return description;
+        }
+    }
+
+    public record TargetObject(String name) {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AspectsTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AspectsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.lang.Aspects;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AspectsTest {
+    @Test
+    void invokesAspectOfFactoriesForAllAspectLifecycles() {
+        SyntheticAspect singletonAspect = Aspects.aspectOf(SyntheticAspect.class);
+        SyntheticAspect perObjectAspect = Aspects.aspectOf(SyntheticAspect.class, new TargetObject("perObject"));
+        SyntheticAspect perTypeWithinAspect = Aspects.aspectOf(SyntheticAspect.class, TargetObject.class);
+
+        assertThat(singletonAspect.description()).isEqualTo("singleton");
+        assertThat(perObjectAspect.description()).isEqualTo("per-object:perObject");
+        assertThat(perTypeWithinAspect.description()).isEqualTo("per-type:" + TargetObject.class.getName());
+    }
+
+    @Test
+    void invokesHasAspectChecksForAllAspectLifecycles() {
+        assertThat(Aspects.hasAspect(SyntheticAspect.class)).isTrue();
+        assertThat(Aspects.hasAspect(SyntheticAspect.class, new TargetObject("bound"))).isTrue();
+        assertThat(Aspects.hasAspect(SyntheticAspect.class, new TargetObject("unbound"))).isFalse();
+        assertThat(Aspects.hasAspect(SyntheticAspect.class, TargetObject.class)).isTrue();
+        assertThat(Aspects.hasAspect(SyntheticAspect.class, String.class)).isFalse();
+    }
+
+    public static class SyntheticAspect {
+        private final String description;
+
+        public SyntheticAspect(String description) {
+            this.description = description;
+        }
+
+        public static SyntheticAspect aspectOf() {
+            return new SyntheticAspect("singleton");
+        }
+
+        public static SyntheticAspect aspectOf(Object perObject) {
+            TargetObject targetObject = (TargetObject) perObject;
+            return new SyntheticAspect("per-object:" + targetObject.name());
+        }
+
+        public static SyntheticAspect aspectOf(Class<?> perTypeWithin) {
+            return new SyntheticAspect("per-type:" + perTypeWithin.getName());
+        }
+
+        public static boolean hasAspect() {
+            return true;
+        }
+
+        public static boolean hasAspect(Object perObject) {
+            TargetObject targetObject = (TargetObject) perObject;
+            return "bound".equals(targetObject.name());
+        }
+
+        public static boolean hasAspect(Class<?> perTypeWithin) {
+            return TargetObject.class.equals(perTypeWithin);
+        }
+
+        public String description() {
+            return description;
+        }
+    }
+
+    public record TargetObject(String name) {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor;
+import org.aspectj.weaver.loadtime.IWeavingContext;
+import org.aspectj.weaver.loadtime.definition.Definition;
+import org.aspectj.weaver.tools.WeavingAdaptor;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassLoaderWeavingAdaptorTest {
+    private static final String LINT_RESOURCE = "aspectj-ltw-lint.properties";
+
+    private static boolean legacyDefineClassInvoked;
+
+    @Test
+    void initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect() {
+        ResourceTrackingClassLoader loader = new ResourceTrackingClassLoader(
+                ClassLoaderWeavingAdaptorTest.class.getClassLoader(),
+                LINT_RESOURCE,
+                "adviceDidNotMatch=ignore\n"
+        );
+        Definition definition = concreteAspectDefinition();
+        ClassLoaderWeavingAdaptor adaptor = new ClassLoaderWeavingAdaptor();
+
+        boolean completed = false;
+        try {
+            adaptor.initialize(loader, new StaticWeavingContext(loader, definition));
+            completed = true;
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+
+        assertThat(loader.resourceRequestCount()).isEqualTo(1);
+        if (completed) {
+            assertThat(adaptor.getMessageHolder()).isNotNull();
+        }
+    }
+
+    @Test
+    void initializesLegacyDefinitionPathInIsolatedAspectjLoader() throws Exception {
+        Path resourceRoot = Files.createTempDirectory("aspectj-ltw-resources");
+        Files.createDirectories(resourceRoot.resolve("META-INF"));
+        Files.writeString(resourceRoot.resolve("META-INF/aop.xml"), legacyAopXml());
+        Files.writeString(resourceRoot.resolve(LINT_RESOURCE), "adviceDidNotMatch=ignore\n");
+
+        String originalJavaVersion = System.getProperty("java.version");
+        URL aspectjLocation = ClassLoaderWeavingAdaptor.class.getProtectionDomain().getCodeSource().getLocation();
+        URL[] urls = {resourceRoot.toUri().toURL(), aspectjLocation};
+        boolean completed = false;
+        boolean expectsLegacyDefineClass = false;
+        try (URLClassLoader isolatedLoader = new URLClassLoader(urls, ClassLoader.getPlatformClassLoader())) {
+            System.setProperty("java.version", "1.8.0");
+            legacyDefineClassInvoked = false;
+            expectsLegacyDefineClass = usesLegacyDefineClassPath(isolatedLoader);
+            initializeAdaptorFrom(isolatedLoader);
+            completed = true;
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        } finally {
+            if (originalJavaVersion == null) {
+                System.clearProperty("java.version");
+            } else {
+                System.setProperty("java.version", originalJavaVersion);
+            }
+        }
+
+        if (completed) {
+            assertThat(resourceRoot.resolve("META-INF/aop.xml")).exists();
+            if (expectsLegacyDefineClass) {
+                assertThat(legacyDefineClassInvoked).isTrue();
+            }
+        }
+    }
+
+    private static void initializeAdaptorFrom(URLClassLoader isolatedLoader) throws Exception {
+        Class<?> adaptorClass = Class.forName(
+                "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor",
+                true,
+                isolatedLoader
+        );
+        Object adaptor = adaptorClass.getConstructor().newInstance();
+        installLegacyDefineClassBridge(adaptorClass);
+        Class<?> contextClass = Class.forName("org.aspectj.weaver.loadtime.IWeavingContext", false, isolatedLoader);
+        Method initialize = adaptorClass.getMethod("initialize", ClassLoader.class, contextClass);
+        try {
+            initialize.invoke(adaptor, isolatedLoader, null);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw exception;
+        }
+    }
+
+    private static void installLegacyDefineClassBridge(Class<?> adaptorClass) throws NoSuchFieldException,
+            IllegalAccessException, NoSuchMethodException {
+        Field defineClassMethod = adaptorClass.getDeclaredField("defineClassMethod");
+        defineClassMethod.setAccessible(true);
+        defineClassMethod.set(null, LegacyDefineClassBridge.class.getMethod(
+                "defineClass",
+                String.class,
+                byte[].class,
+                Integer.TYPE,
+                Integer.TYPE,
+                ClassLoader.class,
+                ProtectionDomain.class
+        ));
+    }
+
+    private static boolean usesLegacyDefineClassPath(URLClassLoader isolatedLoader) throws Exception {
+        Class<?> langUtilClass = Class.forName("org.aspectj.util.LangUtil", true, isolatedLoader);
+        Method is11VmOrGreater = langUtilClass.getMethod("is11VMOrGreater");
+        return !((Boolean) is11VmOrGreater.invoke(null));
+    }
+
+    private static String legacyAopXml() {
+        return """
+                <aspectj>
+                    <weaver options="-Xlintfile:%s"/>
+                    <aspects>
+                        <concrete-aspect
+                            name="org_aspectj.aspectjweaver.generated.LegacyConcreteAspect"
+                            precedence="org_aspectj.aspectjweaver..*"/>
+                    </aspects>
+                </aspectj>
+                """.formatted(LINT_RESOURCE);
+    }
+
+    private static Definition concreteAspectDefinition() {
+        Definition definition = new Definition();
+        definition.appendWeaverOptions("-Xlintfile:" + LINT_RESOURCE);
+        definition.getConcreteAspects().add(new Definition.ConcreteAspect(
+                "org_aspectj.aspectjweaver.generated.LoadTimeConcreteAspect",
+                null,
+                "org_aspectj.aspectjweaver..*",
+                null
+        ));
+        return definition;
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Throwable throwable) {
+        if (!hasUnsupportedFeatureError(throwable) && !hasUnsupportedIsolatedClassLoadingFailure(throwable)) {
+            if (throwable instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (throwable instanceof Error error) {
+                throw error;
+            }
+            throw new AssertionError(throwable);
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean hasUnsupportedIsolatedClassLoadingFailure(Throwable throwable) {
+        if (!"runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ClassNotFoundException
+                    && "org.aspectj.util.LangUtil".equals(current.getMessage())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class StaticWeavingContext implements IWeavingContext {
+        private final ClassLoader classLoader;
+        private final List<Definition> definitions;
+
+        private StaticWeavingContext(ClassLoader classLoader, Definition definition) {
+            this.classLoader = classLoader;
+            this.definitions = Collections.singletonList(definition);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) {
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public String getBundleIdFromURL(URL url) {
+            return null;
+        }
+
+        @Override
+        public String getClassLoaderName() {
+            return "class-loader-weaving-adaptor-test";
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return classLoader;
+        }
+
+        @Override
+        public String getFile(URL url) {
+            return url.toExternalForm();
+        }
+
+        @Override
+        public String getId() {
+            return "class-loader-weaving-adaptor-test";
+        }
+
+        @Override
+        public boolean isLocallyDefined(String classname) {
+            return classname.startsWith("org_aspectj.aspectjweaver");
+        }
+
+        @Override
+        public List<Definition> getDefinitions(ClassLoader loader, WeavingAdaptor adaptor) {
+            return definitions;
+        }
+    }
+
+    public static final class LegacyDefineClassBridge {
+        private LegacyDefineClassBridge() {
+        }
+
+        public static Class<?> defineClass(String name, byte[] bytes, int offset, int length, ClassLoader loader,
+                ProtectionDomain protectionDomain) {
+            legacyDefineClassInvoked = true;
+            return Object.class;
+        }
+    }
+
+    private static final class ResourceTrackingClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final byte[] contents;
+        private int resourceRequestCount;
+
+        private ResourceTrackingClassLoader(ClassLoader parent, String resourceName, String contents) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.contents = contents.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (resourceName.equals(name)) {
+                resourceRequestCount++;
+                return new ByteArrayInputStream(contents);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        private int resourceRequestCount() {
+            return resourceRequestCount;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
@@ -24,6 +24,12 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import aj.org.objectweb.asm.ClassReader;
+import aj.org.objectweb.asm.ClassVisitor;
+import aj.org.objectweb.asm.ClassWriter;
+import aj.org.objectweb.asm.MethodVisitor;
+import aj.org.objectweb.asm.Opcodes;
+
 import org.aspectj.util.LangUtil;
 import org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor;
 import org.aspectj.weaver.loadtime.IWeavingContext;
@@ -36,6 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassLoaderWeavingAdaptorTest {
     private static final String LINT_RESOURCE = "aspectj-ltw-lint.properties";
+    private static final String ADAPTOR_CLASS_NAME = "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor";
+    private static final String ACCESSIBLE_OBJECT_CLASS_NAME = "java.lang.reflect.AccessibleObject";
+    private static final String MIRROR_SEED_CLASS_NAME = "org_aspectj.aspectjweaver.MirrorSeed";
 
     private static boolean legacyDefineClassInvoked;
 
@@ -72,6 +81,19 @@ public class ClassLoaderWeavingAdaptorTest {
             );
 
             assertThat(methodHandle.invokeWithArguments()).isEqualTo(LangUtil.is11VMOrGreater());
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    @Test
+    void initializesDefineClassFallbackWithGeneratedMirrorClass() throws Exception {
+        URL aspectjLocation = ClassLoaderWeavingAdaptor.class.getProtectionDomain().getCodeSource().getLocation();
+        URL[] urls = {aspectjLocation};
+        try (MirrorFriendlyAspectjLoader isolatedLoader = new MirrorFriendlyAspectjLoader(urls)) {
+            Class<?> adaptorClass = Class.forName(ADAPTOR_CLASS_NAME, true, isolatedLoader);
+
+            assertThat(adaptorClass.getName()).isEqualTo(ADAPTOR_CLASS_NAME);
         } catch (Throwable throwable) {
             rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
         }
@@ -115,7 +137,7 @@ public class ClassLoaderWeavingAdaptorTest {
 
     private static void initializeAdaptorFrom(URLClassLoader isolatedLoader) throws Exception {
         Class<?> adaptorClass = Class.forName(
-                "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor",
+                ADAPTOR_CLASS_NAME,
                 true,
                 isolatedLoader
         );
@@ -223,7 +245,9 @@ public class ClassLoaderWeavingAdaptorTest {
         Throwable current = throwable;
         while (current != null) {
             if (current instanceof ClassNotFoundException
-                    && "org.aspectj.util.LangUtil".equals(current.getMessage())) {
+                    && ("org.aspectj.util.LangUtil".equals(current.getMessage())
+                    || ADAPTOR_CLASS_NAME.equals(current.getMessage())
+                    || MIRROR_SEED_CLASS_NAME.equals(current.getMessage()))) {
                 return true;
             }
             if (current instanceof NoSuchFieldException
@@ -283,6 +307,81 @@ public class ClassLoaderWeavingAdaptorTest {
         @Override
         public List<Definition> getDefinitions(ClassLoader loader, WeavingAdaptor adaptor) {
             return definitions;
+        }
+    }
+
+    private static final class MirrorFriendlyAspectjLoader extends URLClassLoader {
+        private static final String ADAPTOR_RESOURCE = ADAPTOR_CLASS_NAME.replace('.', '/') + ".class";
+        private static final String MIRROR_SEED_RESOURCE = MIRROR_SEED_CLASS_NAME.replace('.', '/') + ".class";
+
+        private final byte[] mirrorSeedBytes;
+
+        private MirrorFriendlyAspectjLoader(URL[] urls) {
+            super(urls, ClassLoader.getPlatformClassLoader());
+            this.mirrorSeedBytes = createMirrorSeedBytes();
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (MIRROR_SEED_CLASS_NAME.equals(name)) {
+                return defineClass(name, mirrorSeedBytes, 0, mirrorSeedBytes.length);
+            }
+            if (ADAPTOR_CLASS_NAME.equals(name)) {
+                try (InputStream input = findResource(ADAPTOR_RESOURCE).openStream()) {
+                    byte[] adaptorBytes = transformAccessibleObjectLookup(input.readAllBytes());
+                    return defineClass(name, adaptorBytes, 0, adaptorBytes.length);
+                } catch (Exception exception) {
+                    throw new ClassNotFoundException(name, exception);
+                }
+            }
+            return super.findClass(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (MIRROR_SEED_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(mirrorSeedBytes);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        private static byte[] transformAccessibleObjectLookup(byte[] originalBytes) {
+            ClassReader reader = new ClassReader(originalBytes);
+            ClassWriter writer = new ClassWriter(0);
+            reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                        String[] exceptions) {
+                    MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                    return new MethodVisitor(Opcodes.ASM9, methodVisitor) {
+                        @Override
+                        public void visitLdcInsn(Object value) {
+                            if (ACCESSIBLE_OBJECT_CLASS_NAME.equals(value)) {
+                                super.visitLdcInsn(MIRROR_SEED_CLASS_NAME);
+                            } else {
+                                super.visitLdcInsn(value);
+                            }
+                        }
+                    };
+                }
+            }, 0);
+            return writer.toByteArray();
+        }
+
+        private static byte[] createMirrorSeedBytes() {
+            ClassWriter writer = new ClassWriter(0);
+            String internalName = MIRROR_SEED_CLASS_NAME.replace('.', '/');
+            writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, internalName, null, "java/lang/Object", null);
+            writer.visitField(Opcodes.ACC_PUBLIC, "override", "Z", null, null).visitEnd();
+            MethodVisitor constructor = writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+            constructor.visitCode();
+            constructor.visitVarInsn(Opcodes.ALOAD, 0);
+            constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            constructor.visitInsn(Opcodes.RETURN);
+            constructor.visitMaxs(1, 1);
+            constructor.visitEnd();
+            writer.visitEnd();
+            return writer.toByteArray();
         }
     }
 

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
@@ -8,6 +8,9 @@ package org_aspectj.aspectjweaver;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -21,6 +24,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import org.aspectj.util.LangUtil;
 import org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor;
 import org.aspectj.weaver.loadtime.IWeavingContext;
 import org.aspectj.weaver.loadtime.definition.Definition;
@@ -56,6 +60,20 @@ public class ClassLoaderWeavingAdaptorTest {
         assertThat(loader.resourceRequestCount()).isEqualTo(1);
         if (completed) {
             assertThat(adaptor.getMessageHolder()).isNotNull();
+        }
+    }
+
+    @Test
+    void createsMethodHandleForKnownAspectjUtilityMethod() {
+        try {
+            MethodHandle methodHandle = ClassLoaderWeavingAdaptor.createMethodHandle(
+                    "org.aspectj.util.LangUtil",
+                    "is11VMOrGreater"
+            );
+
+            assertThat(methodHandle.invokeWithArguments()).isEqualTo(LangUtil.is11VMOrGreater());
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
         }
     }
 
@@ -121,16 +139,25 @@ public class ClassLoaderWeavingAdaptorTest {
 
     private static void installLegacyDefineClassBridge(Class<?> adaptorClass) throws NoSuchFieldException,
             IllegalAccessException, NoSuchMethodException {
-        Field defineClassMethod = adaptorClass.getDeclaredField("defineClassMethod");
-        defineClassMethod.setAccessible(true);
-        defineClassMethod.set(null, LegacyDefineClassBridge.class.getMethod(
+        Field unsafeInstance = adaptorClass.getDeclaredField("unsafeInstance");
+        unsafeInstance.setAccessible(true);
+        unsafeInstance.set(null, LegacyDefineClassBridge.class);
+
+        Field defineClassMethodHandle = adaptorClass.getDeclaredField("defineClassMethodHandle");
+        defineClassMethodHandle.setAccessible(true);
+        defineClassMethodHandle.set(null, MethodHandles.lookup().findStatic(
+                LegacyDefineClassBridge.class,
                 "defineClass",
-                String.class,
-                byte[].class,
-                Integer.TYPE,
-                Integer.TYPE,
-                ClassLoader.class,
-                ProtectionDomain.class
+                MethodType.methodType(
+                        Class.class,
+                        Object.class,
+                        String.class,
+                        byte[].class,
+                        Integer.TYPE,
+                        Integer.TYPE,
+                        ClassLoader.class,
+                        ProtectionDomain.class
+                )
         ));
     }
 
@@ -199,6 +226,11 @@ public class ClassLoaderWeavingAdaptorTest {
                     && "org.aspectj.util.LangUtil".equals(current.getMessage())) {
                 return true;
             }
+            if (current instanceof NoSuchFieldException
+                    && ("unsafeInstance".equals(current.getMessage())
+                    || "defineClassMethodHandle".equals(current.getMessage()))) {
+                return true;
+            }
             current = current.getCause();
         }
         return false;
@@ -258,8 +290,8 @@ public class ClassLoaderWeavingAdaptorTest {
         private LegacyDefineClassBridge() {
         }
 
-        public static Class<?> defineClass(String name, byte[] bytes, int offset, int length, ClassLoader loader,
-                ProtectionDomain protectionDomain) {
+        public static Class<?> defineClass(Object unsafe, String name, byte[] bytes, int offset, int length,
+                ClassLoader loader, ProtectionDomain protectionDomain) {
             legacyDefineClassInvoked = true;
             return Object.class;
         }

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassPathTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassPathTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.aspectj.apache.bcel.util.ClassPath;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassPathTest {
+    private static final String RESOURCE_NAME = "org_aspectj/aspectjweaver/classpath-resource";
+    private static final String RESOURCE_SUFFIX = ".txt";
+
+    @Test
+    void readsResourceFromClassLoaderBeforeSearchingConfiguredClassPath() throws Exception {
+        ClassPath classPath = new ClassPath("");
+
+        try (InputStream stream = classPath.getInputStream(RESOURCE_NAME, RESOURCE_SUFFIX)) {
+            assertThat(stream).isNotNull();
+            String content = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertThat(content).contains("loaded through ClassPath.getInputStream");
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassReaderTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassReaderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import aj.org.objectweb.asm.ClassReader;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ClassReaderTest {
+    @Test
+    void readsClassFromSystemResource() throws IOException {
+        ClassReader classReader = new ClassReader("aj.org.objectweb.asm.ClassReader");
+
+        assertThat(classReader.getClassName()).isEqualTo("aj/org/objectweb/asm/ClassReader");
+        assertThat(classReader.getSuperName()).isEqualTo("java/lang/Object");
+    }
+
+    @Test
+    void reportsMissingSystemResource() {
+        assertThatThrownBy(() -> new ClassReader("example.missing.AspectJWeaverClass"))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Class not found");
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassWriterTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import aj.org.objectweb.asm.ClassWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassWriterTest {
+    @Test
+    void returnsSharedAbstractSuperclassForConcreteCollectionTypes() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/ArrayList", "java/util/LinkedList");
+
+        assertThat(commonSuperClass).isEqualTo("java/util/AbstractList");
+    }
+
+    @Test
+    void returnsObjectWhenEitherLoadedTypeIsAnInterface() {
+        TestableClassWriter classWriter = new TestableClassWriter();
+
+        String commonSuperClass = classWriter.commonSuperClass("java/util/List", "java/util/Set");
+
+        assertThat(commonSuperClass).isEqualTo("java/lang/Object");
+    }
+
+    private static final class TestableClassWriter extends ClassWriter {
+        private TestableClassWriter() {
+            super(0);
+        }
+
+        private String commonSuperClass(String firstType, String secondType) {
+            return super.getCommonSuperClass(firstType, secondType);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ConstructorSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ConstructorSignatureImplTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.ConstructorSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConstructorSignatureImplTest {
+    @Test
+    void resolvesDeclaredConstructorFromSignature() {
+        Factory factory = new Factory("ConstructorSignatureImplTest.java", ConstructorSignatureImplTest.class);
+        ConstructorSignature signature = factory.makeConstructorSig(
+                Modifier.PUBLIC,
+                ConstructorFixture.class,
+                new Class[] {String.class, int.class},
+                new String[] {"name", "amount"},
+                new Class[0]
+        );
+
+        Constructor constructor = signature.getConstructor();
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructorFixture.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class);
+    }
+
+    public static final class ConstructorFixture {
+        public ConstructorFixture(String name, int amount) {
+            assertThat(name).hasSize(amount);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/DefaultWeavingContextTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/DefaultWeavingContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+import org.aspectj.weaver.loadtime.DefaultWeavingContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultWeavingContextTest {
+    private static final String LOCAL_ONLY_TYPE = "example.LocalOnlyAspect";
+    private static final String SHARED_TYPE = "example.SharedAspect";
+
+    @Test
+    void reportsClassAsLocallyDefinedWhenOnlyConfiguredLoaderFindsResource() throws Exception {
+        URL localUrl = testResourceUrl("local-only");
+        ClassLoader parent = new ResourceClassLoader(null, Collections.emptyMap());
+        ClassLoader loader = new ResourceClassLoader(parent, Map.of(resourceName(LOCAL_ONLY_TYPE), localUrl));
+        DefaultWeavingContext context = new DefaultWeavingContext(loader);
+
+        boolean locallyDefined = context.isLocallyDefined(LOCAL_ONLY_TYPE);
+
+        assertThat(locallyDefined).isTrue();
+    }
+
+    @Test
+    void reportsClassAsNotLocallyDefinedWhenParentFindsSameResource() throws Exception {
+        URL sharedUrl = testResourceUrl("shared");
+        String sharedResource = resourceName(SHARED_TYPE);
+        ClassLoader parent = new ResourceClassLoader(null, Map.of(sharedResource, sharedUrl));
+        ClassLoader loader = new ResourceClassLoader(parent, Map.of(sharedResource, sharedUrl));
+        DefaultWeavingContext context = new DefaultWeavingContext(loader);
+
+        boolean locallyDefined = context.isLocallyDefined(SHARED_TYPE);
+
+        assertThat(locallyDefined).isFalse();
+    }
+
+    private static String resourceName(String className) {
+        return className.replace('.', '/') + ".class";
+    }
+
+    private static URL testResourceUrl(String name) throws MalformedURLException {
+        return URI.create("file:/default-weaving-context-test/" + name + ".class").toURL();
+    }
+
+    private static final class ResourceClassLoader extends ClassLoader {
+        private final Map<String, URL> resources;
+
+        private ResourceClassLoader(ClassLoader parent, Map<String, URL> resources) {
+            super(parent);
+            this.resources = resources;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return resources.get(name);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/FactoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/FactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.lang.reflect.FieldSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FactoryTest {
+    @Test
+    void createsSignatureTypesWithBootstrapClassLoader() {
+        Factory factory = new Factory("Object.java", Object.class);
+
+        FieldSignature signature = factory.makeFieldSig("1", "value", "java.lang.Object", "java.lang.String");
+
+        assertThat(signature.getName()).isEqualTo("value");
+        assertThat(signature.getDeclaringType()).isEqualTo(Object.class);
+        assertThat(signature.getFieldType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void createsSignatureTypesWithApplicationClassLoader() {
+        Factory factory = new Factory("FactoryTest.java", FactoryTest.class);
+
+        FieldSignature signature = factory.makeFieldSig(
+                "1",
+                "fixture",
+                FactoryTest.class.getName(),
+                SignatureFixture.class.getName()
+        );
+
+        assertThat(signature.getName()).isEqualTo("fixture");
+        assertThat(signature.getDeclaringType()).isEqualTo(FactoryTest.class);
+        assertThat(signature.getFieldType()).isEqualTo(SignatureFixture.class);
+    }
+
+    public static final class SignatureFixture {
+        private SignatureFixture() {
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/FieldSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/FieldSignatureImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.FieldSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FieldSignatureImplTest {
+    @Test
+    void resolvesDeclaredFieldFromSignature() {
+        Factory factory = new Factory("FieldSignatureImplTest.java", FieldSignatureImplTest.class);
+        FieldSignature signature = factory.makeFieldSig(
+                Modifier.PRIVATE,
+                "message",
+                FieldFixture.class,
+                String.class
+        );
+
+        Field field = signature.getField();
+
+        assertThat(field).isNotNull();
+        assertThat(field.getDeclaringClass()).isEqualTo(FieldFixture.class);
+        assertThat(field.getName()).isEqualTo("message");
+        assertThat(field.getType()).isEqualTo(String.class);
+        assertThat(Modifier.isPrivate(field.getModifiers())).isTrue();
+    }
+
+    public static final class FieldFixture {
+        private String message;
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/InitializerSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/InitializerSignatureImplTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.InitializerSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InitializerSignatureImplTest {
+    @Test
+    void resolvesDeclaredNoArgConstructorForInitializerSignature() {
+        Factory factory = new Factory("InitializerSignatureImplTest.java", InitializerSignatureImplTest.class);
+        InitializerSignature signature = factory.makeInitializerSig(Modifier.PUBLIC, InitializerFixture.class);
+
+        Constructor constructor = signature.getInitializer();
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(InitializerFixture.class);
+        assertThat(constructor.getParameterTypes()).isEmpty();
+        assertThat(signature.getName()).isEqualTo("<init>");
+    }
+
+    public static final class InitializerFixture {
+        public InitializerFixture() {
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Java15AnnotationFinderTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Java15AnnotationFinderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Method;
+
+import org.aspectj.weaver.ResolvedType;
+import org.aspectj.weaver.UnresolvedType;
+import org.aspectj.weaver.reflect.Java15AnnotationFinder;
+import org.aspectj.weaver.reflect.ReflectionWorld;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Java15AnnotationFinderTest {
+    @Test
+    void findsAnnotationOnObjectClass() {
+        Java15AnnotationFinder finderAnnotationAccess = annotationFinder();
+        ResolvedType markerType = markerType();
+
+        Object annotation = finderAnnotationAccess.getAnnotation(markerType, new Java15AnnotationFinderAnnotatedComponent());
+
+        assertThat(annotation).isInstanceOf(Java15AnnotationFinderMarker.class);
+        assertThat(((Java15AnnotationFinderMarker) annotation).value()).isEqualTo("component");
+    }
+
+    @Test
+    void findsAnnotationFromClass() {
+        Java15AnnotationFinder finder = annotationFinder();
+        ResolvedType markerType = markerType();
+
+        Object annotation = finder.getAnnotationFromClass(markerType, Java15AnnotationFinderAnnotatedComponent.class);
+
+        assertThat(annotation).isInstanceOf(Java15AnnotationFinderMarker.class);
+        assertThat(((Java15AnnotationFinderMarker) annotation).value()).isEqualTo("component");
+    }
+
+    @Test
+    void findsAnnotationFromMember() throws NoSuchMethodException {
+        Java15AnnotationFinder finder = annotationFinder();
+        ResolvedType markerType = markerType();
+        Method method = Java15AnnotationFinderAnnotatedComponent.class.getMethod("annotatedOperation");
+
+        Object annotation = finder.getAnnotationFromMember(markerType, method);
+
+        assertThat(annotation).isInstanceOf(Java15AnnotationFinderMarker.class);
+        assertThat(((Java15AnnotationFinderMarker) annotation).value()).isEqualTo("operation");
+    }
+
+    private static Java15AnnotationFinder annotationFinder() {
+        ClassLoader classLoader = Java15AnnotationFinderTest.class.getClassLoader();
+        ReflectionWorld world = new ReflectionWorld(classLoader);
+        Java15AnnotationFinder finder = new Java15AnnotationFinder();
+        finder.setClassLoader(classLoader);
+        finder.setWorld(world);
+        return finder;
+    }
+
+    private static ResolvedType markerType() {
+        ReflectionWorld world = new ReflectionWorld(Java15AnnotationFinderTest.class.getClassLoader());
+        return UnresolvedType.forName(Java15AnnotationFinderMarker.class.getName()).resolve(world);
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface Java15AnnotationFinderMarker {
+    String value();
+}
+
+@Java15AnnotationFinderMarker("component")
+class Java15AnnotationFinderAnnotatedComponent {
+    @Java15AnnotationFinderMarker("operation")
+    public void annotatedOperation() {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Java15ReflectionBasedReferenceTypeDelegateTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/Java15ReflectionBasedReferenceTypeDelegateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.weaver.ReferenceType;
+import org.aspectj.weaver.ResolvedMember;
+import org.aspectj.weaver.UnresolvedType;
+import org.aspectj.weaver.World;
+import org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate;
+import org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory;
+import org.aspectj.weaver.reflect.ReflectionWorld;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Java15ReflectionBasedReferenceTypeDelegateTest {
+    @Test
+    void discoversPointcutParameterNamesFromDeclaredMethodsWhenAnnotationArgNamesAreMissing() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        ReflectionWorld world = new ReflectionWorld(classLoader);
+        Class<?> aspectType = Java15ReflectionBasedReferenceTypeDelegatePointcutAspect.class;
+        ReferenceType referenceType = referenceTypeFor(aspectType, world);
+        ReflectionBasedReferenceTypeDelegate delegate = ReflectionBasedReferenceTypeDelegateFactory.createDelegate(
+                referenceType,
+                world,
+                classLoader
+        );
+
+        ResolvedMember[] pointcuts = delegate.getDeclaredPointcuts();
+
+        assertThat(pointcuts)
+                .filteredOn(pointcut -> pointcut.getName().equals("capturesStringArgument"))
+                .singleElement()
+                .satisfies(pointcut -> {
+                    assertThat(pointcut.getParameterTypes())
+                            .extracting(UnresolvedType::getName)
+                            .containsExactly("java.lang.String");
+                    assertThat(pointcut.getParameterNames()).containsExactly("value");
+                });
+    }
+
+    private static ReferenceType referenceTypeFor(Class<?> type, World world) {
+        UnresolvedType unresolvedType = UnresolvedType.forName(type.getName());
+        return ReferenceType.fromTypeX(unresolvedType, world);
+    }
+}
+
+@Aspect
+class Java15ReflectionBasedReferenceTypeDelegatePointcutAspect {
+    @Pointcut("args(value)")
+    public void capturesStringArgument(String value) {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/LTWWorldTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/LTWWorldTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.aspectj.weaver.ltw.LTWWorld;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LTWWorldTest {
+    @Test
+    void discoversJdkConcurrentMapImplementationForBootstrapTypeCache() throws Exception {
+        Class<?> mapClass = invokeMakeConcurrentMapClass();
+
+        assertThat(mapClass).isEqualTo(ConcurrentHashMap.class);
+        assertThat(Map.class).isAssignableFrom(mapClass);
+    }
+
+    private static Class<?> invokeMakeConcurrentMapClass() throws Exception {
+        Method method = LTWWorld.class.getDeclaredMethod("makeConcurrentMapClass");
+        method.setAccessible(true);
+        try {
+            return (Class<?>) method.invoke(null);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw exception;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/LangUtilTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/LangUtilTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.util.LangUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LangUtilTest {
+    @Test
+    void safeCopyCreatesTypedArrayWhenSinkHasWrongSize() {
+        Object[] source = {"alpha", new StringBuilder("ignored"), "beta", null};
+        String[] sink = new String[0];
+
+        Object[] copy = LangUtil.safeCopy(source, sink);
+
+        assertThat(copy).isInstanceOf(String[].class);
+        assertThat(copy).isNotSameAs(sink);
+        assertThat(copy).containsExactly("alpha", "beta");
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/MethodSignatureImplTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/MethodSignatureImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.aspectj.lang.reflect.MethodSignature;
+import org.aspectj.runtime.reflect.Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MethodSignatureImplTest {
+    @Test
+    void resolvesMethodDeclaredBySignatureType() {
+        Factory factory = new Factory("MethodSignatureImplTest.java", MethodSignatureImplTest.class);
+        MethodSignature signature = factory.makeMethodSig(
+                Modifier.PUBLIC,
+                "declaredOperation",
+                DeclaredOperationFixture.class,
+                new Class[] {String.class, int.class},
+                new String[] {"value", "count"},
+                new Class[0],
+                String.class
+        );
+
+        Method method = signature.getMethod();
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(DeclaredOperationFixture.class);
+        assertThat(method.getName()).isEqualTo("declaredOperation");
+        assertThat(method.getParameterTypes()).containsExactly(String.class, int.class);
+        assertThat(method.getReturnType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void searchesHierarchyWhenSignatureTypeInheritsMethod() {
+        Factory factory = new Factory("MethodSignatureImplTest.java", MethodSignatureImplTest.class);
+        MethodSignature signature = factory.makeMethodSig(
+                Modifier.PUBLIC,
+                "inheritedOperation",
+                InheritingOperationFixture.class,
+                new Class[] {long.class},
+                new String[] {"value"},
+                new Class[0],
+                long.class
+        );
+
+        Method method = signature.getMethod();
+
+        assertThat(method).isNotNull();
+        assertThat(method.getDeclaringClass()).isEqualTo(BaseOperationFixture.class);
+        assertThat(method.getName()).isEqualTo("inheritedOperation");
+        assertThat(method.getParameterTypes()).containsExactly(long.class);
+        assertThat(method.getReturnType()).isEqualTo(long.class);
+    }
+
+    public static final class DeclaredOperationFixture {
+        public String declaredOperation(String value, int count) {
+            return value.repeat(count);
+        }
+    }
+
+    public static class BaseOperationFixture {
+        public long inheritedOperation(long value) {
+            return value + 1;
+        }
+    }
+
+    public static final class InheritingOperationFixture extends BaseOperationFixture {
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/NonCachingClassLoaderRepositoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/NonCachingClassLoaderRepositoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+import org.aspectj.apache.bcel.classfile.JavaClass;
+import org.aspectj.apache.bcel.util.NonCachingClassLoaderRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NonCachingClassLoaderRepositoryTest {
+    private static final String CLASS_NAME = "org_aspectj.aspectjweaver.RepositoryLoadedType";
+    private static final String INTERNAL_CLASS_NAME = "org_aspectj/aspectjweaver/RepositoryLoadedType";
+    private static final String CLASS_RESOURCE_NAME = INTERNAL_CLASS_NAME + ".class";
+
+    @Test
+    void loadsClassFromClassLoaderResourceStream() throws Exception {
+        ClassLoader classLoader = new ByteArrayResourceClassLoader(CLASS_RESOURCE_NAME, minimalClassBytes());
+        NonCachingClassLoaderRepository repository = new NonCachingClassLoaderRepository(classLoader);
+
+        JavaClass loadedClass = repository.loadClass(CLASS_NAME);
+
+        assertThat(loadedClass.getClassName()).isEqualTo(CLASS_NAME);
+        assertThat(loadedClass.getSuperclassName()).isEqualTo(Object.class.getName());
+        assertThat(repository.findClass(CLASS_NAME)).isSameAs(loadedClass);
+    }
+
+    private static byte[] minimalClassBytes() throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+
+        output.writeInt(0xCAFEBABE);
+        output.writeShort(0);
+        output.writeShort(52);
+        output.writeShort(5);
+        writeClassConstant(output, 2);
+        writeUtf8Constant(output, INTERNAL_CLASS_NAME);
+        writeClassConstant(output, 4);
+        writeUtf8Constant(output, "java/lang/Object");
+        output.writeShort(0x0021);
+        output.writeShort(1);
+        output.writeShort(3);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.flush();
+
+        return bytes.toByteArray();
+    }
+
+    private static void writeClassConstant(DataOutputStream output, int nameIndex) throws IOException {
+        output.writeByte(7);
+        output.writeShort(nameIndex);
+    }
+
+    private static void writeUtf8Constant(DataOutputStream output, String value) throws IOException {
+        output.writeByte(1);
+        output.writeUTF(value);
+    }
+
+    private static final class ByteArrayResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final byte[] resourceBytes;
+
+        private ByteArrayResourceClassLoader(String resourceName, byte[] resourceBytes) {
+            super(null);
+            this.resourceName = resourceName;
+            this.resourceBytes = resourceBytes.clone();
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (!resourceName.equals(name)) {
+                return null;
+            }
+            try {
+                return new URL(null, "memory:///" + name, new ByteArrayUrlStreamHandler(resourceBytes));
+            } catch (MalformedURLException exception) {
+                throw new IllegalStateException("Unable to create in-memory class resource URL", exception);
+            }
+        }
+    }
+
+    private static final class ByteArrayUrlStreamHandler extends URLStreamHandler {
+        private final byte[] resourceBytes;
+
+        private ByteArrayUrlStreamHandler(byte[] resourceBytes) {
+            this.resourceBytes = resourceBytes.clone();
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new URLConnection(url) {
+                @Override
+                public void connect() {
+                    connected = true;
+                }
+
+                @Override
+                public InputStream getInputStream() {
+                    return new ByteArrayInputStream(resourceBytes);
+                }
+            };
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/OptionsTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/OptionsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aspectj.bridge.IMessage;
+import org.aspectj.bridge.IMessageHandler;
+import org.aspectj.weaver.loadtime.Options;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionsTest {
+    @BeforeEach
+    void resetMessageHandlers() {
+        RecordingMessageHandler.reset();
+    }
+
+    @Test
+    void parseInstantiatesConfiguredMessageHandlerAndRoutesSubsequentWarnings() {
+        SilentMessageHandler fallbackMessageHandler = new SilentMessageHandler();
+        String options = "-XmessageHandlerClass:" + RecordingMessageHandler.class.getName() + " -unknownLtwOption";
+
+        Options.parse(options, OptionsTest.class.getClassLoader(), fallbackMessageHandler);
+
+        assertThat(fallbackMessageHandler.messages()).isEmpty();
+        assertThat(RecordingMessageHandler.constructorCalls()).isOne();
+        assertThat(RecordingMessageHandler.messages()).hasSize(1);
+        IMessage warning = RecordingMessageHandler.messages().get(0);
+        assertThat(warning.getKind()).isSameAs(IMessage.WARNING);
+        assertThat(warning.getMessage()).contains("-unknownLtwOption", "unknown option");
+    }
+
+    public static final class RecordingMessageHandler implements IMessageHandler {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+        private static final List<IMessage> MESSAGES = Collections.synchronizedList(new ArrayList<>());
+
+        public RecordingMessageHandler() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+
+        @Override
+        public boolean handleMessage(IMessage message) {
+            MESSAGES.add(message);
+            return true;
+        }
+
+        @Override
+        public boolean isIgnoring(IMessage.Kind kind) {
+            return false;
+        }
+
+        @Override
+        public void dontIgnore(IMessage.Kind kind) {
+        }
+
+        @Override
+        public void ignore(IMessage.Kind kind) {
+        }
+
+        static int constructorCalls() {
+            return CONSTRUCTOR_CALLS.get();
+        }
+
+        static List<IMessage> messages() {
+            return MESSAGES;
+        }
+
+        static void reset() {
+            CONSTRUCTOR_CALLS.set(0);
+            MESSAGES.clear();
+        }
+    }
+
+    private static final class SilentMessageHandler implements IMessageHandler {
+        private final List<IMessage> messages = new ArrayList<>();
+
+        @Override
+        public boolean handleMessage(IMessage message) {
+            messages.add(message);
+            return true;
+        }
+
+        @Override
+        public boolean isIgnoring(IMessage.Kind kind) {
+            return false;
+        }
+
+        @Override
+        public void dontIgnore(IMessage.Kind kind) {
+        }
+
+        @Override
+        public void ignore(IMessage.Kind kind) {
+        }
+
+        List<IMessage> messages() {
+            return messages;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PersistenceSupportTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PersistenceSupportTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+import org.aspectj.weaver.CompressingDataOutputStream;
+import org.aspectj.weaver.PersistenceSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PersistenceSupportTest {
+    @Test
+    void serializableObjectsAreWrittenToTheCompressingStream() throws IOException, ClassNotFoundException {
+        Serializable value = "persisted aspectj state";
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        try (CompressingDataOutputStream output = new CompressingDataOutputStream(bytes, null)) {
+            PersistenceSupport.write(output, value);
+        }
+
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            assertThat(input.readObject()).isEqualTo(value);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PointcutDesignatorHandlerBasedPointcutTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PointcutDesignatorHandlerBasedPointcutTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.weaver.tools.ContextBasedMatcher;
+import org.aspectj.weaver.tools.DefaultMatchingContext;
+import org.aspectj.weaver.tools.FuzzyBoolean;
+import org.aspectj.weaver.tools.MatchingContext;
+import org.aspectj.weaver.tools.PointcutDesignatorHandler;
+import org.aspectj.weaver.tools.PointcutExpression;
+import org.aspectj.weaver.tools.PointcutParser;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PointcutDesignatorHandlerBasedPointcutTest {
+    @Test
+    void customDesignatorFastMatchLoadsCandidateTypeThroughParserApi() {
+        PointcutParser parser = PointcutParser
+                .getPointcutParserSupportingAllPrimitivesAndUsingSpecifiedClassloaderForResolution(
+                        getClass().getClassLoader());
+        RecordingPointcutDesignatorHandler handler = new RecordingPointcutDesignatorHandler();
+        parser.registerPointcutDesignatorHandler(handler);
+        DefaultMatchingContext context = new DefaultMatchingContext();
+        context.addContextBinding("enabled", Boolean.TRUE);
+
+        PointcutExpression expression = parser.parsePointcutExpression("recorded(enabled)");
+        expression.setMatchingContext(context);
+
+        boolean couldMatch = expression.couldMatchJoinPointsInType(PointcutParser.class);
+
+        assertThat(couldMatch).isTrue();
+        assertThat(handler.matcher().candidateType()).isEqualTo(PointcutParser.class);
+        assertThat(handler.matcher().context()).isSameAs(context);
+        assertThat(handler.matcher().expression()).isEqualTo("enabled");
+    }
+
+    private static final class RecordingPointcutDesignatorHandler implements PointcutDesignatorHandler {
+        private RecordingContextBasedMatcher matcher;
+
+        @Override
+        public String getDesignatorName() {
+            return "recorded";
+        }
+
+        @Override
+        public ContextBasedMatcher parse(String expression) {
+            matcher = new RecordingContextBasedMatcher(expression);
+            return matcher;
+        }
+
+        RecordingContextBasedMatcher matcher() {
+            return matcher;
+        }
+    }
+
+    private static final class RecordingContextBasedMatcher implements ContextBasedMatcher {
+        private final String expression;
+        private Class<?> candidateType;
+        private MatchingContext context;
+
+        private RecordingContextBasedMatcher(String expression) {
+            this.expression = expression;
+        }
+
+        @Override
+        public boolean couldMatchJoinPointsInType(Class aClass) {
+            return false;
+        }
+
+        @Override
+        public boolean couldMatchJoinPointsInType(Class aClass, MatchingContext matchContext) {
+            candidateType = aClass;
+            context = matchContext;
+            return matchContext.hasContextBinding(expression)
+                    && Boolean.TRUE.equals(matchContext.getBinding(expression));
+        }
+
+        @Override
+        public boolean mayNeedDynamicTest() {
+            return false;
+        }
+
+        @Override
+        public FuzzyBoolean matchesStatically(MatchingContext matchContext) {
+            return FuzzyBoolean.NO;
+        }
+
+        @Override
+        public boolean matchesDynamically(MatchingContext matchContext) {
+            return false;
+        }
+
+        String expression() {
+            return expression;
+        }
+
+        Class<?> candidateType() {
+            return candidateType;
+        }
+
+        MatchingContext context() {
+            return context;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PointcutParserTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/PointcutParserTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.IOException;
+
+import org.aspectj.weaver.tools.PointcutExpression;
+import org.aspectj.weaver.tools.PointcutParser;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PointcutParserTest {
+    private static final String LINT_PROPERTIES_RESOURCE =
+            "org_aspectj/aspectjweaver/pointcut-parser-lint.properties";
+
+    @Test
+    void loadsLintPropertiesFromClasspathResource() throws IOException {
+        PointcutParser parser = PointcutParser
+                .getPointcutParserSupportingAllPrimitivesAndUsingSpecifiedClassloaderForResolution(
+                        getClass().getClassLoader());
+
+        parser.setLintProperties(LINT_PROPERTIES_RESOURCE);
+        PointcutExpression expression = parser.parsePointcutExpression("execution(* *(..))");
+
+        assertThat(expression.mayNeedDynamicTest()).isFalse();
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionBasedReferenceTypeDelegateFactoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionBasedReferenceTypeDelegateFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.weaver.ReferenceType;
+import org.aspectj.weaver.ResolvedMember;
+import org.aspectj.weaver.UnresolvedType;
+import org.aspectj.weaver.World;
+import org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate;
+import org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegateFactory;
+import org.aspectj.weaver.reflect.ReflectionWorld;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionBasedReferenceTypeDelegateFactoryTest {
+    @Test
+    void createsJava15ReflectionDelegateByClassName() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        ReflectionWorld world = new ReflectionWorld(classLoader);
+        ReferenceType referenceType = referenceTypeFor(String.class, world);
+
+        ReflectionBasedReferenceTypeDelegate delegate = ReflectionBasedReferenceTypeDelegateFactory.createDelegate(
+                referenceType,
+                world,
+                classLoader
+        );
+
+        assertThat(delegate).isNotNull();
+        assertThat(delegate.getClazz()).isEqualTo(String.class);
+        assertThat(delegate.getResolvedTypeX()).isSameAs(referenceType);
+    }
+
+    @Test
+    void createsJava14ReflectionDelegateByClassName() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        ReflectionWorld world = new ReflectionWorld(true, classLoader);
+        ReferenceType referenceType = referenceTypeFor(String.class, world);
+
+        ReflectionBasedReferenceTypeDelegate delegate = ReflectionBasedReferenceTypeDelegateFactory.create14Delegate(
+                referenceType,
+                world,
+                classLoader
+        );
+
+        assertThat(delegate).isNotNull();
+        assertThat(delegate.getClazz()).isEqualTo(String.class);
+        assertThat(delegate.getResolvedTypeX()).isSameAs(referenceType);
+    }
+
+    @Test
+    void createsGenericSignatureProviderForResolvedMethodMembers() throws NoSuchMethodException {
+        ReflectionWorld world = new ReflectionWorld(getClass().getClassLoader());
+        Method method = String.class.getMethod("substring", int.class, int.class);
+
+        ResolvedMember resolvedMember = ReflectionBasedReferenceTypeDelegateFactory.createResolvedMember(method, world);
+
+        assertThat(resolvedMember.getName()).isEqualTo("substring");
+        assertThat(resolvedMember.getArity()).isEqualTo(2);
+        assertThat(resolvedMember.getReturnType().getName()).isEqualTo(String.class.getName());
+    }
+
+    private static ReferenceType referenceTypeFor(Class<?> type, World world) {
+        UnresolvedType unresolvedType = UnresolvedType.forName(type.getName());
+        return ReferenceType.fromTypeX(unresolvedType, world);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionBasedReferenceTypeDelegateTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionBasedReferenceTypeDelegateTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.weaver.Member;
+import org.aspectj.weaver.ReferenceType;
+import org.aspectj.weaver.ResolvedMember;
+import org.aspectj.weaver.UnresolvedType;
+import org.aspectj.weaver.World;
+import org.aspectj.weaver.reflect.ReflectionBasedReferenceTypeDelegate;
+import org.aspectj.weaver.reflect.ReflectionWorld;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionBasedReferenceTypeDelegateTest {
+    @Test
+    void exposesDeclaredFieldsMethodsAndConstructorsFromReflectionBackedType() {
+        Class<?> reflectedType = ReflectionBasedReferenceTypeDelegate.class;
+        ClassLoader classLoader = reflectedType.getClassLoader();
+        ReflectionWorld world = new ReflectionWorld(true, classLoader);
+        ReferenceType referenceType = referenceTypeFor(reflectedType, world);
+        ReflectionBasedReferenceTypeDelegate delegate = new ReflectionBasedReferenceTypeDelegate(
+                reflectedType,
+                classLoader,
+                world,
+                referenceType
+        );
+
+        ResolvedMember[] fields = delegate.getDeclaredFields();
+        ResolvedMember[] methods = delegate.getDeclaredMethods();
+
+        assertThat(fields)
+                .filteredOn(member -> member.getKind() == Member.FIELD)
+                .extracting(Member::getName)
+                .contains("myClass", "world", "resolvedType");
+        assertThat(methods)
+                .filteredOn(member -> member.getKind() == Member.METHOD)
+                .extracting(Member::getName)
+                .contains("getDeclaredFields", "getDeclaredMethods", "initialize");
+        assertThat(methods)
+                .filteredOn(member -> member.getKind() == Member.CONSTRUCTOR)
+                .extracting(Member::getName)
+                .contains("<init>");
+    }
+
+    private static ReferenceType referenceTypeFor(Class<?> type, World world) {
+        UnresolvedType unresolvedType = UnresolvedType.forName(type.getName());
+        return ReferenceType.fromTypeX(unresolvedType, world);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionFactoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.aspectj.bridge.ICommand;
+import org.aspectj.bridge.IMessage;
+import org.aspectj.bridge.IMessageHandler;
+import org.aspectj.bridge.ReflectionFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionFactoryTest {
+    @Test
+    void createsCommandUsingPublicNoArgumentConstructor() {
+        CollectingMessageHandler messages = new CollectingMessageHandler();
+
+        ICommand command = ReflectionFactory.makeCommand(RecordingCommand.class.getName(), messages);
+
+        assertThat(command).isInstanceOf(RecordingCommand.class);
+        assertThat(messages.messages()).isEmpty();
+        assertThat(command.runCommand(new String[] {"compile", "woven"}, messages)).isTrue();
+        assertThat(((RecordingCommand) command).arguments()).containsExactly("compile", "woven");
+    }
+
+    @Test
+    void createsCommandFromAlternateFactoryPathUsingEmptyArgumentArray() throws ReflectiveOperationException {
+        CollectingMessageHandler messages = new CollectingMessageHandler();
+
+        ICommand command = invokeFactoryMake(EmptyArgumentsCommand.class.getName(), new Object[0], messages);
+
+        assertThat(command).isInstanceOf(EmptyArgumentsCommand.class);
+        assertThat(messages.messages()).isEmpty();
+        assertThat(command.repeatCommand(messages)).isTrue();
+    }
+
+    private static ICommand invokeFactoryMake(String className, Object[] args, IMessageHandler messages)
+            throws ReflectiveOperationException {
+        Method factoryMethod = ReflectionFactory.class.getDeclaredMethod(
+                "make",
+                Class.class,
+                String.class,
+                Object[].class,
+                IMessageHandler.class
+        );
+        factoryMethod.setAccessible(true);
+        return (ICommand) factoryMethod.invoke(null, ICommand.class, className, args, messages);
+    }
+
+    public static final class RecordingCommand implements ICommand {
+        private String[] arguments = new String[0];
+
+        public RecordingCommand() {
+        }
+
+        @Override
+        public boolean runCommand(String[] args, IMessageHandler handler) {
+            arguments = Arrays.copyOf(args, args.length);
+            return true;
+        }
+
+        @Override
+        public boolean repeatCommand(IMessageHandler handler) {
+            return runCommand(arguments, handler);
+        }
+
+        String[] arguments() {
+            return Arrays.copyOf(arguments, arguments.length);
+        }
+    }
+
+    public static final class EmptyArgumentsCommand implements ICommand {
+        private boolean repeated;
+
+        public EmptyArgumentsCommand() {
+        }
+
+        @Override
+        public boolean runCommand(String[] args, IMessageHandler handler) {
+            return true;
+        }
+
+        @Override
+        public boolean repeatCommand(IMessageHandler handler) {
+            repeated = true;
+            return repeated;
+        }
+    }
+
+    private static final class CollectingMessageHandler implements IMessageHandler {
+        private final List<IMessage> messages = new ArrayList<>();
+
+        @Override
+        public boolean handleMessage(IMessage message) {
+            messages.add(message);
+            return true;
+        }
+
+        @Override
+        public boolean isIgnoring(IMessage.Kind kind) {
+            return false;
+        }
+
+        @Override
+        public void dontIgnore(IMessage.Kind kind) {
+        }
+
+        @Override
+        public void ignore(IMessage.Kind kind) {
+        }
+
+        List<IMessage> messages() {
+            return messages;
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ReflectionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+
+import org.aspectj.util.Reflection;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionTest {
+    @Test
+    void invokesPublicMethodSelectedByNameAndArgumentCount() {
+        SampleOperations target = new SampleOperations("aspectj");
+
+        Object result = Reflection.invoke(
+                SampleOperations.class,
+                target,
+                "format",
+                "weaver",
+                Integer.valueOf(7)
+        );
+
+        assertThat(result).isEqualTo("aspectj:weaver:7");
+    }
+
+    @Test
+    void readsPublicStaticField() {
+        Object value = Reflection.getStaticField(StaticFieldHolder.class, "MESSAGE");
+
+        assertThat(value).isEqualTo("metadata-ready");
+    }
+
+    @Test
+    void runsMainByNameOnCurrentClassPath() throws Exception {
+        MainRecorder.reset();
+
+        Reflection.runMainInSameVM("", MainRecorder.class.getName(), new String[] {"by-name", "current-classpath"});
+
+        assertThat(MainRecorder.invocations()).isEqualTo(1);
+        assertThat(MainRecorder.arguments()).containsExactly("by-name", "current-classpath");
+    }
+
+    @Test
+    void runsMainThroughUtilityClassLoader() throws Exception {
+        MainRecorder.reset();
+
+        boolean completed = false;
+        try {
+            Reflection.runMainInSameVM(
+                    new URL[0],
+                    new File[0],
+                    new File[0],
+                    MainRecorder.class.getName(),
+                    new String[] {"utility-loader"}
+            );
+            completed = true;
+        } catch (Error error) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(error);
+        }
+
+        if (completed) {
+            assertThat(MainRecorder.invocations()).isEqualTo(1);
+            assertThat(MainRecorder.arguments()).containsExactly("utility-loader");
+        }
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    public static final class SampleOperations {
+        private final String prefix;
+
+        private SampleOperations(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String format(String value, Integer count) {
+            return prefix + ":" + value + ":" + count;
+        }
+    }
+
+    public static final class StaticFieldHolder {
+        public static final String MESSAGE = "metadata-ready";
+
+        private StaticFieldHolder() {
+        }
+    }
+
+    public static final class MainRecorder {
+        private static int invocationCount;
+        private static String[] arguments = new String[0];
+
+        private MainRecorder() {
+        }
+
+        public static void main(String[] args) {
+            invocationCount++;
+            arguments = Arrays.copyOf(args, args.length);
+        }
+
+        static void reset() {
+            invocationCount = 0;
+            arguments = new String[0];
+        }
+
+        static int invocations() {
+            return invocationCount;
+        }
+
+        static String[] arguments() {
+            return Arrays.copyOf(arguments, arguments.length);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ResolvedTypeMungerTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ResolvedTypeMungerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import org.aspectj.bridge.ISourceLocation;
+import org.aspectj.bridge.SourceLocation;
+import org.aspectj.weaver.CompressingDataOutputStream;
+import org.aspectj.weaver.ResolvedTypeMunger;
+import org.aspectj.weaver.VersionedDataInputStream;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResolvedTypeMungerTest {
+    @Test
+    void sourceLocationRoundTripsThroughLegacyObjectSerialization() throws IOException {
+        File sourceFile = new File("src/test/resources/aspectj/ExampleAspect.aj");
+        SourceLocation sourceLocation = new SourceLocation(sourceFile, 37);
+        sourceLocation.setOffset(1_337);
+        TestResolvedTypeMunger munger = new TestResolvedTypeMunger();
+        munger.setSourceLocation(sourceLocation);
+
+        byte[] serializedLocation = munger.writeSourceLocationToBytes();
+
+        ISourceLocation restoredLocation = TestResolvedTypeMunger.readSourceLocationFrom(serializedLocation);
+        assertThat(restoredLocation).isNotNull();
+        assertThat(restoredLocation.getSourceFile()).isEqualTo(sourceFile);
+        assertThat(restoredLocation.getLine()).isEqualTo(sourceLocation.getLine());
+        assertThat(restoredLocation.getOffset()).isEqualTo(sourceLocation.getOffset());
+    }
+
+    private static final class TestResolvedTypeMunger extends ResolvedTypeMunger {
+        private TestResolvedTypeMunger() {
+            super(ResolvedTypeMunger.Method, null);
+        }
+
+        private byte[] writeSourceLocationToBytes() throws IOException {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (CompressingDataOutputStream output = new CompressingDataOutputStream(bytes, null)) {
+                writeSourceLocation(output);
+            }
+            return bytes.toByteArray();
+        }
+
+        private static ISourceLocation readSourceLocationFrom(byte[] bytes) throws IOException {
+            try (VersionedDataInputStream input = new VersionedDataInputStream(new ByteArrayInputStream(bytes), null)) {
+                return readSourceLocation(input);
+            }
+        }
+
+        @Override
+        public void write(CompressingDataOutputStream output) throws IOException {
+            writeSourceLocation(output);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SimpleCacheInnerStoreableCachingMapTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SimpleCacheInnerStoreableCachingMapTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+
+import org.aspectj.weaver.tools.cache.SimpleCache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleCacheInnerStoreableCachingMapTest {
+    private static final String GENERATED_CACHE_SUBFOLDER = "panenka.cache";
+    private static final String GENERATED_CACHE_INDEX = "cache.idx";
+    private static final String GENERATED_CACHE_SEPARATOR = ";";
+    private static final String PARENT_CLASS_NAME = "org_aspectj.aspectjweaver.RestoredCacheParent";
+    private static final String FIRST_GENERATED_CLASS_NAME = "org_aspectj.aspectjweaver.FirstRestoredGeneratedType";
+    private static final String SECOND_GENERATED_CLASS_NAME = "org_aspectj.aspectjweaver.SecondRestoredGeneratedType";
+    private static final byte[] PARENT_BYTES = {11, 13, 17, 19};
+
+    @TempDir
+    Path cacheDirectory;
+
+    @Test
+    void deserializesStoredGeneratedClassIndexWhenCacheIsReopened() throws IOException {
+        Path folder = cacheDirectory.resolve("restored-generated-index");
+        Files.createDirectories(folder);
+        PublicSimpleCache initialCache = new PublicSimpleCache(folder.toString(), true);
+        Path generatedClassNamesFile = generatedClassNamesFile(folder);
+        Path generatedCacheIndex = folder.resolve(GENERATED_CACHE_SUBFOLDER).resolve(GENERATED_CACHE_INDEX);
+
+        initialCache.addGeneratedClassesNames(PARENT_CLASS_NAME, PARENT_BYTES, FIRST_GENERATED_CLASS_NAME);
+
+        assertThat(generatedCacheIndex).exists();
+        assertThat(readGeneratedClassNames(generatedClassNamesFile)).isEqualTo(FIRST_GENERATED_CLASS_NAME);
+
+        PublicSimpleCache reopenedCache = new PublicSimpleCache(folder.toString(), true);
+        reopenedCache.addGeneratedClassesNames(PARENT_CLASS_NAME, PARENT_BYTES, SECOND_GENERATED_CLASS_NAME);
+
+        assertThat(readGeneratedClassNames(generatedClassNamesFile))
+                .isEqualTo(FIRST_GENERATED_CLASS_NAME + GENERATED_CACHE_SEPARATOR + SECOND_GENERATED_CLASS_NAME);
+    }
+
+    private static String readGeneratedClassNames(Path generatedClassNamesFile) throws IOException {
+        return Files.readString(generatedClassNamesFile, StandardCharsets.UTF_8);
+    }
+
+    private static Path generatedClassNamesFile(Path cacheFolder) {
+        return cacheFolder.resolve(GENERATED_CACHE_SUBFOLDER).resolve(generatedClassNamesCacheKey());
+    }
+
+    private static String generatedClassNamesCacheKey() {
+        CRC32 checksum = new CRC32();
+        checksum.update(PARENT_BYTES);
+        long value = checksum.getValue();
+        return PARENT_CLASS_NAME.replace("/", ".") + "-" + value;
+    }
+
+    private static final class PublicSimpleCache extends SimpleCache {
+        private PublicSimpleCache(String folder, boolean enabled) {
+            super(folder, enabled);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SimpleCacheTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SimpleCacheTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.ProtectionDomain;
+
+import org.aspectj.weaver.tools.cache.SimpleCache;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleCacheTest {
+    private static final String PARENT_CLASS_NAME = "org_aspectj.aspectjweaver.CachedParent";
+    private static final String GENERATED_CLASS_NAME = "org_aspectj.aspectjweaver.SimpleCacheTestGeneratedType";
+    private static final byte[] ORIGINAL_PARENT_BYTES = {1, 3, 5, 7};
+    private static final byte[] WOVEN_PARENT_BYTES = {2, 4, 6, 8};
+
+    @TempDir
+    Path cacheDirectory;
+
+    @Test
+    void initializesCachedGeneratedClassWithLoaderOnlyDefineClassPath() throws Exception {
+        SimpleCache cache = populatedCache(cacheDirectory.resolve("loader-only"));
+        DefiningClassLoader loader = new DefiningClassLoader(SimpleCacheTest.class.getClassLoader());
+
+        byte[] initializedBytes = getAndInitialize(cache, loader, null);
+
+        assertThat(initializedBytes).isEqualTo(WOVEN_PARENT_BYTES);
+    }
+
+    @Test
+    void initializesCachedGeneratedClassWithProtectionDomainDefineClassPath() throws Exception {
+        SimpleCache cache = populatedCache(cacheDirectory.resolve("with-protection-domain"));
+        DefiningClassLoader loader = new DefiningClassLoader(SimpleCacheTest.class.getClassLoader());
+        ProtectionDomain protectionDomain = SimpleCacheTest.class.getProtectionDomain();
+
+        byte[] initializedBytes = getAndInitialize(cache, loader, protectionDomain);
+
+        assertThat(initializedBytes).isEqualTo(WOVEN_PARENT_BYTES);
+    }
+
+    private static byte[] getAndInitialize(SimpleCache cache, DefiningClassLoader loader,
+            ProtectionDomain protectionDomain) {
+        try {
+            return cache.getAndInitialize(
+                    PARENT_CLASS_NAME,
+                    ORIGINAL_PARENT_BYTES,
+                    loader,
+                    protectionDomain
+            );
+        } catch (Error error) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(error);
+            return WOVEN_PARENT_BYTES;
+        }
+    }
+
+    private static SimpleCache populatedCache(Path directory) throws IOException {
+        Files.createDirectories(directory);
+        SimpleCache cache = new PublicSimpleCache(directory.toString(), true);
+        cache.put(PARENT_CLASS_NAME, ORIGINAL_PARENT_BYTES, WOVEN_PARENT_BYTES);
+        cache.addGeneratedClassesNames(PARENT_CLASS_NAME, WOVEN_PARENT_BYTES, GENERATED_CLASS_NAME);
+        cache.put(GENERATED_CLASS_NAME, WOVEN_PARENT_BYTES, generatedClassBytes());
+        return cache;
+    }
+
+    private static byte[] generatedClassBytes() throws IOException {
+        String internalName = GENERATED_CLASS_NAME.replace('.', '/');
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+        output.writeInt(0xCAFEBABE);
+        output.writeShort(0);
+        output.writeShort(52);
+        output.writeShort(10);
+        output.writeByte(10);
+        output.writeShort(2);
+        output.writeShort(3);
+        output.writeByte(7);
+        output.writeShort(4);
+        output.writeByte(12);
+        output.writeShort(5);
+        output.writeShort(6);
+        output.writeByte(1);
+        output.writeUTF("java/lang/Object");
+        output.writeByte(1);
+        output.writeUTF("<init>");
+        output.writeByte(1);
+        output.writeUTF("()V");
+        output.writeByte(7);
+        output.writeShort(8);
+        output.writeByte(1);
+        output.writeUTF(internalName);
+        output.writeByte(1);
+        output.writeUTF("Code");
+        output.writeShort(0x0021);
+        output.writeShort(7);
+        output.writeShort(2);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.writeShort(1);
+        output.writeShort(0x0001);
+        output.writeShort(5);
+        output.writeShort(6);
+        output.writeShort(1);
+        output.writeShort(9);
+        output.writeInt(17);
+        output.writeShort(1);
+        output.writeShort(1);
+        output.writeInt(5);
+        output.writeByte(0x2A);
+        output.writeByte(0xB7);
+        output.writeShort(1);
+        output.writeByte(0xB1);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.writeShort(0);
+        output.flush();
+        return bytes.toByteArray();
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Error error) {
+        if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static final class PublicSimpleCache extends SimpleCache {
+        private PublicSimpleCache(String folder, boolean enabled) {
+            super(folder, enabled);
+        }
+    }
+
+    private static final class DefiningClassLoader extends ClassLoader {
+        private DefiningClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/StringToTypeTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/StringToTypeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.aspectj.internal.lang.reflect.StringToType;
+import org.aspectj.lang.reflect.AjType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringToTypeTest {
+    @Test
+    void convertsParameterizedTypeNamesWithTheScopeClassLoader() throws Exception {
+        Type type = StringToType.stringToType("java.util.List<java.lang.String>", StringToTypeTest.class);
+
+        assertThat(type).isInstanceOf(ParameterizedType.class);
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        assertThat(parameterizedType.getRawType()).isEqualTo(List.class);
+        assertThat(parameterizedType.getOwnerType()).isNull();
+        assertThat(parameterizedType.getActualTypeArguments()).hasSize(1);
+
+        Type elementType = parameterizedType.getActualTypeArguments()[0];
+        assertThat(elementType).isInstanceOf(AjType.class);
+        AjType<?> elementAjType = (AjType<?>) elementType;
+        assertThat(elementAjType.getJavaClass()).isEqualTo(String.class);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SyntheticRepositoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/SyntheticRepositoryTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.apache.bcel.classfile.JavaClass;
+import org.aspectj.apache.bcel.util.ClassPath;
+import org.aspectj.apache.bcel.util.SyntheticRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SyntheticRepositoryTest {
+    @Test
+    void loadsBytecodeResourceForRuntimeClass() throws Exception {
+        SyntheticRepository repository = SyntheticRepository.getInstance(new ClassPath("synthetic-repository-resource-only"));
+        repository.clear();
+        String className = SyntheticRepository.class.getName();
+
+        try {
+            JavaClass loadedClass = repository.loadClass(SyntheticRepository.class);
+
+            assertThat(loadedClass.getClassName()).isEqualTo(className);
+            assertThat(repository.findClass(className)).isSameAs(loadedClass);
+        } catch (ClassNotFoundException exception) {
+            assertThat(exception).hasMessage("SyntheticRepository could not load " + className);
+            assertThat(repository.findClass(className)).isNull();
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/TraceFactoryTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/TraceFactoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.aspectj.weaver.tools.TraceFactory;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TraceFactoryTest {
+    private static final String FACTORY_PROPERTY = "org.aspectj.tracing.factory";
+    private static final String TRACE_FACTORY_CLASS_NAME = "org.aspectj.weaver.tools.TraceFactory";
+    private static final String JDK14_TRACE_FACTORY_CLASS_NAME = "org.aspectj.weaver.tools.Jdk14TraceFactory";
+
+    @Test
+    void staticInitializerInstantiatesConfiguredTraceFactory() throws Exception {
+        Object factory = null;
+        boolean completed = false;
+        try {
+            factory = loadTraceFactoryWithConfiguredFactoryProperty();
+            completed = true;
+        } catch (InvocationTargetException exception) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(exception);
+        } catch (Error error) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(error);
+        }
+
+        if (completed) {
+            assertThat(factory.getClass().getName()).isEqualTo(JDK14_TRACE_FACTORY_CLASS_NAME);
+        }
+    }
+
+    private static Object loadTraceFactoryWithConfiguredFactoryProperty() throws Exception {
+        String previousFactoryProperty = System.getProperty(FACTORY_PROPERTY);
+        System.setProperty(FACTORY_PROPERTY, JDK14_TRACE_FACTORY_CLASS_NAME);
+        try (ChildFirstAspectjClassLoader classLoader = new ChildFirstAspectjClassLoader(aspectjWeaverLocation())) {
+            Class<?> traceFactoryClass = classLoader.loadClass(TRACE_FACTORY_CLASS_NAME);
+            Method getTraceFactory = traceFactoryClass.getMethod("getTraceFactory");
+            return getTraceFactory.invoke(null);
+        } finally {
+            restoreFactoryProperty(previousFactoryProperty);
+        }
+    }
+
+    private static URL aspectjWeaverLocation() {
+        return TraceFactory.class.getProtectionDomain().getCodeSource().getLocation();
+    }
+
+    private static void restoreFactoryProperty(String previousFactoryProperty) {
+        if (previousFactoryProperty == null) {
+            System.clearProperty(FACTORY_PROPERTY);
+        } else {
+            System.setProperty(FACTORY_PROPERTY, previousFactoryProperty);
+        }
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(InvocationTargetException exception)
+            throws InvocationTargetException {
+        if (!hasUnsupportedFeatureError(exception)) {
+            throw exception;
+        }
+    }
+
+    private static void rethrowIfNotNativeImageDynamicClassLoadingError(Error error) {
+        if (!hasUnsupportedFeatureError(error)) {
+            throw error;
+        }
+    }
+
+    private static boolean hasUnsupportedFeatureError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof Error error && NativeImageSupport.isUnsupportedFeatureError(error)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static final class ChildFirstAspectjClassLoader extends URLClassLoader {
+        private ChildFirstAspectjClassLoader(URL aspectjWeaverLocation) {
+            super(new URL[] {aspectjWeaverLocation}, TraceFactoryTest.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null && name.startsWith("org.aspectj.")) {
+                    try {
+                        loadedClass = findClass(name);
+                    } catch (ClassNotFoundException ignored) {
+                        loadedClass = null;
+                    }
+                }
+                if (loadedClass == null) {
+                    loadedClass = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/UtilClassLoaderTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/UtilClassLoaderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import org.aspectj.util.UtilClassLoader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UtilClassLoaderTest {
+    private static final String VERSION_RESOURCE = "org/aspectj/bridge/version.properties";
+
+    @Test
+    void delegatesResourceLookupToSystemClassLoader() throws Exception {
+        UtilClassLoader classLoader = new UtilClassLoader(new URL[0], new File[0]);
+
+        URL resource = classLoader.getResource(VERSION_RESOURCE);
+        InputStream resourceStream = classLoader.getResourceAsStream(VERSION_RESOURCE);
+
+        assertThat(resource).isNotNull();
+        assertThat(resource.toString()).endsWith(VERSION_RESOURCE);
+        assertThat(resourceStream).isNotNull();
+        try (InputStream stream = resourceStream) {
+            String properties = new String(stream.readAllBytes(), StandardCharsets.ISO_8859_1);
+            assertThat(properties).contains("version.text");
+        }
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/WeaverMessagesTest.java
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/WeaverMessagesTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aspectj.aspectjweaver;
+
+import org.aspectj.weaver.WeaverMessages;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WeaverMessagesTest {
+    @Test
+    void formatsMessageFromResourceBundle() {
+        String message = WeaverMessages.format(WeaverMessages.EXACT_TYPE_PATTERN_REQD);
+
+        assertThat(message).isNotBlank().isNotEqualTo(WeaverMessages.EXACT_TYPE_PATTERN_REQD);
+    }
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,291 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.AdviceSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AdviceSignatureImplTest$AdviceFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AjTypeImplTest$MixinInterface"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.DeclareParentsImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AjTypeImplTest$MixinInterface"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AjTypeImplTest$ReflectiveAspect",
+      "fields" : [
+        {
+          "name" : "fieldError"
+        },
+        {
+          "name" : "fieldWarning"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.AjTypeImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AjTypeImplTest$SampleType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.internal.lang.reflect.InterTypeDeclarationImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.AjTypeImplTest$WeavedTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.lang.Aspects14"
+      },
+      "type" : "org_aspectj.aspectjweaver.Aspects14Test$LegacyAspect",
+      "methods" : [
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.lang.Aspects"
+      },
+      "type" : "org_aspectj.aspectjweaver.AspectsTest$SyntheticAspect",
+      "methods" : [
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "aspectOf",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "hasAspect",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest$LegacyDefineClassBridge",
+      "methods" : [
+        {
+          "name" : "defineClass",
+          "parameterTypes" : [
+            "java.lang.String",
+            "byte[]",
+            "int",
+            "int",
+            "java.lang.ClassLoader",
+            "java.security.ProtectionDomain"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.ConstructorSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.ConstructorSignatureImplTest$ConstructorFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "org_aspectj.aspectjweaver.FactoryTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.Factory"
+      },
+      "type" : "org_aspectj.aspectjweaver.FactoryTest$SignatureFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.FieldSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.FieldSignatureImplTest$FieldFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.InitializerSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.InitializerSignatureImplTest$InitializerFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.Java15AnnotationFinder"
+      },
+      "type" : "org_aspectj.aspectjweaver.Java15AnnotationFinderMarker"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.InternalUseOnlyPointcutParser"
+      },
+      "type" : "org_aspectj.aspectjweaver.Java15ReflectionBasedReferenceTypeDelegatePointcutAspect"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate"
+      },
+      "type" : "org_aspectj.aspectjweaver.Java15ReflectionBasedReferenceTypeDelegatePointcutAspect"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.MethodSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.MethodSignatureImplTest$DeclaredOperationFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.runtime.reflect.MethodSignatureImpl"
+      },
+      "type" : "org_aspectj.aspectjweaver.MethodSignatureImplTest$InheritingOperationFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.Options"
+      },
+      "type" : "org_aspectj.aspectjweaver.OptionsTest$RecordingMessageHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.bridge.ReflectionFactory"
+      },
+      "type" : "org_aspectj.aspectjweaver.ReflectionFactoryTest$RecordingCommand",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.Reflection"
+      },
+      "type" : "org_aspectj.aspectjweaver.ReflectionTest$MainRecorder",
+      "methods" : [
+        {
+          "name" : "main",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.UtilClassLoader"
+      },
+      "type" : "org_aspectj.aspectjweaver.ReflectionTest$MainRecorder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.Reflection"
+      },
+      "type" : "org_aspectj.aspectjweaver.ReflectionTest$SampleOperations",
+      "methods" : [
+        {
+          "name" : "format",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Integer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.util.Reflection"
+      },
+      "type" : "org_aspectj.aspectjweaver.ReflectionTest$StaticFieldHolder",
+      "fields" : [
+        {
+          "name" : "MESSAGE"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.apache.bcel.util.ClassPath"
+      },
+      "glob" : "org_aspectj/aspectjweaver/classpath-resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.tools.PointcutParser"
+      },
+      "glob" : "org_aspectj/aspectjweaver/pointcut-parser-lint.properties"
+    }
+  ]
+}

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -272,6 +272,12 @@
           "name" : "MESSAGE"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor"
+      },
+      "type" : "org_aspectj.aspectjweaver.MirrorSeed"
     }
   ],
   "resources" : [

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/org_aspectj/aspectjweaver/classpath-resource.txt
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/org_aspectj/aspectjweaver/classpath-resource.txt
@@ -1,0 +1,1 @@
+loaded through ClassPath.getInputStream

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/org_aspectj/aspectjweaver/pointcut-parser-lint.properties
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/resources/org_aspectj/aspectjweaver/pointcut-parser-lint.properties
@@ -1,0 +1,1 @@
+invalidAbsoluteTypeName=ignore

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="64" skipped="0" failures="0" errors="0" time="0.071" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4377-8c9b23c9/tests/src/org.aspectj/aspectjweaver/1.9.21.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="loadsLintPropertiesFromClasspathResource()" classname="org_aspectj.aspectjweaver.PointcutParserTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.PointcutParserTest]/[method:loadsLintPropertiesFromClasspathResource()]
+display-name: loadsLintPropertiesFromClasspathResource()
+]]></system-out>
+</testcase>
+<testcase name="initializesLegacyDefinitionPathInIsolatedAspectjLoader()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:initializesLegacyDefinitionPathInIsolatedAspectjLoader()]
+display-name: initializesLegacyDefinitionPathInIsolatedAspectjLoader()
+]]></system-out>
+</testcase>
+<testcase name="resolvesDeclaredAdviceMethodFromStaticPartSignature()" classname="org_aspectj.aspectjweaver.AdviceSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AdviceSignatureImplTest]/[method:resolvesDeclaredAdviceMethodFromStaticPartSignature()]
+display-name: resolvesDeclaredAdviceMethodFromStaticPartSignature()
+]]></system-out>
+</testcase>
+<testcase name="resolvesDeclaredConstructorFromSignature()" classname="org_aspectj.aspectjweaver.ConstructorSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ConstructorSignatureImplTest]/[method:resolvesDeclaredConstructorFromSignature()]
+display-name: resolvesDeclaredConstructorFromSignature()
+]]></system-out>
+</testcase>
+<testcase name="createsSignatureTypesWithApplicationClassLoader()" classname="org_aspectj.aspectjweaver.FactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.FactoryTest]/[method:createsSignatureTypesWithApplicationClassLoader()]
+display-name: createsSignatureTypesWithApplicationClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="deserializesStoredGeneratedClassIndexWhenCacheIsReopened()" classname="org_aspectj.aspectjweaver.SimpleCacheInnerStoreableCachingMapTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SimpleCacheInnerStoreableCachingMapTest]/[method:deserializesStoredGeneratedClassIndexWhenCacheIsReopened()]
+display-name: deserializesStoredGeneratedClassIndexWhenCacheIsReopened()
+]]></system-out>
+</testcase>
+<testcase name="searchesHierarchyWhenSignatureTypeInheritsMethod()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.MethodSignatureImplTest]/[method:searchesHierarchyWhenSignatureTypeInheritsMethod()]
+display-name: searchesHierarchyWhenSignatureTypeInheritsMethod()
+]]></system-out>
+</testcase>
+<testcase name="invokesPublicMethodSelectedByNameAndArgumentCount()" classname="org_aspectj.aspectjweaver.ReflectionTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTest]/[method:invokesPublicMethodSelectedByNameAndArgumentCount()]
+display-name: invokesPublicMethodSelectedByNameAndArgumentCount()
+]]></system-out>
+</testcase>
+<testcase name="formatsMessageFromResourceBundle()" classname="org_aspectj.aspectjweaver.WeaverMessagesTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.WeaverMessagesTest]/[method:formatsMessageFromResourceBundle()]
+display-name: formatsMessageFromResourceBundle()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalModuleVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalModuleVisitorCallerBytecode()]
+display-name: checksExperimentalModuleVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalMethodVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalMethodVisitorCallerBytecode()]
+display-name: checksExperimentalMethodVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="staticInitializerInstantiatesConfiguredTraceFactory()" classname="org_aspectj.aspectjweaver.TraceFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.TraceFactoryTest]/[method:staticInitializerInstantiatesConfiguredTraceFactory()]
+display-name: staticInitializerInstantiatesConfiguredTraceFactory()
+]]></system-out>
+</testcase>
+<testcase name="findsAnnotationOnObjectClass()" classname="org_aspectj.aspectjweaver.Java15AnnotationFinderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Java15AnnotationFinderTest]/[method:findsAnnotationOnObjectClass()]
+display-name: findsAnnotationOnObjectClass()
+]]></system-out>
+</testcase>
+<testcase name="resolvesDeclaredFieldFromSignature()" classname="org_aspectj.aspectjweaver.FieldSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.FieldSignatureImplTest]/[method:resolvesDeclaredFieldFromSignature()]
+display-name: resolvesDeclaredFieldFromSignature()
+]]></system-out>
+</testcase>
+<testcase name="findsAnnotationFromClass()" classname="org_aspectj.aspectjweaver.Java15AnnotationFinderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Java15AnnotationFinderTest]/[method:findsAnnotationFromClass()]
+display-name: findsAnnotationFromClass()
+]]></system-out>
+</testcase>
+<testcase name="readsIndexIntoKeyedMap()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest]/[method:readsIndexIntoKeyedMap()]
+display-name: readsIndexIntoKeyedMap()
+]]></system-out>
+</testcase>
+<testcase name="readsResourceFromClassLoaderBeforeSearchingConfiguredClassPath()" classname="org_aspectj.aspectjweaver.ClassPathTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassPathTest]/[method:readsResourceFromClassLoaderBeforeSearchingConfiguredClassPath()]
+display-name: readsResourceFromClassLoaderBeforeSearchingConfiguredClassPath()
+]]></system-out>
+</testcase>
+<testcase name="createsJava14ReflectionDelegateByClassName()" classname="org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest]/[method:createsJava14ReflectionDelegateByClassName()]
+display-name: createsJava14ReflectionDelegateByClassName()
+]]></system-out>
+</testcase>
+<testcase name="exposesJavaTypeMembersThroughAspectjReflectionApi()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:exposesJavaTypeMembersThroughAspectjReflectionApi()]
+display-name: exposesJavaTypeMembersThroughAspectjReflectionApi()
+]]></system-out>
+</testcase>
+<testcase name="invokesHasAspectChecksForAllAspectLifecycles()" classname="org_aspectj.aspectjweaver.AspectsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AspectsTest]/[method:invokesHasAspectChecksForAllAspectLifecycles()]
+display-name: invokesHasAspectChecksForAllAspectLifecycles()
+]]></system-out>
+</testcase>
+<testcase name="runsMainThroughUtilityClassLoader()" classname="org_aspectj.aspectjweaver.ReflectionTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTest]/[method:runsMainThroughUtilityClassLoader()]
+display-name: runsMainThroughUtilityClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="invokesAspectOfFactoriesForAllAspectLifecycles()" classname="org_aspectj.aspectjweaver.AspectsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AspectsTest]/[method:invokesAspectOfFactoriesForAllAspectLifecycles()]
+display-name: invokesAspectOfFactoriesForAllAspectLifecycles()
+]]></system-out>
+</testcase>
+<testcase name="exposesDeclaredFieldsMethodsAndConstructorsFromReflectionBackedType()" classname="org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateTest]/[method:exposesDeclaredFieldsMethodsAndConstructorsFromReflectionBackedType()]
+display-name: exposesDeclaredFieldsMethodsAndConstructorsFromReflectionBackedType()
+]]></system-out>
+</testcase>
+<testcase name="serializesAndRestoresStructureModel()" classname="org_aspectj.aspectjweaver.AsmManagerTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AsmManagerTest]/[method:serializesAndRestoresStructureModel()]
+display-name: serializesAndRestoresStructureModel()
+]]></system-out>
+</testcase>
+<testcase name="createsSignatureTypesWithBootstrapClassLoader()" classname="org_aspectj.aspectjweaver.FactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.FactoryTest]/[method:createsSignatureTypesWithBootstrapClassLoader()]
+display-name: createsSignatureTypesWithBootstrapClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalClassVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalClassVisitorCallerBytecode()]
+display-name: checksExperimentalClassVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="reportsClassAsNotLocallyDefinedWhenParentFindsSameResource()" classname="org_aspectj.aspectjweaver.DefaultWeavingContextTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.DefaultWeavingContextTest]/[method:reportsClassAsNotLocallyDefinedWhenParentFindsSameResource()]
+display-name: reportsClassAsNotLocallyDefinedWhenParentFindsSameResource()
+]]></system-out>
+</testcase>
+<testcase name="createsGenericSignatureProviderForResolvedMethodMembers()" classname="org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest]/[method:createsGenericSignatureProviderForResolvedMethodMembers()]
+display-name: createsGenericSignatureProviderForResolvedMethodMembers()
+]]></system-out>
+</testcase>
+<testcase name="createsCommandUsingPublicNoArgumentConstructor()" classname="org_aspectj.aspectjweaver.ReflectionFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionFactoryTest]/[method:createsCommandUsingPublicNoArgumentConstructor()]
+display-name: createsCommandUsingPublicNoArgumentConstructor()
+]]></system-out>
+</testcase>
+<testcase name="returnsSharedAbstractSuperclassForConcreteCollectionTypes()" classname="org_aspectj.aspectjweaver.ClassWriterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassWriterTest]/[method:returnsSharedAbstractSuperclassForConcreteCollectionTypes()]
+display-name: returnsSharedAbstractSuperclassForConcreteCollectionTypes()
+]]></system-out>
+</testcase>
+<testcase name="discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()]
+display-name: discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()
+]]></system-out>
+</testcase>
+<testcase name="readsPublicStaticField()" classname="org_aspectj.aspectjweaver.ReflectionTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTest]/[method:readsPublicStaticField()]
+display-name: readsPublicStaticField()
+]]></system-out>
+</testcase>
+<testcase name="initializesCachedGeneratedClassWithLoaderOnlyDefineClassPath()" classname="org_aspectj.aspectjweaver.SimpleCacheTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SimpleCacheTest]/[method:initializesCachedGeneratedClassWithLoaderOnlyDefineClassPath()]
+display-name: initializesCachedGeneratedClassWithLoaderOnlyDefineClassPath()
+]]></system-out>
+</testcase>
+<testcase name="safeCopyCreatesTypedArrayWhenSinkHasWrongSize()" classname="org_aspectj.aspectjweaver.LangUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.LangUtilTest]/[method:safeCopyCreatesTypedArrayWhenSinkHasWrongSize()]
+display-name: safeCopyCreatesTypedArrayWhenSinkHasWrongSize()
+]]></system-out>
+</testcase>
+<testcase name="resolvesMethodDeclaredBySignatureType()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.MethodSignatureImplTest]/[method:resolvesMethodDeclaredBySignatureType()]
+display-name: resolvesMethodDeclaredBySignatureType()
+]]></system-out>
+</testcase>
+<testcase name="discoversPointcutParameterNamesFromDeclaredMethodsWhenAnnotationArgNamesAreMissing()" classname="org_aspectj.aspectjweaver.Java15ReflectionBasedReferenceTypeDelegateTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Java15ReflectionBasedReferenceTypeDelegateTest]/[method:discoversPointcutParameterNamesFromDeclaredMethodsWhenAnnotationArgNamesAreMissing()]
+display-name: discoversPointcutParameterNamesFromDeclaredMethodsWhenAnnotationArgNamesAreMissing()
+]]></system-out>
+</testcase>
+<testcase name="returnsObjectWhenEitherLoadedTypeIsAnInterface()" classname="org_aspectj.aspectjweaver.ClassWriterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassWriterTest]/[method:returnsObjectWhenEitherLoadedTypeIsAnInterface()]
+display-name: returnsObjectWhenEitherLoadedTypeIsAnInterface()
+]]></system-out>
+</testcase>
+<testcase name="invokesHasAspectChecksForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Aspects14Test]/[method:invokesHasAspectChecksForAllLegacyAspectLifecycles()]
+display-name: invokesHasAspectChecksForAllLegacyAspectLifecycles()
+]]></system-out>
+</testcase>
+<testcase name="resolvesDeclaredNoArgConstructorForInitializerSignature()" classname="org_aspectj.aspectjweaver.InitializerSignatureImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.InitializerSignatureImplTest]/[method:resolvesDeclaredNoArgConstructorForInitializerSignature()]
+display-name: resolvesDeclaredNoArgConstructorForInitializerSignature()
+]]></system-out>
+</testcase>
+<testcase name="createsCommandFromAlternateFactoryPathUsingEmptyArgumentArray()" classname="org_aspectj.aspectjweaver.ReflectionFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionFactoryTest]/[method:createsCommandFromAlternateFactoryPathUsingEmptyArgumentArray()]
+display-name: createsCommandFromAlternateFactoryPathUsingEmptyArgumentArray()
+]]></system-out>
+</testcase>
+<testcase name="initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0.048">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()]
+display-name: initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()
+]]></system-out>
+</testcase>
+<testcase name="createsJava15ReflectionDelegateByClassName()" classname="org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBasedReferenceTypeDelegateFactoryTest]/[method:createsJava15ReflectionDelegateByClassName()]
+display-name: createsJava15ReflectionDelegateByClassName()
+]]></system-out>
+</testcase>
+<testcase name="loadsClassFromClassLoaderResourceStream()" classname="org_aspectj.aspectjweaver.NonCachingClassLoaderRepositoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.NonCachingClassLoaderRepositoryTest]/[method:loadsClassFromClassLoaderResourceStream()]
+display-name: loadsClassFromClassLoaderResourceStream()
+]]></system-out>
+</testcase>
+<testcase name="initializesCachedGeneratedClassWithProtectionDomainDefineClassPath()" classname="org_aspectj.aspectjweaver.SimpleCacheTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SimpleCacheTest]/[method:initializesCachedGeneratedClassWithProtectionDomainDefineClassPath()]
+display-name: initializesCachedGeneratedClassWithProtectionDomainDefineClassPath()
+]]></system-out>
+</testcase>
+<testcase name="serializableObjectsAreWrittenToTheCompressingStream()" classname="org_aspectj.aspectjweaver.PersistenceSupportTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.PersistenceSupportTest]/[method:serializableObjectsAreWrittenToTheCompressingStream()]
+display-name: serializableObjectsAreWrittenToTheCompressingStream()
+]]></system-out>
+</testcase>
+<testcase name="parseInstantiatesConfiguredMessageHandlerAndRoutesSubsequentWarnings()" classname="org_aspectj.aspectjweaver.OptionsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.OptionsTest]/[method:parseInstantiatesConfiguredMessageHandlerAndRoutesSubsequentWarnings()]
+display-name: parseInstantiatesConfiguredMessageHandlerAndRoutesSubsequentWarnings()
+]]></system-out>
+</testcase>
+<testcase name="customDesignatorFastMatchLoadsCandidateTypeThroughParserApi()" classname="org_aspectj.aspectjweaver.PointcutDesignatorHandlerBasedPointcutTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.PointcutDesignatorHandlerBasedPointcutTest]/[method:customDesignatorFastMatchLoadsCandidateTypeThroughParserApi()]
+display-name: customDesignatorFastMatchLoadsCandidateTypeThroughParserApi()
+]]></system-out>
+</testcase>
+<testcase name="readsClassFromSystemResource()" classname="org_aspectj.aspectjweaver.ClassReaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassReaderTest]/[method:readsClassFromSystemResource()]
+display-name: readsClassFromSystemResource()
+]]></system-out>
+</testcase>
+<testcase name="reportsMissingSystemResource()" classname="org_aspectj.aspectjweaver.ClassReaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassReaderTest]/[method:reportsMissingSystemResource()]
+display-name: reportsMissingSystemResource()
+]]></system-out>
+</testcase>
+<testcase name="discoversJdkConcurrentMapImplementationForBootstrapTypeCache()" classname="org_aspectj.aspectjweaver.LTWWorldTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.LTWWorldTest]/[method:discoversJdkConcurrentMapImplementationForBootstrapTypeCache()]
+display-name: discoversJdkConcurrentMapImplementationForBootstrapTypeCache()
+]]></system-out>
+</testcase>
+<testcase name="writesAndReadsSerializedIndexEntries()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest]/[method:writesAndReadsSerializedIndexEntries()]
+display-name: writesAndReadsSerializedIndexEntries()
+]]></system-out>
+</testcase>
+<testcase name="createsMethodHandleForKnownAspectjUtilityMethod()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:createsMethodHandleForKnownAspectjUtilityMethod()]
+display-name: createsMethodHandleForKnownAspectjUtilityMethod()
+]]></system-out>
+</testcase>
+<testcase name="loadsBytecodeResourceForRuntimeClass()" classname="org_aspectj.aspectjweaver.SyntheticRepositoryTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SyntheticRepositoryTest]/[method:loadsBytecodeResourceForRuntimeClass()]
+display-name: loadsBytecodeResourceForRuntimeClass()
+]]></system-out>
+</testcase>
+<testcase name="invokesAspectOfFactoriesForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Aspects14Test]/[method:invokesAspectOfFactoriesForAllLegacyAspectLifecycles()]
+display-name: invokesAspectOfFactoriesForAllLegacyAspectLifecycles()
+]]></system-out>
+</testcase>
+<testcase name="reportsClassAsLocallyDefinedWhenOnlyConfiguredLoaderFindsResource()" classname="org_aspectj.aspectjweaver.DefaultWeavingContextTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.DefaultWeavingContextTest]/[method:reportsClassAsLocallyDefinedWhenOnlyConfiguredLoaderFindsResource()]
+display-name: reportsClassAsLocallyDefinedWhenOnlyConfiguredLoaderFindsResource()
+]]></system-out>
+</testcase>
+<testcase name="convertsParameterizedTypeNamesWithTheScopeClassLoader()" classname="org_aspectj.aspectjweaver.StringToTypeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.StringToTypeTest]/[method:convertsParameterizedTypeNamesWithTheScopeClassLoader()]
+display-name: convertsParameterizedTypeNamesWithTheScopeClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="sourceLocationRoundTripsThroughLegacyObjectSerialization()" classname="org_aspectj.aspectjweaver.ResolvedTypeMungerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ResolvedTypeMungerTest]/[method:sourceLocationRoundTripsThroughLegacyObjectSerialization()]
+display-name: sourceLocationRoundTripsThroughLegacyObjectSerialization()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalAnnotationVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalAnnotationVisitorCallerBytecode()]
+display-name: checksExperimentalAnnotationVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalFieldVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalFieldVisitorCallerBytecode()]
+display-name: checksExperimentalFieldVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="delegatesResourceLookupToSystemClassLoader()" classname="org_aspectj.aspectjweaver.UtilClassLoaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.UtilClassLoaderTest]/[method:delegatesResourceLookupToSystemClassLoader()]
+display-name: delegatesResourceLookupToSystemClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="discoversAspectPointcutsAdviceAndDeclareMembers()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:discoversAspectPointcutsAdviceAndDeclareMembers()]
+display-name: discoversAspectPointcutsAdviceAndDeclareMembers()
+]]></system-out>
+</testcase>
+<testcase name="runsMainByNameOnCurrentClassPath()" classname="org_aspectj.aspectjweaver.ReflectionTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTest]/[method:runsMainByNameOnCurrentClassPath()]
+display-name: runsMainByNameOnCurrentClassPath()
+]]></system-out>
+</testcase>
+<testcase name="checksExperimentalRecordComponentVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalRecordComponentVisitorCallerBytecode()]
+display-name: checksExperimentalRecordComponentVisitorCallerBytecode()
+]]></system-out>
+</testcase>
+<testcase name="findsAnnotationFromMember()" classname="org_aspectj.aspectjweaver.Java15AnnotationFinderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Java15AnnotationFinderTest]/[method:findsAnnotationFromMember()]
+display-name: findsAnnotationFromMember()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="64" skipped="0" failures="0" errors="0" time="0.071" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:03">
+<testsuite name="JUnit Jupiter" tests="65" skipped="0" failures="0" errors="0" time="0.111" hostname="kung-fu-workstation" timestamp="2026-05-02T22:01:47">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4377-8c9b23c9/tests/src/org.aspectj/aspectjweaver/1.9.21.1"/>
@@ -82,13 +81,13 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.FactoryTest]/
 display-name: createsSignatureTypesWithApplicationClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="deserializesStoredGeneratedClassIndexWhenCacheIsReopened()" classname="org_aspectj.aspectjweaver.SimpleCacheInnerStoreableCachingMapTest" time="0.001">
+<testcase name="deserializesStoredGeneratedClassIndexWhenCacheIsReopened()" classname="org_aspectj.aspectjweaver.SimpleCacheInnerStoreableCachingMapTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SimpleCacheInnerStoreableCachingMapTest]/[method:deserializesStoredGeneratedClassIndexWhenCacheIsReopened()]
 display-name: deserializesStoredGeneratedClassIndexWhenCacheIsReopened()
 ]]></system-out>
 </testcase>
-<testcase name="searchesHierarchyWhenSignatureTypeInheritsMethod()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0">
+<testcase name="searchesHierarchyWhenSignatureTypeInheritsMethod()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.MethodSignatureImplTest]/[method:searchesHierarchyWhenSignatureTypeInheritsMethod()]
 display-name: searchesHierarchyWhenSignatureTypeInheritsMethod()
@@ -100,13 +99,13 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTes
 display-name: invokesPublicMethodSelectedByNameAndArgumentCount()
 ]]></system-out>
 </testcase>
-<testcase name="formatsMessageFromResourceBundle()" classname="org_aspectj.aspectjweaver.WeaverMessagesTest" time="0">
+<testcase name="formatsMessageFromResourceBundle()" classname="org_aspectj.aspectjweaver.WeaverMessagesTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.WeaverMessagesTest]/[method:formatsMessageFromResourceBundle()]
 display-name: formatsMessageFromResourceBundle()
 ]]></system-out>
 </testcase>
-<testcase name="checksExperimentalModuleVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<testcase name="checksExperimentalModuleVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalModuleVisitorCallerBytecode()]
 display-name: checksExperimentalModuleVisitorCallerBytecode()
@@ -142,7 +141,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Java15Annotat
 display-name: findsAnnotationFromClass()
 ]]></system-out>
 </testcase>
-<testcase name="readsIndexIntoKeyedMap()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0.001">
+<testcase name="readsIndexIntoKeyedMap()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest]/[method:readsIndexIntoKeyedMap()]
 display-name: readsIndexIntoKeyedMap()
@@ -160,7 +159,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBas
 display-name: createsJava14ReflectionDelegateByClassName()
 ]]></system-out>
 </testcase>
-<testcase name="exposesJavaTypeMembersThroughAspectjReflectionApi()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<testcase name="exposesJavaTypeMembersThroughAspectjReflectionApi()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:exposesJavaTypeMembersThroughAspectjReflectionApi()]
 display-name: exposesJavaTypeMembersThroughAspectjReflectionApi()
@@ -178,7 +177,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTes
 display-name: runsMainThroughUtilityClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="invokesAspectOfFactoriesForAllAspectLifecycles()" classname="org_aspectj.aspectjweaver.AspectsTest" time="0">
+<testcase name="invokesAspectOfFactoriesForAllAspectLifecycles()" classname="org_aspectj.aspectjweaver.AspectsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AspectsTest]/[method:invokesAspectOfFactoriesForAllAspectLifecycles()]
 display-name: invokesAspectOfFactoriesForAllAspectLifecycles()
@@ -190,7 +189,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionBas
 display-name: exposesDeclaredFieldsMethodsAndConstructorsFromReflectionBackedType()
 ]]></system-out>
 </testcase>
-<testcase name="serializesAndRestoresStructureModel()" classname="org_aspectj.aspectjweaver.AsmManagerTest" time="0.001">
+<testcase name="serializesAndRestoresStructureModel()" classname="org_aspectj.aspectjweaver.AsmManagerTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AsmManagerTest]/[method:serializesAndRestoresStructureModel()]
 display-name: serializesAndRestoresStructureModel()
@@ -202,7 +201,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.FactoryTest]/
 display-name: createsSignatureTypesWithBootstrapClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="checksExperimentalClassVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<testcase name="checksExperimentalClassVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalClassVisitorCallerBytecode()]
 display-name: checksExperimentalClassVisitorCallerBytecode()
@@ -232,7 +231,13 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassWriterTe
 display-name: returnsSharedAbstractSuperclassForConcreteCollectionTypes()
 ]]></system-out>
 </testcase>
-<testcase name="discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<testcase name="initializesDefineClassFallbackWithGeneratedMirrorClass()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:initializesDefineClassFallbackWithGeneratedMirrorClass()]
+display-name: initializesDefineClassFallbackWithGeneratedMirrorClass()
+]]></system-out>
+</testcase>
+<testcase name="discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()]
 display-name: discoversInterTypeDeclarationsFromWovenStyleMembersAndDeclareParents()
@@ -256,7 +261,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.LangUtilTest]
 display-name: safeCopyCreatesTypedArrayWhenSinkHasWrongSize()
 ]]></system-out>
 </testcase>
-<testcase name="resolvesMethodDeclaredBySignatureType()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0">
+<testcase name="resolvesMethodDeclaredBySignatureType()" classname="org_aspectj.aspectjweaver.MethodSignatureImplTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.MethodSignatureImplTest]/[method:resolvesMethodDeclaredBySignatureType()]
 display-name: resolvesMethodDeclaredBySignatureType()
@@ -274,7 +279,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassWriterTe
 display-name: returnsObjectWhenEitherLoadedTypeIsAnInterface()
 ]]></system-out>
 </testcase>
-<testcase name="invokesHasAspectChecksForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0">
+<testcase name="invokesHasAspectChecksForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Aspects14Test]/[method:invokesHasAspectChecksForAllLegacyAspectLifecycles()]
 display-name: invokesHasAspectChecksForAllLegacyAspectLifecycles()
@@ -292,7 +297,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionFac
 display-name: createsCommandFromAlternateFactoryPathUsingEmptyArgumentArray()
 ]]></system-out>
 </testcase>
-<testcase name="initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0.048">
+<testcase name="initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0.065">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()]
 display-name: initializesLoadTimeWeaverWithLintResourceAndGeneratedConcreteAspect()
@@ -352,13 +357,13 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.LTWWorldTest]
 display-name: discoversJdkConcurrentMapImplementationForBootstrapTypeCache()
 ]]></system-out>
 </testcase>
-<testcase name="writesAndReadsSerializedIndexEntries()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0">
+<testcase name="writesAndReadsSerializedIndexEntries()" classname="org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AbstractIndexedFileCacheBackingTest]/[method:writesAndReadsSerializedIndexEntries()]
 display-name: writesAndReadsSerializedIndexEntries()
 ]]></system-out>
 </testcase>
-<testcase name="createsMethodHandleForKnownAspectjUtilityMethod()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0">
+<testcase name="createsMethodHandleForKnownAspectjUtilityMethod()" classname="org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ClassLoaderWeavingAdaptorTest]/[method:createsMethodHandleForKnownAspectjUtilityMethod()]
 display-name: createsMethodHandleForKnownAspectjUtilityMethod()
@@ -370,7 +375,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.SyntheticRepo
 display-name: loadsBytecodeResourceForRuntimeClass()
 ]]></system-out>
 </testcase>
-<testcase name="invokesAspectOfFactoriesForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0.003">
+<testcase name="invokesAspectOfFactoriesForAllLegacyAspectLifecycles()" classname="org_aspectj.aspectjweaver.Aspects14Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.Aspects14Test]/[method:invokesAspectOfFactoriesForAllLegacyAspectLifecycles()]
 display-name: invokesAspectOfFactoriesForAllLegacyAspectLifecycles()
@@ -382,7 +387,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.DefaultWeavin
 display-name: reportsClassAsLocallyDefinedWhenOnlyConfiguredLoaderFindsResource()
 ]]></system-out>
 </testcase>
-<testcase name="convertsParameterizedTypeNamesWithTheScopeClassLoader()" classname="org_aspectj.aspectjweaver.StringToTypeTest" time="0">
+<testcase name="convertsParameterizedTypeNamesWithTheScopeClassLoader()" classname="org_aspectj.aspectjweaver.StringToTypeTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.StringToTypeTest]/[method:convertsParameterizedTypeNamesWithTheScopeClassLoader()]
 display-name: convertsParameterizedTypeNamesWithTheScopeClassLoader()
@@ -394,13 +399,13 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ResolvedTypeM
 display-name: sourceLocationRoundTripsThroughLegacyObjectSerialization()
 ]]></system-out>
 </testcase>
-<testcase name="checksExperimentalAnnotationVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<testcase name="checksExperimentalAnnotationVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalAnnotationVisitorCallerBytecode()]
 display-name: checksExperimentalAnnotationVisitorCallerBytecode()
 ]]></system-out>
 </testcase>
-<testcase name="checksExperimentalFieldVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.001">
+<testcase name="checksExperimentalFieldVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalFieldVisitorCallerBytecode()]
 display-name: checksExperimentalFieldVisitorCallerBytecode()
@@ -412,7 +417,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.UtilClassLoad
 display-name: delegatesResourceLookupToSystemClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="discoversAspectPointcutsAdviceAndDeclareMembers()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0">
+<testcase name="discoversAspectPointcutsAdviceAndDeclareMembers()" classname="org_aspectj.aspectjweaver.AjTypeImplTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjTypeImplTest]/[method:discoversAspectPointcutsAdviceAndDeclareMembers()]
 display-name: discoversAspectPointcutsAdviceAndDeclareMembers()
@@ -424,7 +429,7 @@ unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.ReflectionTes
 display-name: runsMainByNameOnCurrentClassPath()
 ]]></system-out>
 </testcase>
-<testcase name="checksExperimentalRecordComponentVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0">
+<testcase name="checksExperimentalRecordComponentVisitorCallerBytecode()" classname="org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_aspectj.aspectjweaver.AjOrgObjectwebAsmConstantsTest]/[method:checksExperimentalRecordComponentVisitorCallerBytecode()]
 display-name: checksExperimentalRecordComponentVisitorCallerBytecode()

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4377-8c9b23c9/tests/src/org.aspectj/aspectjweaver/1.9.21.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:21:03">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:01:46">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4377-8c9b23c9/tests/src/org.aspectj/aspectjweaver/1.9.21.1"/>

--- a/tests/src/org.aspectj/aspectjweaver/1.9.21.1/user-code-filter.json
+++ b/tests/src/org.aspectj/aspectjweaver/1.9.21.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "aj.org.objectweb.asm.**"
+    },
+    {
+      "includeClasses" : "org.aspectj.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4377

This PR provides test fixes and new metadata for org.aspectj:aspectjweaver:1.9.21.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 282445
- Cached input tokens: 3673600
- Output tokens: 38856
- Metadata entries: 139
- Test-only metadata entries: 48
- Iterations: 5
- Library coverage percentage: 19.06
- Previous library version metadata entries: 145
- Previous library version test-only metadata entries: 47
- Previous library version coverage percentage: 17.18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.aspectj:aspectjweaver:1.9.7: 155/156 covered calls (99.36%)
- org.aspectj:aspectjweaver:1.9.21.1: 154/157 covered calls (98.09%)

**Reflection:**
- org.aspectj:aspectjweaver:1.9.7: 140/140 covered calls (100.00%)
- org.aspectj:aspectjweaver:1.9.21.1: 138/140 covered calls (98.57%)

**Resources:**
- org.aspectj:aspectjweaver:1.9.7: 15/16 covered calls (93.75%)
- org.aspectj:aspectjweaver:1.9.21.1: 16/17 covered calls (94.12%)

#### Library coverage

**Instruction:**
- org.aspectj:aspectjweaver:1.9.7: 45897/259057 (17.72%)
- org.aspectj:aspectjweaver:1.9.21.1: 53353/271523 (19.65%)

**Line:**
- org.aspectj:aspectjweaver:1.9.7: 9644/56122 (17.18%)
- org.aspectj:aspectjweaver:1.9.21.1: 11310/59348 (19.06%)

**Method:**
- org.aspectj:aspectjweaver:1.9.7: 1969/9307 (21.16%)
- org.aspectj:aspectjweaver:1.9.21.1: 2167/9920 (21.84%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.aspectj/aspectjweaver/1.9.7/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java 2/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
index 8d7a6e55ba..54c325b2f0 100644
--- 1/tests/src/org.aspectj/aspectjweaver/1.9.7/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
+++ 2/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/AjOrgObjectwebAsmConstantsTest.java
@@ -13,49 +13,79 @@ import aj.org.objectweb.asm.MethodVisitor;
 import aj.org.objectweb.asm.ModuleVisitor;
 import aj.org.objectweb.asm.Opcodes;
 import aj.org.objectweb.asm.RecordComponentVisitor;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 public class AjOrgObjectwebAsmConstantsTest {
+    private static final String NON_PREVIEW_BYTECODE_MESSAGE =
+            "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview";
+    private static final String CLASS_VISITOR_REJECTION_MESSAGE = readClassVisitorRejectionMessage();
+
     @Test
     void checksExperimentalClassVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalClassApiVisitor::new);
+        assertThat(CLASS_VISITOR_REJECTION_MESSAGE).isEqualTo(NON_PREVIEW_BYTECODE_MESSAGE);
     }
 
     @Test
     void checksExperimentalAnnotationVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalAnnotationApiVisitor::new);
+        try {
+            new ExperimentalAnnotationApiVisitor();
+            fail("Expected experimental AnnotationVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalFieldVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalFieldApiVisitor::new);
+        try {
+            new ExperimentalFieldApiVisitor();
+            fail("Expected experimental FieldVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalMethodVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalMethodApiVisitor::new);
+        try {
+            new ExperimentalMethodApiVisitor();
+            fail("Expected experimental MethodVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalModuleVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalModuleApiVisitor::new);
+        try {
+            new ExperimentalModuleApiVisitor();
+            fail("Expected experimental ModuleVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
     @Test
     void checksExperimentalRecordComponentVisitorCallerBytecode() {
-        assertExperimentalApiRejected(ExperimentalRecordComponentApiVisitor::new);
+        try {
+            new ExperimentalRecordComponentApiVisitor();
+            fail("Expected experimental RecordComponentVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            assertThat(exception).hasMessage(NON_PREVIEW_BYTECODE_MESSAGE);
+        }
     }
 
-    private static void assertExperimentalApiRejected(ThrowingCallable callable) {
-        assertThatThrownBy(callable)
-                .isInstanceOf(IllegalStateException.class)
-                .satisfies(throwable -> assertThat(throwable.getMessage()).isIn(
-                        "ASM9_EXPERIMENTAL can only be used by classes compiled with --enable-preview",
-                        "Bytecode not available, can't check class version"));
+    private static String readClassVisitorRejectionMessage() {
+        try {
+            new ExperimentalClassApiVisitor();
+            fail("Expected experimental ClassVisitor API to reject non-preview bytecode");
+        } catch (IllegalStateException exception) {
+            return exception.getMessage();
+        }
+        throw new AssertionError("Unreachable");
     }
 }
 
diff --git 1/tests/src/org.aspectj/aspectjweaver/1.9.7/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java 2/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
index 40cc95550b..8713a06cdf 100644
--- 1/tests/src/org.aspectj/aspectjweaver/1.9.7/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
+++ 2/tests/src/org.aspectj/aspectjweaver/1.9.21.1/src/test/java/org_aspectj/aspectjweaver/ClassLoaderWeavingAdaptorTest.java
@@ -8,6 +8,9 @@ package org_aspectj.aspectjweaver;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -21,6 +24,13 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import aj.org.objectweb.asm.ClassReader;
+import aj.org.objectweb.asm.ClassVisitor;
+import aj.org.objectweb.asm.ClassWriter;
+import aj.org.objectweb.asm.MethodVisitor;
+import aj.org.objectweb.asm.Opcodes;
+
+import org.aspectj.util.LangUtil;
 import org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor;
 import org.aspectj.weaver.loadtime.IWeavingContext;
 import org.aspectj.weaver.loadtime.definition.Definition;
@@ -32,6 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassLoaderWeavingAdaptorTest {
     private static final String LINT_RESOURCE = "aspectj-ltw-lint.properties";
+    private static final String ADAPTOR_CLASS_NAME = "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor";
+    private static final String ACCESSIBLE_OBJECT_CLASS_NAME = "java.lang.reflect.AccessibleObject";
+    private static final String MIRROR_SEED_CLASS_NAME = "org_aspectj.aspectjweaver.MirrorSeed";
 
     private static boolean legacyDefineClassInvoked;
 
@@ -59,6 +72,33 @@ public class ClassLoaderWeavingAdaptorTest {
         }
     }
 
+    @Test
+    void createsMethodHandleForKnownAspectjUtilityMethod() {
+        try {
+            MethodHandle methodHandle = ClassLoaderWeavingAdaptor.createMethodHandle(
+                    "org.aspectj.util.LangUtil",
+                    "is11VMOrGreater"
+            );
+
+            assertThat(methodHandle.invokeWithArguments()).isEqualTo(LangUtil.is11VMOrGreater());
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
+    @Test
+    void initializesDefineClassFallbackWithGeneratedMirrorClass() throws Exception {
+        URL aspectjLocation = ClassLoaderWeavingAdaptor.class.getProtectionDomain().getCodeSource().getLocation();
+        URL[] urls = {aspectjLocation};
+        try (MirrorFriendlyAspectjLoader isolatedLoader = new MirrorFriendlyAspectjLoader(urls)) {
+            Class<?> adaptorClass = Class.forName(ADAPTOR_CLASS_NAME, true, isolatedLoader);
+
+            assertThat(adaptorClass.getName()).isEqualTo(ADAPTOR_CLASS_NAME);
+        } catch (Throwable throwable) {
+            rethrowIfNotNativeImageDynamicClassLoadingError(throwable);
+        }
+    }
+
     @Test
     void initializesLegacyDefinitionPathInIsolatedAspectjLoader() throws Exception {
         Path resourceRoot = Files.createTempDirectory("aspectj-ltw-resources");
@@ -97,7 +137,7 @@ public class ClassLoaderWeavingAdaptorTest {
 
     private static void initializeAdaptorFrom(URLClassLoader isolatedLoader) throws Exception {
         Class<?> adaptorClass = Class.forName(
-                "org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor",
+                ADAPTOR_CLASS_NAME,
                 true,
                 isolatedLoader
         );
@@ -121,16 +161,25 @@ public class ClassLoaderWeavingAdaptorTest {
 
     private static void installLegacyDefineClassBridge(Class<?> adaptorClass) throws NoSuchFieldException,
             IllegalAccessException, NoSuchMethodException {
-        Field defineClassMethod = adaptorClass.getDeclaredField("defineClassMethod");
-        defineClassMethod.setAccessible(true);
-        defineClassMethod.set(null, LegacyDefineClassBridge.class.getMethod(
+        Field unsafeInstance = adaptorClass.getDeclaredField("unsafeInstance");
+        unsafeInstance.setAccessible(true);
+        unsafeInstance.set(null, LegacyDefineClassBridge.class);
+
+        Field defineClassMethodHandle = adaptorClass.getDeclaredField("defineClassMethodHandle");
+        defineClassMethodHandle.setAccessible(true);
+        defineClassMethodHandle.set(null, MethodHandles.lookup().findStatic(
+                LegacyDefineClassBridge.class,
                 "defineClass",
-                String.class,
-                byte[].class,
-                Integer.TYPE,
-                Integer.TYPE,
-                ClassLoader.class,
-                ProtectionDomain.class
+                MethodType.methodType(
+                        Class.class,
+                        Object.class,
+                        String.class,
+                        byte[].class,
+                        Integer.TYPE,
+                        Integer.TYPE,
+                        ClassLoader.class,
+                        ProtectionDomain.class
+                )
         ));
     }
 
@@ -196,7 +245,14 @@ public class ClassLoaderWeavingAdaptorTest {
         Throwable current = throwable;
         while (current != null) {
             if (current instanceof ClassNotFoundException
-                    && "org.aspectj.util.LangUtil".equals(current.getMessage())) {
+                    && ("org.aspectj.util.LangUtil".equals(current.getMessage())
+                    || ADAPTOR_CLASS_NAME.equals(current.getMessage())
+                    || MIRROR_SEED_CLASS_NAME.equals(current.getMessage()))) {
+                return true;
+            }
+            if (current instanceof NoSuchFieldException
+                    && ("unsafeInstance".equals(current.getMessage())
+                    || "defineClassMethodHandle".equals(current.getMessage()))) {
                 return true;
             }
             current = current.getCause();
@@ -254,12 +310,87 @@ public class ClassLoaderWeavingAdaptorTest {
         }
     }
 
+    private static final class MirrorFriendlyAspectjLoader extends URLClassLoader {
+        private static final String ADAPTOR_RESOURCE = ADAPTOR_CLASS_NAME.replace('.', '/') + ".class";
+        private static final String MIRROR_SEED_RESOURCE = MIRROR_SEED_CLASS_NAME.replace('.', '/') + ".class";
+
+        private final byte[] mirrorSeedBytes;
+
+        private MirrorFriendlyAspectjLoader(URL[] urls) {
+            super(urls, ClassLoader.getPlatformClassLoader());
+            this.mirrorSeedBytes = createMirrorSeedBytes();
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (MIRROR_SEED_CLASS_NAME.equals(name)) {
+                return defineClass(name, mirrorSeedBytes, 0, mirrorSeedBytes.length);
+            }
+            if (ADAPTOR_CLASS_NAME.equals(name)) {
+                try (InputStream input = findResource(ADAPTOR_RESOURCE).openStream()) {
+                    byte[] adaptorBytes = transformAccessibleObjectLookup(input.readAllBytes());
+                    return defineClass(name, adaptorBytes, 0, adaptorBytes.length);
+                } catch (Exception exception) {
+                    throw new ClassNotFoundException(name, exception);
+                }
+            }
+            return super.findClass(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (MIRROR_SEED_RESOURCE.equals(name)) {
+                return new ByteArrayInputStream(mirrorSeedBytes);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        private static byte[] transformAccessibleObjectLookup(byte[] originalBytes) {
+            ClassReader reader = new ClassReader(originalBytes);
+            ClassWriter writer = new ClassWriter(0);
+            reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                        String[] exceptions) {
+                    MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                    return new MethodVisitor(Opcodes.ASM9, methodVisitor) {
+                        @Override
+                        public void visitLdcInsn(Object value) {
+                            if (ACCESSIBLE_OBJECT_CLASS_NAME.equals(value)) {
+                                super.visitLdcInsn(MIRROR_SEED_CLASS_NAME);
+                            } else {
+                                super.visitLdcInsn(value);
+                            }
+                        }
+                    };
+                }
+            }, 0);
+            return writer.toByteArray();
+        }
+
+        private static byte[] createMirrorSeedBytes() {
+            ClassWriter writer = new ClassWriter(0);
+            String internalName = MIRROR_SEED_CLASS_NAME.replace('.', '/');
+            writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, internalName, null, "java/lang/Object", null);
+            writer.visitField(Opcodes.ACC_PUBLIC, "override", "Z", null, null).visitEnd();
+            MethodVisitor constructor = writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+            constructor.visitCode();
+            constructor.visitVarInsn(Opcodes.ALOAD, 0);
+            constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            constructor.visitInsn(Opcodes.RETURN);
+            constructor.visitMaxs(1, 1);
+            constructor.visitEnd();
+            writer.visitEnd();
+            return writer.toByteArray();
+        }
+    }
+
     public static final class LegacyDefineClassBridge {
         private LegacyDefineClassBridge() {
         }
 
-        public static Class<?> defineClass(String name, byte[] bytes, int offset, int length, ClassLoader loader,
-                ProtectionDomain protectionDomain) {
+        public static Class<?> defineClass(Object unsafe, String name, byte[] bytes, int offset, int length,
+                ClassLoader loader, ProtectionDomain protectionDomain) {
             legacyDefineClassInvoked = true;
             return Object.class;
         }

```
