### PR TITLE
[GenAI] Add support for com.fasterxml:aalto-xml:1.0.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml/aalto-xml/1.0.0/reachability-metadata.json
+++ b/metadata/com.fasterxml/aalto-xml/1.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.fasterxml.aalto.in.XmlScanner"
+      },
+      "type": "com.fasterxml.aalto.in.NsBinding[]"
+    }
+  ]
+}

--- a/metadata/com.fasterxml/aalto-xml/index.json
+++ b/metadata/com.fasterxml/aalto-xml/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/aalto-xml/$version$/aalto-xml-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/aalto-xml",
+    "test-code-url" : "https://github.com/FasterXML/aalto-xml/tree/aalto-xml-$version$/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/aalto-xml/$version$/aalto-xml-$version$-javadoc.jar",
+    "description" : "Aalto XML is a high-performance Java XML processor that implements StAX, StAX2, SAX, and SAX2 APIs. It supports both regular stream processing and non-blocking asynchronous XML parsing for JVM applications.",
+    "tested-versions" : [
+      "1.0.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.aalto"
+    ]
+  }
+]

--- a/stats/com.fasterxml/aalto-xml/1.0.0/execution-metrics.json
+++ b/stats/com.fasterxml/aalto-xml/1.0.0/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T20:32:56.619578Z",
+    "library": "com.fasterxml:aalto-xml:1.0.0",
+    "starting_commit": "7587a1d97a92a50e51d7862452f7cf2536613f21",
+    "ending_commit": "7b3f750b23a4331501b3ba41953a3ce7ac831832",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8394,
+          "missed": 68284,
+          "ratio": 0.109471,
+          "total": 76678
+        },
+        "line": {
+          "covered": 2096,
+          "missed": 16086,
+          "ratio": 0.115279,
+          "total": 18182
+        },
+        "method": {
+          "covered": 327,
+          "missed": 1430,
+          "ratio": 0.186113,
+          "total": 1757
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 18774,
+      "cached_input_tokens_used": 112640,
+      "output_tokens_used": 2165,
+      "iterations": 1,
+      "cost_usd": 0.1212,
+      "generated_loc": 139,
+      "tested_library_loc": 2096,
+      "metadata_entries": 1,
+      "code_coverage_percent": 11.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java",
+      "metadata_file": "metadata/com.fasterxml/aalto-xml/1.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml/aalto-xml/1.0.0/stats.json
+++ b/stats/com.fasterxml/aalto-xml/1.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8394,
+        "missed" : 68284,
+        "ratio" : 0.109471,
+        "total" : 76678
+      },
+      "line" : {
+        "covered" : 2096,
+        "missed" : 16086,
+        "ratio" : 0.115279,
+        "total" : 18182
+      },
+      "method" : {
+        "covered" : 327,
+        "missed" : 1430,
+        "ratio" : 0.186113,
+        "total" : 1757
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/.gitignore
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/build.gradle
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml:aalto-xml:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/gradle.properties
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml:aalto-xml:1.0.0
+library.version = 1.0.0
+metadata.dir = com.fasterxml/aalto-xml/1.0.0/

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/settings.gradle
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.aalto-xml_tests'

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml.aalto_xml;
+
+import org.junit.jupiter.api.Test;
+
+class Aalto_xmlTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
@@ -8,7 +8,7 @@ package com_fasterxml.aalto_xml;
 
 import org.junit.jupiter.api.Test;
 
-class Aalto_xmlTest {
+public class Aalto_xmlTest {
     @Test
     void test() throws Exception {
         System.out.println("This is just a placeholder, implement your test");

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/Aalto_xmlTest.java
@@ -6,11 +6,127 @@
  */
 package com_fasterxml.aalto_xml;
 
+import com.fasterxml.aalto.stax.EventFactoryImpl;
+import com.fasterxml.aalto.stax.InputFactoryImpl;
+import com.fasterxml.aalto.stax.OutputFactoryImpl;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Aalto_xmlTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void xmlInputFactoryLoadsAaltoProviderAndParsesXml() throws Exception {
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+
+        assertThat(inputFactory).isInstanceOf(InputFactoryImpl.class);
+
+        byte[] xmlBytes = "<root attribute='value'>hello</root>".getBytes(StandardCharsets.UTF_8);
+        XMLStreamReader streamReader = inputFactory.createXMLStreamReader(new ByteArrayInputStream(xmlBytes));
+
+        assertThat(streamReader.nextTag()).isEqualTo(XMLStreamConstants.START_ELEMENT);
+        assertThat(streamReader.getLocalName()).isEqualTo("root");
+        assertThat(streamReader.getAttributeValue(null, "attribute")).isEqualTo("value");
+        assertThat(streamReader.next()).isEqualTo(XMLStreamConstants.CHARACTERS);
+        assertThat(streamReader.getText()).isEqualTo("hello");
+        assertThat(streamReader.next()).isEqualTo(XMLStreamConstants.END_ELEMENT);
+
+        streamReader.close();
+    }
+
+    @Test
+    void xmlInputFactoryHandlesNamespaceBindingGrowth() throws Exception {
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+
+        assertThat(inputFactory).isInstanceOf(InputFactoryImpl.class);
+
+        StringBuilder xmlBuilder = new StringBuilder("<root");
+        for (int i = 0; i < 20; i++) {
+            xmlBuilder.append(" xmlns:n").append(i).append("='urn:test:").append(i).append("'");
+        }
+        xmlBuilder.append(">");
+        for (int i = 0; i < 20; i++) {
+            xmlBuilder.append("<n").append(i).append(":item>");
+            xmlBuilder.append(i);
+            xmlBuilder.append("</n").append(i).append(":item>");
+        }
+        xmlBuilder.append("</root>");
+
+        byte[] xmlBytes = xmlBuilder.toString().getBytes(StandardCharsets.UTF_8);
+        XMLStreamReader streamReader = inputFactory.createXMLStreamReader(new ByteArrayInputStream(xmlBytes));
+
+        int namespaceAwareElementCount = 0;
+        while (streamReader.hasNext()) {
+            int eventType = streamReader.next();
+            if (eventType == XMLStreamConstants.START_ELEMENT && !"root".equals(streamReader.getLocalName())) {
+                assertThat(streamReader.getNamespaceURI()).startsWith("urn:test:");
+                namespaceAwareElementCount++;
+            }
+        }
+
+        assertThat(namespaceAwareElementCount).isEqualTo(20);
+
+        streamReader.close();
+    }
+
+    @Test
+    void xmlOutputAndEventFactoriesLoadAaltoProvidersAndWriteXml() throws Exception {
+        XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
+        XMLEventFactory eventFactory = XMLEventFactory.newFactory();
+
+        assertThat(outputFactory).isInstanceOf(OutputFactoryImpl.class);
+        assertThat(eventFactory).isInstanceOf(EventFactoryImpl.class);
+
+        StringWriter stringWriter = new StringWriter();
+        XMLEventWriter eventWriter = outputFactory.createXMLEventWriter(stringWriter);
+
+        eventWriter.add(eventFactory.createStartDocument("UTF-8", "1.0"));
+        eventWriter.add(eventFactory.createStartElement(new QName("message"), null, null));
+        eventWriter.add(eventFactory.createCharacters("native-image"));
+        eventWriter.add(eventFactory.createEndElement(new QName("message"), null));
+        eventWriter.add(eventFactory.createEndDocument());
+        eventWriter.close();
+
+        assertThat(stringWriter.toString()).contains("message").contains("native-image");
+    }
+
+    @Test
+    void xmlEventReaderUsesAaltoInputFactoryForEventIteration() throws Exception {
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+
+        assertThat(inputFactory).isInstanceOf(InputFactoryImpl.class);
+
+        byte[] xmlBytes = "<items><item>one</item><item>two</item></items>".getBytes(StandardCharsets.UTF_8);
+        XMLEventReader eventReader = inputFactory.createXMLEventReader(new ByteArrayInputStream(xmlBytes));
+
+        int startElementCount = 0;
+        String lastItemValue = null;
+        while (eventReader.hasNext()) {
+            javax.xml.stream.events.XMLEvent event = eventReader.nextEvent();
+            if (event.isStartElement()) {
+                startElementCount++;
+            }
+            if (event.isCharacters() && !event.asCharacters().isWhiteSpace()) {
+                lastItemValue = event.asCharacters().getData();
+            }
+        }
+
+        assertThat(startElementCount).isEqualTo(3);
+        assertThat(lastItemValue).isEqualTo("two");
+
+        eventReader.close();
     }
 }

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/DataUtilTest.java
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/DataUtilTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DataUtilTest {
     @Test
     void growsReferenceArrayPreservingComponentTypeAndContents() {
-        String[] originalValues = { "alpha", "beta" };
+        String[] originalValues = {"alpha", "beta"};
 
         Object grownArray = DataUtil.growAnyArrayBy(originalValues, 2);
 
@@ -27,7 +27,7 @@ public class DataUtilTest {
 
     @Test
     void growsPrimitiveArrayPreservingComponentTypeAndContents() {
-        int[] originalValues = { 3, 5, 8 };
+        int[] originalValues = {3, 5, 8};
 
         Object grownArray = DataUtil.growAnyArrayBy(originalValues, 1);
 

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/DataUtilTest.java
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/src/test/java/com_fasterxml/aalto_xml/DataUtilTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml.aalto_xml;
+
+import com.fasterxml.aalto.util.DataUtil;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DataUtilTest {
+    @Test
+    void growsReferenceArrayPreservingComponentTypeAndContents() {
+        String[] originalValues = { "alpha", "beta" };
+
+        Object grownArray = DataUtil.growAnyArrayBy(originalValues, 2);
+
+        assertThat(grownArray).isInstanceOf(String[].class);
+        assertThat((String[]) grownArray).containsExactly("alpha", "beta", null, null);
+        assertThat(grownArray).isNotSameAs(originalValues);
+    }
+
+    @Test
+    void growsPrimitiveArrayPreservingComponentTypeAndContents() {
+        int[] originalValues = { 3, 5, 8 };
+
+        Object grownArray = DataUtil.growAnyArrayBy(originalValues, 1);
+
+        assertThat(grownArray).isInstanceOf(int[].class);
+        assertThat((int[]) grownArray).containsExactly(3, 5, 8, 0);
+        assertThat(grownArray).isNotSameAs(originalValues);
+    }
+
+    @Test
+    void rejectsNullInputForGenericArrayGrowth() {
+        assertThatThrownBy(() -> DataUtil.growAnyArrayBy(null, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Null array");
+    }
+}

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-02T22:17:59">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="&#xa;"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3130-e3345e3b/tests/src/com.fasterxml/aalto-xml/1.0.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="rejectsNullInputForGenericArrayGrowth()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:rejectsNullInputForGenericArrayGrowth()]
+display-name: rejectsNullInputForGenericArrayGrowth()
+]]></system-out>
+</testcase>
+<testcase name="growsPrimitiveArrayPreservingComponentTypeAndContents()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:growsPrimitiveArrayPreservingComponentTypeAndContents()]
+display-name: growsPrimitiveArrayPreservingComponentTypeAndContents()
+]]></system-out>
+</testcase>
+<testcase name="growsReferenceArrayPreservingComponentTypeAndContents()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:growsReferenceArrayPreservingComponentTypeAndContents()]
+display-name: growsReferenceArrayPreservingComponentTypeAndContents()
+]]></system-out>
+</testcase>
+<testcase name="test()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:test()]
+display-name: test()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-02T22:17:59">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-02T22:32:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -51,28 +51,46 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
+<testcase name="xmlEventReaderUsesAaltoInputFactoryForEventIteration()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:xmlEventReaderUsesAaltoInputFactoryForEventIteration()]
+display-name: xmlEventReaderUsesAaltoInputFactoryForEventIteration()
+]]></system-out>
+</testcase>
 <testcase name="rejectsNullInputForGenericArrayGrowth()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:rejectsNullInputForGenericArrayGrowth()]
 display-name: rejectsNullInputForGenericArrayGrowth()
 ]]></system-out>
 </testcase>
-<testcase name="growsPrimitiveArrayPreservingComponentTypeAndContents()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0.003">
+<testcase name="xmlInputFactoryLoadsAaltoProviderAndParsesXml()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:xmlInputFactoryLoadsAaltoProviderAndParsesXml()]
+display-name: xmlInputFactoryLoadsAaltoProviderAndParsesXml()
+]]></system-out>
+</testcase>
+<testcase name="growsPrimitiveArrayPreservingComponentTypeAndContents()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:growsPrimitiveArrayPreservingComponentTypeAndContents()]
 display-name: growsPrimitiveArrayPreservingComponentTypeAndContents()
+]]></system-out>
+</testcase>
+<testcase name="xmlInputFactoryHandlesNamespaceBindingGrowth()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:xmlInputFactoryHandlesNamespaceBindingGrowth()]
+display-name: xmlInputFactoryHandlesNamespaceBindingGrowth()
+]]></system-out>
+</testcase>
+<testcase name="xmlOutputAndEventFactoriesLoadAaltoProvidersAndWriteXml()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:xmlOutputAndEventFactoriesLoadAaltoProvidersAndWriteXml()]
+display-name: xmlOutputAndEventFactoriesLoadAaltoProvidersAndWriteXml()
 ]]></system-out>
 </testcase>
 <testcase name="growsReferenceArrayPreservingComponentTypeAndContents()" classname="com_fasterxml.aalto_xml.DataUtilTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.DataUtilTest]/[method:growsReferenceArrayPreservingComponentTypeAndContents()]
 display-name: growsReferenceArrayPreservingComponentTypeAndContents()
-]]></system-out>
-</testcase>
-<testcase name="test()" classname="com_fasterxml.aalto_xml.Aalto_xmlTest" time="0.003">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:com_fasterxml.aalto_xml.Aalto_xmlTest]/[method:test()]
-display-name: test()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:17:59">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="&#xa;"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3130-e3345e3b/tests/src/com.fasterxml/aalto-xml/1.0.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:17:59">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:32:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/user-code-filter.json
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.fasterxml.aalto.**"
+      "includeClasses" : "com.fasterxml.aalto.**"
     }
   ]
 }

--- a/tests/src/com.fasterxml/aalto-xml/1.0.0/user-code-filter.json
+++ b/tests/src/com.fasterxml/aalto-xml/1.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.fasterxml.aalto.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3130

This PR introduces tests and metadata for com.fasterxml:aalto-xml:1.0.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 18774
- Cached input tokens: 112640
- Output tokens: 2165
- Metadata entries: 1
- Iterations: 1
- Library coverage percentage: 11.53
- Generated lines of code: 139
- Tested library lines of code: 2096

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `101d82d593cc1d1ed52c59a29cd82a574d6f038b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 1/1 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 8394/76678 (10.95%)
- Line: 2096/18182 (11.53%)
- Method: 327/1757 (18.61%)
