### PR TITLE
[GenAI] Add support for org.apache.geronimo.specs:geronimo-osgi-locator:1.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json
+++ b/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "glob" : "META-INF/services/org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$TestService"
+    }
+  ]
+}

--- a/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/index.json
+++ b/metadata/org.apache.geronimo.specs/geronimo-osgi-locator/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator/$version$/geronimo-osgi-locator-$version$-sources.jar",
+    "repository-url" : "https://svn.apache.org/repos/asf/geronimo/specs",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator-itests/$version$/geronimo-osgi-locator-itests-$version$-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-osgi-locator/$version$/geronimo-osgi-locator-$version$-javadoc.jar",
+    "description" : "Geronimo OSGi Locator supplies helper classes for Geronimo specification bundles to locate provider implementations through the Geronimo OSGi registry. It is intended to be embedded as a private package inside other bundles rather than used as a standalone API.",
+    "tested-versions" : [
+      "1.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.geronimo.osgi.locator"
+    ]
+  }
+]

--- a/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/execution-metrics.json
+++ b/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T20:11:51.512923Z",
+    "library": "org.apache.geronimo.specs:geronimo-osgi-locator:1.0",
+    "starting_commit": "37a9a2b310fae6c86bf41f2f43991ad89d7cbcc3",
+    "ending_commit": "7c352f5146f24cb9b48b31ecb5bba70018db9cc1",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 390,
+          "missed": 107,
+          "ratio": 0.784708,
+          "total": 497
+        },
+        "line": {
+          "covered": 113,
+          "missed": 40,
+          "ratio": 0.738562,
+          "total": 153
+        },
+        "method": {
+          "covered": 18,
+          "missed": 6,
+          "ratio": 0.75,
+          "total": 24
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 193248,
+      "cached_input_tokens_used": 2720256,
+      "output_tokens_used": 24384,
+      "iterations": 3,
+      "cost_usd": 2.0916,
+      "generated_loc": 236,
+      "tested_library_loc": 113,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 6,
+      "code_coverage_percent": 73.86
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java",
+      "metadata_file": "metadata/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/stats.json
+++ b/stats/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 390,
+        "missed" : 107,
+        "ratio" : 0.784708,
+        "total" : 497
+      },
+      "line" : {
+        "covered" : 113,
+        "missed" : 40,
+        "ratio" : 0.738562,
+        "total" : 153
+      },
+      "method" : {
+        "covered" : 18,
+        "missed" : 6,
+        "ratio" : 0.75,
+        "total" : 24
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/.gitignore
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/build.gradle
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.geronimo.specs:geronimo-osgi-locator:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/gradle.properties
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.geronimo.specs:geronimo-osgi-locator:1.0
+library.version = 1.0
+metadata.dir = org.apache.geronimo.specs/geronimo-osgi-locator/1.0/

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/settings.gradle
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.geronimo.specs.geronimo-osgi-locator_tests'

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_geronimo_specs.geronimo_osgi_locator;
+
+import org.junit.jupiter.api.Test;
+
+class Geronimo_osgi_locatorTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -6,11 +6,188 @@
  */
 package org_apache_geronimo_specs.geronimo_osgi_locator;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Geronimo_osgi_locatorTest {
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.geronimo.osgi.locator.ProviderLocator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Geronimo_osgi_locatorTest {
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void resetProviderLocator() {
+        ProviderLocator.destroy();
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable() throws Exception {
+        ResourceBackedClassLoader emptyClassLoader = new ResourceBackedClassLoader(Map.of());
+
+        assertThat(ProviderLocator.locate(TestService.class.getName())).isNull();
+        assertThat(ProviderLocator.locateAll(TestService.class.getName())).isEmpty();
+        assertThat(ProviderLocator.getServiceClass(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, emptyClassLoader)).isNull();
+        assertThat(ProviderLocator.getService(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, emptyClassLoader)).isNull();
+        assertThat(ProviderLocator.getServiceClasses(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, emptyClassLoader)).isEmpty();
+        assertThat(ProviderLocator.getServices(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, emptyClassLoader)).isEmpty();
+    }
+
+    @Test
+    void loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader originalContextClassLoader = thread.getContextClassLoader();
+        ResourceBackedClassLoader contextClassLoader = new ResourceBackedClassLoader(Map.of());
+        thread.setContextClassLoader(contextClassLoader);
+        try {
+            assertThat(ProviderLocator.loadClass(PrimaryProvider.class.getName())).isSameAs(PrimaryProvider.class);
+            assertThat(ProviderLocator.loadClass(
+                    SecondaryProvider.class.getName(), Geronimo_osgi_locatorTest.class, null))
+                    .isSameAs(SecondaryProvider.class);
+            assertThatThrownBy(() -> ProviderLocator.loadClass(
+                    "example.DoesNotExist", Geronimo_osgi_locatorTest.class, contextClassLoader))
+                    .isInstanceOf(ClassNotFoundException.class);
+        } finally {
+            thread.setContextClassLoader(originalContextClassLoader);
+        }
+    }
+
+    @Test
+    void readsFirstProviderClassFromServiceDefinitionAndCreatesInstance() throws Exception {
+        URL serviceDefinition = writeServiceDefinition(
+                "first-provider",
+                "# ignored comment\n"
+                        + "   \n"
+                        + PrimaryProvider.class.getName() + "   # trailing comments are ignored\n"
+                        + SecondaryProvider.class.getName() + "\n");
+        ResourceBackedClassLoader classLoader = new ResourceBackedClassLoader(
+                Map.of(serviceResourceName(), List.of(serviceDefinition)));
+
+        Class<?> serviceClass = ProviderLocator.getServiceClass(TestService.class.getName(), null, classLoader);
+        Object service = ProviderLocator.getService(TestService.class.getName(), null, classLoader);
+
+        assertThat(serviceClass).isSameAs(PrimaryProvider.class);
+        assertThat(service).isInstanceOf(PrimaryProvider.class);
+        assertThat(((TestService) service).value()).isEqualTo("primary");
+    }
+
+    @Test
+    void readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses() throws Exception {
+        URL firstServiceDefinition = writeServiceDefinition(
+                "ordered-providers-1",
+                PrimaryProvider.class.getName() + "\n"
+                        + "# a blank line follows\n"
+                        + "\n"
+                        + SecondaryProvider.class.getName() + "\n");
+        URL secondServiceDefinition = writeServiceDefinition(
+                "ordered-providers-2",
+                SecondaryProvider.class.getName() + "\n"
+                        + PrimaryProvider.class.getName() + "\n");
+        ResourceBackedClassLoader classLoader = new ResourceBackedClassLoader(
+                Map.of(serviceResourceName(), List.of(firstServiceDefinition, secondServiceDefinition)));
+
+        List<Class<?>> serviceClasses = ProviderLocator.getServiceClasses(
+                TestService.class.getName(), null, classLoader);
+        List<Object> services = ProviderLocator.getServices(TestService.class.getName(), null, classLoader);
+
+        assertThat(serviceClasses).containsExactly(PrimaryProvider.class, SecondaryProvider.class);
+        assertThat(services).hasSize(2);
+        assertThat(services)
+                .extracting(service -> ((TestService) service).value())
+                .containsExactly("primary", "secondary");
+    }
+
+    @Test
+    void readsPropertiesFromConfiguredJavaHomeRelativeFile() throws Exception {
+        Path relativePropertiesPath = Path.of("conf", "locator.properties");
+        Path missingPropertiesPath = Path.of("conf", "missing.properties");
+        Path propertiesFile = Files.createDirectories(tempDir.resolve("conf")).resolve("locator.properties");
+        Properties properties = new Properties();
+        properties.setProperty("provider", PrimaryProvider.class.getName());
+        try (OutputStream outputStream = Files.newOutputStream(propertiesFile)) {
+            properties.store(outputStream, "test properties");
+        }
+
+        String originalJavaHome = System.getProperty("java.home");
+        System.setProperty("java.home", tempDir.toString());
+        try {
+            assertThat(ProviderLocator.lookupByJREPropertyFile(relativePropertiesPath.toString(), "provider"))
+                    .isEqualTo(PrimaryProvider.class.getName());
+            assertThat(ProviderLocator.lookupByJREPropertyFile(relativePropertiesPath.toString(), "missing")).isNull();
+            assertThat(ProviderLocator.lookupByJREPropertyFile(missingPropertiesPath.toString(), "provider")).isNull();
+        } finally {
+            System.setProperty("java.home", originalJavaHome);
+        }
+    }
+
+    private URL writeServiceDefinition(String directoryName, String contents) throws IOException {
+        Path servicesDirectory = Files.createDirectories(tempDir.resolve(directoryName).resolve("META-INF/services"));
+        Path serviceDefinition = servicesDirectory.resolve(TestService.class.getName());
+        Files.writeString(serviceDefinition, contents, StandardCharsets.UTF_8);
+        return serviceDefinition.toUri().toURL();
+    }
+
+    private String serviceResourceName() {
+        return "META-INF/services/" + TestService.class.getName();
+    }
+
+    public interface TestService {
+        String value();
+    }
+
+    public static class PrimaryProvider implements TestService {
+        public PrimaryProvider() {
+        }
+
+        @Override
+        public String value() {
+            return "primary";
+        }
+    }
+
+    public static class SecondaryProvider implements TestService {
+        public SecondaryProvider() {
+        }
+
+        @Override
+        public String value() {
+            return "secondary";
+        }
+    }
+
+    private static final class ResourceBackedClassLoader extends ClassLoader {
+        private final Map<String, List<URL>> resources;
+
+        private ResourceBackedClassLoader(Map<String, List<URL>> resources) {
+            super(Geronimo_osgi_locatorTest.class.getClassLoader());
+            this.resources = resources;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            List<URL> matchingResources = resources.get(name);
+            if (matchingResources != null) {
+                return Collections.enumeration(matchingResources);
+            }
+            return super.getResources(name);
+        }
     }
 }

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -10,8 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -133,6 +137,19 @@ public class Geronimo_osgi_locatorTest {
     }
 
     @Test
+    void continuesServiceDiscoveryAfterUnreadableServiceDefinition() throws Exception {
+        URL unreadableServiceDefinition = unreadableServiceDefinition("unreadable-providers");
+        URL readableServiceDefinition = writeServiceDefinition("readable-providers", PrimaryProvider.class.getName());
+        ResourceBackedClassLoader classLoader = new ResourceBackedClassLoader(
+                Map.of(serviceResourceName(), List.of(unreadableServiceDefinition, readableServiceDefinition)));
+
+        List<Class<?>> serviceClasses = ProviderLocator.getServiceClasses(
+                TestService.class.getName(), null, classLoader);
+
+        assertThat(serviceClasses).containsExactly(PrimaryProvider.class);
+    }
+
+    @Test
     void readsPropertiesFromConfiguredJavaHomeRelativeFile() throws Exception {
         Path relativePropertiesPath = Path.of("conf", "locator.properties");
         Path missingPropertiesPath = Path.of("conf", "missing.properties");
@@ -164,6 +181,10 @@ public class Geronimo_osgi_locatorTest {
         Path serviceDefinition = servicesDirectory.resolve(TestService.class.getName());
         Files.writeString(serviceDefinition, contents, StandardCharsets.UTF_8);
         return serviceDefinition.toUri().toURL();
+    }
+
+    private URL unreadableServiceDefinition(String path) throws IOException {
+        return URL.of(URI.create("test://service-definitions/" + path), new UnreadableUrlStreamHandler());
     }
 
     private String serviceResourceName() {
@@ -201,6 +222,22 @@ public class Geronimo_osgi_locatorTest {
         @Override
         public String value() {
             return "caller";
+        }
+    }
+
+    private static final class UnreadableUrlStreamHandler extends URLStreamHandler {
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new URLConnection(url) {
+                @Override
+                public void connect() {
+                }
+
+                @Override
+                public InputStream getInputStream() throws IOException {
+                    throw new IOException("Service definition is not readable");
+                }
+            };
         }
     }
 

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/java/org_apache_geronimo_specs/geronimo_osgi_locator/Geronimo_osgi_locatorTest.java
@@ -90,6 +90,23 @@ public class Geronimo_osgi_locatorTest {
     }
 
     @Test
+    void loadsDiscoveredProviderClassFromCallerClassLoaderWhenResourceClassLoaderCannotLoadIt() throws Exception {
+        URL serviceDefinition = writeServiceDefinition("caller-loader-provider", CallerLoadedProvider.class.getName());
+        ResourceBackedClassLoader classLoader = new ResourceBackedClassLoader(
+                Map.of(serviceResourceName(), List.of(serviceDefinition)),
+                List.of(CallerLoadedProvider.class.getName()));
+
+        Class<?> serviceClass = ProviderLocator.getServiceClass(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, classLoader);
+        Object service = ProviderLocator.getService(
+                TestService.class.getName(), Geronimo_osgi_locatorTest.class, classLoader);
+
+        assertThat(serviceClass).isSameAs(CallerLoadedProvider.class);
+        assertThat(service).isInstanceOf(CallerLoadedProvider.class);
+        assertThat(((TestService) service).value()).isEqualTo("caller");
+    }
+
+    @Test
     void readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses() throws Exception {
         URL firstServiceDefinition = writeServiceDefinition(
                 "ordered-providers-1",
@@ -134,7 +151,11 @@ public class Geronimo_osgi_locatorTest {
             assertThat(ProviderLocator.lookupByJREPropertyFile(relativePropertiesPath.toString(), "missing")).isNull();
             assertThat(ProviderLocator.lookupByJREPropertyFile(missingPropertiesPath.toString(), "provider")).isNull();
         } finally {
-            System.setProperty("java.home", originalJavaHome);
+            if (originalJavaHome == null) {
+                System.clearProperty("java.home");
+            } else {
+                System.setProperty("java.home", originalJavaHome);
+            }
         }
     }
 
@@ -173,12 +194,36 @@ public class Geronimo_osgi_locatorTest {
         }
     }
 
+    public static class CallerLoadedProvider implements TestService {
+        public CallerLoadedProvider() {
+        }
+
+        @Override
+        public String value() {
+            return "caller";
+        }
+    }
+
     private static final class ResourceBackedClassLoader extends ClassLoader {
         private final Map<String, List<URL>> resources;
+        private final List<String> unavailableClasses;
 
         private ResourceBackedClassLoader(Map<String, List<URL>> resources) {
+            this(resources, List.of());
+        }
+
+        private ResourceBackedClassLoader(Map<String, List<URL>> resources, List<String> unavailableClasses) {
             super(Geronimo_osgi_locatorTest.class.getClassLoader());
             this.resources = resources;
+            this.unavailableClasses = unavailableClasses;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (unavailableClasses.contains(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
         }
 
         @Override

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$CallerLoadedProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$PrimaryProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.geronimo.osgi.locator.ProviderLocator"
+      },
+      "type" : "org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest$SecondaryProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T21:59:14">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-02T22:04:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.home" value="/tmp/junit15333921549196870103"/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
@@ -53,40 +52,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="readsPropertiesFromConfiguredJavaHomeRelativeFile()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
-<error type="java.lang.NullPointerException"><![CDATA[java.lang.NullPointerException
-	at java.base@25.0.2/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1023)
-	at java.base@25.0.2/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1018)
-	at java.base@25.0.2/java.util.Properties.put(Properties.java:1344)
-	at java.base@25.0.2/java.util.Properties.setProperty(Properties.java:231)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.setCurrentProperty(SystemPropertiesSupport.java:293)
-	at java.base@25.0.2/java.lang.System.setProperty(System.java:449)
-	at org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest.readsPropertiesFromConfiguredJavaHomeRelativeFile(Geronimo_osgi_locatorTest.java:137)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="readsPropertiesFromConfiguredJavaHomeRelativeFile()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsPropertiesFromConfiguredJavaHomeRelativeFile()]
 display-name: readsPropertiesFromConfiguredJavaHomeRelativeFile()
 ]]></system-out>
 </testcase>
-<testcase name="readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<testcase name="readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()]
 display-name: readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()
 ]]></system-out>
 </testcase>
-<testcase name="returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<testcase name="returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()]
 display-name: returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()
@@ -102,6 +80,12 @@ display-name: readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()]
 display-name: loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()
+]]></system-out>
+</testcase>
+<testcase name="loadsDiscoveredProviderClassFromCallerClassLoaderWhenResourceClassLoaderCannotLoadIt()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:loadsDiscoveredProviderClassFromCallerClassLoaderWhenResourceClassLoaderCannotLoadIt()]
+display-name: loadsDiscoveredProviderClassFromCallerClassLoaderWhenResourceClassLoaderCannotLoadIt()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-02T22:04:29">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T22:09:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,19 +52,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="readsPropertiesFromConfiguredJavaHomeRelativeFile()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.002">
+<testcase name="readsPropertiesFromConfiguredJavaHomeRelativeFile()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsPropertiesFromConfiguredJavaHomeRelativeFile()]
 display-name: readsPropertiesFromConfiguredJavaHomeRelativeFile()
 ]]></system-out>
 </testcase>
-<testcase name="readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.001">
+<testcase name="readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()]
 display-name: readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()
 ]]></system-out>
 </testcase>
-<testcase name="returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0.002">
+<testcase name="returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()]
 display-name: returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()
@@ -74,6 +74,12 @@ display-name: returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable(
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()]
 display-name: readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()
+]]></system-out>
+</testcase>
+<testcase name="continuesServiceDiscoveryAfterUnreadableServiceDefinition()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:continuesServiceDiscoveryAfterUnreadableServiceDefinition()]
+display-name: continuesServiceDiscoveryAfterUnreadableServiceDefinition()
 ]]></system-out>
 </testcase>
 <testcase name="loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T22:09:03">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-02T22:11:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3132-7aedbc1c/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0"/>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T21:59:14">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.home" value="/tmp/junit15333921549196870103"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3132-7aedbc1c/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="readsPropertiesFromConfiguredJavaHomeRelativeFile()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<error type="java.lang.NullPointerException"><![CDATA[java.lang.NullPointerException
+	at java.base@25.0.2/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1023)
+	at java.base@25.0.2/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1018)
+	at java.base@25.0.2/java.util.Properties.put(Properties.java:1344)
+	at java.base@25.0.2/java.util.Properties.setProperty(Properties.java:231)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.SystemPropertiesSupport.setCurrentProperty(SystemPropertiesSupport.java:293)
+	at java.base@25.0.2/java.lang.System.setProperty(System.java:449)
+	at org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest.readsPropertiesFromConfiguredJavaHomeRelativeFile(Geronimo_osgi_locatorTest.java:137)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsPropertiesFromConfiguredJavaHomeRelativeFile()]
+display-name: readsPropertiesFromConfiguredJavaHomeRelativeFile()
+]]></system-out>
+</testcase>
+<testcase name="readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()]
+display-name: readsFirstProviderClassFromServiceDefinitionAndCreatesInstance()
+]]></system-out>
+</testcase>
+<testcase name="returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()]
+display-name: returnsEmptyResultsWhenRegistryAndServiceDefinitionAreUnavailable()
+]]></system-out>
+</testcase>
+<testcase name="readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()]
+display-name: readsAllServiceDefinitionsInOrderAndDeduplicatesProviderClasses()
+]]></system-out>
+</testcase>
+<testcase name="loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()" classname="org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_geronimo_specs.geronimo_osgi_locator.Geronimo_osgi_locatorTest]/[method:loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()]
+display-name: loadsOrdinaryClassesUsingCurrentAndFallbackClassLoaders()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:09:03">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:11:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3132-7aedbc1c/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0"/>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:59:14">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:04:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:04:29">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:09:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:59:14">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3132-7aedbc1c/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.geronimo.osgi.locator.**"
+      "includeClasses" : "org.apache.geronimo.osgi.locator.**"
     }
   ]
 }

--- a/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
+++ b/tests/src/org.apache.geronimo.specs/geronimo-osgi-locator/1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.geronimo.osgi.locator.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3132

This PR introduces tests and metadata for org.apache.geronimo.specs:geronimo-osgi-locator:1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 193248
- Cached input tokens: 2720256
- Output tokens: 24384
- Metadata entries: 1
- Test-only metadata entries: 6
- Iterations: 3
- Library coverage percentage: 73.86
- Generated lines of code: 236
- Tested library lines of code: 113

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `101d82d593cc1d1ed52c59a29cd82a574d6f038b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 6/6 covered calls (100.00%)
- Reflection: 4/4 covered calls (100.00%)
- Resources: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 390/497 (78.47%)
- Line: 113/153 (73.86%)
- Method: 18/24 (75.00%)
