### PR TITLE
[GenAI] Test fix for org.opengauss:opengauss-jdbc:3.1.1 using gpt-5.5

### DIFF
--- a/metadata/org.opengauss/opengauss-jdbc/3.1.1/reachability-metadata.json
+++ b/metadata/org.opengauss/opengauss-jdbc/3.1.1/reachability-metadata.json
@@ -1,0 +1,1909 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.postgresql.log.LogFactory"
+      },
+      "type": "JdkLogger"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "com.sun.crypto.provider.HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "com.sun.crypto.provider.PKCS12PBECipherCore$PBEWithSHA1AndDESede",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.common.BaseDataSource"
+      },
+      "type": "int[]",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Boolean[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Double[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Float[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Integer[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Integer[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Long[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.Short[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.common.BaseDataSource"
+      },
+      "type": "java.lang.String",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.lang.String[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.math.BigDecimal[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.core.v3.ConnectionFactoryImpl"
+      },
+      "type": "java.security.SecureRandomParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.PGPooledConnection$ConnectionHandler"
+      },
+      "type": "java.sql.Connection",
+      "methods": [
+        {
+          "name": "createStatement",
+          "parameterTypes": []
+        },
+        {
+          "name": "getAutoCommit",
+          "parameterTypes": []
+        },
+        {
+          "name": "prepareCall",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "prepareStatement",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.sql.Date[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.core.v3.ConnectionFactoryImpl"
+      },
+      "type": "java.sql.SQLException"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.sql.Time[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.sql.Timestamp[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.common.BaseDataSource"
+      },
+      "type": "java.util.Hashtable",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.common.BaseDataSource"
+      },
+      "type": "java.util.Properties",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.util.UUID[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgArray"
+      },
+      "type": "java.util.UUID[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.asn1.ASN1Sequence",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo",
+      "methods": [
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.asn1.pkcs.PrivateKeyInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.COMPOSITE$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DH$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.DSTU4145$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.ElGamal$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.GM$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.GOST$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.IES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.asymmetric.X509$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Blake2b$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Blake2s$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.DSTU7564$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.GOST3411$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Haraka$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Keccak$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.MD5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD160$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.RIPEMD320$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA224$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA384$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SHA512$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.SM3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Skein$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Tiger$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.digest.Whirlpool$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.BC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.AES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ARC4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ARIA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Blowfish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.CAST5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.CAST6$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Camellia$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DES$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DESede$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.DSTU7624$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.GOST28147$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.GOST3412_2015$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Grain128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Grainv1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.HC128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.HC256$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.IDEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Noekeon$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Poly1305$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC5$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.RC6$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Rijndael$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SCRYPT$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SEED$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SM4$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Salsa20$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Serpent$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Shacal2$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SipHash$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.SipHash128$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Skipjack$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.TEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.TLSKDF$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Threefish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Twofish$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.VMPC$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.VMPCKSA3$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.XSalsa20$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.XTEA$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jcajce.provider.symmetric.Zuc$Mappings",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.jce.provider.BouncyCastleProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPrivateKey",
+          "parameterTypes": [
+            "org.bouncycastle.asn1.pkcs.PrivateKeyInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "build",
+          "parameterTypes": [
+            "char[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.operator.InputDecryptorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo"
+          ]
+        },
+        {
+          "name": "decryptPrivateKeyInfo",
+          "parameterTypes": [
+            "org.bouncycastle.operator.InputDecryptorProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.common.BaseDataSource"
+      },
+      "type": "org.postgresql.Driver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.core.Oid"
+      },
+      "type": "org.postgresql.core.Oid",
+      "allPublicFields": true,
+      "fields": [
+        {
+          "name": "BIT"
+        },
+        {
+          "name": "BIT_ARRAY"
+        },
+        {
+          "name": "BLOB"
+        },
+        {
+          "name": "BOOL"
+        },
+        {
+          "name": "BOOL_ARRAY"
+        },
+        {
+          "name": "BOX"
+        },
+        {
+          "name": "BPCHAR"
+        },
+        {
+          "name": "BPCHAR_ARRAY"
+        },
+        {
+          "name": "BYTEA"
+        },
+        {
+          "name": "BYTEA_ARRAY"
+        },
+        {
+          "name": "CHAR"
+        },
+        {
+          "name": "CHAR_ARRAY"
+        },
+        {
+          "name": "CLOB"
+        },
+        {
+          "name": "DATE"
+        },
+        {
+          "name": "DATE_ARRAY"
+        },
+        {
+          "name": "FLOAT4"
+        },
+        {
+          "name": "FLOAT4_ARRAY"
+        },
+        {
+          "name": "FLOAT8"
+        },
+        {
+          "name": "FLOAT8_ARRAY"
+        },
+        {
+          "name": "INT1"
+        },
+        {
+          "name": "INT1_ARRAY"
+        },
+        {
+          "name": "INT2"
+        },
+        {
+          "name": "INT2_ARRAY"
+        },
+        {
+          "name": "INT4"
+        },
+        {
+          "name": "INT4_ARRAY"
+        },
+        {
+          "name": "INT8"
+        },
+        {
+          "name": "INT8_ARRAY"
+        },
+        {
+          "name": "INTERVAL"
+        },
+        {
+          "name": "INTERVAL_ARRAY"
+        },
+        {
+          "name": "JSON"
+        },
+        {
+          "name": "JSONB_ARRAY"
+        },
+        {
+          "name": "JSON_ARRAY"
+        },
+        {
+          "name": "MONEY"
+        },
+        {
+          "name": "MONEY_ARRAY"
+        },
+        {
+          "name": "NAME"
+        },
+        {
+          "name": "NAME_ARRAY"
+        },
+        {
+          "name": "NUMERIC"
+        },
+        {
+          "name": "NUMERIC_ARRAY"
+        },
+        {
+          "name": "NVARCHAR2"
+        },
+        {
+          "name": "NVARCHAR2_ARRAY"
+        },
+        {
+          "name": "OID"
+        },
+        {
+          "name": "OID_ARRAY"
+        },
+        {
+          "name": "POINT"
+        },
+        {
+          "name": "POINT_ARRAY"
+        },
+        {
+          "name": "REF_CURSOR"
+        },
+        {
+          "name": "REF_CURSOR_ARRAY"
+        },
+        {
+          "name": "SMALLDATETIME"
+        },
+        {
+          "name": "SMALLDATETIME_ARRAY"
+        },
+        {
+          "name": "TEXT"
+        },
+        {
+          "name": "TEXT_ARRAY"
+        },
+        {
+          "name": "TIME"
+        },
+        {
+          "name": "TIMESTAMP"
+        },
+        {
+          "name": "TIMESTAMPTZ"
+        },
+        {
+          "name": "TIMESTAMPTZ_ARRAY"
+        },
+        {
+          "name": "TIMESTAMP_ARRAY"
+        },
+        {
+          "name": "TIMETZ"
+        },
+        {
+          "name": "TIMETZ_ARRAY"
+        },
+        {
+          "name": "TIME_ARRAY"
+        },
+        {
+          "name": "UNSPECIFIED"
+        },
+        {
+          "name": "UUID"
+        },
+        {
+          "name": "UUID_ARRAY"
+        },
+        {
+          "name": "VARBIT"
+        },
+        {
+          "name": "VARBIT_ARRAY"
+        },
+        {
+          "name": "VARCHAR"
+        },
+        {
+          "name": "VARCHAR_ARRAY"
+        },
+        {
+          "name": "VOID"
+        },
+        {
+          "name": "XML"
+        },
+        {
+          "name": "XML_ARRAY"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGbox",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGcircle",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGline",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGlseg",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGpath",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGpoint",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.geometric.PGpolygon",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgStatement"
+      },
+      "type": "org.postgresql.jdbc.PgStatement"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.log.LogFactory"
+      },
+      "type": "org.postgresql.log.JdkLogger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.util.PGInterval",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.jdbc.PgConnection"
+      },
+      "type": "org.postgresql.util.PGmoney",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "sun.security.provider.MD5",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.core.v3.ConnectionFactoryImpl"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.core.v3.ConnectionFactoryImpl"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.MD5Digest"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ssl.BouncyCastlePrivateKeyFactory"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.PGPooledConnection$ConnectionHandler"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.CallableStatement",
+          "org.postgresql.PGStatement"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.PGPooledConnection"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.Connection",
+          "org.postgresql.PGConnection"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.PGPooledConnection$ConnectionHandler"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.PreparedStatement",
+          "org.postgresql.PGStatement"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.ds.PGPooledConnection$ConnectionHandler"
+      },
+      "type": {
+        "proxy": [
+          "java.sql.Statement",
+          "org.postgresql.PGStatement"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.postgresql.log.JdkLogger"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.GT"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.Driver"
+      },
+      "glob": "org/postgresql/driverconfig.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.GT"
+      },
+      "glob": "org/postgresql/translation/messages.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.GT"
+      },
+      "glob": "org/postgresql/translation/messages_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.util.GT"
+      },
+      "glob": "org/postgresql/translation/messages_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.log.JdkLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.postgresql.log.JdkLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "org.postgresql.translation.messages"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/org.opengauss/opengauss-jdbc/index.json
+++ b/metadata/org.opengauss/opengauss-jdbc/index.json
@@ -1,17 +1,26 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "org.opengauss"
+    "latest" : true,
+    "metadata-version" : "3.1.1",
+    "tested-versions" : [
+      "3.1.1"
     ],
-    "metadata-version": "3.1.0-og",
-    "source-code-url": "https://repo.maven.apache.org/maven2/org/opengauss/opengauss-jdbc/$version$/opengauss-jdbc-$version$-sources.jar",
-    "repository-url": "https://gitee.com/opengauss/openGauss-connector-jdbc",
-    "test-code-url": "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/pgjdbc/src/test",
-    "documentation-url": "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/docs",
-    "description": "This artifact is the Java JDBC driver for openGauss. It enables Java applications to connect to openGauss databases and execute SQL through the standard JDBC API.",
-    "tested-versions": [
+    "allowed-packages" : [
+      "org.opengauss"
+    ]
+  },
+  {
+    "metadata-version" : "3.1.0-og",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/opengauss/opengauss-jdbc/$version$/opengauss-jdbc-$version$-sources.jar",
+    "repository-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc",
+    "test-code-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/pgjdbc/src/test",
+    "documentation-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v3.1.0/docs",
+    "description" : "This artifact is the Java JDBC driver for openGauss. It enables Java applications to connect to openGauss databases and execute SQL through the standard JDBC API.",
+    "tested-versions" : [
       "3.1.0-og"
+    ],
+    "allowed-packages" : [
+      "org.opengauss"
     ]
   }
 ]

--- a/metadata/org.opengauss/opengauss-jdbc/index.json
+++ b/metadata/org.opengauss/opengauss-jdbc/index.json
@@ -2,11 +2,16 @@
   {
     "latest" : true,
     "metadata-version" : "3.1.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/opengauss/opengauss-jdbc/$version$/opengauss-jdbc-$version$-sources.jar",
+    "repository-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc",
+    "test-code-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v$version$/pgjdbc/src/test",
+    "documentation-url" : "https://gitee.com/opengauss/openGauss-connector-jdbc/tree/v$version$/docs",
+    "description" : "This artifact is the Java JDBC driver for openGauss. It enables Java applications to connect to openGauss databases and execute SQL through the standard JDBC API.",
     "tested-versions" : [
       "3.1.1"
     ],
     "allowed-packages" : [
-      "org.opengauss"
+      "org.postgresql"
     ]
   },
   {

--- a/stats/org.opengauss/opengauss-jdbc/3.1.1/execution-metrics.json
+++ b/stats/org.opengauss/opengauss-jdbc/3.1.1/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-02": {
+    "timestamp": "2026-05-02T21:34:40.858664Z",
+    "library": "org.opengauss:opengauss-jdbc:3.1.1",
+    "starting_commit": "3c71d2e2e2af973d0e8bdb3030ea6ac2c7addbcc",
+    "ending_commit": "7e68768b1010e7c3df4f699655f1de64ebfeb226",
+    "previous_library": "org.opengauss:opengauss-jdbc:3.1.0-og",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.1.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.7125,
+            "coveredCalls": 57,
+            "totalCalls": 80
+          },
+          "resources": {
+            "coverageRatio": 0.333333,
+            "coveredCalls": 1,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.698795,
+        "coveredCalls": 58,
+        "totalCalls": 83
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 21957,
+          "missed": 85054,
+          "ratio": 0.205185,
+          "total": 107011
+        },
+        "line": {
+          "covered": 4518,
+          "missed": 18719,
+          "ratio": 0.194431,
+          "total": 23237
+        },
+        "method": {
+          "covered": 787,
+          "missed": 2502,
+          "ratio": 0.239282,
+          "total": 3289
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.1.0-og",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.076923,
+            "coveredCalls": 6,
+            "totalCalls": 78
+          },
+          "resources": {
+            "coverageRatio": 0.333333,
+            "coveredCalls": 1,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.08642,
+        "coveredCalls": 7,
+        "totalCalls": 81
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18509,
+          "missed": 88258,
+          "ratio": 0.173359,
+          "total": 106767
+        },
+        "line": {
+          "covered": 3788,
+          "missed": 19403,
+          "ratio": 0.163339,
+          "total": 23191
+        },
+        "method": {
+          "covered": 671,
+          "missed": 2617,
+          "ratio": 0.204075,
+          "total": 3288
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 375928,
+      "cached_input_tokens_used": 5998080,
+      "output_tokens_used": 45769,
+      "iterations": 6,
+      "cost_usd": 4.3721,
+      "tested_library_loc": 4518,
+      "metadata_entries": 354,
+      "previous_library_metadata_entries": 27,
+      "code_coverage_percent": 19.44,
+      "previous_library_coverage_percent": 16.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java",
+      "metadata_file": "metadata/org.opengauss/opengauss-jdbc/3.1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.opengauss/opengauss-jdbc/3.1.1/stats.json
+++ b/stats/org.opengauss/opengauss-jdbc/3.1.1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.1.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.7125,
+          "coveredCalls" : 57,
+          "totalCalls" : 80
+        },
+        "resources" : {
+          "coverageRatio" : 0.333333,
+          "coveredCalls" : 1,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 0.698795,
+      "coveredCalls" : 58,
+      "totalCalls" : 83
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 21957,
+        "missed" : 85054,
+        "ratio" : 0.205185,
+        "total" : 107011
+      },
+      "line" : {
+        "covered" : 4518,
+        "missed" : 18719,
+        "ratio" : 0.194431,
+        "total" : 23237
+      },
+      "method" : {
+        "covered" : 787,
+        "missed" : 2502,
+        "ratio" : 0.239282,
+        "total" : 3289
+      }
+    }
+  } ]
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/.gitignore
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.opengauss:opengauss-jdbc:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+        metadataCopy {
+            mergeWithExisting = true
+            inputTaskNames.add("test")
+            outputDirectories.add("src/test/resources/META-INF/native-image/org.opengauss/opengauss-jdbc")
+        }
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
@@ -31,4 +31,11 @@ graalvmNative {
             outputDirectories.add("src/test/resources/META-INF/native-image/org.opengauss/opengauss-jdbc")
         }
     }
+    binaries {
+        all {
+            buildArgs.add("--future-defaults=run-time-initialize-security-providers")
+            buildArgs.add("-Djava.security.properties=${file('java.security.properties').absolutePath}")
+            buildArgs.add("-H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider")
+        }
+    }
 }

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.opengauss:opengauss-jdbc:$libraryVersion"
+    testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/gradle.properties
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 3.1.1
+metadata.dir = org.opengauss/opengauss-jdbc/3.1.1/

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/java.security.properties
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/java.security.properties
@@ -1,0 +1,1 @@
+security.provider.13=org.bouncycastle.jce.provider.BouncyCastleProvider

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 5789c2277ac9 
+0 LOG:  [Alarm Module]Host Name: c2d58772f604 
 	
-0 LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:01:15.249 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:12:00.452 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5789c2277ac9 
+2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: c2d58772f604 
 	
-2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:12:00.457 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:12:00.457 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:01:15.255 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:01:15.256 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:15.256 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:01:15.301 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:01:15.327 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:01:15.363 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:01:15.363 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:01:15.384 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:12:00.495 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:12:00.521 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:12:00.554 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:12:00.554 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:12:00.592 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:01:15.389 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:01:15.389 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:12:00.598 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:12:00.598 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+0 LOG:  [Alarm Module]Host Name: 72b816ee9192 
 	
-0 LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:34:26.474 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 04:45:47.174 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 72b816ee9192 
 	
-2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:34:26.483 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:34:26.484 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:26.484 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:34:26.537 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:34:26.565 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:34:26.599 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:34:26.599 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:34:26.631 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 04:45:47.180 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:45:47.181 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:47.181 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:45:47.230 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:45:47.260 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:45:47.300 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:45:47.300 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:45:47.317 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 04:34:26.637 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:34:26.637 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:47.323 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:45:47.323 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 72b816ee9192 
+0 LOG:  [Alarm Module]Host Name: 5789c2277ac9 
 	
-0 LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:45:47.174 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:01:15.249 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 72b816ee9192 
+2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5789c2277ac9 
 	
-2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:45:47.179 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:01:15.253 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:45:47.180 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:45:47.181 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:47.181 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:45:47.184 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:45:47.230 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:45:47.260 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:45:47.300 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:45:47.300 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:45:47.317 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:01:15.255 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:01:15.256 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:15.256 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:01:15.260 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:01:15.301 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:01:15.327 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:01:15.363 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:01:15.363 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:01:15.384 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 04:45:47.323 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:45:47.323 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:47.370 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:47.372 [unknown] [unknown] localhost 130651592033664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:15.389 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:01:15.389 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:15.431 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:15.432 [unknown] [unknown] localhost 133816687535488 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: c2d58772f604 
+0 LOG:  [Alarm Module]Host Name: b57f3edacbed 
 	
-0 LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:12:00.452 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:26:46.753 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: c2d58772f604 
+2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: b57f3edacbed 
 	
-2026-05-03 05:12:00.456 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:12:00.457 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:12:00.457 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:12:00.458 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:12:00.461 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:12:00.495 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:12:00.521 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:12:00.554 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:12:00.554 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:12:00.592 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:26:46.759 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:46.760 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:46.760 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:46.803 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:46.830 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:46.868 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:46.868 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:46.890 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:12:00.598 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:12:00.598 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:12:00.641 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:12:00.643 [unknown] [unknown] localhost 136902421345664 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:46.897 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:46.897 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: b57f3edacbed 
+0 LOG:  [Alarm Module]Host Name: 73da76a9d11e 
 	
-0 LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 73da76a9d11e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:46.753 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:31.253 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:33:31.258 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: b57f3edacbed 
+2026-05-03 05:33:31.258 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 73da76a9d11e 
 	
-2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:31.258 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 73da76a9d11e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:31.258 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:46.757 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:31.258 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:46.759 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:46.760 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:46.760 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:46.763 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:46.803 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:46.830 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:46.868 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:46.868 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:46.890 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:33:31.262 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:31.262 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:31.262 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:31.277 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:31.277 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:31.277 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:31.277 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:31.277 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:31.315 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:31.346 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:31.383 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:31.383 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:31.400 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:26:46.897 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:46.897 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:46.943 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:46.944 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:46.945 [unknown] [unknown] localhost 128511743284608 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:31.406 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:31.406 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:31.447 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:31.447 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:31.447 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:31.447 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:31.448 [unknown] [unknown] localhost 125633659925888 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stderr.txt
@@ -1,0 +1,56 @@
+
+                        Message: The supplied GS_PASSWORD is meet requirements.
+
+0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+	
+0 LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 04:34:26.474 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+	
+2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 04:34:26.479 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 04:34:26.483 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:34:26.484 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:26.484 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:34:26.494 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:34:26.537 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:34:26.565 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:34:26.599 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:34:26.599 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:34:26.631 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+The core dump path is an invalid directory
+2026-05-03 04:34:26.637 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:34:26.637 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:26.680 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:26.682 [unknown] [unknown] localhost 127855279244672 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -1,0 +1,130 @@
+The files belonging to this database system will be owned by user "opengauss".
+This user must also own the server process.
+
+The database cluster will be initialized with locale "C".
+The default database encoding has accordingly been set to "SQL_ASCII".
+The default text search configuration will be set to "english".
+
+fixing permissions on existing directory /var/lib/opengauss/data ... ok
+creating subdirectories ... in ordinary occasionok
+creating configuration files ... ok
+selecting default max_connections ... 100
+selecting default shared_buffers ... 1024MB
+Begin init undo subsystem meta.
+[INIT UNDO] Init undo subsystem meta successfully.
+creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
+2026-05-03 04:34:15.632 [unknown] [unknown] localhost 124721051293056 0[0:0#0]  [BACKEND] WARNING:  macAddr is 5870/1417580941, sysidentifier is 384717950/2441949405, randomNum is 3002806493
+ok
+initializing pg_authid ... ok
+setting password ... ok
+initializing dependencies ... ok
+loading PL/pgSQL server-side language ... ok
+creating system views ... ok
+creating performance views ... ok
+loading system objects' descriptions ... ok
+creating collations ... ok
+creating conversions ... ok
+creating dictionaries ... ok
+setting privileges on built-in objects ... ok
+initialize global configure for bucketmap length ... ok
+creating information schema ... ok
+loading foreign-data wrapper for distfs access ... ok
+loading foreign-data wrapper for log access ... ok
+loading hstore extension ... ok
+loading security plugin ... ok
+update system tables ... ok
+creating snapshots catalog ... ok
+vacuuming database template1 ... ok
+copying template1 to template0 ... ok
+copying template1 to postgres ... ok
+freezing database template0 ... ok
+freezing database template1 ... ok
+freezing database postgres ... ok
+
+WARNING: enabling "trust" authentication for local connections
+You can change this by editing pg_hba.conf or using the option -A, or
+--auth-local and --auth-host, the next time you run gs_initdb.
+
+Success. You can now start the database server of single node using:
+
+    gaussdb -D /var/lib/opengauss/data --single_node
+or
+    gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
+
+[2026-05-03 04:34:23.526][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:34:23.544][173][][gs_ctl]: waiting for server to start...
+.0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+	
+0 LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 04:34:23.585 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+	
+2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:34:23.634 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:34:23.662 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:34:23.697 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:34:23.697 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:34:23.746 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+The core dump path is an invalid directory
+2026-05-03 04:34:23.752 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 04:34:23.756 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:34:23.756 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+
+[2026-05-03 04:34:24.553][173][][gs_ctl]:  done
+[2026-05-03 04:34:24.553][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+GS_DB = opengauss
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
+CREATE DATABASE
+CREATE ROLE
+ALTER ROLE
+
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set user=fred
+CREATE ROLE
+ default no repuser created
+
+/var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
+
+[2026-05-03 04:34:25.434][230][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+waiting for server to shut down.... done
+server stopped
+
+openGauss  init process complete; ready for start up.
+

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:11:50.150 [unknown] [unknown] localhost 139683422274944 0[0:0#0]  [BACKEND] WARNING:  macAddr is 37470/761935295, sysidentifier is 2455645546/901760455, randomNum is 426493383
+2026-05-03 05:26:35.741 [unknown] [unknown] localhost 131920223491456 0[0:0#0]  [BACKEND] WARNING:  macAddr is 51800/381041659, sysidentifier is 3394770614/1006319777, randomNum is 386545825
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:11:57.431][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:11:57.446][174][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:26:43.678][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:26:43.696][174][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: c2d58772f604 
+0 LOG:  [Alarm Module]Host Name: b57f3edacbed 
 	
-0 LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:11:57.482 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:26:43.741 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: c2d58772f604 
+2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: b57f3edacbed 
 	
-2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:11:57.535 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:11:57.562 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:11:57.600 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:11:57.600 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:11:57.655 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:26:43.749 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:43.750 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:43.750 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:43.753 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:43.793 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:43.821 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:43.858 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:43.858 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:43.893 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:11:57.658 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:11:57.661 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:11:57.661 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:43.899 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:26:43.903 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:43.903 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:11:58.455][174][][gs_ctl]:  done
-[2026-05-03 05:11:58.455][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:26:44.704][174][][gs_ctl]:  done
+[2026-05-03 05:26:44.704][174][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:11:59.417][234][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:26:45.715][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:01:04.062 [unknown] [unknown] localhost 134657774298496 0[0:0#0]  [BACKEND] WARNING:  macAddr is 14912/4289983704, sysidentifier is 977338291/4107831082, randomNum is 805144362
+2026-05-03 05:11:50.150 [unknown] [unknown] localhost 139683422274944 0[0:0#0]  [BACKEND] WARNING:  macAddr is 37470/761935295, sysidentifier is 2455645546/901760455, randomNum is 426493383
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:01:12.177][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:01:12.195][174][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:11:57.431][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:11:57.446][174][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 5789c2277ac9 
+0 LOG:  [Alarm Module]Host Name: c2d58772f604 
 	
-0 LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:01:12.237 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:11:57.482 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5789c2277ac9 
+2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: c2d58772f604 
 	
-2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: c2d58772f604. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:11:57.488 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:01:12.244 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:01:12.245 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:12.245 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:01:12.283 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:01:12.313 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:01:12.351 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:01:12.351 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:01:12.392 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:57.490 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:11:57.494 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:11:57.535 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:11:57.562 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:11:57.600 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:11:57.600 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:11:57.655 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:01:12.397 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:01:12.401 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:01:12.401 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:57.658 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:11:57.661 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:11:57.661 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:57.701 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:57.702 [unknown] [unknown] localhost 127307298915712 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:01:13.202][174][][gs_ctl]:  done
-[2026-05-03 05:01:13.202][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:11:58.455][174][][gs_ctl]:  done
+[2026-05-03 05:11:58.455][174][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:01:14.209][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:11:59.417][234][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:26:35.741 [unknown] [unknown] localhost 131920223491456 0[0:0#0]  [BACKEND] WARNING:  macAddr is 51800/381041659, sysidentifier is 3394770614/1006319777, randomNum is 386545825
+2026-05-03 05:33:20.888 [unknown] [unknown] localhost 126147878442368 0[0:0#0]  [BACKEND] WARNING:  macAddr is 34312/3051618371, sysidentifier is 2248717796/4398026, randomNum is 3546553290
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:26:43.678][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:26:43.696][174][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:33:28.175][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:28.190][174][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: b57f3edacbed 
+0 LOG:  [Alarm Module]Host Name: 73da76a9d11e 
 	
-0 LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 73da76a9d11e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:43.741 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:28.224 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:33:28.229 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: b57f3edacbed 
+2026-05-03 05:33:28.229 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 73da76a9d11e 
 	
-2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: b57f3edacbed. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:28.229 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 73da76a9d11e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:28.229 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:43.747 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:28.229 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:43.749 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:43.750 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:43.750 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:43.753 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:43.754 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:43.793 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:43.821 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:43.858 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:43.858 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:43.893 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:33:28.231 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:28.232 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:28.232 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:28.235 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:28.235 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:28.235 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:28.235 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:28.235 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:28.265 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:28.295 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:28.330 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:28.330 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:28.376 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:26:43.899 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:26:43.903 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:43.903 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:43.949 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:43.950 [unknown] [unknown] localhost 127064845383040 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:28.383 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:33:28.387 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:28.387 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:28.426 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:28.426 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:28.426 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:28.426 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:28.427 [unknown] [unknown] localhost 132791887009152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:26:44.704][174][][gs_ctl]:  done
-[2026-05-03 05:26:44.704][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:33:29.195][174][][gs_ctl]:  done
+[2026-05-03 05:33:29.195][174][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:26:45.715][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:30.220][234][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 04:34:15.632 [unknown] [unknown] localhost 124721051293056 0[0:0#0]  [BACKEND] WARNING:  macAddr is 5870/1417580941, sysidentifier is 384717950/2441949405, randomNum is 3002806493
+2026-05-03 04:45:35.650 [unknown] [unknown] localhost 138860895896960 0[0:0#0]  [BACKEND] WARNING:  macAddr is 46710/60514129, sysidentifier is 3061187483/1599195003, randomNum is 2747451259
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 04:34:23.526][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 04:34:23.544][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 04:45:44.029][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:45:44.047][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+0 LOG:  [Alarm Module]Host Name: 72b816ee9192 
 	
-0 LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:34:23.585 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 04:45:44.087 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 88da788b3e0e 
+2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 72b816ee9192 
 	
-2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 88da788b3e0e. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:34:23.591 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:23.593 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:34:23.598 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:34:23.634 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:34:23.662 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:34:23.697 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:34:23.697 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:34:23.746 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:45:44.133 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:45:44.161 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:45:44.197 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:45:44.197 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:45:44.239 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 04:34:23.752 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 04:34:23.756 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:34:23.756 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:23.799 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:23.800 [unknown] [unknown] localhost 129665649702272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:44.244 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 04:45:44.247 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:45:44.247 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 04:34:24.553][173][][gs_ctl]:  done
-[2026-05-03 04:34:24.553][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 04:45:45.056][173][][gs_ctl]:  done
+[2026-05-03 04:45:45.056][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 04:34:25.434][230][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:45:46.132][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pg-array-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 04:45:35.650 [unknown] [unknown] localhost 138860895896960 0[0:0#0]  [BACKEND] WARNING:  macAddr is 46710/60514129, sysidentifier is 3061187483/1599195003, randomNum is 2747451259
+2026-05-03 05:01:04.062 [unknown] [unknown] localhost 134657774298496 0[0:0#0]  [BACKEND] WARNING:  macAddr is 14912/4289983704, sysidentifier is 977338291/4107831082, randomNum is 805144362
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 04:45:44.029][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 04:45:44.047][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:01:12.177][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:01:12.195][174][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 72b816ee9192 
+0 LOG:  [Alarm Module]Host Name: 5789c2277ac9 
 	
-0 LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:45:44.087 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:01:12.237 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 72b816ee9192 
+2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5789c2277ac9 
 	
-2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 72b816ee9192. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5789c2277ac9. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:45:44.093 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:01:12.243 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:44.095 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:45:44.099 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:45:44.133 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:45:44.161 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:45:44.197 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:45:44.197 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:45:44.239 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:01:12.244 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:01:12.245 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:12.245 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:01:12.248 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:01:12.283 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:01:12.313 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:01:12.351 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:01:12.351 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:01:12.392 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 04:45:44.244 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 04:45:44.247 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:45:44.247 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:44.290 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:44.291 [unknown] [unknown] localhost 132607552783744 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:12.397 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:01:12.401 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:01:12.401 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:12.443 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:12.445 [unknown] [unknown] localhost 126401351828864 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 04:45:45.056][173][][gs_ctl]:  done
-[2026-05-03 04:45:45.056][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:01:13.202][174][][gs_ctl]:  done
+[2026-05-03 05:01:13.202][174][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 04:45:46.132][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:01:14.209][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+0 LOG:  [Alarm Module]Host Name: 645964a40092 
 	
-0 LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 645964a40092. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:33.766 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:19.093 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:33:19.098 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+2026-05-03 05:33:19.098 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 645964a40092 
 	
-2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:19.098 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 645964a40092. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:19.098 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:19.098 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:33.772 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:33.773 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:33.773 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:33.821 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:33.852 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:33.893 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:33.893 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:33.917 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:33:19.100 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:19.100 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:19.100 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:19.104 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:19.104 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:19.104 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:19.104 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:19.104 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:19.136 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:19.166 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:19.202 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:19.202 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:19.230 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:26:33.923 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:33.923 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:19.235 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:19.235 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:19.275 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:19.275 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:19.275 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:19.275 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:19.276 [unknown] [unknown] localhost 133601934304640 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stderr.txt
@@ -1,0 +1,56 @@
+
+                        Message: The supplied GS_PASSWORD is meet requirements.
+
+0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+	
+0 LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 05:26:33.766 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+	
+2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 05:26:33.771 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 05:26:33.772 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:33.773 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:33.773 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:33.776 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:33.821 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:33.852 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:33.893 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:33.893 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:33.917 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+The core dump path is an invalid directory
+2026-05-03 05:26:33.923 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:33.923 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:33.971 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:33.972 [unknown] [unknown] localhost 136111321912704 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stdout.txt
@@ -1,0 +1,130 @@
+The files belonging to this database system will be owned by user "opengauss".
+This user must also own the server process.
+
+The database cluster will be initialized with locale "C".
+The default database encoding has accordingly been set to "SQL_ASCII".
+The default text search configuration will be set to "english".
+
+fixing permissions on existing directory /var/lib/opengauss/data ... ok
+creating subdirectories ... in ordinary occasionok
+creating configuration files ... ok
+selecting default max_connections ... 100
+selecting default shared_buffers ... 1024MB
+Begin init undo subsystem meta.
+[INIT UNDO] Init undo subsystem meta successfully.
+creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
+2026-05-03 05:26:22.669 [unknown] [unknown] localhost 139872727020928 0[0:0#0]  [BACKEND] WARNING:  macAddr is 42646/4078680351, sysidentifier is 2794910491/3105817963, randomNum is 3475965291
+ok
+initializing pg_authid ... ok
+setting password ... ok
+initializing dependencies ... ok
+loading PL/pgSQL server-side language ... ok
+creating system views ... ok
+creating performance views ... ok
+loading system objects' descriptions ... ok
+creating collations ... ok
+creating conversions ... ok
+creating dictionaries ... ok
+setting privileges on built-in objects ... ok
+initialize global configure for bucketmap length ... ok
+creating information schema ... ok
+loading foreign-data wrapper for distfs access ... ok
+loading foreign-data wrapper for log access ... ok
+loading hstore extension ... ok
+loading security plugin ... ok
+update system tables ... ok
+creating snapshots catalog ... ok
+vacuuming database template1 ... ok
+copying template1 to template0 ... ok
+copying template1 to postgres ... ok
+freezing database template0 ... ok
+freezing database template1 ... ok
+freezing database postgres ... ok
+
+WARNING: enabling "trust" authentication for local connections
+You can change this by editing pg_hba.conf or using the option -A, or
+--auth-local and --auth-host, the next time you run gs_initdb.
+
+Success. You can now start the database server of single node using:
+
+    gaussdb -D /var/lib/opengauss/data --single_node
+or
+    gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
+
+[2026-05-03 05:26:30.641][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:26:30.660][174][][gs_ctl]: waiting for server to start...
+.0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+	
+0 LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 05:26:30.703 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+	
+2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 05:26:30.710 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:30.711 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:30.711 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:30.756 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:30.786 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:30.825 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:30.825 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:30.879 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+The core dump path is an invalid directory
+2026-05-03 05:26:30.884 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:26:30.888 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:30.888 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+
+[2026-05-03 05:26:31.669][174][][gs_ctl]:  done
+[2026-05-03 05:26:31.669][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+GS_DB = opengauss
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
+CREATE DATABASE
+CREATE ROLE
+ALTER ROLE
+
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set user=fred
+CREATE ROLE
+ default no repuser created
+
+/var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
+
+[2026-05-03 05:26:32.725][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+waiting for server to shut down.... done
+server stopped
+
+openGauss  init process complete; ready for start up.
+

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-pooled-connection-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:26:22.669 [unknown] [unknown] localhost 139872727020928 0[0:0#0]  [BACKEND] WARNING:  macAddr is 42646/4078680351, sysidentifier is 2794910491/3105817963, randomNum is 3475965291
+2026-05-03 05:33:08.711 [unknown] [unknown] localhost 128012889527680 0[0:0#0]  [BACKEND] WARNING:  macAddr is 21032/14816454, sysidentifier is 1378353378/348584170, randomNum is 1794111722
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:26:30.641][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:26:30.660][174][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:33:15.978][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:15.994][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+0 LOG:  [Alarm Module]Host Name: 645964a40092 
 	
-0 LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 645964a40092. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:30.703 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:16.027 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:33:16.033 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 41db912e0ca4 
+2026-05-03 05:33:16.033 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 645964a40092 
 	
-2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 41db912e0ca4. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:16.033 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 645964a40092. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:16.033 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:30.708 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:16.033 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:30.710 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:30.711 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:30.711 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:30.715 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:30.756 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:30.786 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:30.825 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:30.825 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:30.879 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:33:16.035 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:16.035 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:16.035 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:16.039 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:16.039 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:16.039 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:16.039 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:16.039 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:16.071 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:16.094 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:16.132 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:16.132 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:16.184 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:26:30.884 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:26:30.888 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:30.888 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:30.934 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:30.936 [unknown] [unknown] localhost 127037113894272 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:16.192 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:33:16.195 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:16.195 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:16.234 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:16.234 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:16.234 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:16.234 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:16.235 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:16.235 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:16.235 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:16.235 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:16.236 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:16.236 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:16.236 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:16.236 [unknown] [unknown] localhost 126138446185856 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:26:31.669][174][][gs_ctl]:  done
-[2026-05-03 05:26:31.669][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:33:17.000][173][][gs_ctl]:  done
+[2026-05-03 05:33:17.000][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:26:32.725][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:18.051][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: ec1972a98c91 
+0 LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
 	
-0 LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:01:01.907 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:11:48.051 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: ec1972a98c91 
+2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
 	
-2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:01:01.953 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:01:01.981 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:01:02.019 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:01:02.019 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:01:02.037 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:11:48.093 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:11:48.116 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:11:48.150 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:11:48.150 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:11:48.183 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:01:02.042 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:01:02.042 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:48.189 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:11:48.189 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -1,0 +1,56 @@
+
+                        Message: The supplied GS_PASSWORD is meet requirements.
+
+0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 766f64295d3d 
+	
+0 LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 04:34:13.410 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 766f64295d3d 
+	
+2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:34:13.459 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:34:13.487 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:34:13.522 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:34:13.522 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:34:13.543 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+The core dump path is an invalid directory
+2026-05-03 04:34:13.550 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:34:13.550 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 766f64295d3d 
+0 LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
 	
-0 LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:34:13.410 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 04:45:33.192 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 766f64295d3d 
+2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
 	
-2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:34:13.414 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:13.416 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:34:13.420 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:34:13.459 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:34:13.487 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:34:13.522 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:34:13.522 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:34:13.543 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:45:33.245 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:45:33.275 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:45:33.314 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:45:33.316 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:45:33.340 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 04:34:13.550 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:34:13.550 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:13.593 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:13.594 [unknown] [unknown] localhost 135491421517184 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:33.346 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:45:33.346 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 46853825370b 
+0 LOG:  [Alarm Module]Host Name: 5b58c0420dd6 
 	
-0 LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 5b58c0420dd6. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:20.418 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:06.484 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:33:06.488 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 46853825370b 
+2026-05-03 05:33:06.488 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5b58c0420dd6 
 	
-2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:06.488 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5b58c0420dd6. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:06.488 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:06.488 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:20.424 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:20.425 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:20.425 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:20.471 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:20.498 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:20.533 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:20.533 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:20.546 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:33:06.491 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:06.491 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:06.491 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:06.495 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:06.495 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:06.495 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:06.495 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:06.495 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:06.535 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:06.563 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:06.600 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:06.601 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:06.628 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:26:20.554 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:20.554 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:06.634 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:06.634 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:06.677 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:06.677 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:06.677 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:06.677 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:06.678 [unknown] [unknown] localhost 133875534730624 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
+0 LOG:  [Alarm Module]Host Name: 46853825370b 
 	
-0 LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:11:48.051 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:26:20.418 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
+2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 46853825370b 
 	
-2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:11:48.056 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:26:20.422 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:48.057 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:11:48.061 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:11:48.093 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:11:48.116 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:11:48.150 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:11:48.150 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:11:48.183 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:26:20.424 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:20.425 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:20.425 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:20.429 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:20.471 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:20.498 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:20.533 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:20.533 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:20.546 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 05:11:48.189 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:11:48.189 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:48.229 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:48.230 [unknown] [unknown] localhost 133987078718848 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:20.554 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:20.554 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:20.598 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:20.599 [unknown] [unknown] localhost 137889861907840 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stderr.txt
@@ -3,9 +3,9 @@
 
 0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
+0 LOG:  [Alarm Module]Host Name: ec1972a98c91 
 	
-0 LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -15,42 +15,42 @@
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:45:33.192 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:01:01.907 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
+2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: ec1972a98c91 
 	
-2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:45:33.198 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:01:01.912 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:33.200 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:45:33.204 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:45:33.245 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:45:33.275 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:45:33.314 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:45:33.316 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:45:33.340 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
+2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:01.914 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:01:01.917 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:01:01.953 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:01:01.981 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:01:02.019 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:01:02.019 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:01:02.037 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 977, usable_fds = 1000, already_open = 13
 The core dump path is an invalid directory
-2026-05-03 04:45:33.346 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:45:33.346 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:33.392 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:33.393 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:33.394 [unknown] [unknown] localhost 138387984160128 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:02.042 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:01:02.042 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:02.085 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:01:02.086 [unknown] [unknown] localhost 132119164089728 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:11:37.064 [unknown] [unknown] localhost 130915715675520 0[0:0#0]  [BACKEND] WARNING:  macAddr is 28389/3847925063, sysidentifier is 1860560218/2907124451, randomNum is 2188391139
+2026-05-03 05:26:09.015 [unknown] [unknown] localhost 126455250380160 0[0:0#0]  [BACKEND] WARNING:  macAddr is 22256/2761054699, sysidentifier is 1458611346/1508596070, randomNum is 194599270
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:11:44.991][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:11:45.007][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:26:17.299][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:26:17.319][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
+0 LOG:  [Alarm Module]Host Name: 46853825370b 
 	
-0 LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:11:45.043 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:26:17.369 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
+2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 46853825370b 
 	
-2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:11:45.088 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:11:45.115 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:11:45.151 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:11:45.151 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:11:45.186 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:26:17.377 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:26:17.378 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:17.378 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:26:17.425 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:26:17.453 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:26:17.490 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:26:17.490 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:26:17.527 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:11:45.191 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:11:45.195 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:11:45.195 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:17.532 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:26:17.536 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:26:17.536 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:11:46.016][173][][gs_ctl]:  done
-[2026-05-03 05:11:46.016][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:26:18.331][173][][gs_ctl]:  done
+[2026-05-03 05:26:18.331][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:11:47.018][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:26:19.377][230][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:00:51.082 [unknown] [unknown] localhost 124636558079360 0[0:0#0]  [BACKEND] WARNING:  macAddr is 47631/2710215052, sysidentifier is 3121586570/2576107995, randomNum is 2249411035
+2026-05-03 05:11:37.064 [unknown] [unknown] localhost 130915715675520 0[0:0#0]  [BACKEND] WARNING:  macAddr is 28389/3847925063, sysidentifier is 1860560218/2907124451, randomNum is 2188391139
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:00:58.758][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:00:58.778][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:11:44.991][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:11:45.007][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: ec1972a98c91 
+0 LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
 	
-0 LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:00:58.822 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:11:45.043 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: ec1972a98c91 
+2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 6d30d0c4a413 
 	
-2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 6d30d0c4a413. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:11:45.049 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:00:58.828 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:00:58.829 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:00:58.829 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:00:58.834 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:00:58.875 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:00:58.902 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:00:58.940 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:00:58.940 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:00:58.993 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:45.051 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:11:45.055 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:11:45.088 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:11:45.115 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:11:45.151 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:11:45.151 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:11:45.186 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:00:58.999 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:00:59.003 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:00:59.003 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:45.191 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:11:45.195 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:11:45.195 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:45.239 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:11:45.240 [unknown] [unknown] localhost 126731087967616 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:00:59.786][173][][gs_ctl]:  done
-[2026-05-03 05:00:59.786][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:11:46.016][173][][gs_ctl]:  done
+[2026-05-03 05:11:46.016][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:01:00.869][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:11:47.018][233][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 04:34:02.213 [unknown] [unknown] localhost 136220612732288 0[0:0#0]  [BACKEND] WARNING:  macAddr is 9731/522589031, sysidentifier is 637738790/325563472, randomNum is 3039278160
+2026-05-03 04:45:22.188 [unknown] [unknown] localhost 139494132200832 0[0:0#0]  [BACKEND] WARNING:  macAddr is 36580/643738492, sysidentifier is 2397316702/2877043684, randomNum is 3520017380
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 04:34:10.355][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 04:34:10.372][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 04:45:30.089][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:45:30.108][174][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 766f64295d3d 
+0 LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
 	
-0 LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:34:10.415 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 04:45:30.153 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 766f64295d3d 
+2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
 	
-2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:34:10.421 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:34:10.422 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:34:10.423 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:10.423 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:34:10.468 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:34:10.498 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:34:10.534 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:34:10.534 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:34:10.571 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:45:30.208 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:45:30.239 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:45:30.279 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:45:30.279 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:45:30.318 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 04:34:10.576 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 04:34:10.580 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:34:10.580 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:30.323 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 04:45:30.326 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:45:30.326 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 04:34:11.380][173][][gs_ctl]:  done
-[2026-05-03 04:34:11.380][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 04:45:31.118][174][][gs_ctl]:  done
+[2026-05-03 04:45:31.118][174][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 04:34:12.371][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:45:32.151][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 04:45:22.188 [unknown] [unknown] localhost 139494132200832 0[0:0#0]  [BACKEND] WARNING:  macAddr is 36580/643738492, sysidentifier is 2397316702/2877043684, randomNum is 3520017380
+2026-05-03 05:00:51.082 [unknown] [unknown] localhost 124636558079360 0[0:0#0]  [BACKEND] WARNING:  macAddr is 47631/2710215052, sysidentifier is 3121586570/2576107995, randomNum is 2249411035
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 04:45:30.089][174][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 04:45:30.108][174][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:00:58.758][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:00:58.778][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
+0 LOG:  [Alarm Module]Host Name: ec1972a98c91 
 	
-0 LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 04:45:30.153 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:00:58.822 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 0f71e26f1b95 
+2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: ec1972a98c91 
 	
-2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 0f71e26f1b95. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: ec1972a98c91. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 04:45:30.158 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:00:58.827 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:30.160 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 04:45:30.165 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 04:45:30.208 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 04:45:30.239 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 04:45:30.279 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 04:45:30.279 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 04:45:30.318 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:00:58.828 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:00:58.829 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:00:58.829 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:00:58.834 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:00:58.835 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:00:58.875 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:00:58.902 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:00:58.940 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:00:58.940 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:00:58.993 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 04:45:30.323 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 04:45:30.326 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 04:45:30.326 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:30.368 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 04:45:30.369 [unknown] [unknown] localhost 135331455739264 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:00:58.999 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:00:59.003 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:00:59.003 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:00:59.049 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:00:59.050 [unknown] [unknown] localhost 125746411681152 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 04:45:31.118][174][][gs_ctl]:  done
-[2026-05-03 04:45:31.118][174][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:00:59.786][173][][gs_ctl]:  done
+[2026-05-03 05:00:59.786][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 04:45:32.151][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:01:00.869][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -1,0 +1,130 @@
+The files belonging to this database system will be owned by user "opengauss".
+This user must also own the server process.
+
+The database cluster will be initialized with locale "C".
+The default database encoding has accordingly been set to "SQL_ASCII".
+The default text search configuration will be set to "english".
+
+fixing permissions on existing directory /var/lib/opengauss/data ... ok
+creating subdirectories ... in ordinary occasionok
+creating configuration files ... ok
+selecting default max_connections ... 100
+selecting default shared_buffers ... 1024MB
+Begin init undo subsystem meta.
+[INIT UNDO] Init undo subsystem meta successfully.
+creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
+2026-05-03 04:34:02.213 [unknown] [unknown] localhost 136220612732288 0[0:0#0]  [BACKEND] WARNING:  macAddr is 9731/522589031, sysidentifier is 637738790/325563472, randomNum is 3039278160
+ok
+initializing pg_authid ... ok
+setting password ... ok
+initializing dependencies ... ok
+loading PL/pgSQL server-side language ... ok
+creating system views ... ok
+creating performance views ... ok
+loading system objects' descriptions ... ok
+creating collations ... ok
+creating conversions ... ok
+creating dictionaries ... ok
+setting privileges on built-in objects ... ok
+initialize global configure for bucketmap length ... ok
+creating information schema ... ok
+loading foreign-data wrapper for distfs access ... ok
+loading foreign-data wrapper for log access ... ok
+loading hstore extension ... ok
+loading security plugin ... ok
+update system tables ... ok
+creating snapshots catalog ... ok
+vacuuming database template1 ... ok
+copying template1 to template0 ... ok
+copying template1 to postgres ... ok
+freezing database template0 ... ok
+freezing database template1 ... ok
+freezing database postgres ... ok
+
+WARNING: enabling "trust" authentication for local connections
+You can change this by editing pg_hba.conf or using the option -A, or
+--auth-local and --auth-host, the next time you run gs_initdb.
+
+Success. You can now start the database server of single node using:
+
+    gaussdb -D /var/lib/opengauss/data --single_node
+or
+    gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
+
+[2026-05-03 04:34:10.355][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 04:34:10.372][173][][gs_ctl]: waiting for server to start...
+.0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+0 LOG:  [Alarm Module]Host Name: 766f64295d3d 
+	
+0 LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+0 LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+0 WARNING:  failed to open feature control file, please check whether it exists: FileName=gaussdb.version, Errno=2, Errmessage=No such file or directory.
+0 WARNING:  failed to parse feature control file: gaussdb.version.
+0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
+The core dump path is an invalid directory
+2026-05-03 04:34:10.415 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+	
+2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 766f64295d3d 
+	
+2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 766f64295d3d. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+	
+2026-05-03 04:34:10.420 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+	
+2026-05-03 04:34:10.421 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+	
+2026-05-03 04:34:10.422 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 04:34:10.423 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:10.423 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 04:34:10.426 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 04:34:10.468 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 04:34:10.498 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 04:34:10.534 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 04:34:10.534 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 04:34:10.571 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+The core dump path is an invalid directory
+2026-05-03 04:34:10.576 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 04:34:10.580 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 04:34:10.580 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:10.624 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 04:34:10.626 [unknown] [unknown] localhost 139265650201984 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+
+[2026-05-03 04:34:11.380][173][][gs_ctl]:  done
+[2026-05-03 04:34:11.380][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+GS_DB = opengauss
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
+CREATE DATABASE
+CREATE ROLE
+ALTER ROLE
+
+Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set user=fred
+CREATE ROLE
+ default no repuser created
+
+/var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
+
+[2026-05-03 04:34:12.371][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+waiting for server to shut down.... done
+server stopped
+
+openGauss  init process complete; ready for start up.
+

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/opengauss-stdout.txt
@@ -13,7 +13,7 @@ selecting default shared_buffers ... 1024MB
 Begin init undo subsystem meta.
 [INIT UNDO] Init undo subsystem meta successfully.
 creating template1 database in /var/lib/opengauss/data/base/1 ... The core dump path is an invalid directory
-2026-05-03 05:26:09.015 [unknown] [unknown] localhost 126455250380160 0[0:0#0]  [BACKEND] WARNING:  macAddr is 22256/2761054699, sysidentifier is 1458611346/1508596070, randomNum is 194599270
+2026-05-03 05:32:55.239 [unknown] [unknown] localhost 137028478616960 0[0:0#0]  [BACKEND] WARNING:  macAddr is 1574/3909690266, sysidentifier is 103213321/597337635, randomNum is 541500963
 ok
 initializing pg_authid ... ok
 setting password ... ok
@@ -51,13 +51,13 @@ Success. You can now start the database server of single node using:
 or
     gs_ctl start -D /var/lib/opengauss/data -Z single_node -l logfile
 
-[2026-05-03 05:26:17.299][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
-[2026-05-03 05:26:17.319][173][][gs_ctl]: waiting for server to start...
+[2026-05-03 05:33:03.342][173][][gs_ctl]: gs_ctl started,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:03.357][173][][gs_ctl]: waiting for server to start...
 .0 LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-0 LOG:  [Alarm Module]Host Name: 46853825370b 
+0 LOG:  [Alarm Module]Host Name: 5b58c0420dd6 
 	
-0 LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+0 LOG:  [Alarm Module]Host IP: 5b58c0420dd6. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
 0 LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
@@ -67,49 +67,49 @@ or
 0 WARNING:  failed to parse feature control file: gaussdb.version.
 0 WARNING:  Failed to load the product control file, so gaussdb cannot distinguish product version.
 The core dump path is an invalid directory
-2026-05-03 05:26:17.369 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
-gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
+2026-05-03 05:33:03.393 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  when starting as multi_standby mode, we couldn't support data replicaton.
+gaussdb.state does not exist, and skipt setting since it is optional.2026-05-03 05:33:03.399 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]can not read GAUSS_WARNING_TYPE env.
 	
-2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 46853825370b 
+2026-05-03 05:33:03.399 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host Name: 5b58c0420dd6 
 	
-2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 46853825370b. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
+2026-05-03 05:33:03.399 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Host IP: 5b58c0420dd6. Copy hostname directly in case of taking 10s to use 'gethostbyname' when /etc/hosts does not contain <HOST IP>
 	
-2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
+2026-05-03 05:33:03.399 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Get ENV GS_CLUSTER_NAME failed!
 	
-2026-05-03 05:26:17.376 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
+2026-05-03 05:33:03.399 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  [Alarm Module]Invalid data in AlarmItem file! Read alarm English name failed! line: 57
 	
-2026-05-03 05:26:17.377 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
-2026-05-03 05:26:17.378 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:17.378 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
-2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
-2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
-2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
-2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
-2026-05-03 05:26:17.383 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
-2026-05-03 05:26:17.425 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
-2026-05-03 05:26:17.453 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
-2026-05-03 05:26:17.490 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
-2026-05-03 05:26:17.490 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
-2026-05-03 05:26:17.527 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
+2026-05-03 05:33:03.401 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  loaded library "security_plugin"
+2026-05-03 05:33:03.401 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:03.401 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] WARNING:  could not create any HA TCP/IP sockets
+2026-05-03 05:33:03.404 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  InitNuma numaNodeNum: 1 numa_distribute_mode: none inheritThreadPool: 0.
+2026-05-03 05:33:03.404 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for backend threads is: 220 MB
+2026-05-03 05:33:03.404 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  reserved memory for WAL buffers is: 128 MB
+2026-05-03 05:33:03.404 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  Set max backend reserve memory is: 348 MB, max dynamic memory is: 8142 MB
+2026-05-03 05:33:03.404 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  shared memory 3285 Mbytes, memory context 8490 Mbytes, max process memory 12288 Mbytes
+2026-05-03 05:33:03.437 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [CACHE] LOG:  set data cache  size(402653184)
+2026-05-03 05:33:03.466 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [SEGMENT_PAGE] LOG:  Segment-page constants: DF_MAP_SIZE: 8156, DF_MAP_BIT_CNT: 65248, DF_MAP_GROUP_EXTENTS: 4175872, IPBLOCK_SIZE: 8168, EXTENTS_PER_IPBLOCK: 1021, IPBLOCK_GROUP_SIZE: 4090, BMT_HEADER_LEVEL0_TOTAL_PAGES: 8323072, BktMapEntryNumberPerBlock: 2038, BktMapBlockNumber: 25, BktBitMaxMapCnt: 512
+2026-05-03 05:33:03.504 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  gaussdb: fsync file "/var/lib/opengauss/data/gaussdb.state.temp" success
+2026-05-03 05:33:03.504 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  create gaussdb state file success: db state(STARTING_STATE), server mode(Normal), connection index(1)
+2026-05-03 05:33:03.559 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  max_safe_fds = 976, usable_fds = 1000, already_open = 14
 The core dump path is an invalid directory
-2026-05-03 05:26:17.532 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
-2026-05-03 05:26:17.536 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
-2026-05-03 05:26:17.536 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
-2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:17.579 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
-2026-05-03 05:26:17.580 [unknown] [unknown] localhost 132078117864832 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:03.564 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  user configure file is not found, it will be created.
+2026-05-03 05:33:03.567 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  the configure file /usr/local/opengauss/etc/gscgroup_opengauss.cfg doesn't exist or the size of configure file has changed. Please create it by root user!
+2026-05-03 05:33:03.567 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [BACKEND] LOG:  Failed to parse cgroup config file.
+2026-05-03 05:33:03.610 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:03.610 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:03.610 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:03.610 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] WARNING:  Failed to obtain environment value $GAUSSLOG!
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] DETAIL:  N/A
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] CAUSE:  Incorrect environment value.
+2026-05-03 05:33:03.611 [unknown] [unknown] localhost 134757030770048 0[0:0#0]  0 [EXECUTOR] ACTION:  Please refer to backend log for more details.
 
-[2026-05-03 05:26:18.331][173][][gs_ctl]:  done
-[2026-05-03 05:26:18.331][173][][gs_ctl]: server started (/var/lib/opengauss/data)
+[2026-05-03 05:33:04.365][173][][gs_ctl]:  done
+[2026-05-03 05:33:04.365][173][][gs_ctl]: server started (/var/lib/opengauss/data)
 GS_DB = opengauss
 Execute SQL: gsql -v ON_ERROR_STOP=1 --username opengauss --password Secretpassword@123 --dbname postgres --set db=opengauss --set passwd=Secretpassword@123 --set passwd=Secretpassword@123
 CREATE DATABASE
@@ -122,7 +122,7 @@ CREATE ROLE
 
 /var/lib/opengauss/entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
 
-[2026-05-03 05:26:19.377][230][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
+[2026-05-03 05:33:05.442][232][][gs_ctl]: gs_ctl stopped ,datadir is /var/lib/opengauss/data 
 waiting for server to shut down.... done
 server stopped
 

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/required-docker-images.txt
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/required-docker-images.txt
@@ -1,0 +1,1 @@
+opengauss/opengauss:5.0.0

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/settings.gradle
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.opengauss.opengauss-jdbc_tests'

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BaseDataSourceTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BaseDataSourceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BaseDataSourceTest {
+
+    @Test
+    void initializeFromCopiesBaseDataSourceStateThroughObjectStreams() throws Exception {
+        PGSimpleDataSource source = new PGSimpleDataSource();
+        source.setServerName("primary.example.test");
+        source.setPortNumber(15432);
+        source.setDatabaseName("sampledb");
+        source.setUser("sample-user");
+        source.setPassword("sample-password");
+        source.setAllowEncodingChanges(true);
+        source.setCharacterEncoding("UTF-8");
+        source.setConnectionExtraInfo(true);
+        source.setApplicationName("metadata-coverage");
+        source.setConnectTimeout(7);
+        source.setSsl(true);
+
+        PGSimpleDataSource target = new PGSimpleDataSource();
+        target.initializeFrom(source);
+
+        assertThat(target.getServerName()).isEqualTo("primary.example.test");
+        assertThat(target.getPortNumber()).isEqualTo(15432);
+        assertThat(target.getDatabaseName()).isEqualTo("sampledb");
+        assertThat(target.getUser()).isEqualTo("sample-user");
+        assertThat(target.getPassword()).isEqualTo("sample-password");
+        assertThat(target.getAllowEncodingChanges()).isTrue();
+        assertThat(target.getCharacterEncoding()).isEqualTo("UTF-8");
+        assertThat(target.getConnectionExtraInfo()).isTrue();
+        assertThat(target.getApplicationName()).isEqualTo("metadata-coverage");
+        assertThat(target.getConnectTimeout()).isEqualTo(7);
+        assertThat(target.getSsl()).isTrue();
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
@@ -33,6 +33,14 @@ public class BouncyCastlePrivateKeyFactoryTest {
     private static final char[] PASSWORD = "changeit".toCharArray();
 
     @Test
+    void initializesBouncyCastleProviderThroughFactory() throws Exception {
+        Provider provider = BouncyCastlePrivateKeyFactory.initBouncyCastleProvider();
+
+        assertThat(provider).isInstanceOf(BouncyCastleProvider.class);
+        assertThat(provider.getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
+    }
+
+    @Test
     void decryptsBouncyCastleEncryptedPkcs8PrivateKey() throws Exception {
         Provider provider = ensureBouncyCastleProvider();
         KeyPair keyPair = generateRsaKeyPair(provider);

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ssl.BouncyCastlePrivateKeyFactory;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Arrays;
+
+import javax.security.auth.callback.PasswordCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BouncyCastlePrivateKeyFactoryTest {
+    private static final char[] PASSWORD = "changeit".toCharArray();
+
+    @Test
+    void decryptsBouncyCastleEncryptedPkcs8PrivateKey() throws Exception {
+        Provider provider = ensureBouncyCastleProvider();
+        KeyPair keyPair = generateRsaKeyPair(provider);
+        byte[] encryptedKey = encryptPrivateKey(provider, keyPair.getPrivate());
+        PasswordCallback passwordCallback = new PasswordCallback("Private key password", false);
+        passwordCallback.setPassword(Arrays.copyOf(PASSWORD, PASSWORD.length));
+
+        try {
+            PrivateKey privateKey = new BouncyCastlePrivateKeyFactory()
+                    .getPrivateKeyFromEncryptedKey(encryptedKey, passwordCallback);
+
+            assertThat(privateKey.getAlgorithm()).isEqualTo(keyPair.getPrivate().getAlgorithm());
+            assertThat(privateKey.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+        } finally {
+            passwordCallback.clearPassword();
+        }
+    }
+
+    private static Provider ensureBouncyCastleProvider() {
+        Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+        if (provider == null) {
+            provider = new BouncyCastleProvider();
+            Security.addProvider(provider);
+        }
+        return provider;
+    }
+
+    private static KeyPair generateRsaKeyPair(Provider provider) throws Exception {
+        ProviderJcaJceHelper helper = new ProviderJcaJceHelper(provider);
+        KeyPairGenerator keyPairGenerator = helper.createKeyPairGenerator("RSA");
+        keyPairGenerator.initialize(1024, new SecureRandom());
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static byte[] encryptPrivateKey(Provider provider, PrivateKey privateKey) throws Exception {
+        OutputEncryptor encryptor = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES)
+                .setProvider(provider)
+                .setRandom(new SecureRandom())
+                .setPasssword(PASSWORD)
+                .build();
+        PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+        PKCS8EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new PKCS8EncryptedPrivateKeyInfoBuilder(privateKeyInfo)
+                .build(encryptor);
+        return encryptedPrivateKeyInfo.getEncoded();
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Opengauss_jdbcTest {
+    private static final String USERNAME = "fred";
+    private static final String PASSWORD = "Secretpassword@123";
+    private static final String DATABASE = "postgres";
+    private static final String JDBC_URL = "jdbc:opengauss://localhost:15432/" + DATABASE;
+    private static Process process;
+
+    private static Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", USERNAME);
+        props.setProperty("password", PASSWORD);
+        return DriverManager.getConnection(JDBC_URL, props);
+    }
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting OpenGauss ...");
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "-p", "15432:5432", "-e", "GS_USERNAME=" + USERNAME,
+                "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                .redirectOutput(new File("opengauss-stdout.txt")).redirectError(new File("opengauss-stderr.txt")).start();
+        Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            openConnection().close();
+            return true;
+        });
+        System.out.println("OpenGauss started");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (process != null && process.isAlive()) {
+            System.out.println("Shutting down OpenGauss");
+            process.destroy();
+        }
+    }
+
+    @Test
+    void commitAndRollback() throws Exception {
+        try (Connection conn = openConnection()) {
+            conn.setAutoCommit(false);
+            // OpenGauss 3.1.0 does not support `CREATE TABLE foo (id INT GENERATED ALWAYS AS IDENTITY, name VARCHAR)` SQL
+            conn.prepareStatement("CREATE TABLE foo (id SERIAL, name VARCHAR)").execute();
+            conn.commit();
+        }
+        try (Connection conn = openConnection()) {
+            conn.setAutoCommit(false);
+            PreparedStatement statement = conn.prepareStatement("INSERT INTO foo (name) VALUES (?)");
+            statement.setString(1, "Adam");
+            statement.execute();
+            statement.setString(1, "Eve");
+            statement.execute();
+            conn.commit();
+        }
+        try (Connection conn = openConnection()) {
+            conn.setAutoCommit(false);
+            conn.prepareStatement("DELETE FROM foo").execute();
+            conn.rollback();
+        }
+        try (Connection conn = openConnection()) {
+            conn.setAutoCommit(false);
+            try (ResultSet resultSet = conn.prepareStatement("SELECT * FROM foo").executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getInt(1)).isEqualTo(1);
+                assertThat(resultSet.getString(2)).isEqualTo("Adam");
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getInt(1)).isEqualTo(2);
+                assertThat(resultSet.getString(2)).isEqualTo("Eve");
+                assertThat(resultSet.next()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    void otherDatatypes() throws Exception {
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            // OpenGauss 3.1.0 does not support macaddr8 type
+            connection.prepareStatement("""
+                    CREATE TABLE other_datatypes
+                    (
+                        c1 cidr,
+                        i1 inet,
+                        i2 interval,
+                        m1 macaddr,
+                        m2 macaddr,
+                        m3 money,
+                        n1 numeric(10, 2),
+                        t1 tsvector
+                    )
+                    """).execute();
+            PreparedStatement statement = connection.prepareStatement("""
+                    INSERT INTO other_datatypes
+                    VALUES (CAST(? as cidr), CAST(? as inet), CAST(? as interval), CAST(? as macaddr), CAST(? as macaddr), ?, ?,
+                            CAST(? as tsvector))
+                    """);
+            statement.setString(1, "192.168.100.128/25");
+            statement.setString(2, "fe80::20c:29ff:fe8a:cd55/64");
+            statement.setString(3, "1 year 2 months 3 days 4 hours 5 minutes 6 seconds");
+            statement.setString(4, "08:00:2b:01:02:03");
+            statement.setString(5, "08:00:2b:01:02:03");
+            statement.setInt(6, 12);
+            statement.setDouble(7, Math.PI);
+            statement.setString(8, "this is an example sentence");
+            statement.execute();
+            try (ResultSet resultSet = connection.prepareStatement("SELECT * FROM other_datatypes").executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                for (int i = 1; i <= 8; i++) {
+                    System.out.printf("column %d: %s%n", i, resultSet.getObject(i));
+                }
+            }
+        }
+    }
+
+    @Test
+    void geometricDatatypes() throws Exception {
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            // OpenGauss 3.1.0 does not support line type
+            connection.prepareStatement("""
+                    CREATE TABLE geometric_datatypes
+                    (
+                        b1 box,
+                        c1 circle,
+                        l1 lseg,
+                        l2 lseg,
+                        p1 path,
+                        p2 point,
+                        p3 polygon
+                    )
+                    """).execute();
+            PreparedStatement statement = connection.prepareStatement("""
+                    INSERT INTO geometric_datatypes
+                    VALUES (CAST(? as box), CAST(? as circle), CAST(? as lseg), CAST(? as lseg), CAST(? as path), CAST(? as point),
+                            CAST(? as polygon))
+                    """);
+            statement.setString(1, "(0, 0), (10, 10)");
+            statement.setString(2, "< (0, 0), 5 >");
+            statement.setString(3, "[ ( 0, 1 ), ( 2, 3 ) ]");
+            statement.setString(4, "[ ( 0, 1 ), ( 2, 3 ) ]");
+            statement.setString(5, "[ ( 1, 2 ), ( 3, 4 ), ( 5, 6 ) ]");
+            statement.setString(6, "( 1, 2 )");
+            statement.setString(7, "( ( 1, 2 ), ( 3, 4 ), ( 5, 6 ) )");
+            statement.execute();
+            try (ResultSet resultSet = connection.prepareStatement("SELECT * FROM geometric_datatypes").executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                for (int i = 1; i <= 7; i++) {
+                    System.out.printf("column %d: %s%n", i, resultSet.getObject(i));
+                }
+            }
+        }
+    }
+
+    @Test
+    void simpleDatatypes() throws Exception {
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            // OpenGauss 3.1.0 does not support xml type
+            connection.prepareStatement("""
+                    CREATE TABLE simple_datatypes
+                    (
+                        b1 bigint,
+                        b2 bit(1),
+                        b3 boolean,
+                        b4 bytea,
+                        c1 character(1),
+                        c2 character varying,
+                        d1 date,
+                        d2 double precision,
+                        i1 integer,
+                        j1 json,
+                        j2 jsonb,
+                        r1 real,
+                        s1 smallint,
+                        t1 text,
+                        t2 time,
+                        t3 time with time zone,
+                        t4 timestamp,
+                        t5 timestamp with time zone,
+                        u1 uuid,
+                        x1 text,
+                        n1 integer
+                    )
+                    """).execute();
+            PreparedStatement statement = connection.prepareStatement("""
+                    INSERT INTO simple_datatypes
+                    VALUES (?, CAST(? AS bit), ?, ?, ?, ?, ?, ?, ?, CAST(? AS json), CAST(? AS jsonb), ?, ?, ?, ?, ?, ?, ?, ?,
+                            CAST(? AS text), ?)
+                    """);
+            statement.setLong(1, Long.MAX_VALUE);
+            statement.setString(2, "1");
+            statement.setBoolean(3, true);
+            statement.setObject(4, "some-bytes".getBytes(StandardCharsets.UTF_8));
+            statement.setString(5, "c");
+            statement.setString(6, "some-string");
+            statement.setDate(7, Date.valueOf(LocalDate.of(2020, 1, 2)));
+            statement.setDouble(8, Math.PI);
+            statement.setInt(9, 42);
+            statement.setString(10, "{ \"foo\": \"bar\"}");
+            statement.setString(11, "{ \"foo\": \"bar\"}");
+            statement.setFloat(12, (float) Math.PI);
+            statement.setInt(13, 5);
+            statement.setString(14, "some-text");
+            statement.setObject(15, LocalTime.of(23, 59));
+            // org.opengauss:opengauss-jdbc:3.1.0-og does not support java.time.OffsetTime
+            statement.setObject(16, LocalTime.of(23, 59, 0, 0));
+            statement.setObject(17, LocalDateTime.of(2020, 1, 2, 23, 59, 0));
+            statement.setObject(18, OffsetDateTime.of(2020, 1, 2, 23, 59, 0, 0, ZoneOffset.ofHours(3)));
+            statement.setObject(19, UUID.randomUUID());
+            statement.setString(20, "<foo><bar></bar></foo>");
+            statement.setNull(21, Types.INTEGER);
+            statement.execute();
+            try (ResultSet resultSet = connection.prepareStatement("SELECT * FROM simple_datatypes").executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                for (int i = 1; i <= 21; i++) {
+                    System.out.printf("column %d: %s%n", i, resultSet.getObject(i));
+                }
+            }
+        }
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -29,6 +31,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,36 +39,77 @@ class Opengauss_jdbcTest {
     private static final String USERNAME = "fred";
     private static final String PASSWORD = "Secretpassword@123";
     private static final String DATABASE = "postgres";
-    private static final String JDBC_URL = "jdbc:opengauss://localhost:15432/" + DATABASE;
+    private static int hostPort;
+    private static Path containerIdFile;
     private static Process process;
+    private static String containerId;
 
     private static Connection openConnection() throws SQLException {
         Properties props = new Properties();
         props.setProperty("user", USERNAME);
         props.setProperty("password", PASSWORD);
-        return DriverManager.getConnection(JDBC_URL, props);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
     }
 
     @BeforeAll
     static void beforeAll() throws IOException {
         System.out.println("Starting OpenGauss ...");
+        containerIdFile = Files.createTempFile("opengauss-jdbc-test-", ".cid");
+        Files.delete(containerIdFile);
         process = new ProcessBuilder(
-                "docker", "run", "--rm", "-p", "15432:5432", "-e", "GS_USERNAME=" + USERNAME,
-                "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
                 .redirectOutput(new File("opengauss-stdout.txt")).redirectError(new File("opengauss-stderr.txt")).start();
         Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
             openConnection().close();
             return true;
         });
-        System.out.println("OpenGauss started");
+        System.out.println("OpenGauss started on port " + hostPort);
     }
 
     @AfterAll
-    static void tearDown() {
-        if (process != null && process.isAlive()) {
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
             System.out.println("Shutting down OpenGauss");
-            process.destroy();
+            runDockerCommand("docker", "stop", containerId);
         }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
+        }
+        return output;
     }
 
     @Test

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PGPooledConnectionInnerConnectionHandlerTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PGPooledConnectionInnerConnectionHandlerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.postgresql.PGStatement;
+import org.postgresql.ds.PGPooledConnection;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PGPooledConnectionInnerConnectionHandlerTest {
+    private static final String USERNAME = "fred";
+    private static final String PASSWORD = "Secretpassword@123";
+    private static final String DATABASE = "postgres";
+    private static int hostPort;
+    private static Path containerIdFile;
+    private static Process process;
+    private static String containerId;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting OpenGauss for PGPooledConnection.ConnectionHandler tests ...");
+        containerIdFile = Files.createTempFile("opengauss-pooled-connection-test-", ".cid");
+        Files.delete(containerIdFile);
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                .redirectOutput(new File("opengauss-pooled-connection-stdout.txt"))
+                .redirectError(new File("opengauss-pooled-connection-stderr.txt"))
+                .start();
+        Awaitility.await().atMost(Duration.ofSeconds(55)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
+            openConnection().close();
+            return true;
+        });
+        System.out.println("OpenGauss for PGPooledConnection.ConnectionHandler tests started on port " + hostPort);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
+            System.out.println("Shutting down OpenGauss for PGPooledConnection.ConnectionHandler tests");
+            runDockerCommand("docker", "stop", containerId);
+        }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    @Test
+    void delegatesConnectionOperationsAndWrapsCreatedStatements() throws Exception {
+        try (Connection physicalConnection = openConnection()) {
+            PGPooledConnection pooledConnection = new PGPooledConnection(physicalConnection, false);
+            try {
+                Connection pooledHandle = pooledConnection.getConnection();
+
+                assertThat(pooledHandle.getAutoCommit()).isFalse();
+
+                try (Statement statement = pooledHandle.createStatement()) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+                try (CallableStatement statement = pooledHandle.prepareCall("SELECT 1")) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+                try (PreparedStatement statement = pooledHandle.prepareStatement("SELECT ?")) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+
+                pooledHandle.close();
+                assertThat(pooledHandle.isClosed()).isTrue();
+            } finally {
+                pooledConnection.close();
+            }
+        }
+    }
+
+    private static Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", USERNAME);
+        props.setProperty("password", PASSWORD);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
+        }
+        return output;
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PgArrayTest.java
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PgArrayTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Oid;
+import org.postgresql.jdbc.PgArray;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PgArrayTest {
+    private static final String USERNAME = "fred";
+    private static final String PASSWORD = "Secretpassword@123";
+    private static final String DATABASE = "postgres";
+    private static int hostPort;
+    private static Path containerIdFile;
+    private static Process process;
+    private static String containerId;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting OpenGauss for PgArray tests ...");
+        containerIdFile = Files.createTempFile("opengauss-pg-array-test-", ".cid");
+        Files.delete(containerIdFile);
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                .redirectOutput(new File("opengauss-pg-array-stdout.txt"))
+                .redirectError(new File("opengauss-pg-array-stderr.txt"))
+                .start();
+        Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
+            openConnection().close();
+            return true;
+        });
+        System.out.println("OpenGauss for PgArray tests started on port " + hostPort);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
+            System.out.println("Shutting down OpenGauss for PgArray tests");
+            runDockerCommand("docker", "stop", containerId);
+        }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    @Test
+    void buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.BOOL_ARRAY, "{{1,0},{t,f}}"))
+                    .isEqualTo(new Boolean[][]{{true, false}, {true, false}});
+            assertThat(arrayFromText(pgConnection, Oid.INT2_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Short[][]{{(short) 1, (short) 2}, {(short) 3, (short) 4}});
+            assertThat(arrayFromText(pgConnection, Oid.INT4_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Integer[][]{{1, 2}, {3, 4}});
+            assertThat(arrayFromText(pgConnection, Oid.INT8_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Long[][]{{1L, 2L}, {3L, 4L}});
+            assertThat(arrayFromText(pgConnection, Oid.FLOAT4_ARRAY, "{{1.25,2.5},{3.75,4.5}}"))
+                    .isEqualTo(new Float[][]{{1.25f, 2.5f}, {3.75f, 4.5f}});
+            assertThat(arrayFromText(pgConnection, Oid.FLOAT8_ARRAY, "{{1.25,2.5},{3.75,4.5}}"))
+                    .isEqualTo(new Double[][]{{1.25d, 2.5d}, {3.75d, 4.5d}});
+        }
+    }
+
+    @Test
+    void buildsTwoDimensionalObjectArraysFromTextValues() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.NUMERIC_ARRAY, "{{1.25,2.50},{3.75,4.50}}"))
+                    .isEqualTo(new BigDecimal[][]{
+                            {new BigDecimal("1.25"), new BigDecimal("2.50")},
+                            {new BigDecimal("3.75"), new BigDecimal("4.50")}
+                    });
+            assertThat(arrayFromText(pgConnection, Oid.TEXT_ARRAY, "{{alpha,beta},{gamma,delta}}"))
+                    .isEqualTo(new String[][]{{"alpha", "beta"}, {"gamma", "delta"}});
+            assertThat(arrayFromText(pgConnection, Oid.DATE_ARRAY, "{{2020-01-01,2020-01-02},{2020-01-03,2020-01-04}}"))
+                    .isInstanceOf(Date[][].class);
+            assertThat(arrayFromText(pgConnection, Oid.TIME_ARRAY, "{{01:02:03,04:05:06},{07:08:09,10:11:12}}"))
+                    .isInstanceOf(Time[][].class);
+            assertThat(arrayFromText(pgConnection, Oid.TIMESTAMP_ARRAY,
+                    "{{\"2020-01-01 01:02:03\",\"2020-01-02 04:05:06\"},"
+                            + "{\"2020-01-03 07:08:09\",\"2020-01-04 10:11:12\"}}"))
+                    .isInstanceOf(Timestamp[][].class);
+        }
+    }
+
+    @Test
+    void buildsUuidArraysThroughArrayAssistant() throws Exception {
+        UUID first = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID second = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        UUID third = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        UUID fourth = UUID.fromString("00000000-0000-0000-0000-000000000004");
+
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.UUID_ARRAY, "{" + first + "," + second + "}"))
+                    .isEqualTo(new UUID[]{first, second});
+            assertThat(arrayFromText(pgConnection, Oid.UUID_ARRAY,
+                    "{{" + first + "," + second + "},{" + third + "," + fourth + "}}"))
+                    .isEqualTo(new UUID[][]{{first, second}, {third, fourth}});
+        }
+    }
+
+    @Test
+    void buildsBinaryArraysFromWireFormat() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(new PgArray(pgConnection, Oid.INT4_ARRAY, binaryArrayHeaderOnly(Oid.INT4)).getArray())
+                    .isEqualTo(new Integer[0]);
+            assertThat(new PgArray(pgConnection, Oid.INT4_ARRAY, binaryIntArray(2, 2, 1, 2, 3, 4)).getArray())
+                    .isEqualTo(new Integer[][]{{1, 2}, {3, 4}});
+        }
+    }
+
+    private static Object arrayFromText(BaseConnection connection, int oid, String value) throws SQLException {
+        return new PgArray(connection, oid, value).getArray();
+    }
+
+    private static BaseConnection asPgConnection(Connection connection) {
+        return (BaseConnection) connection;
+    }
+
+    private static Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", USERNAME);
+        props.setProperty("password", PASSWORD);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
+        }
+        return output;
+    }
+
+    private static byte[] binaryArrayHeaderOnly(int elementOid) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+        output.writeInt(0);
+        output.writeInt(0);
+        output.writeInt(elementOid);
+        return bytes.toByteArray();
+    }
+
+    private static byte[] binaryIntArray(int rows, int columns, int... values) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+        output.writeInt(2);
+        output.writeInt(0);
+        output.writeInt(Oid.INT4);
+        output.writeInt(rows);
+        output.writeInt(1);
+        output.writeInt(columns);
+        output.writeInt(1);
+        for (int value : values) {
+            output.writeInt(Integer.BYTES);
+            output.writeInt(value);
+        }
+        return bytes.toByteArray();
+    }
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="26.009" hostname="kung-fu-workstation" timestamp="2026-05-02T23:01:16">
+<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="1" time="25.282" hostname="kung-fu-workstation" timestamp="2026-05-02T23:12:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -53,19 +53,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.144">
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.14">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
 display-name: commitAndRollback()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.033">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
 display-name: buildsTwoDimensionalObjectArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.048">
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.035">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
 display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
@@ -77,37 +77,105 @@ unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCast
 display-name: initializesBouncyCastleProviderThroughFactory()
 ]]></system-out>
 </testcase>
-<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.034">
+<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.023">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:decryptsBouncyCastleEncryptedPkcs8PrivateKey()]
 display-name: decryptsBouncyCastleEncryptedPkcs8PrivateKey()
 ]]></system-out>
 </testcase>
-<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.042">
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.048">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
 display-name: otherDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.035">
+<testcase name="initializeFromCopiesBaseDataSourceStateThroughObjectStreams()" classname="org_opengauss.opengauss_jdbc.BaseDataSourceTest" time="0">
+<error message="Cannot reflectively read or write field 'private static final long java.lang.String.serialVersionUID'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      &quot;type&quot;: &quot;java.lang.String&quot;,
+      &quot;fields&quot;: [
+        {
+          &quot;name&quot;: &quot;serialVersionUID&quot;
+        }
+      ]
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively read or write field 'private static final long java.lang.String.serialVersionUID'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
+
+    {
+      "type": "java.lang.String",
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportAccessedField(MissingReflectionRegistrationUtils.java:79)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.UnsafeFieldUtil.getFieldOffset(UnsafeFieldUtil.java:48)
+	at java.base@25.0.2/jdk.internal.misc.Unsafe.staticFieldOffset(Unsafe.java:51)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeFieldAccessorImpl.<init>(UnsafeFieldAccessorImpl.java:56)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeStaticFieldAccessorImpl.<init>(UnsafeStaticFieldAccessorImpl.java:42)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeQualifiedStaticFieldAccessorImpl.<init>(UnsafeQualifiedStaticFieldAccessorImpl.java:39)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeQualifiedStaticLongFieldAccessorImpl.<init>(UnsafeQualifiedStaticLongFieldAccessorImpl.java:33)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeFieldAccessorFactory.newFieldAccessor(UnsafeFieldAccessorFactory.java:78)
+	at java.base@25.0.2/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:2622)
+	at java.base@25.0.2/java.lang.reflect.Field.acquireOverrideFieldAccessor(Field.java:1195)
+	at java.base@25.0.2/java.lang.reflect.Field.getOverrideFieldAccessor(Field.java:134)
+	at java.base@25.0.2/java.lang.reflect.Field.getLong(Field.java:664)
+	at java.base@25.0.2/java.io.ObjectStreamClass.getDeclaredSUID(ObjectStreamClass.java:1583)
+	at java.base@25.0.2/java.io.ObjectStreamClass.<init>(ObjectStreamClass.java:355)
+	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:93)
+	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:90)
+	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:78)
+	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:75)
+	at java.base@25.0.2/java.lang.ClassValue.get(JavaLangSubstitutions.java:587)
+	at java.base@25.0.2/java.io.ClassCache.get(ClassCache.java:89)
+	at java.base@25.0.2/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:78)
+	at java.base@25.0.2/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1035)
+	at java.base@25.0.2/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:325)
+	at org.postgresql.ds.common.BaseDataSource.writeBaseObject(BaseDataSource.java:1300)
+	at org.postgresql.ds.common.BaseDataSource.initializeFrom(BaseDataSource.java:1327)
+	at org_opengauss.opengauss_jdbc.BaseDataSourceTest.initializeFromCopiesBaseDataSourceStateThroughObjectStreams(BaseDataSourceTest.java:32)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BaseDataSourceTest]/[method:initializeFromCopiesBaseDataSourceStateThroughObjectStreams()]
+display-name: initializeFromCopiesBaseDataSourceStateThroughObjectStreams()
+]]></system-out>
+</testcase>
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.028">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
 display-name: buildsBinaryArraysFromWireFormat()
 ]]></system-out>
 </testcase>
-<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.049">
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.047">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
 display-name: simpleDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.044">
+<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.038">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:geometricDatatypes()]
 display-name: geometricDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.03">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
 display-name: buildsUuidArraysThroughArrayAssistant()

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="26.534" hostname="kung-fu-workstation" timestamp="2026-05-02T22:34:28">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/719-2e9bd1af/tests/src/org.opengauss/opengauss-jdbc/3.1.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.157">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
+display-name: commitAndRollback()
+]]></system-out>
+</testcase>
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.04">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
+display-name: buildsTwoDimensionalObjectArraysFromTextValues()
+]]></system-out>
+</testcase>
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.036">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
+display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
+]]></system-out>
+</testcase>
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.058">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
+display-name: otherDatatypes()
+]]></system-out>
+</testcase>
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
+display-name: buildsBinaryArraysFromWireFormat()
+]]></system-out>
+</testcase>
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.057">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
+display-name: simpleDatatypes()
+]]></system-out>
+</testcase>
+<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.05">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:geometricDatatypes()]
+display-name: geometricDatatypes()
+]]></system-out>
+</testcase>
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.045">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
+display-name: buildsUuidArraysThroughArrayAssistant()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="1" time="25.282" hostname="kung-fu-workstation" timestamp="2026-05-02T23:12:01">
+<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="40.155" hostname="kung-fu-workstation" timestamp="2026-05-02T23:26:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -53,19 +53,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.14">
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.149">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
 display-name: commitAndRollback()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.033">
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.037">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
 display-name: buildsTwoDimensionalObjectArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.035">
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.042">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
 display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
@@ -77,105 +77,49 @@ unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCast
 display-name: initializesBouncyCastleProviderThroughFactory()
 ]]></system-out>
 </testcase>
-<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.023">
+<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.03">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:decryptsBouncyCastleEncryptedPkcs8PrivateKey()]
 display-name: decryptsBouncyCastleEncryptedPkcs8PrivateKey()
 ]]></system-out>
 </testcase>
-<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.048">
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.061">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
 display-name: otherDatatypes()
 ]]></system-out>
 </testcase>
 <testcase name="initializeFromCopiesBaseDataSourceStateThroughObjectStreams()" classname="org_opengauss.opengauss_jdbc.BaseDataSourceTest" time="0">
-<error message="Cannot reflectively read or write field 'private static final long java.lang.String.serialVersionUID'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      &quot;type&quot;: &quot;java.lang.String&quot;,
-      &quot;fields&quot;: [
-        {
-          &quot;name&quot;: &quot;serialVersionUID&quot;
-        }
-      ]
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/&lt;group-id&gt;/&lt;artifact-id&gt;/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection" type="org.graalvm.nativeimage.MissingReflectionRegistrationError"><![CDATA[org.graalvm.nativeimage.MissingReflectionRegistrationError: Cannot reflectively read or write field 'private static final long java.lang.String.serialVersionUID'. To allow this operation, add the following to the 'reflection' section of 'reachability-metadata.json' and rebuild the native image:
-
-    {
-      "type": "java.lang.String",
-      "fields": [
-        {
-          "name": "serialVersionUID"
-        }
-      ]
-    }
-
-The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.MissingReflectionRegistrationUtils.reportAccessedField(MissingReflectionRegistrationUtils.java:79)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.UnsafeFieldUtil.getFieldOffset(UnsafeFieldUtil.java:48)
-	at java.base@25.0.2/jdk.internal.misc.Unsafe.staticFieldOffset(Unsafe.java:51)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeFieldAccessorImpl.<init>(UnsafeFieldAccessorImpl.java:56)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeStaticFieldAccessorImpl.<init>(UnsafeStaticFieldAccessorImpl.java:42)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeQualifiedStaticFieldAccessorImpl.<init>(UnsafeQualifiedStaticFieldAccessorImpl.java:39)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeQualifiedStaticLongFieldAccessorImpl.<init>(UnsafeQualifiedStaticLongFieldAccessorImpl.java:33)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.reflect.fieldaccessor.UnsafeFieldAccessorFactory.newFieldAccessor(UnsafeFieldAccessorFactory.java:78)
-	at java.base@25.0.2/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:2622)
-	at java.base@25.0.2/java.lang.reflect.Field.acquireOverrideFieldAccessor(Field.java:1195)
-	at java.base@25.0.2/java.lang.reflect.Field.getOverrideFieldAccessor(Field.java:134)
-	at java.base@25.0.2/java.lang.reflect.Field.getLong(Field.java:664)
-	at java.base@25.0.2/java.io.ObjectStreamClass.getDeclaredSUID(ObjectStreamClass.java:1583)
-	at java.base@25.0.2/java.io.ObjectStreamClass.<init>(ObjectStreamClass.java:355)
-	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:93)
-	at java.base@25.0.2/java.io.ObjectStreamClass$Caches$1.computeValue(ObjectStreamClass.java:90)
-	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:78)
-	at java.base@25.0.2/java.io.ClassCache$1.computeValue(ClassCache.java:75)
-	at java.base@25.0.2/java.lang.ClassValue.get(JavaLangSubstitutions.java:587)
-	at java.base@25.0.2/java.io.ClassCache.get(ClassCache.java:89)
-	at java.base@25.0.2/java.io.ObjectStreamClass.lookup(ObjectStreamClass.java:78)
-	at java.base@25.0.2/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1035)
-	at java.base@25.0.2/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:325)
-	at org.postgresql.ds.common.BaseDataSource.writeBaseObject(BaseDataSource.java:1300)
-	at org.postgresql.ds.common.BaseDataSource.initializeFrom(BaseDataSource.java:1327)
-	at org_opengauss.opengauss_jdbc.BaseDataSourceTest.initializeFromCopiesBaseDataSourceStateThroughObjectStreams(BaseDataSourceTest.java:32)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BaseDataSourceTest]/[method:initializeFromCopiesBaseDataSourceStateThroughObjectStreams()]
 display-name: initializeFromCopiesBaseDataSourceStateThroughObjectStreams()
 ]]></system-out>
 </testcase>
-<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.028">
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.032">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
 display-name: buildsBinaryArraysFromWireFormat()
 ]]></system-out>
 </testcase>
-<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.047">
+<testcase name="delegatesConnectionOperationsAndWrapsCreatedStatements()" classname="org_opengauss.opengauss_jdbc.PGPooledConnectionInnerConnectionHandlerTest" time="0.039">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PGPooledConnectionInnerConnectionHandlerTest]/[method:delegatesConnectionOperationsAndWrapsCreatedStatements()]
+display-name: delegatesConnectionOperationsAndWrapsCreatedStatements()
+]]></system-out>
+</testcase>
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.05">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
 display-name: simpleDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.038">
+<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.057">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:geometricDatatypes()]
 display-name: geometricDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.03">
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.036">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
 display-name: buildsUuidArraysThroughArrayAssistant()

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="40.155" hostname="kung-fu-workstation" timestamp="2026-05-02T23:26:48">
+<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="38.018" hostname="kung-fu-workstation" timestamp="2026-05-02T23:33:32">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
@@ -44,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/719-2e9bd1af/tests/src/org.opengauss/opengauss-jdbc/3.1.1"/>
@@ -53,19 +52,19 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.149">
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.18">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
 display-name: commitAndRollback()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.037">
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.033">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
 display-name: buildsTwoDimensionalObjectArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.042">
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.035">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
 display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
@@ -77,13 +76,13 @@ unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCast
 display-name: initializesBouncyCastleProviderThroughFactory()
 ]]></system-out>
 </testcase>
-<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.03">
+<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.035">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:decryptsBouncyCastleEncryptedPkcs8PrivateKey()]
 display-name: decryptsBouncyCastleEncryptedPkcs8PrivateKey()
 ]]></system-out>
 </testcase>
-<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.061">
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.058">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
 display-name: otherDatatypes()
@@ -95,19 +94,19 @@ unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BaseDataSo
 display-name: initializeFromCopiesBaseDataSourceStateThroughObjectStreams()
 ]]></system-out>
 </testcase>
-<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.032">
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.031">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
 display-name: buildsBinaryArraysFromWireFormat()
 ]]></system-out>
 </testcase>
-<testcase name="delegatesConnectionOperationsAndWrapsCreatedStatements()" classname="org_opengauss.opengauss_jdbc.PGPooledConnectionInnerConnectionHandlerTest" time="0.039">
+<testcase name="delegatesConnectionOperationsAndWrapsCreatedStatements()" classname="org_opengauss.opengauss_jdbc.PGPooledConnectionInnerConnectionHandlerTest" time="0.034">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PGPooledConnectionInnerConnectionHandlerTest]/[method:delegatesConnectionOperationsAndWrapsCreatedStatements()]
 display-name: delegatesConnectionOperationsAndWrapsCreatedStatements()
 ]]></system-out>
 </testcase>
-<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.05">
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.07">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
 display-name: simpleDatatypes()
@@ -119,7 +118,7 @@ unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_
 display-name: geometricDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.036">
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.032">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
 display-name: buildsUuidArraysThroughArrayAssistant()

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="1" time="27.248" hostname="kung-fu-workstation" timestamp="2026-05-02T22:45:48">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="26.009" hostname="kung-fu-workstation" timestamp="2026-05-02T23:01:16">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -33,6 +33,7 @@
 "/>
 <property name="native.encoding" value="UTF-8"/>
 <property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -52,75 +53,61 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.351">
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.144">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
 display-name: commitAndRollback()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.045">
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
 display-name: buildsTwoDimensionalObjectArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.039">
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.048">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
 display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.073">
-<error message="Attempted to verify a provider that was not registered at build time: org.bouncycastle.jce.provider.BouncyCastleProvider. All security providers must be registered and verified during native image generation. Try adding the option: -H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider and rebuild the image." type="java.lang.SecurityException"><![CDATA[java.lang.SecurityException: Attempted to verify a provider that was not registered at build time: org.bouncycastle.jce.provider.BouncyCastleProvider. All security providers must be registered and verified during native image generation. Try adding the option: -H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider and rebuild the image.
-	at java.base@25.0.2/javax.crypto.JceSecurity.getVerificationResult(JceSecurity.java:300)
-	at java.base@25.0.2/javax.crypto.Cipher.getInstance(Cipher.java:731)
-	at org.bouncycastle.jcajce.util.ProviderJcaJceHelper.createCipher(Unknown Source)
-	at org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.build(Unknown Source)
-	at org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest.encryptPrivateKey(BouncyCastlePrivateKeyFactoryTest.java:75)
-	at org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest.decryptsBouncyCastleEncryptedPkcs8PrivateKey(BouncyCastlePrivateKeyFactoryTest.java:39)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="initializesBouncyCastleProviderThroughFactory()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:initializesBouncyCastleProviderThroughFactory()]
+display-name: initializesBouncyCastleProviderThroughFactory()
+]]></system-out>
+</testcase>
+<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.034">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:decryptsBouncyCastleEncryptedPkcs8PrivateKey()]
 display-name: decryptsBouncyCastleEncryptedPkcs8PrivateKey()
 ]]></system-out>
 </testcase>
-<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.049">
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.042">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
 display-name: otherDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.047">
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.035">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
 display-name: buildsBinaryArraysFromWireFormat()
 ]]></system-out>
 </testcase>
-<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.062">
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.049">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
 display-name: simpleDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.073">
+<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.044">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:geometricDatatypes()]
 display-name: geometricDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.03">
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
 display-name: buildsUuidArraysThroughArrayAssistant()

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="26.534" hostname="kung-fu-workstation" timestamp="2026-05-02T22:34:28">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="1" time="27.248" hostname="kung-fu-workstation" timestamp="2026-05-02T22:45:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,49 +52,75 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.157">
+<testcase name="commitAndRollback()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.351">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:commitAndRollback()]
 display-name: commitAndRollback()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.04">
+<testcase name="buildsTwoDimensionalObjectArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.045">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalObjectArraysFromTextValues()]
 display-name: buildsTwoDimensionalObjectArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.036">
+<testcase name="buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.039">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()]
 display-name: buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues()
 ]]></system-out>
 </testcase>
-<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.058">
+<testcase name="decryptsBouncyCastleEncryptedPkcs8PrivateKey()" classname="org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest" time="0.073">
+<error message="Attempted to verify a provider that was not registered at build time: org.bouncycastle.jce.provider.BouncyCastleProvider. All security providers must be registered and verified during native image generation. Try adding the option: -H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider and rebuild the image." type="java.lang.SecurityException"><![CDATA[java.lang.SecurityException: Attempted to verify a provider that was not registered at build time: org.bouncycastle.jce.provider.BouncyCastleProvider. All security providers must be registered and verified during native image generation. Try adding the option: -H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider and rebuild the image.
+	at java.base@25.0.2/javax.crypto.JceSecurity.getVerificationResult(JceSecurity.java:300)
+	at java.base@25.0.2/javax.crypto.Cipher.getInstance(Cipher.java:731)
+	at org.bouncycastle.jcajce.util.ProviderJcaJceHelper.createCipher(Unknown Source)
+	at org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.build(Unknown Source)
+	at org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest.encryptPrivateKey(BouncyCastlePrivateKeyFactoryTest.java:75)
+	at org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest.decryptsBouncyCastleEncryptedPkcs8PrivateKey(BouncyCastlePrivateKeyFactoryTest.java:39)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.BouncyCastlePrivateKeyFactoryTest]/[method:decryptsBouncyCastleEncryptedPkcs8PrivateKey()]
+display-name: decryptsBouncyCastleEncryptedPkcs8PrivateKey()
+]]></system-out>
+</testcase>
+<testcase name="otherDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.049">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:otherDatatypes()]
 display-name: otherDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.034">
+<testcase name="buildsBinaryArraysFromWireFormat()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.047">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsBinaryArraysFromWireFormat()]
 display-name: buildsBinaryArraysFromWireFormat()
 ]]></system-out>
 </testcase>
-<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.057">
+<testcase name="simpleDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.062">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:simpleDatatypes()]
 display-name: simpleDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.05">
+<testcase name="geometricDatatypes()" classname="org_opengauss.opengauss_jdbc.Opengauss_jdbcTest" time="0.073">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.Opengauss_jdbcTest]/[method:geometricDatatypes()]
 display-name: geometricDatatypes()
 ]]></system-out>
 </testcase>
-<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.045">
+<testcase name="buildsUuidArraysThroughArrayAssistant()" classname="org_opengauss.opengauss_jdbc.PgArrayTest" time="0.03">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_opengauss.opengauss_jdbc.PgArrayTest]/[method:buildsUuidArraysThroughArrayAssistant()]
 display-name: buildsUuidArraysThroughArrayAssistant()

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:26:08">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:32:54">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
@@ -44,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/719-2e9bd1af/tests/src/org.opengauss/opengauss-jdbc/3.1.1"/>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:11:36">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:26:08">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:34:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:45:21">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:45:21">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:00:50">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -33,6 +33,7 @@
 "/>
 <property name="native.encoding" value="UTF-8"/>
 <property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T22:34:01">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/719-2e9bd1af/tests/src/org.opengauss/opengauss-jdbc/3.1.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:00:50">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:11:36">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.opengauss.**"
+    }
+  ]
+}

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
@@ -1,13 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.opengauss.**"
-    },
-    {
-      "includeClasses": "org.postgresql.**"
+      "includeClasses" : "org.postgresql.**"
     }
   ]
 }

--- a/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
+++ b/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses": "org.opengauss.**"
+    },
+    {
+      "includeClasses": "org.postgresql.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #719

This PR provides test fixes and new metadata for org.opengauss:opengauss-jdbc:3.1.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 375928
- Cached input tokens: 5998080
- Output tokens: 45769
- Metadata entries: 354
- Iterations: 6
- Library coverage percentage: 19.44
- Previous library version metadata entries: 27
- Previous library version coverage percentage: 16.33

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a758056b19dbb8f8b60efbcc3641b8b9192af511`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.opengauss:opengauss-jdbc:3.1.0-og: 7/81 covered calls (8.64%)
- org.opengauss:opengauss-jdbc:3.1.1: 58/83 covered calls (69.88%)

**Reflection:**
- org.opengauss:opengauss-jdbc:3.1.0-og: 6/78 covered calls (7.69%)
- org.opengauss:opengauss-jdbc:3.1.1: 57/80 covered calls (71.25%)

**Resources:**
- org.opengauss:opengauss-jdbc:3.1.0-og: 1/3 covered calls (33.33%)
- org.opengauss:opengauss-jdbc:3.1.1: 1/3 covered calls (33.33%)

#### Library coverage

**Instruction:**
- org.opengauss:opengauss-jdbc:3.1.0-og: 18509/106767 (17.34%)
- org.opengauss:opengauss-jdbc:3.1.1: 21957/107011 (20.52%)

**Line:**
- org.opengauss:opengauss-jdbc:3.1.0-og: 3788/23191 (16.33%)
- org.opengauss:opengauss-jdbc:3.1.1: 4518/23237 (19.44%)

**Method:**
- org.opengauss:opengauss-jdbc:3.1.0-og: 671/3288 (20.41%)
- org.opengauss:opengauss-jdbc:3.1.1: 787/3289 (23.93%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/build.gradle 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
index 366aa0fe8d..628581f607 100644
--- 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/build.gradle
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.opengauss:opengauss-jdbc:$libraryVersion"
+    testImplementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }
@@ -30,4 +31,11 @@ graalvmNative {
             outputDirectories.add("src/test/resources/META-INF/native-image/org.opengauss/opengauss-jdbc")
         }
     }
+    binaries {
+        all {
+            buildArgs.add("--future-defaults=run-time-initialize-security-providers")
+            buildArgs.add("-Djava.security.properties=${file('java.security.properties').absolutePath}")
+            buildArgs.add("-H:AdditionalSecurityProviders=org.bouncycastle.jce.provider.BouncyCastleProvider")
+        }
+    }
 }
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BaseDataSourceTest.java 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BaseDataSourceTest.java
new file mode 100644
index 0000000000..c3088ca052
--- /dev/null
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BaseDataSourceTest.java
@@ -0,0 +1,46 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BaseDataSourceTest {
+
+    @Test
+    void initializeFromCopiesBaseDataSourceStateThroughObjectStreams() throws Exception {
+        PGSimpleDataSource source = new PGSimpleDataSource();
+        source.setServerName("primary.example.test");
+        source.setPortNumber(15432);
+        source.setDatabaseName("sampledb");
+        source.setUser("sample-user");
+        source.setPassword("sample-password");
+        source.setAllowEncodingChanges(true);
+        source.setCharacterEncoding("UTF-8");
+        source.setConnectionExtraInfo(true);
+        source.setApplicationName("metadata-coverage");
+        source.setConnectTimeout(7);
+        source.setSsl(true);
+
+        PGSimpleDataSource target = new PGSimpleDataSource();
+        target.initializeFrom(source);
+
+        assertThat(target.getServerName()).isEqualTo("primary.example.test");
+        assertThat(target.getPortNumber()).isEqualTo(15432);
+        assertThat(target.getDatabaseName()).isEqualTo("sampledb");
+        assertThat(target.getUser()).isEqualTo("sample-user");
+        assertThat(target.getPassword()).isEqualTo("sample-password");
+        assertThat(target.getAllowEncodingChanges()).isTrue();
+        assertThat(target.getCharacterEncoding()).isEqualTo("UTF-8");
+        assertThat(target.getConnectionExtraInfo()).isTrue();
+        assertThat(target.getApplicationName()).isEqualTo("metadata-coverage");
+        assertThat(target.getConnectTimeout()).isEqualTo(7);
+        assertThat(target.getSsl()).isTrue();
+    }
+}
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
new file mode 100644
index 0000000000..782f2b0924
--- /dev/null
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/BouncyCastlePrivateKeyFactoryTest.java
@@ -0,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ssl.BouncyCastlePrivateKeyFactory;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Arrays;
+
+import javax.security.auth.callback.PasswordCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BouncyCastlePrivateKeyFactoryTest {
+    private static final char[] PASSWORD = "changeit".toCharArray();
+
+    @Test
+    void initializesBouncyCastleProviderThroughFactory() throws Exception {
+        Provider provider = BouncyCastlePrivateKeyFactory.initBouncyCastleProvider();
+
+        assertThat(provider).isInstanceOf(BouncyCastleProvider.class);
+        assertThat(provider.getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
+    }
+
+    @Test
+    void decryptsBouncyCastleEncryptedPkcs8PrivateKey() throws Exception {
+        Provider provider = ensureBouncyCastleProvider();
+        KeyPair keyPair = generateRsaKeyPair(provider);
+        byte[] encryptedKey = encryptPrivateKey(provider, keyPair.getPrivate());
+        PasswordCallback passwordCallback = new PasswordCallback("Private key password", false);
+        passwordCallback.setPassword(Arrays.copyOf(PASSWORD, PASSWORD.length));
+
+        try {
+            PrivateKey privateKey = new BouncyCastlePrivateKeyFactory()
+                    .getPrivateKeyFromEncryptedKey(encryptedKey, passwordCallback);
+
+            assertThat(privateKey.getAlgorithm()).isEqualTo(keyPair.getPrivate().getAlgorithm());
+            assertThat(privateKey.getEncoded()).isEqualTo(keyPair.getPrivate().getEncoded());
+        } finally {
+            passwordCallback.clearPassword();
+        }
+    }
+
+    private static Provider ensureBouncyCastleProvider() {
+        Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+        if (provider == null) {
+            provider = new BouncyCastleProvider();
+            Security.addProvider(provider);
+        }
+        return provider;
+    }
+
+    private static KeyPair generateRsaKeyPair(Provider provider) throws Exception {
+        ProviderJcaJceHelper helper = new ProviderJcaJceHelper(provider);
+        KeyPairGenerator keyPairGenerator = helper.createKeyPairGenerator("RSA");
+        keyPairGenerator.initialize(1024, new SecureRandom());
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static byte[] encryptPrivateKey(Provider provider, PrivateKey privateKey) throws Exception {
+        OutputEncryptor encryptor = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES)
+                .setProvider(provider)
+                .setRandom(new SecureRandom())
+                .setPasssword(PASSWORD)
+                .build();
+        PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+        PKCS8EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new PKCS8EncryptedPrivateKeyInfoBuilder(privateKeyInfo)
+                .build(encryptor);
+        return encryptedPrivateKeyInfo.getEncoded();
+    }
+}
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
index 13adcc184b..6ba083c1a3 100644
--- 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/Opengauss_jdbcTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -29,6 +31,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,36 +39,77 @@ class Opengauss_jdbcTest {
     private static final String USERNAME = "fred";
     private static final String PASSWORD = "Secretpassword@123";
     private static final String DATABASE = "postgres";
-    private static final String JDBC_URL = "jdbc:opengauss://localhost:15432/" + DATABASE;
+    private static int hostPort;
+    private static Path containerIdFile;
     private static Process process;
+    private static String containerId;
 
     private static Connection openConnection() throws SQLException {
         Properties props = new Properties();
         props.setProperty("user", USERNAME);
         props.setProperty("password", PASSWORD);
-        return DriverManager.getConnection(JDBC_URL, props);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
     }
 
     @BeforeAll
     static void beforeAll() throws IOException {
         System.out.println("Starting OpenGauss ...");
+        containerIdFile = Files.createTempFile("opengauss-jdbc-test-", ".cid");
+        Files.delete(containerIdFile);
         process = new ProcessBuilder(
-                "docker", "run", "--rm", "-p", "15432:5432", "-e", "GS_USERNAME=" + USERNAME,
-                "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
                 .redirectOutput(new File("opengauss-stdout.txt")).redirectError(new File("opengauss-stderr.txt")).start();
         Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
             openConnection().close();
             return true;
         });
-        System.out.println("OpenGauss started");
+        System.out.println("OpenGauss started on port " + hostPort);
     }
 
     @AfterAll
-    static void tearDown() {
-        if (process != null && process.isAlive()) {
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
             System.out.println("Shutting down OpenGauss");
+            runDockerCommand("docker", "stop", containerId);
+        }
+        if (process != null && process.isAlive()) {
             process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
         }
+        return output;
     }
 
     @Test
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PGPooledConnectionInnerConnectionHandlerTest.java 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PGPooledConnectionInnerConnectionHandlerTest.java
new file mode 100644
index 0000000000..b051225281
--- /dev/null
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PGPooledConnectionInnerConnectionHandlerTest.java
@@ -0,0 +1,141 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.postgresql.PGStatement;
+import org.postgresql.ds.PGPooledConnection;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PGPooledConnectionInnerConnectionHandlerTest {
+    private static final String USERNAME = "fred";
+    private static final String PASSWORD = "Secretpassword@123";
+    private static final String DATABASE = "postgres";
+    private static int hostPort;
+    private static Path containerIdFile;
+    private static Process process;
+    private static String containerId;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting OpenGauss for PGPooledConnection.ConnectionHandler tests ...");
+        containerIdFile = Files.createTempFile("opengauss-pooled-connection-test-", ".cid");
+        Files.delete(containerIdFile);
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                .redirectOutput(new File("opengauss-pooled-connection-stdout.txt"))
+                .redirectError(new File("opengauss-pooled-connection-stderr.txt"))
+                .start();
+        Awaitility.await().atMost(Duration.ofSeconds(55)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
+            openConnection().close();
+            return true;
+        });
+        System.out.println("OpenGauss for PGPooledConnection.ConnectionHandler tests started on port " + hostPort);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
+            System.out.println("Shutting down OpenGauss for PGPooledConnection.ConnectionHandler tests");
+            runDockerCommand("docker", "stop", containerId);
+        }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    @Test
+    void delegatesConnectionOperationsAndWrapsCreatedStatements() throws Exception {
+        try (Connection physicalConnection = openConnection()) {
+            PGPooledConnection pooledConnection = new PGPooledConnection(physicalConnection, false);
+            try {
+                Connection pooledHandle = pooledConnection.getConnection();
+
+                assertThat(pooledHandle.getAutoCommit()).isFalse();
+
+                try (Statement statement = pooledHandle.createStatement()) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+                try (CallableStatement statement = pooledHandle.prepareCall("SELECT 1")) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+                try (PreparedStatement statement = pooledHandle.prepareStatement("SELECT ?")) {
+                    assertThat(statement).isInstanceOf(PGStatement.class);
+                    assertThat(statement.getConnection()).isSameAs(pooledHandle);
+                }
+
+                pooledHandle.close();
+                assertThat(pooledHandle.isClosed()).isTrue();
+            } finally {
+                pooledConnection.close();
+            }
+        }
+    }
+
+    private static Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", USERNAME);
+        props.setProperty("password", PASSWORD);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
+        }
+        return output;
+    }
+}
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PgArrayTest.java 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PgArrayTest.java
new file mode 100644
index 0000000000..8bdd49bfbb
--- /dev/null
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/src/test/java/org_opengauss/opengauss_jdbc/PgArrayTest.java
@@ -0,0 +1,223 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_opengauss.opengauss_jdbc;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Oid;
+import org.postgresql.jdbc.PgArray;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PgArrayTest {
+    private static final String USERNAME = "fred";
+    private static final String PASSWORD = "Secretpassword@123";
+    private static final String DATABASE = "postgres";
+    private static int hostPort;
+    private static Path containerIdFile;
+    private static Process process;
+    private static String containerId;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        System.out.println("Starting OpenGauss for PgArray tests ...");
+        containerIdFile = Files.createTempFile("opengauss-pg-array-test-", ".cid");
+        Files.delete(containerIdFile);
+        process = new ProcessBuilder(
+                "docker", "run", "--rm", "--cidfile", containerIdFile.toString(), "-p", "127.0.0.1::5432", "-e",
+                "GS_USERNAME=" + USERNAME, "-e", "GS_PASSWORD=" + PASSWORD, "opengauss/opengauss:5.0.0")
+                .redirectOutput(new File("opengauss-pg-array-stdout.txt"))
+                .redirectError(new File("opengauss-pg-array-stderr.txt"))
+                .start();
+        Awaitility.await().atMost(Duration.ofMinutes(1)).ignoreExceptions().until(() -> {
+            discoverMappedPort();
+            openConnection().close();
+            return true;
+        });
+        System.out.println("OpenGauss for PgArray tests started on port " + hostPort);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException, InterruptedException {
+        if (containerId != null) {
+            System.out.println("Shutting down OpenGauss for PgArray tests");
+            runDockerCommand("docker", "stop", containerId);
+        }
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        }
+        if (containerIdFile != null) {
+            Files.deleteIfExists(containerIdFile);
+        }
+    }
+
+    @Test
+    void buildsTwoDimensionalPrimitiveWrapperArraysFromTextValues() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.BOOL_ARRAY, "{{1,0},{t,f}}"))
+                    .isEqualTo(new Boolean[][]{{true, false}, {true, false}});
+            assertThat(arrayFromText(pgConnection, Oid.INT2_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Short[][]{{(short) 1, (short) 2}, {(short) 3, (short) 4}});
+            assertThat(arrayFromText(pgConnection, Oid.INT4_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Integer[][]{{1, 2}, {3, 4}});
+            assertThat(arrayFromText(pgConnection, Oid.INT8_ARRAY, "{{1,2},{3,4}}"))
+                    .isEqualTo(new Long[][]{{1L, 2L}, {3L, 4L}});
+            assertThat(arrayFromText(pgConnection, Oid.FLOAT4_ARRAY, "{{1.25,2.5},{3.75,4.5}}"))
+                    .isEqualTo(new Float[][]{{1.25f, 2.5f}, {3.75f, 4.5f}});
+            assertThat(arrayFromText(pgConnection, Oid.FLOAT8_ARRAY, "{{1.25,2.5},{3.75,4.5}}"))
+                    .isEqualTo(new Double[][]{{1.25d, 2.5d}, {3.75d, 4.5d}});
+        }
+    }
+
+    @Test
+    void buildsTwoDimensionalObjectArraysFromTextValues() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.NUMERIC_ARRAY, "{{1.25,2.50},{3.75,4.50}}"))
+                    .isEqualTo(new BigDecimal[][]{
+                            {new BigDecimal("1.25"), new BigDecimal("2.50")},
+                            {new BigDecimal("3.75"), new BigDecimal("4.50")}
+                    });
+            assertThat(arrayFromText(pgConnection, Oid.TEXT_ARRAY, "{{alpha,beta},{gamma,delta}}"))
+                    .isEqualTo(new String[][]{{"alpha", "beta"}, {"gamma", "delta"}});
+            assertThat(arrayFromText(pgConnection, Oid.DATE_ARRAY, "{{2020-01-01,2020-01-02},{2020-01-03,2020-01-04}}"))
+                    .isInstanceOf(Date[][].class);
+            assertThat(arrayFromText(pgConnection, Oid.TIME_ARRAY, "{{01:02:03,04:05:06},{07:08:09,10:11:12}}"))
+                    .isInstanceOf(Time[][].class);
+            assertThat(arrayFromText(pgConnection, Oid.TIMESTAMP_ARRAY,
+                    "{{\"2020-01-01 01:02:03\",\"2020-01-02 04:05:06\"},"
+                            + "{\"2020-01-03 07:08:09\",\"2020-01-04 10:11:12\"}}"))
+                    .isInstanceOf(Timestamp[][].class);
+        }
+    }
+
+    @Test
+    void buildsUuidArraysThroughArrayAssistant() throws Exception {
+        UUID first = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID second = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        UUID third = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        UUID fourth = UUID.fromString("00000000-0000-0000-0000-000000000004");
+
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(arrayFromText(pgConnection, Oid.UUID_ARRAY, "{" + first + "," + second + "}"))
+                    .isEqualTo(new UUID[]{first, second});
+            assertThat(arrayFromText(pgConnection, Oid.UUID_ARRAY,
+                    "{{" + first + "," + second + "},{" + third + "," + fourth + "}}"))
+                    .isEqualTo(new UUID[][]{{first, second}, {third, fourth}});
+        }
+    }
+
+    @Test
+    void buildsBinaryArraysFromWireFormat() throws Exception {
+        try (Connection connection = openConnection()) {
+            BaseConnection pgConnection = asPgConnection(connection);
+
+            assertThat(new PgArray(pgConnection, Oid.INT4_ARRAY, binaryArrayHeaderOnly(Oid.INT4)).getArray())
+                    .isEqualTo(new Integer[0]);
+            assertThat(new PgArray(pgConnection, Oid.INT4_ARRAY, binaryIntArray(2, 2, 1, 2, 3, 4)).getArray())
+                    .isEqualTo(new Integer[][]{{1, 2}, {3, 4}});
+        }
+    }
+
+    private static Object arrayFromText(BaseConnection connection, int oid, String value) throws SQLException {
+        return new PgArray(connection, oid, value).getArray();
+    }
+
+    private static BaseConnection asPgConnection(Connection connection) {
+        return (BaseConnection) connection;
+    }
+
+    private static Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        props.setProperty("user", USERNAME);
+        props.setProperty("password", PASSWORD);
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + hostPort + "/" + DATABASE, props);
+    }
+
+    private static void discoverMappedPort() throws IOException, InterruptedException {
+        if (containerId == null || containerId.isEmpty()) {
+            containerId = Files.readString(containerIdFile, StandardCharsets.UTF_8).trim();
+        }
+        if (containerId.isEmpty()) {
+            throw new IOException("OpenGauss container id is not available yet");
+        }
+        String portMapping = runDockerCommand("docker", "port", containerId, "5432/tcp");
+        int lineSeparatorIndex = portMapping.indexOf(System.lineSeparator());
+        String firstPortMapping = lineSeparatorIndex == -1 ? portMapping : portMapping.substring(0, lineSeparatorIndex);
+        int portSeparatorIndex = firstPortMapping.lastIndexOf(':');
+        hostPort = Integer.parseInt(firstPortMapping.substring(portSeparatorIndex + 1));
+    }
+
+    private static String runDockerCommand(String... command) throws IOException, InterruptedException {
+        Process commandProcess = new ProcessBuilder(command).redirectErrorStream(true).start();
+        if (!commandProcess.waitFor(5, TimeUnit.SECONDS)) {
+            commandProcess.destroyForcibly();
+            throw new IOException("Docker command timed out");
+        }
+        String output = new String(commandProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        if (commandProcess.exitValue() != 0) {
+            throw new IOException(output);
+        }
+        return output;
+    }
+
+    private static byte[] binaryArrayHeaderOnly(int elementOid) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+        output.writeInt(0);
+        output.writeInt(0);
+        output.writeInt(elementOid);
+        return bytes.toByteArray();
+    }
+
+    private static byte[] binaryIntArray(int rows, int columns, int... values) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(bytes);
+        output.writeInt(2);
+        output.writeInt(0);
+        output.writeInt(Oid.INT4);
+        output.writeInt(rows);
+        output.writeInt(1);
+        output.writeInt(columns);
+        output.writeInt(1);
+        for (int value : values) {
+            output.writeInt(Integer.BYTES);
+            output.writeInt(value);
+        }
+        return bytes.toByteArray();
+    }
+}
diff --git 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/user-code-filter.json 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
index d6fc930e42..3a8dae5671 100644
--- 1/tests/src/org.opengauss/opengauss-jdbc/3.1.0-og/user-code-filter.json
+++ 2/tests/src/org.opengauss/opengauss-jdbc/3.1.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.opengauss.**"
+      "includeClasses" : "org.postgresql.**"
     }
   ]
 }

```
