### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-io-bytestring as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-io-bytestring/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-io-bytestring/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; the Gradle module metadata redirects JVM variants to kotlinx-io-bytestring-jvm.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:0.8.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3714

This PR records `org.jetbrains.kotlinx:kotlinx-io-bytestring` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; the Gradle module metadata redirects JVM variants to kotlinx-io-bytestring-jvm.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:0.8.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b855c6862fb91adc3c27ed7036414cd1edcf699f`
