### PR TITLE
[GenAI] Test fix for org.apache.xbean:xbean-reflect:3.6 using gpt-5.5

### DIFF
--- a/metadata/org.apache.xbean/xbean-reflect/3.6/reachability-metadata.json
+++ b/metadata/org.apache.xbean/xbean-reflect/3.6/reachability-metadata.json
@@ -1,0 +1,114 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type" : "java.beans.ConstructorProperties",
+      "methods" : [
+        {
+          "name" : "value",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.PropertyEditors"
+      },
+      "type" : "java.lang.Integer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.ArrayConverter"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ArrayRecipe"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.RecipeHelper"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.CollectionRecipe"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.MapRecipe"
+      },
+      "type" : "java.util.LinkedHashMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type" : "org.apache.xbean.recipe.AsmParameterNameLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.EnumConverter"
+      },
+      "type" : "org.apache.xbean.recipe.Option",
+      "methods" : [
+        {
+          "name" : "values",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type" : "org.apache.xbean.recipe.XbeanAsmParameterNameLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.AsmParameterNameLoader"
+      },
+      "glob" : "org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest$ParameterNamedTarget.class"
+    }
+  ]
+}

--- a/metadata/org.apache.xbean/xbean-reflect/index.json
+++ b/metadata/org.apache.xbean/xbean-reflect/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.6",
+    "tested-versions" : [
+      "3.6"
+    ],
+    "allowed-packages" : [
+      "org.apache.xbean"
+    ]
+  },
+  {
     "metadata-version" : "3.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4-sources.jar",
     "repository-url" : "https://svn.apache.org/repos/asf/geronimo/xbean/tags/xbean-3.4/",

--- a/metadata/org.apache.xbean/xbean-reflect/index.json
+++ b/metadata/org.apache.xbean/xbean-reflect/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/$version$/xbean-reflect-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/geronimo/xbean/",
+    "test-code-url" : "https://svn.apache.org/repos/asf/geronimo/xbean/tags/xbean-$version$/xbean-reflect/src/test/",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/$version$/xbean-reflect-$version$-javadoc.jar",
+    "description" : "Apache XBean Reflect provides utilities for constructing and configuring Java objects from recipes, resolving dependencies, references, collections, maps, and factory methods through reflection. It also includes property editors and converters that coerce string or generic values into Java types used during object assembly.",
     "tested-versions" : [
       "3.6"
     ],

--- a/stats/org.apache.xbean/xbean-reflect/3.6/execution-metrics.json
+++ b/stats/org.apache.xbean/xbean-reflect/3.6/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T20:09:47.972620Z",
+    "library": "org.apache.xbean:xbean-reflect:3.6",
+    "starting_commit": "1f7181757211f8c2a91a4b1ae36baa93aede9f56",
+    "ending_commit": "c947e1b1be2020fec6ad8fc42702958f205b8af8",
+    "previous_library": "org.apache.xbean:xbean-reflect:3.4",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 51,
+            "totalCalls": 51
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 52,
+        "totalCalls": 52
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4431,
+          "missed": 8203,
+          "ratio": 0.35072,
+          "total": 12634
+        },
+        "line": {
+          "covered": 1115,
+          "missed": 1726,
+          "ratio": 0.392467,
+          "total": 2841
+        },
+        "method": {
+          "covered": 205,
+          "missed": 296,
+          "ratio": 0.409182,
+          "total": 501
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 47,
+            "totalCalls": 47
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 48,
+        "totalCalls": 48
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4104,
+          "missed": 7037,
+          "ratio": 0.368369,
+          "total": 11141
+        },
+        "line": {
+          "covered": 1068,
+          "missed": 1543,
+          "ratio": 0.409039,
+          "total": 2611
+        },
+        "method": {
+          "covered": 197,
+          "missed": 252,
+          "ratio": 0.438753,
+          "total": 449
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 182514,
+      "cached_input_tokens_used": 2552832,
+      "output_tokens_used": 19471,
+      "iterations": 4,
+      "cost_usd": 1.8605,
+      "tested_library_loc": 1115,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 47,
+      "previous_library_metadata_entries": 17,
+      "previous_library_test_only_metadata_entries": 37,
+      "code_coverage_percent": 39.25,
+      "previous_library_coverage_percent": 40.9
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ClassEditorTest.java",
+      "metadata_file": "metadata/org.apache.xbean/xbean-reflect/3.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.xbean/xbean-reflect/3.6/stats.json
+++ b/stats/org.apache.xbean/xbean-reflect/3.6/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.6",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 51,
+          "totalCalls" : 51
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 52,
+      "totalCalls" : 52
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4431,
+        "missed" : 8203,
+        "ratio" : 0.35072,
+        "total" : 12634
+      },
+      "line" : {
+        "covered" : 1115,
+        "missed" : 1726,
+        "ratio" : 0.392467,
+        "total" : 2841
+      },
+      "method" : {
+        "covered" : 205,
+        "missed" : 296,
+        "ratio" : 0.409182,
+        "total" : 501
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/.gitignore
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.xbean:xbean-reflect:$libraryVersion"
+    testImplementation 'asm:asm:2.2.3'
+    testImplementation 'asm:asm-commons:2.2.3'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
@@ -12,8 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.xbean:xbean-reflect:$libraryVersion"
-    testImplementation 'asm:asm:2.2.3'
-    testImplementation 'asm:asm-commons:2.2.3'
+    testImplementation 'asm:asm:3.1'
+    testImplementation 'asm:asm-commons:3.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/gradle.properties
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.xbean:xbean-reflect:3.6
+library.version = 3.6
+metadata.dir = org.apache.xbean/xbean-reflect/3.6/

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/settings.gradle
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.xbean.xbean-reflect_tests'

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayConverterTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayConverterTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.propertyeditor.ArrayConverter;
+import org.apache.xbean.propertyeditor.StringEditor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayConverterTest {
+    @Test
+    void createsArrayFromDelimitedText() {
+        ArrayConverter converter = new ArrayConverter(String[].class, new StringEditor());
+
+        Object value = converter.toObject("[alpha, beta, gamma]");
+
+        assertThat(value).isInstanceOf(String[].class);
+        assertThat((String[]) value).containsExactly("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayRecipeTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayRecipeTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.recipe.ArrayRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayRecipeTest {
+    @Test
+    void createsArrayInstanceForConfiguredComponentType() {
+        ArrayRecipe recipe = new ArrayRecipe(String.class);
+        recipe.add("alpha");
+        recipe.add("beta");
+
+        Object value = recipe.create(String[].class, false);
+
+        assertThat(value).isInstanceOf(String[].class);
+        assertThat((String[]) value).containsExactly("alpha", "beta");
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.xbean.recipe.AsmParameterNameLoader;
+import org.apache.xbean.recipe.CollectionRecipe;
+import org.apache.xbean.recipe.Option;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsmParameterNameLoaderTest {
+    @Test
+    void loadsNamesForPublicAndDeclaredConstructors() throws Exception {
+        AsmParameterNameLoader loader = new AsmParameterNameLoader();
+        Constructor<CollectionRecipe> typeNameConstructor = CollectionRecipe.class.getConstructor(String.class);
+        Constructor<CollectionRecipe> typeClassConstructor = CollectionRecipe.class.getConstructor(Class.class);
+
+        Map<Constructor, List<String>> parameterNames = loader.getAllConstructorParameters(CollectionRecipe.class);
+
+        assertThat(parameterNames).containsKeys(typeNameConstructor, typeClassConstructor);
+        assertThat(parameterNames.get(typeNameConstructor)).containsExactly("type");
+        assertThat(parameterNames.get(typeClassConstructor)).containsExactly("type");
+    }
+
+    @Test
+    void loadsNamesForPublicAndDeclaredMethods() throws Exception {
+        AsmParameterNameLoader loader = new AsmParameterNameLoader();
+        Method allowMethod = CollectionRecipe.class.getMethod("allow", Option.class);
+        Method disallowMethod = CollectionRecipe.class.getMethod("disallow", Option.class);
+
+        Map<Method, List<String>> allowParameterNames = loader.getAllMethodParameters(CollectionRecipe.class, "allow");
+        Map<Method, List<String>> disallowParameterNames = loader.getAllMethodParameters(
+                CollectionRecipe.class,
+                "disallow");
+
+        assertThat(allowParameterNames).containsKey(allowMethod);
+        assertThat(disallowParameterNames).containsKey(disallowMethod);
+        assertThat(allowParameterNames.get(allowMethod)).containsExactly("option");
+        assertThat(disallowParameterNames.get(disallowMethod)).containsExactly("option");
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.xbean.recipe.AsmParameterNameLoader;
-import org.apache.xbean.recipe.CollectionRecipe;
 import org.apache.xbean.recipe.Option;
 import org.junit.jupiter.api.Test;
 
@@ -22,30 +21,44 @@ public class AsmParameterNameLoaderTest {
     @Test
     void loadsNamesForPublicAndDeclaredConstructors() throws Exception {
         AsmParameterNameLoader loader = new AsmParameterNameLoader();
-        Constructor<CollectionRecipe> typeNameConstructor = CollectionRecipe.class.getConstructor(String.class);
-        Constructor<CollectionRecipe> typeClassConstructor = CollectionRecipe.class.getConstructor(Class.class);
+        Constructor<ParameterNamedTarget> nameConstructor = ParameterNamedTarget.class.getConstructor(String.class);
+        Constructor<ParameterNamedTarget> countConstructor = ParameterNamedTarget.class.getDeclaredConstructor(Integer.class);
 
-        Map<Constructor, List<String>> parameterNames = loader.getAllConstructorParameters(CollectionRecipe.class);
+        Map<Constructor, List<String>> parameterNames = loader.getAllConstructorParameters(ParameterNamedTarget.class);
 
-        assertThat(parameterNames).containsKeys(typeNameConstructor, typeClassConstructor);
-        assertThat(parameterNames.get(typeNameConstructor)).containsExactly("type");
-        assertThat(parameterNames.get(typeClassConstructor)).containsExactly("type");
+        assertThat(parameterNames).containsKeys(nameConstructor, countConstructor);
+        assertThat(parameterNames.get(nameConstructor)).containsExactly("name");
+        assertThat(parameterNames.get(countConstructor)).containsExactly("count");
     }
 
     @Test
     void loadsNamesForPublicAndDeclaredMethods() throws Exception {
         AsmParameterNameLoader loader = new AsmParameterNameLoader();
-        Method allowMethod = CollectionRecipe.class.getMethod("allow", Option.class);
-        Method disallowMethod = CollectionRecipe.class.getMethod("disallow", Option.class);
+        Method allowMethod = ParameterNamedTarget.class.getMethod("allow", Option.class);
+        Method disallowMethod = ParameterNamedTarget.class.getDeclaredMethod("disallow", Option.class);
 
-        Map<Method, List<String>> allowParameterNames = loader.getAllMethodParameters(CollectionRecipe.class, "allow");
+        Map<Method, List<String>> allowParameterNames = loader.getAllMethodParameters(ParameterNamedTarget.class, "allow");
         Map<Method, List<String>> disallowParameterNames = loader.getAllMethodParameters(
-                CollectionRecipe.class,
+                ParameterNamedTarget.class,
                 "disallow");
 
         assertThat(allowParameterNames).containsKey(allowMethod);
         assertThat(disallowParameterNames).containsKey(disallowMethod);
         assertThat(allowParameterNames.get(allowMethod)).containsExactly("option");
         assertThat(disallowParameterNames.get(disallowMethod)).containsExactly("option");
+    }
+
+    public static final class ParameterNamedTarget {
+        public ParameterNamedTarget(String name) {
+        }
+
+        private ParameterNamedTarget(Integer count) {
+        }
+
+        public void allow(Option option) {
+        }
+
+        private void disallow(Option option) {
+        }
     }
 }

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ClassEditorTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ClassEditorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.propertyeditor.ClassEditor;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassEditorTest {
+    @Test
+    void convertsMetadataRegisteredClassNameWithACustomContextClassLoader() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader customContextClassLoader = new ClassLoader(originalClassLoader) {
+        };
+
+        try {
+            Thread.currentThread().setContextClassLoader(customContextClassLoader);
+
+            ClassEditor editor = new ClassEditor();
+            editor.setAsText(ContextLoadedTarget.class.getName());
+
+            assertThat(editor.getValue()).isSameAs(ContextLoadedTarget.class);
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    public static final class ContextLoadedTarget {
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/CollectionRecipeTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/CollectionRecipeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.xbean.recipe.CollectionRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionRecipeTest {
+    @Test
+    void createsDefaultListImplementationFromRecipeValues() {
+        CollectionRecipe recipe = new CollectionRecipe();
+        recipe.add("alpha");
+        recipe.add("beta");
+
+        Object value = recipe.create(List.class, false);
+
+        List<?> values = (List<?>) value;
+        assertThat(value).isInstanceOf(ArrayList.class);
+        assertThat(values).hasSize(2);
+        assertThat(values.get(0)).isEqualTo("alpha");
+        assertThat(values.get(1)).isEqualTo("beta");
+    }
+
+    @Test
+    void createsRequestedCollectionImplementationFromDefaultConstructor() {
+        CollectionRecipe recipe = new CollectionRecipe(RecordingCollection.class);
+        recipe.add("first");
+        recipe.add("second");
+
+        Object value = recipe.create(RecordingCollection.class, false);
+
+        assertThat(value).isInstanceOf(RecordingCollection.class);
+        assertThat((RecordingCollection) value).containsExactly("first", "second");
+    }
+
+    public static class RecordingCollection extends ArrayList<String> {
+        public RecordingCollection() {
+            super();
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/EnumConverterTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/EnumConverterTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.propertyeditor.EnumConverter;
+import org.apache.xbean.recipe.Option;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnumConverterTest {
+    @Test
+    void convertsOrdinalTextUsingEnumValuesMethod() {
+        EnumConverter converter = new EnumConverter(Option.class);
+
+        Object value = converter.toObject("2");
+
+        assertThat(value).isEqualTo(Option.FIELD_INJECTION);
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/GenericCollectionConverterTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/GenericCollectionConverterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.util.ArrayList;
+
+import org.apache.xbean.propertyeditor.GenericCollectionConverter;
+import org.apache.xbean.propertyeditor.StringEditor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericCollectionConverterTest {
+    @Test
+    void createsRequestedCollectionImplementationFromDelimitedText() {
+        GenericCollectionConverter converter = new GenericCollectionConverter(RecordingCollection.class, new StringEditor());
+
+        Object value = converter.toObject("[alpha, beta, gamma]");
+
+        assertThat(value).isInstanceOf(RecordingCollection.class);
+        assertThat((RecordingCollection) value).containsExactly("alpha", "beta", "gamma");
+    }
+
+    public static class RecordingCollection extends ArrayList<String> {
+        public RecordingCollection() {
+            super();
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/GenericMapConverterTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/GenericMapConverterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.util.LinkedHashMap;
+
+import org.apache.xbean.propertyeditor.GenericMapConverter;
+import org.apache.xbean.propertyeditor.StringEditor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericMapConverterTest {
+    @Test
+    void createsRequestedMapImplementationFromPropertiesText() {
+        GenericMapConverter converter = new GenericMapConverter(RecordingMap.class, new StringEditor(), new StringEditor());
+
+        Object value = converter.toObject("first=alpha\nsecond=beta\n");
+
+        assertThat(value).isInstanceOf(RecordingMap.class);
+        RecordingMap map = (RecordingMap) value;
+        assertThat(map.wasCreatedByNoArgumentConstructor()).isTrue();
+        assertThat(map)
+                .containsEntry("first", "alpha")
+                .containsEntry("second", "beta");
+    }
+
+    public static class RecordingMap extends LinkedHashMap<String, String> {
+        private final boolean createdByNoArgumentConstructor;
+
+        public RecordingMap() {
+            super();
+            createdByNoArgumentConstructor = true;
+        }
+
+        public boolean wasCreatedByNoArgumentConstructor() {
+            return createdByNoArgumentConstructor;
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/MapRecipeTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/MapRecipeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.xbean.recipe.MapRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapRecipeTest {
+    @Test
+    void createsRequestedMapImplementationFromRecipeEntries() {
+        MapRecipe recipe = new MapRecipe(LinkedHashMap.class);
+        recipe.put("first", "alpha");
+        recipe.put("second", "beta");
+
+        Object value = recipe.create(LinkedHashMap.class, false);
+
+        assertThat(value).isInstanceOf(LinkedHashMap.class);
+        Map<?, ?> map = (Map<?, ?>) value;
+        assertThat(map.get("first")).isEqualTo("alpha");
+        assertThat(map.get("second")).isEqualTo("beta");
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeInnerFieldMemberTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeInnerFieldMemberTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.recipe.ObjectRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectRecipeInnerFieldMemberTest {
+    @Test
+    void setsPublicFieldValueThroughFieldMember() {
+        ObjectRecipe recipe = new ObjectRecipe(FieldInjectedTarget.class);
+        recipe.setFieldProperty("name", "configured through field injection");
+
+        FieldInjectedTarget target = (FieldInjectedTarget) recipe.create();
+
+        assertThat(target.name).isEqualTo("configured through field injection");
+    }
+
+    public static class FieldInjectedTarget {
+        public String name;
+
+        public FieldInjectedTarget() {
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeInnerMethodMemberTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeInnerMethodMemberTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.recipe.ObjectRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectRecipeInnerMethodMemberTest {
+    @Test
+    void setsPropertyValueThroughSetterMethodMember() {
+        ObjectRecipe recipe = new ObjectRecipe(SetterInjectedTarget.class);
+        recipe.setMethodProperty("name", "configured through setter injection");
+
+        SetterInjectedTarget target = (SetterInjectedTarget) recipe.create();
+
+        assertThat(target.getName()).isEqualTo("configured through setter injection");
+    }
+
+    public static class SetterInjectedTarget {
+        private String name;
+
+        public SetterInjectedTarget() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.recipe.ObjectRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectRecipeTest {
+    @Test
+    void invokesInstanceFactoryMethodAfterConstructingObject() {
+        ObjectRecipe recipe = new ObjectRecipe(ProductBuilder.class, "build");
+
+        Object value = recipe.create();
+
+        assertThat(value).isInstanceOf(Product.class);
+        assertThat(((Product) value).getDescription()).isEqualTo("created by instance factory");
+    }
+
+    public static class ProductBuilder {
+        public Product build() {
+            return new Product("created by instance factory");
+        }
+    }
+
+    public static class Product {
+        private final String description;
+
+        public Product(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
@@ -22,6 +22,17 @@ public class ObjectRecipeTest {
         assertThat(((Product) value).getDescription()).isEqualTo("created by instance factory");
     }
 
+    @Test
+    void setsNestedValueThroughCompoundPropertyGetter() {
+        ObjectRecipe recipe = new ObjectRecipe(CompoundPropertyTarget.class);
+        recipe.setCompoundProperty("settings.label", "configured through compound property");
+
+        CompoundPropertyTarget target = (CompoundPropertyTarget) recipe.create();
+
+        assertThat(target.getSettingsAccessCount()).isEqualTo(1);
+        assertThat(target.peekSettings().getLabel()).isEqualTo("configured through compound property");
+    }
+
     public static class ProductBuilder {
         public Product build() {
             return new Product("created by instance factory");
@@ -37,6 +48,42 @@ public class ObjectRecipeTest {
 
         public String getDescription() {
             return description;
+        }
+    }
+
+    public static class CompoundPropertyTarget {
+        private final NestedSettings settings = new NestedSettings();
+        private int settingsAccessCount;
+
+        public CompoundPropertyTarget() {
+        }
+
+        public NestedSettings getSettings() {
+            settingsAccessCount++;
+            return settings;
+        }
+
+        public NestedSettings peekSettings() {
+            return settings;
+        }
+
+        public int getSettingsAccessCount() {
+            return settingsAccessCount;
+        }
+    }
+
+    public static class NestedSettings {
+        private String label;
+
+        public NestedSettings() {
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
         }
     }
 }

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/PropertyEditorsTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/PropertyEditorsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.propertyeditor.AbstractConverter;
+import org.apache.xbean.propertyeditor.PropertyEditors;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyEditorsTest {
+    @Test
+    void checksConversionSupportFromAClassName() {
+        ClassLoader classLoader = PropertyEditorsTest.class.getClassLoader();
+
+        boolean canConvert = PropertyEditors.canConvert(Integer.class.getName(), classLoader);
+
+        assertThat(canConvert).isTrue();
+    }
+
+    @Test
+    void convertsValueFromAClassName() {
+        ClassLoader classLoader = PropertyEditorsTest.class.getClassLoader();
+
+        Object value = PropertyEditors.getValue(Integer.class.getName(), "42", classLoader);
+
+        assertThat(value).isEqualTo(Integer.valueOf(42));
+    }
+
+    @Test
+    void discoversNestedConverterDeclaredOnTargetType() {
+        Object value = PropertyEditors.getValue(ConverterBackedValue.class, "nested converter");
+
+        assertThat(value).isInstanceOf(ConverterBackedValue.class);
+        assertThat(((ConverterBackedValue) value).getText()).isEqualTo("nested converter");
+        assertThat(PropertyEditors.toString(value)).isEqualTo("nested converter");
+    }
+
+    public static class ConverterBackedValue {
+        private final String text;
+
+        public ConverterBackedValue(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public String toString() {
+            return text;
+        }
+
+        public static class ConverterBackedValueConverter extends AbstractConverter {
+            public ConverterBackedValueConverter() {
+                super(ConverterBackedValue.class);
+            }
+
+            @Override
+            protected Object toObjectImpl(String text) {
+                return new ConverterBackedValue(text);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/RecipeHelperTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/RecipeHelperTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import org.apache.xbean.recipe.DefaultExecutionContext;
+import org.apache.xbean.recipe.ExecutionContext;
+import org.apache.xbean.recipe.RecipeHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecipeHelperTest {
+    @Test
+    void loadsClassWithTheCurrentExecutionContextClassLoader() throws ClassNotFoundException {
+        ExecutionContext previousContext = ExecutionContext.setContext(new DefaultExecutionContext());
+        try {
+            Class<?> loadedClass = RecipeHelper.loadClass(LoadTarget.class.getName());
+
+            assertThat(loadedClass).isSameAs(LoadTarget.class);
+        } finally {
+            ExecutionContext.setContext(previousContext);
+        }
+    }
+
+    @Test
+    void detectsPublicDefaultConstructors() {
+        boolean hasDefaultConstructor = RecipeHelper.hasDefaultConstructor(PublicDefaultConstructorTarget.class);
+        boolean missingDefaultConstructor = RecipeHelper.hasDefaultConstructor(ConstructorArgumentTarget.class);
+
+        assertThat(hasDefaultConstructor).isTrue();
+        assertThat(missingDefaultConstructor).isFalse();
+    }
+
+    @Test
+    void convertsGenericArrayTypeToArrayClass() {
+        Class<?> arrayClass = RecipeHelper.toClass(new GenericArrayOfStrings());
+
+        assertThat(arrayClass).isSameAs(String[].class);
+    }
+
+    public static class LoadTarget {
+        public LoadTarget() {
+        }
+    }
+
+    public static class PublicDefaultConstructorTarget {
+        public PublicDefaultConstructorTarget() {
+        }
+    }
+
+    public static class ConstructorArgumentTarget {
+        public ConstructorArgumentTarget(String value) {
+        }
+    }
+
+    private static class GenericArrayOfStrings implements GenericArrayType {
+        @Override
+        public Type getGenericComponentType() {
+            return String.class;
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import java.beans.ConstructorProperties;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.xbean.recipe.Option;
+import org.apache.xbean.recipe.ReflectionUtil;
+import org.apache.xbean.recipe.ReflectionUtil.ConstructorFactory;
+import org.apache.xbean.recipe.ReflectionUtil.StaticFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectionUtilTest {
+    @Test
+    void findsDeclaredAndInheritedFieldsByName() {
+        Field declaredField = ReflectionUtil.findField(FieldTarget.class, "number", 1, null);
+        Field inheritedField = ReflectionUtil.findField(FieldTarget.class, "inheritedText", "value", null);
+
+        assertThat(declaredField.getName()).isEqualTo("number");
+        assertThat(inheritedField.getName()).isEqualTo("inheritedText");
+    }
+
+    @Test
+    void findsAllDeclaredAndInheritedFieldsByType() {
+        List<Field> fields = ReflectionUtil.findAllFieldsByType(
+                FieldTarget.class,
+                "value",
+                EnumSet.of(Option.PRIVATE_PROPERTIES));
+
+        assertThat(fields).extracting(Field::getName).contains("localText", "hiddenText", "inheritedText");
+    }
+
+    @Test
+    void findsDeclaredAndInheritedSettersByName() {
+        List<Method> publicSetters = ReflectionUtil.findAllSetters(FieldTarget.class, "localText", "value", null);
+        List<Method> privateSetters = ReflectionUtil.findAllSetters(
+                FieldTarget.class,
+                "hiddenText",
+                "value",
+                EnumSet.of(Option.PRIVATE_PROPERTIES));
+
+        assertThat(publicSetters).extracting(Method::getName).contains("setLocalText");
+        assertThat(privateSetters).extracting(Method::getName).contains("setHiddenText");
+    }
+
+    @Test
+    void findsDeclaredAndInheritedSettersByType() {
+        List<Method> setters = ReflectionUtil.findAllSettersByType(FieldTarget.class, Integer.valueOf(7), null);
+
+        assertThat(setters).extracting(Method::getName).contains("setNumber", "setInheritedNumber");
+    }
+
+    @Test
+    void findsPublicAndPrivateConstructors() {
+        ConstructorFactory publicConstructor = ReflectionUtil.findConstructor(
+                ConstructedTarget.class,
+                Collections.emptyList(),
+                null);
+        ConstructorFactory privateConstructor = ReflectionUtil.findConstructor(
+                ConstructedTarget.class,
+                Collections.singletonList("value"),
+                Collections.<Class<?>>singletonList(String.class),
+                Collections.<String>emptySet(),
+                EnumSet.of(Option.PRIVATE_CONSTRUCTOR));
+
+        ConstructedTarget publicInstance = (ConstructedTarget) publicConstructor.create();
+        ConstructedTarget privateInstance = (ConstructedTarget) privateConstructor.create("private");
+
+        assertThat(publicInstance.getValue()).isEqualTo("public");
+        assertThat(privateInstance.getValue()).isEqualTo("private");
+    }
+
+    @Test
+    void findsStaticFactoriesFromPublicAndDeclaredMethods() {
+        StaticFactory publicFactory = ReflectionUtil.findStaticFactory(
+                FactoryTarget.class,
+                "create",
+                Collections.emptyList(),
+                null);
+        StaticFactory privateFactory = ReflectionUtil.findStaticFactory(
+                FactoryTarget.class,
+                "hidden",
+                Collections.singletonList("value"),
+                Collections.<Class<?>>singletonList(String.class),
+                Collections.<String>emptySet(),
+                EnumSet.of(Option.PRIVATE_FACTORY));
+
+        FactoryTarget publicInstance = (FactoryTarget) publicFactory.create();
+        FactoryTarget privateInstance = (FactoryTarget) privateFactory.create("private");
+
+        assertThat(publicInstance.getValue()).isEqualTo("public");
+        assertThat(privateInstance.getValue()).isEqualTo("private");
+    }
+
+    @Test
+    void findsInstanceFactoryFromPublicAndDeclaredMethods() {
+        Method factory = ReflectionUtil.findInstanceFactory(FactoryTarget.class, "build", null);
+        Method privateFactory = ReflectionUtil.findInstanceFactory(
+                FactoryTarget.class,
+                "hiddenBuild",
+                EnumSet.of(Option.PRIVATE_FACTORY));
+
+        assertThat(factory.getName()).isEqualTo("build");
+        assertThat(privateFactory.getName()).isEqualTo("hiddenBuild");
+    }
+
+    @Test
+    void resolvesConstructorParameterNamesFromConstructorProperties() {
+        Set<String> availableProperties = new LinkedHashSet<String>(Arrays.asList("name", "amount"));
+        ConstructorFactory constructor = ReflectionUtil.findConstructor(
+                NamedConstructorTarget.class,
+                null,
+                null,
+                availableProperties,
+                EnumSet.of(Option.NAMED_PARAMETERS));
+
+        Object instance = constructor.create("coffee", Integer.valueOf(2));
+
+        NamedConstructorTarget namedInstance = (NamedConstructorTarget) instance;
+
+        assertThat(constructor.getParameterNames()).containsExactly("name", "amount");
+        assertThat(namedInstance.getName()).isEqualTo("coffee");
+        assertThat(namedInstance.getAmount()).isEqualTo(2);
+    }
+
+    public static class FieldBase {
+        public String inheritedText;
+
+        public void setInheritedNumber(Integer inheritedNumber) {
+        }
+    }
+
+    public static class FieldTarget extends FieldBase {
+        public int number;
+        public String localText;
+        private String hiddenText;
+
+        public void setLocalText(String localText) {
+            this.localText = localText;
+        }
+
+        public void setNumber(Integer number) {
+            this.number = number;
+        }
+
+        private void setHiddenText(String hiddenText) {
+            this.hiddenText = hiddenText;
+        }
+    }
+
+    public static class ConstructedTarget {
+        private final String value;
+
+        public ConstructedTarget() {
+            this.value = "public";
+        }
+
+        private ConstructedTarget(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static class FactoryTarget {
+        private final String value;
+
+        private FactoryTarget(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static FactoryTarget create() {
+            return new FactoryTarget("public");
+        }
+
+        private static FactoryTarget hidden(String value) {
+            return new FactoryTarget(value);
+        }
+
+        public FactoryTarget build() {
+            return new FactoryTarget("instance");
+        }
+
+        private FactoryTarget hiddenBuild() {
+            return new FactoryTarget("hidden-instance");
+        }
+    }
+
+    public static class NamedConstructorTarget {
+        private final String name;
+        private final int amount;
+
+        @ConstructorProperties({"name", "amount"})
+        public NamedConstructorTarget(String name, int amount) {
+            this.name = name;
+            this.amount = amount;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAmount() {
+            return amount;
+        }
+    }
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
@@ -65,6 +65,21 @@ public class ReflectionUtilTest {
     }
 
     @Test
+    void findsPublicInheritedAndPrivateGettersByName() {
+        Method publicGetter = ReflectionUtil.findGetter(GetterTarget.class, "name", null);
+        Method inheritedGetter = ReflectionUtil.findGetter(GetterTarget.class, "inheritedName", null);
+        Method privateGetter = ReflectionUtil.findGetter(
+                GetterTarget.class,
+                "secret",
+                EnumSet.of(Option.PRIVATE_PROPERTIES));
+
+        assertThat(publicGetter.getName()).isEqualTo("getName");
+        assertThat(publicGetter.getReturnType()).isEqualTo(String.class);
+        assertThat(inheritedGetter.getName()).isEqualTo("getInheritedName");
+        assertThat(privateGetter.getName()).isEqualTo("getSecret");
+    }
+
+    @Test
     void findsPublicAndPrivateConstructors() {
         ConstructorFactory publicConstructor = ReflectionUtil.findConstructor(
                 ConstructedTarget.class,
@@ -159,6 +174,22 @@ public class ReflectionUtilTest {
 
         private void setHiddenText(String hiddenText) {
             this.hiddenText = hiddenText;
+        }
+    }
+
+    public static class GetterBase {
+        public String getInheritedName() {
+            return "inherited";
+        }
+    }
+
+    public static class GetterTarget extends GetterBase {
+        public String getName() {
+            return "name";
+        }
+
+        private String getSecret() {
+            return "secret";
         }
     }
 

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,193 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.propertyeditor.ClassEditor"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ClassEditorTest$ContextLoadedTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.CollectionRecipe"
+      },
+      "type": "org_apache_xbean.xbean_reflect.CollectionRecipeTest$RecordingCollection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.propertyeditor.GenericCollectionConverter"
+      },
+      "type": "org_apache_xbean.xbean_reflect.GenericCollectionConverterTest$RecordingCollection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.propertyeditor.GenericMapConverter"
+      },
+      "type": "org_apache_xbean.xbean_reflect.GenericMapConverterTest$RecordingMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ObjectRecipe$FieldMember"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
+      "fields": [
+        {
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ObjectRecipe$MethodMember"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
+      "methods": [
+        {
+          "name": "setName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeTest$ProductBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.propertyeditor.PropertyEditors"
+      },
+      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.propertyeditor.PropertyEditors"
+      },
+      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue$ConverterBackedValueConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.RecipeHelper"
+      },
+      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$ConstructedTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil$StaticFactory"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget",
+      "methods": [
+        {
+          "name": "create",
+          "parameterTypes": []
+        },
+        {
+          "name": "hidden",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldTarget"
+    },
+    {
+      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$ConstructorArgumentTarget",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$PublicDefaultConstructorTarget",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue",
+      "allDeclaredClasses": true
+    }
+  ]
+}

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,214 +1,251 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.propertyeditor.ClassEditor"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.ClassEditor"
       },
-      "type": "org_apache_xbean.xbean_reflect.ClassEditorTest$ContextLoadedTarget"
+      "type" : "org_apache_xbean.xbean_reflect.ClassEditorTest$ContextLoadedTarget"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.CollectionRecipe"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.CollectionRecipe"
       },
-      "type": "org_apache_xbean.xbean_reflect.CollectionRecipeTest$RecordingCollection",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.CollectionRecipeTest$RecordingCollection",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.propertyeditor.GenericCollectionConverter"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.GenericCollectionConverter"
       },
-      "type": "org_apache_xbean.xbean_reflect.GenericCollectionConverterTest$RecordingCollection",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.GenericCollectionConverterTest$RecordingCollection",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.propertyeditor.GenericMapConverter"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.GenericMapConverter"
       },
-      "type": "org_apache_xbean.xbean_reflect.GenericMapConverterTest$RecordingMap",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.GenericMapConverterTest$RecordingMap",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe"
       },
-      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ObjectRecipe$FieldMember"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe$FieldMember"
       },
-      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
-      "fields": [
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest$FieldInjectedTarget",
+      "fields" : [
         {
-          "name": "name"
+          "name" : "name"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe"
       },
-      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ObjectRecipe$MethodMember"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe$MethodMember"
       },
-      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest$SetterInjectedTarget",
+      "methods" : [
         {
-          "name": "setName",
-          "parameterTypes": [
+          "name" : "setName",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ObjectRecipe"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe"
       },
-      "type": "org_apache_xbean.xbean_reflect.ObjectRecipeTest$ProductBuilder",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeTest$ProductBuilder",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "build",
-          "parameterTypes": []
+          "name" : "build",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.propertyeditor.PropertyEditors"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.PropertyEditors"
       },
-      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue"
+      "type" : "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.propertyeditor.PropertyEditors"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.propertyeditor.PropertyEditors"
       },
-      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue$ConverterBackedValueConverter",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue$ConverterBackedValueConverter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.RecipeHelper"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.RecipeHelper"
       },
-      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget"
+      "type" : "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$ConstructedTarget"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$ConstructedTarget"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil$StaticFactory"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil$StaticFactory"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget",
-      "methods": [
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FactoryTarget",
+      "methods" : [
         {
-          "name": "create",
-          "parameterTypes": []
+          "name" : "create",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "hidden",
-          "parameterTypes": [
+          "name" : "hidden",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldBase"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldBase"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldTarget"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldTarget"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterBase"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterBase"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ReflectionUtil"
       },
-      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterTarget"
+      "type" : "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterTarget"
     },
     {
-      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$ConstructorArgumentTarget",
-      "allPublicConstructors": true
+      "type" : "org_apache_xbean.xbean_reflect.RecipeHelperTest$ConstructorArgumentTarget",
+      "allPublicConstructors" : true
     },
     {
-      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget",
-      "allPublicConstructors": true
+      "type" : "org_apache_xbean.xbean_reflect.RecipeHelperTest$LoadTarget",
+      "allPublicConstructors" : true
     },
     {
-      "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$PublicDefaultConstructorTarget",
-      "allPublicConstructors": true
+      "type" : "org_apache_xbean.xbean_reflect.RecipeHelperTest$PublicDefaultConstructorTarget",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.apache.xbean.recipe.AsmParameterNameLoader"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.AsmParameterNameLoader"
       },
-      "type": "org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest$ParameterNamedTarget",
-      "allDeclaredConstructors": true,
-      "allDeclaredMethods": true
-    }
-  ],
-  "resources": [
+      "type" : "org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest$ParameterNamedTarget",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true
+    },
     {
-      "glob": "org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest$ParameterNamedTarget.class"
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.AsmParameterNameLoader"
+      },
+      "type" : "org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest$ParameterNamedTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.AsmParameterNameLoader$AllParameterNamesDiscoveringVisitor"
+      },
+      "type" : "org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest$ParameterNamedTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe"
+      },
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeTest$CompoundPropertyTarget",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getSettings",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.xbean.recipe.ObjectRecipe$MethodMember"
+      },
+      "type" : "org_apache_xbean.xbean_reflect.ObjectRecipeTest$NestedSettings",
+      "methods" : [
+        {
+          "name" : "setLabel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -198,10 +198,6 @@
       "allPublicConstructors": true
     },
     {
-      "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue",
-      "allDeclaredClasses": true
-    },
-    {
       "condition": {
         "typeReached": "org.apache.xbean.recipe.AsmParameterNameLoader"
       },

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -174,6 +174,18 @@
       "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$FieldTarget"
     },
     {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.ReflectionUtil"
+      },
+      "type": "org_apache_xbean.xbean_reflect.ReflectionUtilTest$GetterTarget"
+    },
+    {
       "type": "org_apache_xbean.xbean_reflect.RecipeHelperTest$ConstructorArgumentTarget",
       "allPublicConstructors": true
     },
@@ -188,6 +200,19 @@
     {
       "type": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue",
       "allDeclaredClasses": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.xbean.recipe.AsmParameterNameLoader"
+      },
+      "type": "org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest$ParameterNamedTarget",
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest$ParameterNamedTarget.class"
     }
   ]
 }

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reflect-config.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "org_apache_xbean.xbean_reflect.PropertyEditorsTest$ConverterBackedValue",
+    "allDeclaredClasses": true
+  }
+]

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="30" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:41">
+<testsuite name="JUnit Jupiter" tests="30" skipped="0" failures="0" errors="0" time="0.045" hostname="kung-fu-workstation" timestamp="2026-05-02T22:08:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4376-2912339d/tests/src/org.apache.xbean/xbean-reflect/3.6"/>
@@ -64,7 +63,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericM
 display-name: createsRequestedMapImplementationFromPropertiesText()
 ]]></system-out>
 </testcase>
-<testcase name="loadsNamesForPublicAndDeclaredConstructors()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0">
+<testcase name="loadsNamesForPublicAndDeclaredConstructors()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest]/[method:loadsNamesForPublicAndDeclaredConstructors()]
 display-name: loadsNamesForPublicAndDeclaredConstructors()
@@ -76,13 +75,13 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Collecti
 display-name: createsDefaultListImplementationFromRecipeValues()
 ]]></system-out>
 </testcase>
-<testcase name="findsDeclaredAndInheritedSettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<testcase name="findsDeclaredAndInheritedSettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedSettersByName()]
 display-name: findsDeclaredAndInheritedSettersByName()
 ]]></system-out>
 </testcase>
-<testcase name="setsNestedValueThroughCompoundPropertyGetter()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0">
+<testcase name="setsNestedValueThroughCompoundPropertyGetter()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeTest]/[method:setsNestedValueThroughCompoundPropertyGetter()]
 display-name: setsNestedValueThroughCompoundPropertyGetter()
@@ -100,25 +99,25 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRe
 display-name: setsPropertyValueThroughSetterMethodMember()
 ]]></system-out>
 </testcase>
-<testcase name="discoversNestedConverterDeclaredOnTargetType()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<testcase name="discoversNestedConverterDeclaredOnTargetType()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:discoversNestedConverterDeclaredOnTargetType()]
 display-name: discoversNestedConverterDeclaredOnTargetType()
 ]]></system-out>
 </testcase>
-<testcase name="convertsMetadataRegisteredClassNameWithACustomContextClassLoader()" classname="org_apache_xbean.xbean_reflect.ClassEditorTest" time="0">
+<testcase name="convertsMetadataRegisteredClassNameWithACustomContextClassLoader()" classname="org_apache_xbean.xbean_reflect.ClassEditorTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ClassEditorTest]/[method:convertsMetadataRegisteredClassNameWithACustomContextClassLoader()]
 display-name: convertsMetadataRegisteredClassNameWithACustomContextClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="findsDeclaredAndInheritedSettersByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<testcase name="findsDeclaredAndInheritedSettersByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedSettersByType()]
 display-name: findsDeclaredAndInheritedSettersByType()
 ]]></system-out>
 </testcase>
-<testcase name="createsRequestedCollectionImplementationFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.GenericCollectionConverterTest" time="0">
+<testcase name="createsRequestedCollectionImplementationFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.GenericCollectionConverterTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericCollectionConverterTest]/[method:createsRequestedCollectionImplementationFromDelimitedText()]
 display-name: createsRequestedCollectionImplementationFromDelimitedText()
@@ -136,19 +135,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Reflecti
 display-name: findsInstanceFactoryFromPublicAndDeclaredMethods()
 ]]></system-out>
 </testcase>
-<testcase name="findsPublicInheritedAndPrivateGettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<testcase name="findsPublicInheritedAndPrivateGettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsPublicInheritedAndPrivateGettersByName()]
 display-name: findsPublicInheritedAndPrivateGettersByName()
 ]]></system-out>
 </testcase>
-<testcase name="resolvesConstructorParameterNamesFromConstructorProperties()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<testcase name="resolvesConstructorParameterNamesFromConstructorProperties()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:resolvesConstructorParameterNamesFromConstructorProperties()]
 display-name: resolvesConstructorParameterNamesFromConstructorProperties()
 ]]></system-out>
 </testcase>
-<testcase name="convertsValueFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<testcase name="convertsValueFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:convertsValueFromAClassName()]
 display-name: convertsValueFromAClassName()
@@ -160,7 +159,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Reflecti
 display-name: findsDeclaredAndInheritedFieldsByName()
 ]]></system-out>
 </testcase>
-<testcase name="loadsNamesForPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0">
+<testcase name="loadsNamesForPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest]/[method:loadsNamesForPublicAndDeclaredMethods()]
 display-name: loadsNamesForPublicAndDeclaredMethods()
@@ -172,13 +171,13 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRe
 display-name: setsPublicFieldValueThroughFieldMember()
 ]]></system-out>
 </testcase>
-<testcase name="checksConversionSupportFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<testcase name="checksConversionSupportFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:checksConversionSupportFromAClassName()]
 display-name: checksConversionSupportFromAClassName()
 ]]></system-out>
 </testcase>
-<testcase name="findsStaticFactoriesFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<testcase name="findsStaticFactoriesFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsStaticFactoriesFromPublicAndDeclaredMethods()]
 display-name: findsStaticFactoriesFromPublicAndDeclaredMethods()
@@ -196,19 +195,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Reflecti
 display-name: findsAllDeclaredAndInheritedFieldsByType()
 ]]></system-out>
 </testcase>
-<testcase name="loadsClassWithTheCurrentExecutionContextClassLoader()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0">
+<testcase name="loadsClassWithTheCurrentExecutionContextClassLoader()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:loadsClassWithTheCurrentExecutionContextClassLoader()]
 display-name: loadsClassWithTheCurrentExecutionContextClassLoader()
 ]]></system-out>
 </testcase>
-<testcase name="createsArrayFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.ArrayConverterTest" time="0">
+<testcase name="createsArrayFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.ArrayConverterTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ArrayConverterTest]/[method:createsArrayFromDelimitedText()]
 display-name: createsArrayFromDelimitedText()
 ]]></system-out>
 </testcase>
-<testcase name="createsArrayInstanceForConfiguredComponentType()" classname="org_apache_xbean.xbean_reflect.ArrayRecipeTest" time="0.001">
+<testcase name="createsArrayInstanceForConfiguredComponentType()" classname="org_apache_xbean.xbean_reflect.ArrayRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ArrayRecipeTest]/[method:createsArrayInstanceForConfiguredComponentType()]
 display-name: createsArrayInstanceForConfiguredComponentType()

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="28" skipped="0" failures="0" errors="0" time="0.045" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4376-2912339d/tests/src/org.apache.xbean/xbean-reflect/3.6"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="convertsOrdinalTextUsingEnumValuesMethod()" classname="org_apache_xbean.xbean_reflect.EnumConverterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.EnumConverterTest]/[method:convertsOrdinalTextUsingEnumValuesMethod()]
+display-name: convertsOrdinalTextUsingEnumValuesMethod()
+]]></system-out>
+</testcase>
+<testcase name="createsRequestedMapImplementationFromPropertiesText()" classname="org_apache_xbean.xbean_reflect.GenericMapConverterTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericMapConverterTest]/[method:createsRequestedMapImplementationFromPropertiesText()]
+display-name: createsRequestedMapImplementationFromPropertiesText()
+]]></system-out>
+</testcase>
+<testcase name="loadsNamesForPublicAndDeclaredConstructors()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest]/[method:loadsNamesForPublicAndDeclaredConstructors()]
+display-name: loadsNamesForPublicAndDeclaredConstructors()
+]]></system-out>
+</testcase>
+<testcase name="createsDefaultListImplementationFromRecipeValues()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.CollectionRecipeTest]/[method:createsDefaultListImplementationFromRecipeValues()]
+display-name: createsDefaultListImplementationFromRecipeValues()
+]]></system-out>
+</testcase>
+<testcase name="findsDeclaredAndInheritedSettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedSettersByName()]
+display-name: findsDeclaredAndInheritedSettersByName()
+]]></system-out>
+</testcase>
+<testcase name="createsRequestedMapImplementationFromRecipeEntries()" classname="org_apache_xbean.xbean_reflect.MapRecipeTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.MapRecipeTest]/[method:createsRequestedMapImplementationFromRecipeEntries()]
+display-name: createsRequestedMapImplementationFromRecipeEntries()
+]]></system-out>
+</testcase>
+<testcase name="setsPropertyValueThroughSetterMethodMember()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeInnerMethodMemberTest]/[method:setsPropertyValueThroughSetterMethodMember()]
+display-name: setsPropertyValueThroughSetterMethodMember()
+]]></system-out>
+</testcase>
+<testcase name="discoversNestedConverterDeclaredOnTargetType()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:discoversNestedConverterDeclaredOnTargetType()]
+display-name: discoversNestedConverterDeclaredOnTargetType()
+]]></system-out>
+</testcase>
+<testcase name="convertsMetadataRegisteredClassNameWithACustomContextClassLoader()" classname="org_apache_xbean.xbean_reflect.ClassEditorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ClassEditorTest]/[method:convertsMetadataRegisteredClassNameWithACustomContextClassLoader()]
+display-name: convertsMetadataRegisteredClassNameWithACustomContextClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="findsDeclaredAndInheritedSettersByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedSettersByType()]
+display-name: findsDeclaredAndInheritedSettersByType()
+]]></system-out>
+</testcase>
+<testcase name="createsRequestedCollectionImplementationFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.GenericCollectionConverterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericCollectionConverterTest]/[method:createsRequestedCollectionImplementationFromDelimitedText()]
+display-name: createsRequestedCollectionImplementationFromDelimitedText()
+]]></system-out>
+</testcase>
+<testcase name="createsRequestedCollectionImplementationFromDefaultConstructor()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.CollectionRecipeTest]/[method:createsRequestedCollectionImplementationFromDefaultConstructor()]
+display-name: createsRequestedCollectionImplementationFromDefaultConstructor()
+]]></system-out>
+</testcase>
+<testcase name="findsInstanceFactoryFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsInstanceFactoryFromPublicAndDeclaredMethods()]
+display-name: findsInstanceFactoryFromPublicAndDeclaredMethods()
+]]></system-out>
+</testcase>
+<testcase name="findsPublicInheritedAndPrivateGettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsPublicInheritedAndPrivateGettersByName()]
+display-name: findsPublicInheritedAndPrivateGettersByName()
+]]></system-out>
+</testcase>
+<testcase name="resolvesConstructorParameterNamesFromConstructorProperties()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:resolvesConstructorParameterNamesFromConstructorProperties()]
+display-name: resolvesConstructorParameterNamesFromConstructorProperties()
+]]></system-out>
+</testcase>
+<testcase name="convertsValueFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:convertsValueFromAClassName()]
+display-name: convertsValueFromAClassName()
+]]></system-out>
+</testcase>
+<testcase name="findsDeclaredAndInheritedFieldsByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedFieldsByName()]
+display-name: findsDeclaredAndInheritedFieldsByName()
+]]></system-out>
+</testcase>
+<testcase name="loadsNamesForPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest]/[method:loadsNamesForPublicAndDeclaredMethods()]
+display-name: loadsNamesForPublicAndDeclaredMethods()
+]]></system-out>
+</testcase>
+<testcase name="setsPublicFieldValueThroughFieldMember()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeInnerFieldMemberTest]/[method:setsPublicFieldValueThroughFieldMember()]
+display-name: setsPublicFieldValueThroughFieldMember()
+]]></system-out>
+</testcase>
+<testcase name="checksConversionSupportFromAClassName()" classname="org_apache_xbean.xbean_reflect.PropertyEditorsTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.PropertyEditorsTest]/[method:checksConversionSupportFromAClassName()]
+display-name: checksConversionSupportFromAClassName()
+]]></system-out>
+</testcase>
+<testcase name="findsStaticFactoriesFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsStaticFactoriesFromPublicAndDeclaredMethods()]
+display-name: findsStaticFactoriesFromPublicAndDeclaredMethods()
+]]></system-out>
+</testcase>
+<testcase name="detectsPublicDefaultConstructors()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:detectsPublicDefaultConstructors()]
+display-name: detectsPublicDefaultConstructors()
+]]></system-out>
+</testcase>
+<testcase name="findsAllDeclaredAndInheritedFieldsByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsAllDeclaredAndInheritedFieldsByType()]
+display-name: findsAllDeclaredAndInheritedFieldsByType()
+]]></system-out>
+</testcase>
+<testcase name="loadsClassWithTheCurrentExecutionContextClassLoader()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:loadsClassWithTheCurrentExecutionContextClassLoader()]
+display-name: loadsClassWithTheCurrentExecutionContextClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="createsArrayFromDelimitedText()" classname="org_apache_xbean.xbean_reflect.ArrayConverterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ArrayConverterTest]/[method:createsArrayFromDelimitedText()]
+display-name: createsArrayFromDelimitedText()
+]]></system-out>
+</testcase>
+<testcase name="findsPublicAndPrivateConstructors()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsPublicAndPrivateConstructors()]
+display-name: findsPublicAndPrivateConstructors()
+]]></system-out>
+</testcase>
+<testcase name="convertsGenericArrayTypeToArrayClass()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0.004">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:convertsGenericArrayTypeToArrayClass()]
+display-name: convertsGenericArrayTypeToArrayClass()
+]]></system-out>
+</testcase>
+<testcase name="invokesInstanceFactoryMethodAfterConstructingObject()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeTest]/[method:invokesInstanceFactoryMethodAfterConstructingObject()]
+display-name: invokesInstanceFactoryMethodAfterConstructingObject()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="29" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:33:01">
+<testsuite name="JUnit Jupiter" tests="30" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:41">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -82,6 +82,12 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Reflecti
 display-name: findsDeclaredAndInheritedSettersByName()
 ]]></system-out>
 </testcase>
+<testcase name="setsNestedValueThroughCompoundPropertyGetter()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeTest]/[method:setsNestedValueThroughCompoundPropertyGetter()]
+display-name: setsNestedValueThroughCompoundPropertyGetter()
+]]></system-out>
+</testcase>
 <testcase name="createsRequestedMapImplementationFromRecipeEntries()" classname="org_apache_xbean.xbean_reflect.MapRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.MapRecipeTest]/[method:createsRequestedMapImplementationFromRecipeEntries()]
@@ -124,7 +130,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Collecti
 display-name: createsRequestedCollectionImplementationFromDefaultConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="findsInstanceFactoryFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
+<testcase name="findsInstanceFactoryFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsInstanceFactoryFromPublicAndDeclaredMethods()]
 display-name: findsInstanceFactoryFromPublicAndDeclaredMethods()

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="28" skipped="0" failures="0" errors="0" time="0.045" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:30">
+<testsuite name="JUnit Jupiter" tests="29" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T21:33:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,19 +58,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.EnumConv
 display-name: convertsOrdinalTextUsingEnumValuesMethod()
 ]]></system-out>
 </testcase>
-<testcase name="createsRequestedMapImplementationFromPropertiesText()" classname="org_apache_xbean.xbean_reflect.GenericMapConverterTest" time="0.003">
+<testcase name="createsRequestedMapImplementationFromPropertiesText()" classname="org_apache_xbean.xbean_reflect.GenericMapConverterTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericMapConverterTest]/[method:createsRequestedMapImplementationFromPropertiesText()]
 display-name: createsRequestedMapImplementationFromPropertiesText()
 ]]></system-out>
 </testcase>
-<testcase name="loadsNamesForPublicAndDeclaredConstructors()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0.001">
+<testcase name="loadsNamesForPublicAndDeclaredConstructors()" classname="org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.AsmParameterNameLoaderTest]/[method:loadsNamesForPublicAndDeclaredConstructors()]
 display-name: loadsNamesForPublicAndDeclaredConstructors()
 ]]></system-out>
 </testcase>
-<testcase name="createsDefaultListImplementationFromRecipeValues()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0.003">
+<testcase name="createsDefaultListImplementationFromRecipeValues()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.CollectionRecipeTest]/[method:createsDefaultListImplementationFromRecipeValues()]
 display-name: createsDefaultListImplementationFromRecipeValues()
@@ -82,7 +82,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Reflecti
 display-name: findsDeclaredAndInheritedSettersByName()
 ]]></system-out>
 </testcase>
-<testcase name="createsRequestedMapImplementationFromRecipeEntries()" classname="org_apache_xbean.xbean_reflect.MapRecipeTest" time="0.003">
+<testcase name="createsRequestedMapImplementationFromRecipeEntries()" classname="org_apache_xbean.xbean_reflect.MapRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.MapRecipeTest]/[method:createsRequestedMapImplementationFromRecipeEntries()]
 display-name: createsRequestedMapImplementationFromRecipeEntries()
@@ -118,19 +118,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.GenericC
 display-name: createsRequestedCollectionImplementationFromDelimitedText()
 ]]></system-out>
 </testcase>
-<testcase name="createsRequestedCollectionImplementationFromDefaultConstructor()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0.003">
+<testcase name="createsRequestedCollectionImplementationFromDefaultConstructor()" classname="org_apache_xbean.xbean_reflect.CollectionRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.CollectionRecipeTest]/[method:createsRequestedCollectionImplementationFromDefaultConstructor()]
 display-name: createsRequestedCollectionImplementationFromDefaultConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="findsInstanceFactoryFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<testcase name="findsInstanceFactoryFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsInstanceFactoryFromPublicAndDeclaredMethods()]
 display-name: findsInstanceFactoryFromPublicAndDeclaredMethods()
 ]]></system-out>
 </testcase>
-<testcase name="findsPublicInheritedAndPrivateGettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
+<testcase name="findsPublicInheritedAndPrivateGettersByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsPublicInheritedAndPrivateGettersByName()]
 display-name: findsPublicInheritedAndPrivateGettersByName()
@@ -148,7 +148,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Property
 display-name: convertsValueFromAClassName()
 ]]></system-out>
 </testcase>
-<testcase name="findsDeclaredAndInheritedFieldsByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.003">
+<testcase name="findsDeclaredAndInheritedFieldsByName()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsDeclaredAndInheritedFieldsByName()]
 display-name: findsDeclaredAndInheritedFieldsByName()
@@ -172,19 +172,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.Property
 display-name: checksConversionSupportFromAClassName()
 ]]></system-out>
 </testcase>
-<testcase name="findsStaticFactoriesFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.005">
+<testcase name="findsStaticFactoriesFromPublicAndDeclaredMethods()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsStaticFactoriesFromPublicAndDeclaredMethods()]
 display-name: findsStaticFactoriesFromPublicAndDeclaredMethods()
 ]]></system-out>
 </testcase>
-<testcase name="detectsPublicDefaultConstructors()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0.001">
+<testcase name="detectsPublicDefaultConstructors()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:detectsPublicDefaultConstructors()]
 display-name: detectsPublicDefaultConstructors()
 ]]></system-out>
 </testcase>
-<testcase name="findsAllDeclaredAndInheritedFieldsByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<testcase name="findsAllDeclaredAndInheritedFieldsByType()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsAllDeclaredAndInheritedFieldsByType()]
 display-name: findsAllDeclaredAndInheritedFieldsByType()
@@ -202,19 +202,25 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ArrayCon
 display-name: createsArrayFromDelimitedText()
 ]]></system-out>
 </testcase>
-<testcase name="findsPublicAndPrivateConstructors()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0.001">
+<testcase name="createsArrayInstanceForConfiguredComponentType()" classname="org_apache_xbean.xbean_reflect.ArrayRecipeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ArrayRecipeTest]/[method:createsArrayInstanceForConfiguredComponentType()]
+display-name: createsArrayInstanceForConfiguredComponentType()
+]]></system-out>
+</testcase>
+<testcase name="findsPublicAndPrivateConstructors()" classname="org_apache_xbean.xbean_reflect.ReflectionUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ReflectionUtilTest]/[method:findsPublicAndPrivateConstructors()]
 display-name: findsPublicAndPrivateConstructors()
 ]]></system-out>
 </testcase>
-<testcase name="convertsGenericArrayTypeToArrayClass()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0.004">
+<testcase name="convertsGenericArrayTypeToArrayClass()" classname="org_apache_xbean.xbean_reflect.RecipeHelperTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.RecipeHelperTest]/[method:convertsGenericArrayTypeToArrayClass()]
 display-name: convertsGenericArrayTypeToArrayClass()
 ]]></system-out>
 </testcase>
-<testcase name="invokesInstanceFactoryMethodAfterConstructingObject()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0.001">
+<testcase name="invokesInstanceFactoryMethodAfterConstructingObject()" classname="org_apache_xbean.xbean_reflect.ObjectRecipeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_xbean.xbean_reflect.ObjectRecipeTest]/[method:invokesInstanceFactoryMethodAfterConstructingObject()]
 display-name: invokesInstanceFactoryMethodAfterConstructingObject()

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:41">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:08:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4376-2912339d/tests/src/org.apache.xbean/xbean-reflect/3.6"/>

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:33:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:45:41">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:30">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:33:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:30">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4376-2912339d/tests/src/org.apache.xbean/xbean-reflect/3.6"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.xbean/xbean-reflect/3.6/user-code-filter.json
+++ b/tests/src/org.apache.xbean/xbean-reflect/3.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.xbean.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4376

This PR provides test fixes and new metadata for org.apache.xbean:xbean-reflect:3.6, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 182514
- Cached input tokens: 2552832
- Output tokens: 19471
- Metadata entries: 18
- Test-only metadata entries: 47
- Iterations: 4
- Library coverage percentage: 39.25
- Previous library version metadata entries: 17
- Previous library version test-only metadata entries: 37
- Previous library version coverage percentage: 40.9

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `503d35864c35771e206a929fb2e5be20456d0bf7`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.xbean:xbean-reflect:3.4: 48/48 covered calls (100.00%)
- org.apache.xbean:xbean-reflect:3.6: 52/52 covered calls (100.00%)

**Reflection:**
- org.apache.xbean:xbean-reflect:3.4: 47/47 covered calls (100.00%)
- org.apache.xbean:xbean-reflect:3.6: 51/51 covered calls (100.00%)

**Resources:**
- org.apache.xbean:xbean-reflect:3.4: 1/1 covered calls (100.00%)
- org.apache.xbean:xbean-reflect:3.6: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.xbean:xbean-reflect:3.4: 4104/11141 (36.84%)
- org.apache.xbean:xbean-reflect:3.6: 4431/12634 (35.07%)

**Line:**
- org.apache.xbean:xbean-reflect:3.4: 1068/2611 (40.90%)
- org.apache.xbean:xbean-reflect:3.6: 1115/2841 (39.25%)

**Method:**
- org.apache.xbean:xbean-reflect:3.4: 197/449 (43.88%)
- org.apache.xbean:xbean-reflect:3.6: 205/501 (40.92%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.xbean/xbean-reflect/3.4/build.gradle 2/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
index 42f7e4b71e..8200ed2b99 100644
--- 1/tests/src/org.apache.xbean/xbean-reflect/3.4/build.gradle
+++ 2/tests/src/org.apache.xbean/xbean-reflect/3.6/build.gradle
@@ -12,8 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.xbean:xbean-reflect:$libraryVersion"
-    testImplementation 'asm:asm:2.2.3'
-    testImplementation 'asm:asm-commons:2.2.3'
+    testImplementation 'asm:asm:3.1'
+    testImplementation 'asm:asm-commons:3.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayRecipeTest.java 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayRecipeTest.java
new file mode 100644
index 0000000000..765acee2e5
--- /dev/null
+++ 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ArrayRecipeTest.java
@@ -0,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_xbean.xbean_reflect;
+
+import org.apache.xbean.recipe.ArrayRecipe;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayRecipeTest {
+    @Test
+    void createsArrayInstanceForConfiguredComponentType() {
+        ArrayRecipe recipe = new ArrayRecipe(String.class);
+        recipe.add("alpha");
+        recipe.add("beta");
+
+        Object value = recipe.create(String[].class, false);
+
+        assertThat(value).isInstanceOf(String[].class);
+        assertThat((String[]) value).containsExactly("alpha", "beta");
+    }
+}
diff --git 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
index 5db5102891..50706b8fb1 100644
--- 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
+++ 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/AsmParameterNameLoaderTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.xbean.recipe.AsmParameterNameLoader;
-import org.apache.xbean.recipe.CollectionRecipe;
 import org.apache.xbean.recipe.Option;
 import org.junit.jupiter.api.Test;
 
@@ -22,25 +21,25 @@ public class AsmParameterNameLoaderTest {
     @Test
     void loadsNamesForPublicAndDeclaredConstructors() throws Exception {
         AsmParameterNameLoader loader = new AsmParameterNameLoader();
-        Constructor<CollectionRecipe> typeNameConstructor = CollectionRecipe.class.getConstructor(String.class);
-        Constructor<CollectionRecipe> typeClassConstructor = CollectionRecipe.class.getConstructor(Class.class);
+        Constructor<ParameterNamedTarget> nameConstructor = ParameterNamedTarget.class.getConstructor(String.class);
+        Constructor<ParameterNamedTarget> countConstructor = ParameterNamedTarget.class.getDeclaredConstructor(Integer.class);
 
-        Map<Constructor, List<String>> parameterNames = loader.getAllConstructorParameters(CollectionRecipe.class);
+        Map<Constructor, List<String>> parameterNames = loader.getAllConstructorParameters(ParameterNamedTarget.class);
 
-        assertThat(parameterNames).containsKeys(typeNameConstructor, typeClassConstructor);
-        assertThat(parameterNames.get(typeNameConstructor)).containsExactly("type");
-        assertThat(parameterNames.get(typeClassConstructor)).containsExactly("type");
+        assertThat(parameterNames).containsKeys(nameConstructor, countConstructor);
+        assertThat(parameterNames.get(nameConstructor)).containsExactly("name");
+        assertThat(parameterNames.get(countConstructor)).containsExactly("count");
     }
 
     @Test
     void loadsNamesForPublicAndDeclaredMethods() throws Exception {
         AsmParameterNameLoader loader = new AsmParameterNameLoader();
-        Method allowMethod = CollectionRecipe.class.getMethod("allow", Option.class);
-        Method disallowMethod = CollectionRecipe.class.getMethod("disallow", Option.class);
+        Method allowMethod = ParameterNamedTarget.class.getMethod("allow", Option.class);
+        Method disallowMethod = ParameterNamedTarget.class.getDeclaredMethod("disallow", Option.class);
 
-        Map<Method, List<String>> allowParameterNames = loader.getAllMethodParameters(CollectionRecipe.class, "allow");
+        Map<Method, List<String>> allowParameterNames = loader.getAllMethodParameters(ParameterNamedTarget.class, "allow");
         Map<Method, List<String>> disallowParameterNames = loader.getAllMethodParameters(
-                CollectionRecipe.class,
+                ParameterNamedTarget.class,
                 "disallow");
 
         assertThat(allowParameterNames).containsKey(allowMethod);
@@ -48,4 +47,18 @@ public class AsmParameterNameLoaderTest {
         assertThat(allowParameterNames.get(allowMethod)).containsExactly("option");
         assertThat(disallowParameterNames.get(disallowMethod)).containsExactly("option");
     }
+
+    public static final class ParameterNamedTarget {
+        public ParameterNamedTarget(String name) {
+        }
+
+        private ParameterNamedTarget(Integer count) {
+        }
+
+        public void allow(Option option) {
+        }
+
+        private void disallow(Option option) {
+        }
+    }
 }
diff --git 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
index 90935e4c54..394f782e35 100644
--- 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
+++ 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ObjectRecipeTest.java
@@ -22,6 +22,17 @@ public class ObjectRecipeTest {
         assertThat(((Product) value).getDescription()).isEqualTo("created by instance factory");
     }
 
+    @Test
+    void setsNestedValueThroughCompoundPropertyGetter() {
+        ObjectRecipe recipe = new ObjectRecipe(CompoundPropertyTarget.class);
+        recipe.setCompoundProperty("settings.label", "configured through compound property");
+
+        CompoundPropertyTarget target = (CompoundPropertyTarget) recipe.create();
+
+        assertThat(target.getSettingsAccessCount()).isEqualTo(1);
+        assertThat(target.peekSettings().getLabel()).isEqualTo("configured through compound property");
+    }
+
     public static class ProductBuilder {
         public Product build() {
             return new Product("created by instance factory");
@@ -39,4 +50,40 @@ public class ObjectRecipeTest {
             return description;
         }
     }
+
+    public static class CompoundPropertyTarget {
+        private final NestedSettings settings = new NestedSettings();
+        private int settingsAccessCount;
+
+        public CompoundPropertyTarget() {
+        }
+
+        public NestedSettings getSettings() {
+            settingsAccessCount++;
+            return settings;
+        }
+
+        public NestedSettings peekSettings() {
+            return settings;
+        }
+
+        public int getSettingsAccessCount() {
+            return settingsAccessCount;
+        }
+    }
+
+    public static class NestedSettings {
+        private String label;
+
+        public NestedSettings() {
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+    }
 }
diff --git 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
index 488d64bbb7..bbbde2f13e 100644
--- 1/tests/src/org.apache.xbean/xbean-reflect/3.4/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
+++ 2/tests/src/org.apache.xbean/xbean-reflect/3.6/src/test/java/org_apache_xbean/xbean_reflect/ReflectionUtilTest.java
@@ -64,6 +64,21 @@ public class ReflectionUtilTest {
         assertThat(setters).extracting(Method::getName).contains("setNumber", "setInheritedNumber");
     }
 
+    @Test
+    void findsPublicInheritedAndPrivateGettersByName() {
+        Method publicGetter = ReflectionUtil.findGetter(GetterTarget.class, "name", null);
+        Method inheritedGetter = ReflectionUtil.findGetter(GetterTarget.class, "inheritedName", null);
+        Method privateGetter = ReflectionUtil.findGetter(
+                GetterTarget.class,
+                "secret",
+                EnumSet.of(Option.PRIVATE_PROPERTIES));
+
+        assertThat(publicGetter.getName()).isEqualTo("getName");
+        assertThat(publicGetter.getReturnType()).isEqualTo(String.class);
+        assertThat(inheritedGetter.getName()).isEqualTo("getInheritedName");
+        assertThat(privateGetter.getName()).isEqualTo("getSecret");
+    }
+
     @Test
     void findsPublicAndPrivateConstructors() {
         ConstructorFactory publicConstructor = ReflectionUtil.findConstructor(
@@ -162,6 +177,22 @@ public class ReflectionUtilTest {
         }
     }
 
+    public static class GetterBase {
+        public String getInheritedName() {
+            return "inherited";
+        }
+    }
+
+    public static class GetterTarget extends GetterBase {
+        public String getName() {
+            return "name";
+        }
+
+        private String getSecret() {
+            return "secret";
+        }
+    }
+
     public static class ConstructedTarget {
         private final String value;
 

```
