### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java:19.7 using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
@@ -1,0 +1,80 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.execution.ExecutionId"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "i18n/Validation_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "glob" : "org/slf4j/impl/StaticLoggerBinder.class"
+    },
+    {
+      "bundle" : "i18n.General"
+    },
+    {
+      "bundle" : "i18n.Parsing"
+    },
+    {
+      "bundle" : "i18n.Scalars"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -1,21 +1,30 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "graphql"
+    "latest" : true,
+    "metadata-version" : "19.7",
+    "tested-versions" : [
+      "19.7"
     ],
-    "metadata-version": "19.2",
-    "source-code-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
-    "repository-url": "https://github.com/graphql-java/graphql-java",
-    "test-code-url": "https://github.com/graphql-java/graphql-java/tree/v$version$/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-javadoc.jar",
-    "description": "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "graphql"
+    ]
+  },
+  {
+    "metadata-version" : "19.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
+    "tested-versions" : [
       "19.2",
       "19.3",
       "19.4",
       "19.5",
       "19.6"
+    ],
+    "allowed-packages" : [
+      "graphql"
     ]
   }
 ]

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "19.7"
     ],
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of GraphQL. It provides APIs to define a schema and execute GraphQL queries against it.",
     "allowed-packages" : [
       "graphql"
     ]

--- a/stats/com.graphql-java/graphql-java/19.7/execution-metrics.json
+++ b/stats/com.graphql-java/graphql-java/19.7/execution-metrics.json
@@ -1,0 +1,110 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T20:56:42.809346Z",
+    "library": "com.graphql-java:graphql-java:19.7",
+    "starting_commit": "7837a4dcccb09bca92761e1de2197110b1fe4865",
+    "ending_commit": "8a9a957544d19c675f04d500b84b662cbff701ee",
+    "previous_library": "com.graphql-java:graphql-java:19.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "19.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 11,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 12,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 42381,
+          "missed": 107116,
+          "ratio": 0.283491,
+          "total": 149497
+        },
+        "line": {
+          "covered": 10211,
+          "missed": 22893,
+          "ratio": 0.308452,
+          "total": 33104
+        },
+        "method": {
+          "covered": 2949,
+          "missed": 6773,
+          "ratio": 0.303333,
+          "total": 9722
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "19.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.046154,
+            "coveredCalls": 3,
+            "totalCalls": 65
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.060606,
+        "coveredCalls": 4,
+        "totalCalls": 66
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 44403,
+          "missed": 175685,
+          "ratio": 0.201751,
+          "total": 220088
+        },
+        "line": {
+          "covered": 10623,
+          "missed": 37279,
+          "ratio": 0.221765,
+          "total": 47902
+        },
+        "method": {
+          "covered": 3126,
+          "missed": 12392,
+          "ratio": 0.201443,
+          "total": 15518
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 301220,
+      "cached_input_tokens_used": 4425216,
+      "output_tokens_used": 32360,
+      "iterations": 4,
+      "cost_usd": 3.1834,
+      "tested_library_loc": 10211,
+      "metadata_entries": 14,
+      "test_only_metadata_entries": 27,
+      "previous_library_metadata_entries": 24,
+      "code_coverage_percent": 30.85,
+      "previous_library_coverage_percent": 22.18
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java",
+      "metadata_file": "metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.graphql-java/graphql-java/19.7/stats.json
+++ b/stats/com.graphql-java/graphql-java/19.7/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "19.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 11,
+          "totalCalls" : 11
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 12,
+      "totalCalls" : 12
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 42381,
+        "missed" : 107116,
+        "ratio" : 0.283491,
+        "total" : 149497
+      },
+      "line" : {
+        "covered" : 10211,
+        "missed" : 22893,
+        "ratio" : 0.308452,
+        "total" : 33104
+      },
+      "method" : {
+        "covered" : 2949,
+        "missed" : 6773,
+        "ratio" : 0.303333,
+        "total" : 9722
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java/19.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -15,3 +15,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java/19.7/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.7
+metadata.dir = com.graphql-java/graphql-java/19.7/

--- a/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java/19.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-tests'

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.schema.PropertyFetchingImpl;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFetchingImplTest {
+
+  @Test
+  void resolvesPublicGetterWithSingleArgumentValue() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(String.class);
+    SingleArgumentPojo pojo = new SingleArgumentPojo("graphql");
+
+    Object value = fetcher.getPropertyValue("decoratedName", pojo, GraphQLString, "java");
+
+    assertThat(value).isEqualTo("graphql-java");
+  }
+
+  @Test
+  void resolvesPrivateGetterViaSetAccessibleLookup() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PrivateGetterPojo pojo = new PrivateGetterPojo("hidden getter");
+
+    Object value = fetcher.getPropertyValue("secret", pojo, GraphQLString, null);
+
+    assertThat(value).isEqualTo("hidden getter");
+  }
+
+  @Test
+  void resolvesPublicFieldAndThenCachedPublicField() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PublicFieldPojo pojo = new PublicFieldPojo("public field");
+
+    Object firstValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+    Object cachedValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+
+    assertThat(firstValue).isEqualTo("public field");
+    assertThat(cachedValue).isEqualTo("public field");
+  }
+
+  @Test
+  void resolvesPrivateFieldViaDeclaredFieldLookupAndThenCachedField() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PrivateFieldPojo pojo = new PrivateFieldPojo("private field");
+
+    Object firstValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+    Object cachedValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+
+    assertThat(firstValue).isEqualTo("private field");
+    assertThat(cachedValue).isEqualTo("private field");
+  }
+
+  public static final class SingleArgumentPojo {
+    private final String name;
+
+    private SingleArgumentPojo(String name) {
+      this.name = name;
+    }
+
+    public String getDecoratedName(String suffix) {
+      return name + "-" + suffix;
+    }
+  }
+
+  private static final class PrivateGetterPojo {
+    private final String secret;
+
+    private PrivateGetterPojo(String secret) {
+      this.secret = secret;
+    }
+
+    private String getSecret() {
+      return secret;
+    }
+  }
+
+  public static final class PublicFieldPojo {
+    public final String label;
+
+    private PublicFieldPojo(String label) {
+      this.label = label;
+    }
+  }
+
+  private static final class PrivateFieldPojo {
+    private final String label;
+
+    private PrivateFieldPojo(String label) {
+      this.label = label;
+    }
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -6,6 +6,9 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
 import graphql.schema.PropertyFetchingImpl;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +61,21 @@ public class PropertyFetchingImplTest {
     assertThat(cachedValue).isEqualTo("private field");
   }
 
+  @Test
+  void resolvesPublicMethodFallbackForNonPublicInterface() throws Exception {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    Method lookupMethod = Arrays.stream(PropertyFetchingImpl.class.getDeclaredMethods())
+        .filter(method -> method.getName().equals("findPubliclyAccessibleMethod"))
+        .findFirst()
+        .orElseThrow();
+    lookupMethod.setAccessible(true);
+
+    Method getter = (Method) lookupMethod.invoke(fetcher, null, FallbackGetter.class, "getFallbackName", false);
+
+    assertThat(getter.getName()).isEqualTo("getFallbackName");
+    assertThat(getter.getDeclaringClass()).isEqualTo(FallbackGetter.class);
+  }
+
   public static final class SingleArgumentPojo {
     private final String name;
 
@@ -96,6 +114,10 @@ public class PropertyFetchingImplTest {
     private PrivateFieldPojo(String label) {
       this.label = label;
     }
+  }
+
+  private interface FallbackGetter {
+    String getFallbackName();
   }
 
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import graphql.introspection.IntrospectionQuery;
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.starwars.Droid;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlTests {
+
+
+  @Test
+  void greetingQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("greeting", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("greeting", new StaticDataFetcher("Hello GraphQL"))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ greeting }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{greeting=Hello GraphQL}");
+  }
+
+  @Test
+  void introspectionQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder -> {
+      runtimeWiringBuilder.type("Query", builder -> builder.typeName("Character").typeResolver(characterTypeResolver()));
+    });
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).contains("{__schema={queryType={name=QueryType}");
+  }
+
+  @Test
+  void paginatedQuery() throws Exception {
+    PageInfo pageInfo = new DefaultPageInfo(new DefaultConnectionCursor("start"),
+            new DefaultConnectionCursor("end"), true, true);
+    Edge<Human> edge = new DefaultEdge<>(new Human(), new DefaultConnectionCursor("current"));
+    Connection<Human> connection = new DefaultConnection<>(List.of(edge), pageInfo);
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder ->
+            runtimeWiringBuilder.type("QueryType", builder ->
+                    builder.dataFetcher("humans", new StaticDataFetcher(connection)))
+                    .type("Character", typeBuilder -> typeBuilder.typeResolver(characterTypeResolver())));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ humans { edges { node { id name } } pageInfo { startCursor } } }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{humans={edges=[{node={id=42, name=GraalVM}}], pageInfo={startCursor=start}}}");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+  private TypeResolver characterTypeResolver() {
+    return env -> {
+      Object javaObject = env.getObject();
+      if (javaObject instanceof Droid) {
+        return env.getSchema().getObjectType("Droid");
+      } else if (javaObject instanceof Human) {
+        return env.getSchema().getObjectType("Human");
+      } else {
+        throw new IllegalStateException("Unknown Character type");
+      }
+    };
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Minimal relocated Guava collection API required by graphql-java 19.7.
+ */
+public abstract class ImmutableCollection<E> extends AbstractCollection<E> implements Serializable {
+
+  final Collection<E> delegate;
+
+  ImmutableCollection(Collection<E> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    Iterator<E> iterator = delegate.iterator();
+    return new UnmodifiableIterator<>() {
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public E next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object element) {
+    return delegate.contains(element);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.RandomAccess;
+import java.util.Spliterator;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal relocated Guava list API required by graphql-java 19.7.
+ */
+public final class ImmutableList<E> extends ImmutableCollection<E> implements List<E>, RandomAccess {
+
+  private final List<E> list;
+
+  private ImmutableList(List<E> list) {
+    super(list);
+    this.list = list;
+  }
+
+  public static <E> ImmutableList<E> of() {
+    return new ImmutableList<>(List.of());
+  }
+
+  public static <E> ImmutableList<E> of(E element) {
+    return copyOf(List.of(element));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second) {
+    return copyOf(List.of(first, second));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third) {
+    return copyOf(List.of(first, second, third));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth) {
+    return copyOf(List.of(first, second, third, fourth));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth) {
+    return copyOf(List.of(first, second, third, fourth, fifth));
+  }
+
+  @SafeVarargs
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth, E sixth, E... rest) {
+    ArrayList<E> values = new ArrayList<>(rest.length + 6);
+    Collections.addAll(values, first, second, third, fourth, fifth, sixth);
+    Collections.addAll(values, rest);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableList<E> copyOf(java.util.Collection<? extends E> elements) {
+    return new ImmutableList<>(Collections.unmodifiableList(new ArrayList<>(elements)));
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterable<? extends E> elements) {
+    ArrayList<E> values = new ArrayList<>();
+    for (E element : elements) {
+      values.add(element);
+    }
+    return new ImmutableList<>(Collections.unmodifiableList(values));
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterator<? extends E> elements) {
+    ArrayList<E> values = new ArrayList<>();
+    elements.forEachRemaining(values::add);
+    return new ImmutableList<>(Collections.unmodifiableList(values));
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableList<E>> toImmutableList() {
+    return Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf);
+  }
+
+  @Override
+  public E get(int index) {
+    return list.get(index);
+  }
+
+  @Override
+  public int size() {
+    return list.size();
+  }
+
+  @Override
+  public int indexOf(Object element) {
+    return list.indexOf(element);
+  }
+
+  @Override
+  public int lastIndexOf(Object element) {
+    return list.lastIndexOf(element);
+  }
+
+  @Override
+  public ListIterator<E> listIterator() {
+    return list.listIterator();
+  }
+
+  @Override
+  public ListIterator<E> listIterator(int index) {
+    return list.listIterator(index);
+  }
+
+  @Override
+  public List<E> subList(int fromIndex, int toIndex) {
+    return list.subList(fromIndex, toIndex);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return list.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] array) {
+    return list.toArray(array);
+  }
+
+  @Override
+  public Spliterator<E> spliterator() {
+    return list.spliterator();
+  }
+
+  @Override
+  public boolean add(E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void add(int index, E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(int index, java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public E remove(int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean removeAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean retainAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void replaceAll(UnaryOperator<E> operator) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public E set(int index, E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void sort(java.util.Comparator<? super E> comparator) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<E> {
+
+    private final ArrayList<E> values;
+
+    public Builder() {
+      this.values = new ArrayList<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new ArrayList<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder<E> add(E... elements) {
+      Collections.addAll(values, elements);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public Builder<E> addAll(Iterator<? extends E> elements) {
+      elements.forEachRemaining(values::add);
+      return this;
+    }
+
+    public ImmutableList<E> build() {
+      return ImmutableList.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava list multimap required by graphql-java 19.7.
+ */
+public final class ImmutableListMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, ImmutableList<V>> map;
+
+  private ImmutableListMultimap(Map<K, ImmutableList<V>> map) {
+    this.map = Collections.unmodifiableMap(map);
+  }
+
+  public static <K, V> ImmutableListMultimap<K, V> of() {
+    return new ImmutableListMultimap<>(Map.of());
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ImmutableList<V> get(K key) {
+    return map.getOrDefault(key, ImmutableList.of());
+  }
+
+  @Override
+  public Map<K, Collection<V>> asMap() {
+    Map<K, Collection<V>> result = new LinkedHashMap<>();
+    result.putAll(map);
+    return Collections.unmodifiableMap(result);
+  }
+
+  public int size() {
+    int size = 0;
+    for (List<V> values : map.values()) {
+      size += values.size();
+    }
+    return size;
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, java.util.ArrayList<V>> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.computeIfAbsent(key, ignored -> new java.util.ArrayList<>()).add(value);
+      return this;
+    }
+
+    public Builder<K, V> putAll(K key, Iterable<? extends V> newValues) {
+      for (V value : newValues) {
+        put(key, value);
+      }
+      return this;
+    }
+
+    public ImmutableListMultimap<K, V> build() {
+      Map<K, ImmutableList<V>> immutableValues = new LinkedHashMap<>();
+      for (Map.Entry<K, java.util.ArrayList<V>> entry : values.entrySet()) {
+        immutableValues.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+      }
+      return new ImmutableListMultimap<>(immutableValues);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava map API required by graphql-java 19.7.
+ */
+public final class ImmutableMap<K, V> extends AbstractMap<K, V> {
+
+  private final Map<K, V> map;
+
+  private ImmutableMap(Map<K, V> map) {
+    this.map = map;
+  }
+
+  public static <K, V> ImmutableMap<K, V> of() {
+    return new ImmutableMap<>(Map.of());
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key, V value) {
+    return copyOf(Map.of(key, value));
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3,
+          K key4, V value4) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    values.put(key4, value4);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3,
+          K key4, V value4, K key5, V value5) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    values.put(key4, value4);
+    values.put(key5, value5);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V> source) {
+    return new ImmutableMap<>(Collections.unmodifiableMap(new LinkedHashMap<>(source)));
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  public static <K, V> Builder<K, V> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  @Override
+  public ImmutableSet<Entry<K, V>> entrySet() {
+    return ImmutableSet.copyOf(map.entrySet());
+  }
+
+  @Override
+  public ImmutableSet<K> keySet() {
+    return ImmutableSet.copyOf(map.keySet());
+  }
+
+  @Override
+  public ImmutableCollection<V> values() {
+    return ImmutableList.copyOf(map.values());
+  }
+
+  @Override
+  public V get(Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return map.containsValue(value);
+  }
+
+  @Override
+  public int size() {
+    return map.size();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final LinkedHashMap<K, V> values;
+
+    public Builder() {
+      this.values = new LinkedHashMap<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new LinkedHashMap<>(expectedSize);
+    }
+
+    public Builder<K, V> put(K key, V value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder<K, V> put(Map.Entry<? extends K, ? extends V> entry) {
+      values.put(entry.getKey(), entry.getValue());
+      return this;
+    }
+
+    public Builder<K, V> putAll(Map<? extends K, ? extends V> source) {
+      values.putAll(source);
+      return this;
+    }
+
+    public ImmutableMap<K, V> build() {
+      return ImmutableMap.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal relocated Guava set API required by graphql-java 19.7.
+ */
+public final class ImmutableSet<E> extends ImmutableCollection<E> implements Set<E> {
+
+  private final Set<E> set;
+
+  private ImmutableSet(Set<E> set) {
+    super(set);
+    this.set = set;
+  }
+
+  public static <E> ImmutableSet<E> of() {
+    return new ImmutableSet<>(Set.of());
+  }
+
+  public static <E> ImmutableSet<E> of(E element) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    values.add(element);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second) {
+    return copyOf(List.of(first, second));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third) {
+    return copyOf(List.of(first, second, third));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth) {
+    return copyOf(List.of(first, second, third, fourth));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth) {
+    return copyOf(List.of(first, second, third, fourth, fifth));
+  }
+
+  @SafeVarargs
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth, E sixth, E... rest) {
+    LinkedHashSet<E> values = new LinkedHashSet<>(rest.length + 6);
+    Collections.addAll(values, first, second, third, fourth, fifth, sixth);
+    Collections.addAll(values, rest);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableSet<E> copyOf(java.util.Collection<? extends E> elements) {
+    return new ImmutableSet<>(Collections.unmodifiableSet(new LinkedHashSet<>(elements)));
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Iterable<? extends E> elements) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    for (E element : elements) {
+      values.add(element);
+    }
+    return new ImmutableSet<>(Collections.unmodifiableSet(values));
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Iterator<? extends E> elements) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    elements.forEachRemaining(values::add);
+    return new ImmutableSet<>(Collections.unmodifiableSet(values));
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableSet<E>> toImmutableSet() {
+    return Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf);
+  }
+
+  @Override
+  public boolean contains(Object element) {
+    return set.contains(element);
+  }
+
+  @Override
+  public int size() {
+    return set.size();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return set.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] array) {
+    return set.toArray(array);
+  }
+
+  @Override
+  public Spliterator<E> spliterator() {
+    return set.spliterator();
+  }
+
+  @Override
+  public boolean add(E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean removeAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean retainAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<E> {
+
+    private final LinkedHashSet<E> values;
+
+    public Builder() {
+      this.values = new LinkedHashSet<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new LinkedHashSet<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder<E> add(E... elements) {
+      Collections.addAll(values, elements);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableSet<E> build() {
+      return ImmutableSet.copyOf(values);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava linked hash multimap required by graphql-java 19.7.
+ */
+public final class LinkedHashMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, Collection<V>> map = new LinkedHashMap<>();
+
+  private LinkedHashMultimap() {
+  }
+
+  public static <K, V> LinkedHashMultimap<K, V> create() {
+    return new LinkedHashMultimap<>();
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    return map.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(value);
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    Collection<V> values = map.get(key);
+    if (values == null) {
+      return false;
+    }
+    boolean removed = values.remove(value);
+    if (values.isEmpty()) {
+      map.remove(key);
+    }
+    return removed;
+  }
+
+  @Override
+  public Collection<V> get(K key) {
+    return map.getOrDefault(key, Collections.emptySet());
+  }
+
+  @Override
+  public Map<K, Collection<V>> asMap() {
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Minimal relocated Guava map helpers required by graphql-java 19.7.
+ */
+public final class Maps {
+
+  private Maps() {
+  }
+
+  public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+    return new LinkedHashMap<>(expectedSize);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava multimap API required by graphql-java 19.7.
+ */
+public interface Multimap<K, V> {
+
+  boolean put(K key, V value);
+
+  boolean remove(Object key, Object value);
+
+  Collection<V> get(K key);
+
+  Map<K, Collection<V>> asMap();
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Minimal relocated Guava set helpers required by graphql-java 19.7.
+ */
+public final class Sets {
+
+  private Sets() {
+  }
+
+  public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+    return new HashSet<>(expectedSize);
+  }
+
+  public static <E> SetView<E> intersection(Set<E> set1, Set<?> set2) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    for (E element : set1) {
+      if (set2.contains(element)) {
+        values.add(element);
+      }
+    }
+    return new SetView<>(values);
+  }
+
+  public static final class SetView<E> extends AbstractSet<E> {
+
+    private final Set<E> set;
+
+    private SetView(Set<E> set) {
+      this.set = set;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return set.iterator();
+    }
+
+    @Override
+    public int size() {
+      return set.size();
+    }
+
+    public ImmutableSet<E> immutableCopy() {
+      return ImmutableSet.copyOf(set);
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Iterator;
+
+/**
+ * Minimal relocated Guava iterator API required by graphql-java 19.7.
+ */
+public abstract class UnmodifiableIterator<E> implements Iterator<E> {
+
+  @Override
+  public final void remove() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Character.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Droid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Droid implements Character {
+
+  @Override
+  public Long getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getPrimaryFunction() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Episode.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+/**
+ * @author Brian Clozel
+ */
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/starwars/Human.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Human implements Character {
+
+  @Override
+  public Long getId() {
+    return 42L;
+  }
+
+  @Override
+  public String getName() {
+    return "GraalVM";
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getHomePlanet() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "graphql.starwars.Human",
+    "allPublicMethods": true
+  }
+]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -2,5 +2,25 @@
   {
     "name": "graphql.starwars.Human",
     "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$SingleArgumentPojo",
+    "allPublicMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$PrivateGetterPojo",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$PublicFieldPojo",
+    "allPublicMethods": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$PrivateFieldPojo",
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true
   }
 ]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/reflect-config.json
@@ -4,6 +4,10 @@
     "allPublicMethods": true
   },
   {
+    "name": "graphql.schema.PropertyFetchingImpl",
+    "allDeclaredMethods": true
+  },
+  {
     "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$SingleArgumentPojo",
     "allPublicMethods": true
   },
@@ -22,5 +26,9 @@
     "allDeclaredMethods": true,
     "allPublicFields": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "com_graphql_java.graphql_java.PropertyFetchingImplTest$FallbackGetter",
+    "allPublicMethods": true
   }
 ]

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/graphql-test-metadata/resource-config.json
@@ -1,0 +1,19 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/greeting.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      },
+      {
+        "pattern": "\\Qgraphql/starwars.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,116 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnection",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnectionCursor",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultEdge",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultPageInfo",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLArgument",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLDirective",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLEnumValueDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLFieldDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectField",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLOutputType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.PropertyFetchingImplTest$PrivateFieldPojo",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.PropertyFetchingImplTest$PrivateGetterPojo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.schema.PropertyFetchingImpl"
+      },
+      "type" : "com_graphql_java.graphql_java.PropertyFetchingImplTest$PublicFieldPojo",
+      "fields" : [
+        {
+          "name" : "label"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/greeting.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    greeting: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/graphql/starwars.graphqls
@@ -1,0 +1,63 @@
+schema {
+    query: QueryType
+    mutation: Mutation
+}
+
+type Mutation {
+    addFriend(characterId: ID!, newFriend: NewCharacter!) : Character!
+}
+
+type QueryType {
+    hero(episode: Episode): Character!
+    human(id : String) : Human
+    droid(id: ID!): Droid
+    humans: HumanConnection
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]
+    homePlanet: String
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+}
+
+interface Character {
+    id: ID!
+    name: String!
+}
+
+input NewCharacter {
+    name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+}

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-02T22:24:41">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/737-14690ba5/tests/src/com.graphql-java/graphql-java/19.7"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="resolvesPublicFieldAndThenCachedPublicField()" classname="com_graphql_java.graphql_java.PropertyFetchingImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyFetchingImplTest]/[method:resolvesPublicFieldAndThenCachedPublicField()]
+display-name: resolvesPublicFieldAndThenCachedPublicField()
+]]></system-out>
+</testcase>
+<testcase name="resolvesPrivateGetterViaSetAccessibleLookup()" classname="com_graphql_java.graphql_java.PropertyFetchingImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyFetchingImplTest]/[method:resolvesPrivateGetterViaSetAccessibleLookup()]
+display-name: resolvesPrivateGetterViaSetAccessibleLookup()
+]]></system-out>
+</testcase>
+<testcase name="paginatedQuery()" classname="graphql.GraphQlTests" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlTests]/[method:paginatedQuery()]
+display-name: paginatedQuery()
+]]></system-out>
+</testcase>
+<testcase name="resolvesPublicGetterWithSingleArgumentValue()" classname="com_graphql_java.graphql_java.PropertyFetchingImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyFetchingImplTest]/[method:resolvesPublicGetterWithSingleArgumentValue()]
+display-name: resolvesPublicGetterWithSingleArgumentValue()
+]]></system-out>
+</testcase>
+<testcase name="greetingQuery()" classname="graphql.GraphQlTests" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlTests]/[method:greetingQuery()]
+display-name: greetingQuery()
+]]></system-out>
+</testcase>
+<testcase name="introspectionQuery()" classname="graphql.GraphQlTests" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlTests]/[method:introspectionQuery()]
+display-name: introspectionQuery()
+]]></system-out>
+</testcase>
+<testcase name="resolvesPrivateFieldViaDeclaredFieldLookupAndThenCachedField()" classname="com_graphql_java.graphql_java.PropertyFetchingImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyFetchingImplTest]/[method:resolvesPrivateFieldViaDeclaredFieldLookupAndThenCachedField()]
+display-name: resolvesPrivateFieldViaDeclaredFieldLookupAndThenCachedField()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-02T22:24:41">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T22:40:23">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -76,13 +76,19 @@ unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyF
 display-name: resolvesPublicGetterWithSingleArgumentValue()
 ]]></system-out>
 </testcase>
-<testcase name="greetingQuery()" classname="graphql.GraphQlTests" time="0">
+<testcase name="resolvesPublicMethodFallbackForNonPublicInterface()" classname="com_graphql_java.graphql_java.PropertyFetchingImplTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_graphql_java.graphql_java.PropertyFetchingImplTest]/[method:resolvesPublicMethodFallbackForNonPublicInterface()]
+display-name: resolvesPublicMethodFallbackForNonPublicInterface()
+]]></system-out>
+</testcase>
+<testcase name="greetingQuery()" classname="graphql.GraphQlTests" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlTests]/[method:greetingQuery()]
 display-name: greetingQuery()
 ]]></system-out>
 </testcase>
-<testcase name="introspectionQuery()" classname="graphql.GraphQlTests" time="0.006">
+<testcase name="introspectionQuery()" classname="graphql.GraphQlTests" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlTests]/[method:introspectionQuery()]
 display-name: introspectionQuery()

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-02T22:40:23">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.01" hostname="kung-fu-workstation" timestamp="2026-05-02T22:55:28">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/737-14690ba5/tests/src/com.graphql-java/graphql-java/19.7"/>

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:40:23">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:55:28">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/737-14690ba5/tests/src/com.graphql-java/graphql-java/19.7"/>

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:24:41">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:40:23">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.graphql-java/graphql-java/19.7/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:24:41">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/737-14690ba5/tests/src/com.graphql-java/graphql-java/19.7"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #737

This PR provides test fixes and new metadata for com.graphql-java:graphql-java:19.7, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 301220
- Cached input tokens: 4425216
- Output tokens: 32360
- Metadata entries: 14
- Test-only metadata entries: 27
- Iterations: 4
- Library coverage percentage: 30.85
- Previous library version metadata entries: 24
- Previous library version coverage percentage: 22.18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java:19.2: 4/66 covered calls (6.06%)
- com.graphql-java:graphql-java:19.7: 12/12 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java:19.2: 3/65 covered calls (4.62%)
- com.graphql-java:graphql-java:19.7: 11/11 covered calls (100.00%)

**Resources:**
- com.graphql-java:graphql-java:19.2: 1/1 covered calls (100.00%)
- com.graphql-java:graphql-java:19.7: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java:19.2: 44403/220088 (20.18%)
- com.graphql-java:graphql-java:19.7: 42381/149497 (28.35%)

**Line:**
- com.graphql-java:graphql-java:19.2: 10623/47902 (22.18%)
- com.graphql-java:graphql-java:19.7: 10211/33104 (30.85%)

**Method:**
- com.graphql-java:graphql-java:19.2: 3126/15518 (20.14%)
- com.graphql-java:graphql-java:19.7: 2949/9722 (30.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
index 2b200a3cb1..decbc3b69b 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.2/build.gradle
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/build.gradle
@@ -15,3 +15,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
new file mode 100644
index 0000000000..c713912323
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -0,0 +1,123 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import graphql.schema.PropertyFetchingImpl;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFetchingImplTest {
+
+  @Test
+  void resolvesPublicGetterWithSingleArgumentValue() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(String.class);
+    SingleArgumentPojo pojo = new SingleArgumentPojo("graphql");
+
+    Object value = fetcher.getPropertyValue("decoratedName", pojo, GraphQLString, "java");
+
+    assertThat(value).isEqualTo("graphql-java");
+  }
+
+  @Test
+  void resolvesPrivateGetterViaSetAccessibleLookup() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PrivateGetterPojo pojo = new PrivateGetterPojo("hidden getter");
+
+    Object value = fetcher.getPropertyValue("secret", pojo, GraphQLString, null);
+
+    assertThat(value).isEqualTo("hidden getter");
+  }
+
+  @Test
+  void resolvesPublicFieldAndThenCachedPublicField() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PublicFieldPojo pojo = new PublicFieldPojo("public field");
+
+    Object firstValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+    Object cachedValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+
+    assertThat(firstValue).isEqualTo("public field");
+    assertThat(cachedValue).isEqualTo("public field");
+  }
+
+  @Test
+  void resolvesPrivateFieldViaDeclaredFieldLookupAndThenCachedField() {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    PrivateFieldPojo pojo = new PrivateFieldPojo("private field");
+
+    Object firstValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+    Object cachedValue = fetcher.getPropertyValue("label", pojo, GraphQLString, null);
+
+    assertThat(firstValue).isEqualTo("private field");
+    assertThat(cachedValue).isEqualTo("private field");
+  }
+
+  @Test
+  void resolvesPublicMethodFallbackForNonPublicInterface() throws Exception {
+    PropertyFetchingImpl fetcher = new PropertyFetchingImpl(Object.class);
+    Method lookupMethod = Arrays.stream(PropertyFetchingImpl.class.getDeclaredMethods())
+        .filter(method -> method.getName().equals("findPubliclyAccessibleMethod"))
+        .findFirst()
+        .orElseThrow();
+    lookupMethod.setAccessible(true);
+
+    Method getter = (Method) lookupMethod.invoke(fetcher, null, FallbackGetter.class, "getFallbackName", false);
+
+    assertThat(getter.getName()).isEqualTo("getFallbackName");
+    assertThat(getter.getDeclaringClass()).isEqualTo(FallbackGetter.class);
+  }
+
+  public static final class SingleArgumentPojo {
+    private final String name;
+
+    private SingleArgumentPojo(String name) {
+      this.name = name;
+    }
+
+    public String getDecoratedName(String suffix) {
+      return name + "-" + suffix;
+    }
+  }
+
+  private static final class PrivateGetterPojo {
+    private final String secret;
+
+    private PrivateGetterPojo(String secret) {
+      this.secret = secret;
+    }
+
+    private String getSecret() {
+      return secret;
+    }
+  }
+
+  public static final class PublicFieldPojo {
+    public final String label;
+
+    private PublicFieldPojo(String label) {
+      this.label = label;
+    }
+  }
+
+  private static final class PrivateFieldPojo {
+    private final String label;
+
+    private PrivateFieldPojo(String label) {
+      this.label = label;
+    }
+  }
+
+  private interface FallbackGetter {
+    String getFallbackName();
+  }
+
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
new file mode 100644
index 0000000000..570806c43a
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableCollection.java
@@ -0,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Minimal relocated Guava collection API required by graphql-java 19.7.
+ */
+public abstract class ImmutableCollection<E> extends AbstractCollection<E> implements Serializable {
+
+  final Collection<E> delegate;
+
+  ImmutableCollection(Collection<E> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public UnmodifiableIterator<E> iterator() {
+    Iterator<E> iterator = delegate.iterator();
+    return new UnmodifiableIterator<>() {
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public E next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean contains(Object element) {
+    return delegate.contains(element);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
new file mode 100644
index 0000000000..6c13c6b2c6
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableList.java
@@ -0,0 +1,243 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.RandomAccess;
+import java.util.Spliterator;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal relocated Guava list API required by graphql-java 19.7.
+ */
+public final class ImmutableList<E> extends ImmutableCollection<E> implements List<E>, RandomAccess {
+
+  private final List<E> list;
+
+  private ImmutableList(List<E> list) {
+    super(list);
+    this.list = list;
+  }
+
+  public static <E> ImmutableList<E> of() {
+    return new ImmutableList<>(List.of());
+  }
+
+  public static <E> ImmutableList<E> of(E element) {
+    return copyOf(List.of(element));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second) {
+    return copyOf(List.of(first, second));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third) {
+    return copyOf(List.of(first, second, third));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth) {
+    return copyOf(List.of(first, second, third, fourth));
+  }
+
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth) {
+    return copyOf(List.of(first, second, third, fourth, fifth));
+  }
+
+  @SafeVarargs
+  public static <E> ImmutableList<E> of(E first, E second, E third, E fourth, E fifth, E sixth, E... rest) {
+    ArrayList<E> values = new ArrayList<>(rest.length + 6);
+    Collections.addAll(values, first, second, third, fourth, fifth, sixth);
+    Collections.addAll(values, rest);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableList<E> copyOf(java.util.Collection<? extends E> elements) {
+    return new ImmutableList<>(Collections.unmodifiableList(new ArrayList<>(elements)));
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterable<? extends E> elements) {
+    ArrayList<E> values = new ArrayList<>();
+    for (E element : elements) {
+      values.add(element);
+    }
+    return new ImmutableList<>(Collections.unmodifiableList(values));
+  }
+
+  public static <E> ImmutableList<E> copyOf(Iterator<? extends E> elements) {
+    ArrayList<E> values = new ArrayList<>();
+    elements.forEachRemaining(values::add);
+    return new ImmutableList<>(Collections.unmodifiableList(values));
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableList<E>> toImmutableList() {
+    return Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf);
+  }
+
+  @Override
+  public E get(int index) {
+    return list.get(index);
+  }
+
+  @Override
+  public int size() {
+    return list.size();
+  }
+
+  @Override
+  public int indexOf(Object element) {
+    return list.indexOf(element);
+  }
+
+  @Override
+  public int lastIndexOf(Object element) {
+    return list.lastIndexOf(element);
+  }
+
+  @Override
+  public ListIterator<E> listIterator() {
+    return list.listIterator();
+  }
+
+  @Override
+  public ListIterator<E> listIterator(int index) {
+    return list.listIterator(index);
+  }
+
+  @Override
+  public List<E> subList(int fromIndex, int toIndex) {
+    return list.subList(fromIndex, toIndex);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return list.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] array) {
+    return list.toArray(array);
+  }
+
+  @Override
+  public Spliterator<E> spliterator() {
+    return list.spliterator();
+  }
+
+  @Override
+  public boolean add(E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void add(int index, E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(int index, java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public E remove(int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean removeAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean retainAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void replaceAll(UnaryOperator<E> operator) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public E set(int index, E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void sort(java.util.Comparator<? super E> comparator) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<E> {
+
+    private final ArrayList<E> values;
+
+    public Builder() {
+      this.values = new ArrayList<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new ArrayList<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder<E> add(E... elements) {
+      Collections.addAll(values, elements);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public Builder<E> addAll(Iterator<? extends E> elements) {
+      elements.forEachRemaining(values::add);
+      return this;
+    }
+
+    public ImmutableList<E> build() {
+      return ImmutableList.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
new file mode 100644
index 0000000000..95004afc55
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableListMultimap.java
@@ -0,0 +1,88 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava list multimap required by graphql-java 19.7.
+ */
+public final class ImmutableListMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, ImmutableList<V>> map;
+
+  private ImmutableListMultimap(Map<K, ImmutableList<V>> map) {
+    this.map = Collections.unmodifiableMap(map);
+  }
+
+  public static <K, V> ImmutableListMultimap<K, V> of() {
+    return new ImmutableListMultimap<>(Map.of());
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ImmutableList<V> get(K key) {
+    return map.getOrDefault(key, ImmutableList.of());
+  }
+
+  @Override
+  public Map<K, Collection<V>> asMap() {
+    Map<K, Collection<V>> result = new LinkedHashMap<>();
+    result.putAll(map);
+    return Collections.unmodifiableMap(result);
+  }
+
+  public int size() {
+    int size = 0;
+    for (List<V> values : map.values()) {
+      size += values.size();
+    }
+    return size;
+  }
+
+  public static final class Builder<K, V> {
+
+    private final Map<K, java.util.ArrayList<V>> values = new LinkedHashMap<>();
+
+    public Builder<K, V> put(K key, V value) {
+      values.computeIfAbsent(key, ignored -> new java.util.ArrayList<>()).add(value);
+      return this;
+    }
+
+    public Builder<K, V> putAll(K key, Iterable<? extends V> newValues) {
+      for (V value : newValues) {
+        put(key, value);
+      }
+      return this;
+    }
+
+    public ImmutableListMultimap<K, V> build() {
+      Map<K, ImmutableList<V>> immutableValues = new LinkedHashMap<>();
+      for (Map.Entry<K, java.util.ArrayList<V>> entry : values.entrySet()) {
+        immutableValues.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+      }
+      return new ImmutableListMultimap<>(immutableValues);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
new file mode 100644
index 0000000000..ad087f3856
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableMap.java
@@ -0,0 +1,147 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava map API required by graphql-java 19.7.
+ */
+public final class ImmutableMap<K, V> extends AbstractMap<K, V> {
+
+  private final Map<K, V> map;
+
+  private ImmutableMap(Map<K, V> map) {
+    this.map = map;
+  }
+
+  public static <K, V> ImmutableMap<K, V> of() {
+    return new ImmutableMap<>(Map.of());
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key, V value) {
+    return copyOf(Map.of(key, value));
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3,
+          K key4, V value4) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    values.put(key4, value4);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> of(K key1, V value1, K key2, V value2, K key3, V value3,
+          K key4, V value4, K key5, V value5) {
+    LinkedHashMap<K, V> values = new LinkedHashMap<>();
+    values.put(key1, value1);
+    values.put(key2, value2);
+    values.put(key3, value3);
+    values.put(key4, value4);
+    values.put(key5, value5);
+    return copyOf(values);
+  }
+
+  public static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V> source) {
+    return new ImmutableMap<>(Collections.unmodifiableMap(new LinkedHashMap<>(source)));
+  }
+
+  public static <K, V> Builder<K, V> builder() {
+    return new Builder<>();
+  }
+
+  public static <K, V> Builder<K, V> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  @Override
+  public ImmutableSet<Entry<K, V>> entrySet() {
+    return ImmutableSet.copyOf(map.entrySet());
+  }
+
+  @Override
+  public ImmutableSet<K> keySet() {
+    return ImmutableSet.copyOf(map.keySet());
+  }
+
+  @Override
+  public ImmutableCollection<V> values() {
+    return ImmutableList.copyOf(map.values());
+  }
+
+  @Override
+  public V get(Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return map.containsValue(value);
+  }
+
+  @Override
+  public int size() {
+    return map.size();
+  }
+
+  public static final class Builder<K, V> {
+
+    private final LinkedHashMap<K, V> values;
+
+    public Builder() {
+      this.values = new LinkedHashMap<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new LinkedHashMap<>(expectedSize);
+    }
+
+    public Builder<K, V> put(K key, V value) {
+      values.put(key, value);
+      return this;
+    }
+
+    public Builder<K, V> put(Map.Entry<? extends K, ? extends V> entry) {
+      values.put(entry.getKey(), entry.getValue());
+      return this;
+    }
+
+    public Builder<K, V> putAll(Map<? extends K, ? extends V> source) {
+      values.putAll(source);
+      return this;
+    }
+
+    public ImmutableMap<K, V> build() {
+      return ImmutableMap.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
new file mode 100644
index 0000000000..99dd75f402
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/ImmutableSet.java
@@ -0,0 +1,183 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal relocated Guava set API required by graphql-java 19.7.
+ */
+public final class ImmutableSet<E> extends ImmutableCollection<E> implements Set<E> {
+
+  private final Set<E> set;
+
+  private ImmutableSet(Set<E> set) {
+    super(set);
+    this.set = set;
+  }
+
+  public static <E> ImmutableSet<E> of() {
+    return new ImmutableSet<>(Set.of());
+  }
+
+  public static <E> ImmutableSet<E> of(E element) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    values.add(element);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second) {
+    return copyOf(List.of(first, second));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third) {
+    return copyOf(List.of(first, second, third));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth) {
+    return copyOf(List.of(first, second, third, fourth));
+  }
+
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth) {
+    return copyOf(List.of(first, second, third, fourth, fifth));
+  }
+
+  @SafeVarargs
+  public static <E> ImmutableSet<E> of(E first, E second, E third, E fourth, E fifth, E sixth, E... rest) {
+    LinkedHashSet<E> values = new LinkedHashSet<>(rest.length + 6);
+    Collections.addAll(values, first, second, third, fourth, fifth, sixth);
+    Collections.addAll(values, rest);
+    return copyOf(values);
+  }
+
+  public static <E> ImmutableSet<E> copyOf(java.util.Collection<? extends E> elements) {
+    return new ImmutableSet<>(Collections.unmodifiableSet(new LinkedHashSet<>(elements)));
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Iterable<? extends E> elements) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    for (E element : elements) {
+      values.add(element);
+    }
+    return new ImmutableSet<>(Collections.unmodifiableSet(values));
+  }
+
+  public static <E> ImmutableSet<E> copyOf(Iterator<? extends E> elements) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    elements.forEachRemaining(values::add);
+    return new ImmutableSet<>(Collections.unmodifiableSet(values));
+  }
+
+  public static <E> Builder<E> builder() {
+    return new Builder<>();
+  }
+
+  public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
+    return new Builder<>(expectedSize);
+  }
+
+  public static <E> Collector<E, ?, ImmutableSet<E>> toImmutableSet() {
+    return Collectors.collectingAndThen(Collectors.toCollection(LinkedHashSet::new), ImmutableSet::copyOf);
+  }
+
+  @Override
+  public boolean contains(Object element) {
+    return set.contains(element);
+  }
+
+  @Override
+  public int size() {
+    return set.size();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return set.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] array) {
+    return set.toArray(array);
+  }
+
+  @Override
+  public Spliterator<E> spliterator() {
+    return set.spliterator();
+  }
+
+  @Override
+  public boolean add(E element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(java.util.Collection<? extends E> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean removeAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean retainAll(java.util.Collection<?> elements) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static final class Builder<E> {
+
+    private final LinkedHashSet<E> values;
+
+    public Builder() {
+      this.values = new LinkedHashSet<>();
+    }
+
+    private Builder(int expectedSize) {
+      this.values = new LinkedHashSet<>(expectedSize);
+    }
+
+    public Builder<E> add(E element) {
+      values.add(element);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder<E> add(E... elements) {
+      Collections.addAll(values, elements);
+      return this;
+    }
+
+    public Builder<E> addAll(Iterable<? extends E> elements) {
+      for (E element : elements) {
+        values.add(element);
+      }
+      return this;
+    }
+
+    public ImmutableSet<E> build() {
+      return ImmutableSet.copyOf(values);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
new file mode 100644
index 0000000000..6f55bfdbdb
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/LinkedHashMultimap.java
@@ -0,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava linked hash multimap required by graphql-java 19.7.
+ */
+public final class LinkedHashMultimap<K, V> implements Multimap<K, V> {
+
+  private final Map<K, Collection<V>> map = new LinkedHashMap<>();
+
+  private LinkedHashMultimap() {
+  }
+
+  public static <K, V> LinkedHashMultimap<K, V> create() {
+    return new LinkedHashMultimap<>();
+  }
+
+  @Override
+  public boolean put(K key, V value) {
+    return map.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(value);
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    Collection<V> values = map.get(key);
+    if (values == null) {
+      return false;
+    }
+    boolean removed = values.remove(value);
+    if (values.isEmpty()) {
+      map.remove(key);
+    }
+    return removed;
+  }
+
+  @Override
+  public Collection<V> get(K key) {
+    return map.getOrDefault(key, Collections.emptySet());
+  }
+
+  @Override
+  public Map<K, Collection<V>> asMap() {
+    return Collections.unmodifiableMap(map);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
new file mode 100644
index 0000000000..f50fd23547
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Maps.java
@@ -0,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Minimal relocated Guava map helpers required by graphql-java 19.7.
+ */
+public final class Maps {
+
+  private Maps() {
+  }
+
+  public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+    return new LinkedHashMap<>(expectedSize);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
new file mode 100644
index 0000000000..feff06b6e4
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Multimap.java
@@ -0,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Minimal relocated Guava multimap API required by graphql-java 19.7.
+ */
+public interface Multimap<K, V> {
+
+  boolean put(K key, V value);
+
+  boolean remove(Object key, Object value);
+
+  Collection<V> get(K key);
+
+  Map<K, Collection<V>> asMap();
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
new file mode 100644
index 0000000000..09be52c2fb
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/Sets.java
@@ -0,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.AbstractSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Minimal relocated Guava set helpers required by graphql-java 19.7.
+ */
+public final class Sets {
+
+  private Sets() {
+  }
+
+  public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+    return new HashSet<>(expectedSize);
+  }
+
+  public static <E> SetView<E> intersection(Set<E> set1, Set<?> set2) {
+    LinkedHashSet<E> values = new LinkedHashSet<>();
+    for (E element : set1) {
+      if (set2.contains(element)) {
+        values.add(element);
+      }
+    }
+    return new SetView<>(values);
+  }
+
+  public static final class SetView<E> extends AbstractSet<E> {
+
+    private final Set<E> set;
+
+    private SetView(Set<E> set) {
+      this.set = set;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return set.iterator();
+    }
+
+    @Override
+    public int size() {
+      return set.size();
+    }
+
+    public ImmutableSet<E> immutableCopy() {
+      return ImmutableSet.copyOf(set);
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
new file mode 100644
index 0000000000..50dc1f05ba
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/com/google/common/collect/UnmodifiableIterator.java
@@ -0,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.com.google.common.collect;
+
+import java.util.Iterator;
+
+/**
+ * Minimal relocated Guava iterator API required by graphql-java 19.7.
+ */
+public abstract class UnmodifiableIterator<E> implements Iterator<E> {
+
+  @Override
+  public final void remove() {
+    throw new UnsupportedOperationException();
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
new file mode 100644
index 0000000000..b154f38b11
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}

```
