### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final using gpt-5.5

### DIFF
--- a/metadata/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/reachability-metadata.json
@@ -1,0 +1,286 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "com.sun.el.ExpressionFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getModule",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "java.lang.Module",
+      "methods" : [
+        {
+          "name" : "isNamed",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.LanguageTraversal"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.rules.TargetedValidationRules"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "javax.money.MonetaryAmount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.apache.log4j.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Messages_$bundle_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "org.joda.time.ReadableInstant"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ContributorValidationMessages_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "META-INF/services/javax.el.ExpressionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "ValidationMessages_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.Validator"
+      },
+      "glob" : "i18n/Validation_fr.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "org/hibernate/validator/ValidationMessages_fr.properties"
+    },
+    {
+      "bundle" : "ContributorValidationMessages"
+    },
+    {
+      "bundle" : "ValidationMessages"
+    },
+    {
+      "bundle" : "graphql.validation.ValidationMessages"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    },
+    {
+      "bundle" : "org.hibernate.validator.ValidationMessages"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -1,32 +1,45 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
+    "latest" : true,
+    "metadata-version" : "19.1-hibernate-validator-6.2.0.Final",
+    "tested-versions" : [
+      "19.1-hibernate-validator-6.2.0.Final"
+    ],
+    "allowed-packages" : [
       "graphql"
     ],
-    "metadata-version": "19.1",
-    "source-code-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-sources.jar",
-    "repository-url": "https://github.com/graphql-java/graphql-java-extended-validation",
-    "test-code-url": "https://github.com/graphql-java/graphql-java-extended-validation/tree/v$version$/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-javadoc.jar",
-    "description": "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
-    "tested-versions": [
-      "19.1"
-    ],
-    "requires": [
+    "requires" : [
       "com.graphql-java:graphql-java",
       "org.hibernate.validator:hibernate-validator"
     ]
   },
   {
-    "allowed-packages": [
+    "metadata-version" : "19.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java-extended-validation",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java-extended-validation/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-javadoc.jar",
+    "description" : "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
+    "tested-versions" : [
+      "19.1"
+    ],
+    "allowed-packages" : [
       "graphql"
     ],
-    "metadata-version": "19.2",
-    "tested-versions": [
+    "requires" : [
+      "com.graphql-java:graphql-java",
+      "org.hibernate.validator:hibernate-validator"
+    ]
+  },
+  {
+    "metadata-version" : "19.2",
+    "tested-versions" : [
       "19.2"
     ],
-    "requires": [
+    "allowed-packages" : [
+      "graphql"
+    ],
+    "requires" : [
       "com.graphql-java:graphql-java",
       "org.hibernate.validator:hibernate-validator",
       "org.hibernate.orm:hibernate-core"

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "19.1-hibernate-validator-6.2.0.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java-extended-validation",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java-extended-validation/tree/v19.1-validator-6.2.0.Final/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java-extended-validation/$version$/graphql-java-extended-validation-$version$-javadoc.jar",
+    "description" : "This library adds extended validation for fields, arguments, and input values in graphql-java schemas. It provides directive-based constraints and validation rules that enforce allowable values during GraphQL execution.",
     "tested-versions" : [
       "19.1-hibernate-validator-6.2.0.Final"
     ],
     "allowed-packages" : [
-      "graphql"
+      "graphql.validation"
     ],
     "requires" : [
       "com.graphql-java:graphql-java",

--- a/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/execution-metrics.json
+++ b/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T21:25:43.055376Z",
+    "library": "com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final",
+    "starting_commit": "597eb8baa92ce6f982d30fe6f6b40efab3b92c29",
+    "ending_commit": "ff8553875b456a9a979721d5d46b713c933757c4",
+    "previous_library": "com.graphql-java:graphql-java-extended-validation:19.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "19.1-hibernate-validator-6.2.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2189,
+          "missed": 2679,
+          "ratio": 0.449671,
+          "total": 4868
+        },
+        "line": {
+          "covered": 522,
+          "missed": 626,
+          "ratio": 0.454704,
+          "total": 1148
+        },
+        "method": {
+          "covered": 158,
+          "missed": 159,
+          "ratio": 0.498423,
+          "total": 317
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "19.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.666667,
+            "coveredCalls": 2,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.666667,
+        "coveredCalls": 2,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2136,
+          "missed": 2732,
+          "ratio": 0.438784,
+          "total": 4868
+        },
+        "line": {
+          "covered": 510,
+          "missed": 638,
+          "ratio": 0.444251,
+          "total": 1148
+        },
+        "method": {
+          "covered": 152,
+          "missed": 165,
+          "ratio": 0.479495,
+          "total": 317
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 80957,
+      "cached_input_tokens_used": 765952,
+      "output_tokens_used": 9847,
+      "iterations": 2,
+      "cost_usd": 0.6784,
+      "tested_library_loc": 522,
+      "metadata_entries": 49,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 4,
+      "code_coverage_percent": 45.47,
+      "previous_library_coverage_percent": 44.43
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/graphql/GraphQlValidationTests.java",
+      "metadata_file": "metadata/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/stats.json
+++ b/stats/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "19.1-hibernate-validator-6.2.0.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2189,
+        "missed" : 2679,
+        "ratio" : 0.449671,
+        "total" : 4868
+      },
+      "line" : {
+        "covered" : 522,
+        "missed" : 626,
+        "ratio" : 0.454704,
+        "total" : 1148
+      },
+      "method" : {
+        "covered" : 158,
+        "missed" : 159,
+        "ratio" : 0.498423,
+        "total" : 317
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
+    implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
+    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+	binaries {
+		test {
+			buildArgs.add('--no-fallback')
+			buildArgs.add('-H:IncludeLocales=fr')
+		}
+	}
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -24,3 +24,14 @@ graalvmNative {
 		}
 	}
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -13,7 +13,6 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
     implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
-    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 19.1-hibernate-validator-6.2.0.Final
+metadata.dir = com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-extended-validation-tests'

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/graphql/GraphQlValidationTests.java
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/graphql/GraphQlValidationTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.schemawiring.ValidationSchemaWiring;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlValidationTests {
+
+
+  @Test
+  void validationErrorQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ hired(application: {name: \"p\"}) }");
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name size must be between 3 and 100");
+  }
+
+  @Test
+  void validationErrorQueryInFrench() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("validation", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("hired", new StaticDataFetcher(true))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(ExecutionInput.newExecutionInput("{ hired(application: {name: \"p\"}) }").locale(Locale.FRENCH).build());
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).isEqualTo("/hired/application/name la taille doit etre comprise entre 3 et 100");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlValidationTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+    ValidationRules validationRules = ValidationRules.newValidationRules()
+        .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
+        .build();
+    ValidationSchemaWiring schemaWiring = new ValidationSchemaWiring(validationRules);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+    runtimeWiringBuilder.directiveWiring(schemaWiring);
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/org/graalvm/tests/graphqlvalidation/ELSupportTest.java
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/org/graalvm/tests/graphqlvalidation/ELSupportTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.tests.graphqlvalidation;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+
+import graphql.validation.el.ELSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ELSupportTest {
+
+  @Test
+  void loadMethodResolvesPublicEvaluationMethod() throws Throwable {
+    ELSupport elSupport = new ELSupport(Locale.ENGLISH);
+    MethodHandle loadMethod = MethodHandles.privateLookupIn(ELSupport.class, MethodHandles.lookup())
+        .findVirtual(ELSupport.class, "loadMethod", MethodType.methodType(Method.class, String.class, Class[].class));
+
+    Method method = (Method) loadMethod.invoke(elSupport, "evaluate", new Class<?>[] {String.class, Map.class});
+
+    assertThat(method.getDeclaringClass()).isEqualTo(ELSupport.class);
+    assertThat(method.getName()).isEqualTo("evaluate");
+    assertThat(method.getParameterTypes()).containsExactly(String.class, Map.class);
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/graphql-validation-test-metadata/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qgraphql/validation.graphqls\\E",
+        "condition": {
+          "typeReachable": "graphql.GraphQL"
+        }
+      }
+    ]
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.locale.LocaleUtil"
+      },
+      "type" : "graphql.schema.DataFetchingEnvironmentImpl",
+      "methods" : [
+        {
+          "name" : "getLocale",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.el.ELSupport"
+      },
+      "type" : "graphql.validation.el.ELSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "type" : {
+        "proxy" : [
+          "graphql.validation.interpolation.ResourceBundleMessageInterpolator$BridgeAnnotation"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.validation.interpolation.ResourceBundleMessageInterpolator"
+      },
+      "glob" : "graphql/validation/ValidationMessages_fr.properties"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation.graphqls
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation.graphqls
@@ -1,0 +1,10 @@
+type Query {
+    hired (application : Application!) : Boolean
+}
+
+directive @Size(min : Int = 0, max : Int = 2147483647, message : String = "graphql.validation.Size.message")
+on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+input Application {
+    name : String @Size(min : 3, max : 100)
+}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation/ValidationMessages_fr.properties
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/resources/graphql/validation/ValidationMessages_fr.properties
@@ -1,0 +1,1 @@
+graphql.validation.Size.message={path} la taille doit etre comprise entre {min} et {max}

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="3" skipped="0" failures="0" errors="0" time="0.01" hostname="kung-fu-workstation" timestamp="2026-05-02T23:13:29">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/718-c8d5aaff/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="validationErrorQuery()" classname="graphql.GraphQlValidationTests" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlValidationTests]/[method:validationErrorQuery()]
+display-name: validationErrorQuery()
+]]></system-out>
+</testcase>
+<testcase name="loadMethodResolvesPublicEvaluationMethod()" classname="org.graalvm.tests.graphqlvalidation.ELSupportTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org.graalvm.tests.graphqlvalidation.ELSupportTest]/[method:loadMethodResolvesPublicEvaluationMethod()]
+display-name: loadMethodResolvesPublicEvaluationMethod()
+]]></system-out>
+</testcase>
+<testcase name="validationErrorQueryInFrench()" classname="graphql.GraphQlValidationTests" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:graphql.GraphQlValidationTests]/[method:validationErrorQueryInFrench()]
+display-name: validationErrorQueryInFrench()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="3" skipped="0" failures="0" errors="0" time="0.01" hostname="kung-fu-workstation" timestamp="2026-05-02T23:13:29">
+<testsuite name="JUnit Jupiter" tests="3" skipped="0" failures="0" errors="0" time="0.01" hostname="kung-fu-workstation" timestamp="2026-05-02T23:24:33">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/718-c8d5aaff/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final"/>

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:13:29">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/718-c8d5aaff/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:13:29">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:24:33">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/718-c8d5aaff/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final"/>

--- a/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.validation.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #718

This PR provides test fixes and new metadata for com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 80957
- Cached input tokens: 765952
- Output tokens: 9847
- Metadata entries: 49
- Test-only metadata entries: 6
- Iterations: 2
- Library coverage percentage: 45.47
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 44.43

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4ad45ed051185c8e462dfe26abd86a49d0c5c12d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java-extended-validation:19.1: 2/3 covered calls (66.67%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 3/3 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java-extended-validation:19.1: 2/3 covered calls (66.67%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java-extended-validation:19.1: 2136/4868 (43.88%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 2189/4868 (44.97%)

**Line:**
- com.graphql-java:graphql-java-extended-validation:19.1: 510/1148 (44.43%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 522/1148 (45.47%)

**Method:**
- com.graphql-java:graphql-java-extended-validation:19.1: 152/317 (47.95%)
- com.graphql-java:graphql-java-extended-validation:19.1-hibernate-validator-6.2.0.Final: 158/317 (49.84%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
index f45c59c71a..efc1136417 100644
--- 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1/build.gradle
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/build.gradle
@@ -13,7 +13,6 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     implementation "com.graphql-java:graphql-java-extended-validation:$libraryVersion"
     implementation "org.jboss.logging:jboss-logging:3.5.0.Final"
-    implementation "org.hibernate.validator:hibernate-validator:7.0.4.Final"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
@@ -25,3 +24,14 @@ graalvmNative {
 		}
 	}
 }
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/org/graalvm/tests/graphqlvalidation/ELSupportTest.java 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/org/graalvm/tests/graphqlvalidation/ELSupportTest.java
new file mode 100644
index 0000000000..e20893d11b
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/src/test/java/org/graalvm/tests/graphqlvalidation/ELSupportTest.java
@@ -0,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.tests.graphqlvalidation;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+
+import graphql.validation.el.ELSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ELSupportTest {
+
+  @Test
+  void loadMethodResolvesPublicEvaluationMethod() throws Throwable {
+    ELSupport elSupport = new ELSupport(Locale.ENGLISH);
+    MethodHandle loadMethod = MethodHandles.privateLookupIn(ELSupport.class, MethodHandles.lookup())
+        .findVirtual(ELSupport.class, "loadMethod", MethodType.methodType(Method.class, String.class, Class[].class));
+
+    Method method = (Method) loadMethod.invoke(elSupport, "evaluate", new Class<?>[] {String.class, Map.class});
+
+    assertThat(method.getDeclaringClass()).isEqualTo(ELSupport.class);
+    assertThat(method.getName()).isEqualTo("evaluate");
+    assertThat(method.getParameterTypes()).containsExactly(String.class, Map.class);
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
new file mode 100644
index 0000000000..a10f61d6ff
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java-extended-validation/19.1-hibernate-validator-6.2.0.Final/user-code-filter.json
@@ -0,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.validation.**"
+    }
+  ]
+}

```
