### PR TITLE
[GenAI] Add support for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json
@@ -1,0 +1,123 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.MeterProviderConfiguration"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "setExemplarFilter",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.PropagatorConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "glob": "io/opentelemetry/sdk/common/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.25.0-alpha",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/$version$/opentelemetry-sdk-extension-autoconfigure-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v1.25.0/sdk-extensions/autoconfigure/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/$version$/opentelemetry-sdk-extension-autoconfigure-$version$-javadoc.jar",
+    "description" : "The OpenTelemetry SDK autoconfigure module builds and configures an OpenTelemetry SDK instance from environment variables and Java system properties. It wires exporters, propagators, resources, processors, samplers, limits, and SPI-based customizers so applications can enable telemetry without hand-building the SDK.",
+    "tested-versions" : [
+      "1.25.0-alpha"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.sdk.autoconfigure"
+    ]
+  }
+]

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T20:31:41.056389Z",
+    "library": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha",
+    "starting_commit": "57e7c4596758abc96f1e5dd856ef9482e828333d",
+    "ending_commit": "49d788f1aee5823ce7c7b3fcb42e35c26b947c34",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.25.0-alpha",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1213,
+          "missed": 902,
+          "ratio": 0.573522,
+          "total": 2115
+        },
+        "line": {
+          "covered": 324,
+          "missed": 215,
+          "ratio": 0.601113,
+          "total": 539
+        },
+        "method": {
+          "covered": 67,
+          "missed": 24,
+          "ratio": 0.736264,
+          "total": 91
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 245576,
+      "cached_input_tokens_used": 2172416,
+      "output_tokens_used": 23547,
+      "iterations": 4,
+      "cost_usd": 1.7926,
+      "generated_loc": 410,
+      "tested_library_loc": 324,
+      "metadata_entries": 22,
+      "code_coverage_percent": 60.11
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.25.0-alpha",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1213,
+        "missed" : 902,
+        "ratio" : 0.573522,
+        "total" : 2115
+      },
+      "line" : {
+        "covered" : 324,
+        "missed" : 215,
+        "ratio" : 0.601113,
+        "total" : 539
+      },
+      "method" : {
+        "covered" : 67,
+        "missed" : 24,
+        "ratio" : 0.736264,
+        "total" : 91
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha
+library.version = 1.25.0-alpha
+metadata.dir = io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.opentelemetry-sdk-extension-autoconfigure_tests'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 public class Opentelemetry_sdk_extension_autoconfigureTest {
     private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
     private static final AttributeKey<String> SERVICE_NAMESPACE = AttributeKey.stringKey("service.namespace");
+    private static final AttributeKey<String> SERVICE_INSTANCE_ID = AttributeKey.stringKey("service.instance.id");
     private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
             AttributeKey.stringKey("deployment.environment");
     private static final AttributeKey<String> CUSTOM_RESOURCE = AttributeKey.stringKey("test.custom.resource");
@@ -175,6 +176,38 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
             assertThat(meterProviderCustomizations).hasValue(1);
             assertThat(loggerProviderCustomizations).hasValue(1);
             assertThat(spanExporterCustomizations).hasValue(1);
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void resourceDisabledKeysFilterDecodedConfiguredAttributes() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.service.name", "filtered-service");
+                        properties.put("otel.resource.attributes",
+                                "service.namespace=filtered-namespace,service.instance.id=node%201,"
+                                        + "deployment.environment=filtered-environment");
+                        properties.put("otel.experimental.resource.disabled.keys",
+                                "service.name,service.namespace,deployment.environment");
+                        return properties;
+                    })
+                    .build();
+
+            Resource resource = configured.getResource();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isNull();
+            assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isNull();
+            assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isNull();
+            assertThat(resource.getAttribute(SERVICE_INSTANCE_ID)).isEqualTo("node 1");
         } finally {
             if (configured != null) {
                 configured.getOpenTelemetrySdk().close();

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+class Opentelemetry_sdk_extension_autoconfigureTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -15,6 +15,9 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapSetter;
@@ -253,6 +256,62 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     }
 
     @Test
+    void parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.traces.sampler", "parentbased_traceidratio");
+                        properties.put("otel.traces.sampler.arg", "0");
+                        return properties;
+                    })
+                    .build();
+
+            Span rootSpan = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("root-span")
+                    .startSpan();
+            try {
+                assertThat(rootSpan.getSpanContext().isSampled()).isFalse();
+            } finally {
+                rootSpan.end();
+            }
+
+            Context sampledRemoteParent = remoteParentContext(TraceFlags.getSampled());
+            Span childOfSampledRemoteParent = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("child-of-sampled-remote-parent")
+                    .setParent(sampledRemoteParent)
+                    .startSpan();
+            try {
+                assertThat(childOfSampledRemoteParent.getSpanContext().isSampled()).isTrue();
+            } finally {
+                childOfSampledRemoteParent.end();
+            }
+
+            Context unsampledRemoteParent = remoteParentContext(TraceFlags.getDefault());
+            Span childOfUnsampledRemoteParent = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("child-of-unsampled-remote-parent")
+                    .setParent(unsampledRemoteParent)
+                    .startSpan();
+            try {
+                assertThat(childOfUnsampledRemoteParent.getSpanContext().isSampled()).isFalse();
+            } finally {
+                childOfUnsampledRemoteParent.end();
+            }
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
     void invalidConfigurationFailsFastWithConfigurationException() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
                 .setResultAsGlobal(false)
@@ -327,6 +386,15 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                 .addLoggerProviderCustomizer(null));
         assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
                 .addLogRecordExporterCustomizer(null));
+    }
+
+    private static Context remoteParentContext(TraceFlags traceFlags) {
+        SpanContext spanContext = SpanContext.createFromRemoteParent(
+                "4bf92f3577b34da6a3ce929d0e0e4736",
+                "00f067aa0ba902b7",
+                traceFlags,
+                TraceState.getDefault());
+        return Span.wrap(spanContext).storeInContext(Context.root());
     }
 
     private static Map<String, String> workingProperties() {

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -6,11 +6,343 @@
  */
 package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
-class Opentelemetry_sdk_extension_autoconfigureTest {
+public class Opentelemetry_sdk_extension_autoconfigureTest {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> SERVICE_NAMESPACE = AttributeKey.stringKey("service.namespace");
+    private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
+            AttributeKey.stringKey("deployment.environment");
+    private static final AttributeKey<String> CUSTOM_RESOURCE = AttributeKey.stringKey("test.custom.resource");
+    private static final TextMapSetter<Map<String, String>> MAP_SETTER =
+            (carrier, key, value) -> carrier.put(key, value);
+    private static final TextMapGetter<Map<String, String>> MAP_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+        }
+    };
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void buildsSdkFromPropertiesAndAppliesAllCoreCustomizers() {
+        RecordingSpanExporter spanExporter = new RecordingSpanExporter();
+        AtomicReference<String> valueSeenByPropertiesCustomizer = new AtomicReference<>();
+        AtomicInteger resourceCustomizations = new AtomicInteger();
+        AtomicInteger samplerCustomizations = new AtomicInteger();
+        AtomicInteger propagatorCustomizations = new AtomicInteger();
+        AtomicInteger tracerProviderCustomizations = new AtomicInteger();
+        AtomicInteger meterProviderCustomizations = new AtomicInteger();
+        AtomicInteger loggerProviderCustomizations = new AtomicInteger();
+        AtomicInteger spanExporterCustomizations = new AtomicInteger();
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .setServiceClassLoader(Opentelemetry_sdk_extension_autoconfigureTest.class.getClassLoader())
+                    .addPropertiesSupplier(() -> Map.of("test.customizer.input", "from-supplier"))
+                    .addPropertiesCustomizer(config -> {
+                        valueSeenByPropertiesCustomizer.set(config.getString("test.customizer.input"));
+                        return workingProperties();
+                    })
+                    .addResourceCustomizer((resource, config) -> {
+                        resourceCustomizations.incrementAndGet();
+                        Resource customResource = Resource.create(Attributes.of(
+                                CUSTOM_RESOURCE, config.getString("test.custom.resource")));
+                        return resource.merge(customResource);
+                    })
+                    .addSamplerCustomizer((sampler, config) -> {
+                        samplerCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.traces.sampler")).isEqualTo("always_off");
+                        return Sampler.alwaysOn();
+                    })
+                    .addPropagatorCustomizer((propagator, config) -> {
+                        propagatorCustomizations.incrementAndGet();
+                        assertThat(config.getList("otel.propagators")).containsExactly("tracecontext", "baggage");
+                        return propagator;
+                    })
+                    .addSpanExporterCustomizer((exporter, config) -> {
+                        spanExporterCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.traces.exporter")).isEqualTo("none");
+                        return spanExporter;
+                    })
+                    .addTracerProviderCustomizer((builder, config) -> {
+                        tracerProviderCustomizations.incrementAndGet();
+                        assertThat(config.getInt("otel.span.attribute.count.limit")).isEqualTo(16);
+                        return builder;
+                    })
+                    .addMeterProviderCustomizer((builder, config) -> {
+                        meterProviderCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.metrics.exporter")).isEqualTo("none");
+                        return builder;
+                    })
+                    .addLoggerProviderCustomizer((builder, config) -> {
+                        loggerProviderCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.logs.exporter")).isEqualTo("none");
+                        return builder;
+                    })
+                    .build();
+
+            ConfigProperties config = configured.getConfig();
+            assertThat(valueSeenByPropertiesCustomizer).hasValue("from-supplier");
+            assertThat(config.getString("otel.service.name")).isEqualTo("payments");
+            assertThat(config.getBoolean("otel.sdk.disabled", true)).isFalse();
+            assertThat(config.getDuration("test.duration")).isEqualTo(Duration.ofSeconds(2));
+            assertThat(config.getList("test.list")).containsExactly("alpha", "beta", "gamma");
+            assertThat(config.getMap("test.map"))
+                    .containsEntry("left", "right")
+                    .containsEntry("region", "eu");
+
+            Resource resource = configured.getResource();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isEqualTo("checkout");
+            assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isEqualTo("integration-test");
+            assertThat(resource.getAttribute(CUSTOM_RESOURCE)).isEqualTo("resource-customized");
+
+            Map<String, String> carrier = new HashMap<>();
+            Context contextWithBaggage = Baggage.builder()
+                    .put("tenant", "acme")
+                    .build()
+                    .storeInContext(Context.root());
+            configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .inject(contextWithBaggage, carrier, MAP_SETTER);
+            Context extractedContext = configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .extract(Context.root(), carrier, MAP_GETTER);
+
+            assertThat(carrier).containsEntry("baggage", "tenant=acme");
+            assertThat(Baggage.fromContext(extractedContext).getEntryValue("tenant")).isEqualTo("acme");
+
+            Span span = configured.getOpenTelemetrySdk()
+                    .getTracer("autoconfigure-test")
+                    .spanBuilder("configured-span")
+                    .startSpan();
+            try {
+                assertThat(span.getSpanContext().isSampled()).isTrue();
+            } finally {
+                span.end();
+            }
+            assertThat(configured.getOpenTelemetrySdk().getSdkTracerProvider().forceFlush().join(5, TimeUnit.SECONDS)
+                    .isSuccess()).isTrue();
+            assertThat(spanExporter.exportedSpanNames()).containsExactly("configured-span");
+
+            LongCounter counter = configured.getOpenTelemetrySdk()
+                    .getMeter("autoconfigure-test")
+                    .counterBuilder("processed.items")
+                    .build();
+            counter.add(1, Attributes.of(AttributeKey.stringKey("queue"), "orders"));
+
+            assertThat(resourceCustomizations).hasValue(1);
+            assertThat(samplerCustomizations).hasValue(1);
+            assertThat(propagatorCustomizations.get()).isGreaterThanOrEqualTo(1);
+            assertThat(tracerProviderCustomizations).hasValue(1);
+            assertThat(meterProviderCustomizations).hasValue(1);
+            assertThat(loggerProviderCustomizations).hasValue(1);
+            assertThat(spanExporterCustomizations).hasValue(1);
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource() {
+        AtomicBoolean tracerProviderCustomizerCalled = new AtomicBoolean();
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.sdk.disabled", "true");
+                        return properties;
+                    })
+                    .addTracerProviderCustomizer((builder, config) -> {
+                        tracerProviderCustomizerCalled.set(true);
+                        return builder;
+                    })
+                    .build();
+
+            Span span = configured.getOpenTelemetrySdk()
+                    .getTracer("disabled-sdk-test")
+                    .spanBuilder("not-recorded")
+                    .startSpan();
+            span.end();
+
+            assertThat(configured.getConfig().getBoolean("otel.sdk.disabled", false)).isTrue();
+            assertThat(configured.getResource().getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            assertThat(configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator().fields()).isEmpty();
+            assertThat(tracerProviderCustomizerCalled).isFalse();
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void invalidConfigurationFailsFastWithConfigurationException() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
+                .setResultAsGlobal(false)
+                .registerShutdownHook(false)
+                .addPropertiesCustomizer(config -> {
+                    Map<String, String> properties = workingProperties();
+                    properties.put("otel.traces.sampler", "not-a-sampler");
+                    return properties;
+                });
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Unrecognized value for otel.traces.sampler");
+    }
+
+    @Test
+    void exporterConfigurationRejectsNoneMixedWithOtherExporters() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
+                .setResultAsGlobal(false)
+                .registerShutdownHook(false)
+                .addPropertiesCustomizer(config -> {
+                    Map<String, String> properties = workingProperties();
+                    properties.put("otel.traces.exporter", "none,custom");
+                    return properties;
+                });
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.traces.exporter contains none along with other exporters");
+    }
+
+    @Test
+    void builderMethodsAreChainableAndValidateRequiredArguments() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder();
+
+        assertThat(builder.registerShutdownHook(false)).isSameAs(builder);
+        assertThat(builder.setResultAsGlobal(false)).isSameAs(builder);
+        assertThat(builder.setServiceClassLoader(getClass().getClassLoader())).isSameAs(builder);
+        assertThat(builder.addPropertiesSupplier(Map::of)).isSameAs(builder);
+        assertThat(builder.addPropertiesCustomizer(config -> Map.of())).isSameAs(builder);
+        assertThat(builder.addResourceCustomizer((resource, config) -> resource)).isSameAs(builder);
+        assertThat(builder.addSamplerCustomizer((sampler, config) -> sampler)).isSameAs(builder);
+        assertThat(builder.addPropagatorCustomizer((propagator, config) -> propagator)).isSameAs(builder);
+        assertThat(builder.addSpanExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+        assertThat(builder.addTracerProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addMeterProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addMetricExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+        assertThat(builder.addLoggerProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addLogRecordExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .setServiceClassLoader(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesSupplier(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addResourceCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addSamplerCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropagatorCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addSpanExporterCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addTracerProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addMeterProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addMetricExporterCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addLoggerProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addLogRecordExporterCustomizer(null));
+    }
+
+    private static Map<String, String> workingProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.propagators", "tracecontext,baggage");
+        properties.put("otel.traces.sampler", "always_off");
+        properties.put("otel.span.attribute.count.limit", "16");
+        properties.put("otel.bsp.schedule.delay", "1d");
+        properties.put("otel.bsp.export.timeout", "5s");
+        properties.put("otel.service.name", "payments");
+        properties.put("otel.resource.attributes",
+                "service.namespace=checkout,deployment.environment=integration-test");
+        properties.put("test.custom.resource", "resource-customized");
+        properties.put("test.duration", "2s");
+        properties.put("test.list", "alpha,beta,,gamma");
+        properties.put("test.map", "left=right,region=eu");
+        return properties;
+    }
+
+    private static final class RecordingSpanExporter implements SpanExporter {
+        private final List<String> exportedSpanNames = new ArrayList<>();
+        private boolean shutdown;
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            for (SpanData span : spans) {
+                exportedSpanNames.add(span.getName());
+            }
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            shutdown = true;
+            return CompletableResultCode.ofSuccess();
+        }
+
+        private List<String> exportedSpanNames() {
+            assertThat(shutdown).isFalse();
+            return exportedSpanNames;
+        }
     }
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.009" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:18:49">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()]
+display-name: disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()
+]]></system-out>
+</testcase>
+<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:exporterConfigurationRejectsNoneMixedWithOtherExporters()]
+display-name: exporterConfigurationRejectsNoneMixedWithOtherExporters()
+]]></system-out>
+</testcase>
+<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:invalidConfigurationFailsFastWithConfigurationException()]
+display-name: invalidConfigurationFailsFastWithConfigurationException()
+]]></system-out>
+</testcase>
+<testcase name="buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()]
+display-name: buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()
+]]></system-out>
+</testcase>
+<testcase name="builderMethodsAreChainableAndValidateRequiredArguments()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:builderMethodsAreChainableAndValidateRequiredArguments()]
+display-name: builderMethodsAreChainableAndValidateRequiredArguments()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.009" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:18:49">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.011" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:21:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,6 +52,12 @@
 <property name="user.name" value="mihailo"/>
 <property name="user.timezone" value="Europe/Belgrade"/>
 </properties>
+<testcase name="resourceDisabledKeysFilterDecodedConfiguredAttributes()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:resourceDisabledKeysFilterDecodedConfiguredAttributes()]
+display-name: resourceDisabledKeysFilterDecodedConfiguredAttributes()
+]]></system-out>
+</testcase>
 <testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()]

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.011" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:21:39">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.012" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:25:29">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,13 +52,19 @@
 <property name="user.name" value="mihailo"/>
 <property name="user.timezone" value="Europe/Belgrade"/>
 </properties>
+<testcase name="parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()]
+display-name: parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()
+]]></system-out>
+</testcase>
 <testcase name="resourceDisabledKeysFilterDecodedConfiguredAttributes()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:resourceDisabledKeysFilterDecodedConfiguredAttributes()]
 display-name: resourceDisabledKeysFilterDecodedConfiguredAttributes()
 ]]></system-out>
 </testcase>
-<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
+<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()]
 display-name: disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.012" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:25:29">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.011" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -25,14 +27,12 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
@@ -70,7 +69,7 @@ unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_exte
 display-name: disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()
 ]]></system-out>
 </testcase>
-<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.003">
+<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:exporterConfigurationRejectsNoneMixedWithOtherExporters()]
 display-name: exporterConfigurationRejectsNoneMixedWithOtherExporters()

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:21:39">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:25:28">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:18:49">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:25:28">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -25,14 +27,12 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:18:49">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:21:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.opentelemetry.sdk.autoconfigure.**"
+      "includeClasses" : "io.opentelemetry.sdk.autoconfigure.**"
     }
   ]
 }

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.sdk.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3885

This PR introduces tests and metadata for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 245576
- Cached input tokens: 2172416
- Output tokens: 23547
- Metadata entries: 22
- Iterations: 4
- Library coverage percentage: 60.11
- Generated lines of code: 410
- Tested library lines of code: 324

### Metadata Forge

- Forge monitored branch: `mm/scope-native-trace-exact-metadata`
- Forge branch: `mm/scope-native-trace-exact-metadata`
- Forge commit hash: `fa047a9def7868e4861545511a01dd47712ffa3f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1213/2115 (57.35%)
- Line: 324/539 (60.11%)
- Method: 67/91 (73.63%)
