### PR TITLE
[GenAI] Test fix for org.slf4j:slf4j-jdk14:1.6.0 using gpt-5.5

### DIFF
--- a/metadata/org.slf4j/slf4j-jdk14/1.6.0/reachability-metadata.json
+++ b/metadata/org.slf4j/slf4j-jdk14/1.6.0/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.LoggerFactory"
+      },
+      "type": "org.slf4j.LoggerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMDCBinder"
+      },
+      "type": "org.slf4j.helpers.BasicMDCAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticMarkerBinder"
+      },
+      "type": "org.slf4j.helpers.BasicMarkerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.JDK14LoggerAdapter"
+      },
+      "type": "org.slf4j.helpers.MarkerIgnoringBase"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.JDK14LoggerAdapter"
+      },
+      "type": "org.slf4j.impl.JDK14LoggerAdapter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.slf4j.impl.StaticLoggerBinder"
+      },
+      "type": "org.slf4j.impl.JDK14LoggerFactory"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.slf4j.LoggerFactory"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.slf4j/slf4j-jdk14/index.json
+++ b/metadata/org.slf4j/slf4j-jdk14/index.json
@@ -1,32 +1,42 @@
 [
   {
-    "latest": true,
-    "metadata-version": "1.5.7",
-    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
-    "repository-url": "https://github.com/qos-ch/slf4j",
-    "test-code-url": "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$_FINAL/slf4j-jdk14/src/test",
-    "documentation-url": "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$_FINAL/slf4j-site/src/site/pages/manual.html",
-    "description": "SLF4J JDK14 is an SLF4J binding that routes SLF4J API logging calls to Java's built-in java.util.logging backend. It provides the runtime implementation needed for applications using SLF4J to emit log records through the JDK logging system.",
-    "test-version": "1.5.6",
-    "tested-versions": [
-      "1.5.7"
+    "latest" : true,
+    "metadata-version" : "1.6.0",
+    "tested-versions" : [
+      "1.6.0"
     ],
-    "allowed-packages": [
+    "allowed-packages" : [
       "org.slf4j.impl",
       "org.slf4j"
     ]
   },
   {
-    "metadata-version": "1.5.6",
-    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
-    "repository-url": "https://github.com/qos-ch/slf4j",
-    "test-code-url": "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$/slf4j-jdk14/src/test",
-    "documentation-url": "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$/slf4j-site/src/site/pages/manual.html",
-    "description": "SLF4J JDK14 binding routes SLF4J API logging calls to Java's built-in java.util.logging framework. It provides the runtime provider needed for applications using SLF4J 1.5.6 to emit logs through the JDK 1.4 logging system.",
-    "tested-versions": [
+    "metadata-version" : "1.5.7",
+    "test-version" : "1.5.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$_FINAL/slf4j-jdk14/src/test",
+    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$_FINAL/slf4j-site/src/site/pages/manual.html",
+    "description" : "SLF4J JDK14 is an SLF4J binding that routes SLF4J API logging calls to Java's built-in java.util.logging backend. It provides the runtime implementation needed for applications using SLF4J to emit log records through the JDK logging system.",
+    "tested-versions" : [
+      "1.5.7"
+    ],
+    "allowed-packages" : [
+      "org.slf4j.impl",
+      "org.slf4j"
+    ]
+  },
+  {
+    "metadata-version" : "1.5.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/slf4j",
+    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$/slf4j-jdk14/src/test",
+    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$/slf4j-site/src/site/pages/manual.html",
+    "description" : "SLF4J JDK14 binding routes SLF4J API logging calls to Java's built-in java.util.logging framework. It provides the runtime provider needed for applications using SLF4J 1.5.6 to emit logs through the JDK 1.4 logging system.",
+    "tested-versions" : [
       "1.5.6"
     ],
-    "allowed-packages": [
+    "allowed-packages" : [
       "org.slf4j.impl"
     ]
   }

--- a/metadata/org.slf4j/slf4j-jdk14/index.json
+++ b/metadata/org.slf4j/slf4j-jdk14/index.json
@@ -1,42 +1,47 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "1.6.0",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "1.6.0",
+    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
+    "repository-url": "https://github.com/qos-ch/slf4j",
+    "test-code-url": "https://github.com/qos-ch/slf4j/tree/v_$version$/slf4j-jdk14/src/test",
+    "documentation-url": "https://github.com/qos-ch/slf4j/blob/v_$version$/slf4j-site/src/site/pages/manual.html",
+    "description": "SLF4J JDK14 is an SLF4J binding that routes SLF4J API logging calls to Java's built-in java.util.logging backend. It provides the runtime implementation needed for applications using SLF4J to emit log records through the JDK logging system.",
+    "tested-versions": [
       "1.6.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.slf4j.impl",
       "org.slf4j"
     ]
   },
   {
-    "metadata-version" : "1.5.7",
-    "test-version" : "1.5.6",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
-    "repository-url" : "https://github.com/qos-ch/slf4j",
-    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$_FINAL/slf4j-jdk14/src/test",
-    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$_FINAL/slf4j-site/src/site/pages/manual.html",
-    "description" : "SLF4J JDK14 is an SLF4J binding that routes SLF4J API logging calls to Java's built-in java.util.logging backend. It provides the runtime implementation needed for applications using SLF4J to emit log records through the JDK logging system.",
-    "tested-versions" : [
+    "metadata-version": "1.5.7",
+    "test-version": "1.5.6",
+    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
+    "repository-url": "https://github.com/qos-ch/slf4j",
+    "test-code-url": "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$_FINAL/slf4j-jdk14/src/test",
+    "documentation-url": "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$_FINAL/slf4j-site/src/site/pages/manual.html",
+    "description": "SLF4J JDK14 is an SLF4J binding that routes SLF4J API logging calls to Java's built-in java.util.logging backend. It provides the runtime implementation needed for applications using SLF4J to emit log records through the JDK logging system.",
+    "tested-versions": [
       "1.5.7"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.slf4j.impl",
       "org.slf4j"
     ]
   },
   {
-    "metadata-version" : "1.5.6",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
-    "repository-url" : "https://github.com/qos-ch/slf4j",
-    "test-code-url" : "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$/slf4j-jdk14/src/test",
-    "documentation-url" : "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$/slf4j-site/src/site/pages/manual.html",
-    "description" : "SLF4J JDK14 binding routes SLF4J API logging calls to Java's built-in java.util.logging framework. It provides the runtime provider needed for applications using SLF4J 1.5.6 to emit logs through the JDK 1.4 logging system.",
-    "tested-versions" : [
+    "metadata-version": "1.5.6",
+    "source-code-url": "https://repo1.maven.org/maven2/org/slf4j/slf4j-jdk14/$version$/slf4j-jdk14-$version$-sources.jar",
+    "repository-url": "https://github.com/qos-ch/slf4j",
+    "test-code-url": "https://github.com/qos-ch/slf4j/tree/SLF4J_$version$/slf4j-jdk14/src/test",
+    "documentation-url": "https://github.com/qos-ch/slf4j/blob/SLF4J_$version$/slf4j-site/src/site/pages/manual.html",
+    "description": "SLF4J JDK14 binding routes SLF4J API logging calls to Java's built-in java.util.logging framework. It provides the runtime provider needed for applications using SLF4J 1.5.6 to emit logs through the JDK 1.4 logging system.",
+    "tested-versions": [
       "1.5.6"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.slf4j.impl"
     ]
   }

--- a/stats/org.slf4j/slf4j-jdk14/1.6.0/execution-metrics.json
+++ b/stats/org.slf4j/slf4j-jdk14/1.6.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T21:39:34.258398Z",
+    "library": "org.slf4j:slf4j-jdk14:1.6.0",
+    "starting_commit": "e2d52cd511ccd5e4ba3626b1ae9c2f2309866793",
+    "ending_commit": "cd52d817929f3528e3c49b05c7633723cb76e904",
+    "previous_library": "org.slf4j:slf4j-jdk14:1.5.6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.6.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 308,
+          "missed": 407,
+          "ratio": 0.430769,
+          "total": 715
+        },
+        "line": {
+          "covered": 77,
+          "missed": 95,
+          "ratio": 0.447674,
+          "total": 172
+        },
+        "method": {
+          "covered": 21,
+          "missed": 28,
+          "ratio": 0.428571,
+          "total": 49
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 304,
+          "missed": 381,
+          "ratio": 0.443796,
+          "total": 685
+        },
+        "line": {
+          "covered": 77,
+          "missed": 95,
+          "ratio": 0.447674,
+          "total": 172
+        },
+        "method": {
+          "covered": 21,
+          "missed": 28,
+          "ratio": 0.428571,
+          "total": 49
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 16281,
+      "cached_input_tokens_used": 94720,
+      "output_tokens_used": 1074,
+      "iterations": 1,
+      "cost_usd": 0.0796,
+      "tested_library_loc": 77,
+      "metadata_entries": 7,
+      "previous_library_metadata_entries": 5,
+      "code_coverage_percent": 44.77,
+      "previous_library_coverage_percent": 44.77
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/StaticMarkerBinderTest.java",
+      "metadata_file": "metadata/org.slf4j/slf4j-jdk14/1.6.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.slf4j/slf4j-jdk14/1.6.0/stats.json
+++ b/stats/org.slf4j/slf4j-jdk14/1.6.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.6.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 308,
+        "missed" : 407,
+        "ratio" : 0.430769,
+        "total" : 715
+      },
+      "line" : {
+        "covered" : 77,
+        "missed" : 95,
+        "ratio" : 0.447674,
+        "total" : 172
+      },
+      "method" : {
+        "covered" : 21,
+        "missed" : 28,
+        "ratio" : 0.428571,
+        "total" : 49
+      }
+    }
+  } ]
+}

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/.gitignore
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/build.gradle
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.slf4j:slf4j-jdk14:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/gradle.properties
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.slf4j:slf4j-jdk14:1.6.0
+library.version = 1.6.0
+metadata.dir = org.slf4j/slf4j-jdk14/1.6.0/

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/settings.gradle
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.slf4j.slf4j-jdk14_tests'

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_jdk14;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDK14LoggerAdapterTest {
+
+    @Test
+    void loggerFactoryBridgesSlf4jCallsToJul() {
+        try (TestLoggerContext context = TestLoggerContext.create("slf4j-jdk14-adapter-standard")) {
+            LocationAwareLogger logger = context.logger();
+            IllegalStateException failure = new IllegalStateException("boom");
+
+            logger.trace("trace {}", "message");
+            logger.info("info {} {}", new Object[]{"first", "second"});
+            logger.error("error message", failure);
+
+            List<LogRecord> records = context.records();
+
+            assertThat(logger.getName()).isEqualTo("slf4j-jdk14-adapter-standard");
+            assertThat(records).hasSize(3);
+            assertThat(records).extracting(LogRecord::getLevel)
+                    .containsExactly(Level.FINEST, Level.INFO, Level.SEVERE);
+            assertThat(records).extracting(LogRecord::getMessage)
+                    .containsExactly("trace message", "info first second", "error message");
+            assertThat(records).extracting(LogRecord::getLoggerName)
+                    .containsOnly("slf4j-jdk14-adapter-standard");
+            assertThat(records.get(0).getSourceClassName()).isEqualTo(JDK14LoggerAdapterTest.class.getName());
+            assertThat(records.get(0).getSourceMethodName()).isEqualTo("loggerFactoryBridgesSlf4jCallsToJul");
+            assertThat(records.get(2).getThrown()).isSameAs(failure);
+        }
+    }
+
+    @Test
+    void locationAwareLoggingUsesCallerBoundaryForSourceInformation() {
+        try (TestLoggerContext context = TestLoggerContext.create("slf4j-jdk14-adapter-location-aware")) {
+            LocationAwareLogger logger = context.logger();
+            IllegalArgumentException failure = new IllegalArgumentException("warn");
+
+            LocationAwareInvoker.logWarning(logger, "warn message", failure);
+
+            assertThat(context.records()).singleElement().satisfies(record -> {
+                assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+                assertThat(record.getMessage()).isEqualTo("warn message");
+                assertThat(record.getThrown()).isSameAs(failure);
+                assertThat(record.getSourceClassName()).isEqualTo(JDK14LoggerAdapterTest.class.getName());
+                assertThat(record.getSourceMethodName())
+                        .isEqualTo("locationAwareLoggingUsesCallerBoundaryForSourceInformation");
+            });
+        }
+    }
+
+    private static final class TestLoggerContext implements AutoCloseable {
+
+        private final Logger julLogger;
+        private final Level previousLevel;
+        private final boolean previousUseParentHandlers;
+        private final Handler[] previousHandlers;
+        private final RecordingHandler handler;
+        private final LocationAwareLogger logger;
+
+        private TestLoggerContext(String loggerName) {
+            this.julLogger = Logger.getLogger(loggerName);
+            this.previousLevel = this.julLogger.getLevel();
+            this.previousUseParentHandlers = this.julLogger.getUseParentHandlers();
+            this.previousHandlers = this.julLogger.getHandlers();
+            this.handler = new RecordingHandler();
+
+            for (Handler previousHandler : this.previousHandlers) {
+                this.julLogger.removeHandler(previousHandler);
+            }
+
+            this.julLogger.setUseParentHandlers(false);
+            this.julLogger.setLevel(Level.ALL);
+            this.handler.setLevel(Level.ALL);
+            this.julLogger.addHandler(this.handler);
+            this.logger = (LocationAwareLogger) LoggerFactory.getLogger(loggerName);
+        }
+
+        private static TestLoggerContext create(String loggerName) {
+            return new TestLoggerContext(loggerName);
+        }
+
+        private LocationAwareLogger logger() {
+            return this.logger;
+        }
+
+        private List<LogRecord> records() {
+            return List.copyOf(this.handler.records);
+        }
+
+        @Override
+        public void close() {
+            this.julLogger.removeHandler(this.handler);
+            this.julLogger.setLevel(this.previousLevel);
+            this.julLogger.setUseParentHandlers(this.previousUseParentHandlers);
+            for (Handler previousHandler : this.previousHandlers) {
+                this.julLogger.addHandler(previousHandler);
+            }
+        }
+    }
+
+    private static final class RecordingHandler extends Handler {
+
+        private final List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            this.records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static final class LocationAwareInvoker {
+
+        private static void logWarning(LocationAwareLogger logger, String message, Throwable throwable) {
+            logger.log(null, LocationAwareInvoker.class.getName(), LocationAwareLogger.WARN_INT, message, throwable);
+        }
+    }
+}

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
@@ -137,7 +137,7 @@ public class JDK14LoggerAdapterTest {
     private static final class LocationAwareInvoker {
 
         private static void logWarning(LocationAwareLogger logger, String message, Throwable throwable) {
-            logger.log(null, LocationAwareInvoker.class.getName(), LocationAwareLogger.WARN_INT, message, throwable);
+            logger.log(null, LocationAwareInvoker.class.getName(), LocationAwareLogger.WARN_INT, message, null, throwable);
         }
     }
 }

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/StaticMDCBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/StaticMDCBinderTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_jdk14;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.impl.StaticMDCBinder;
+import org.slf4j.spi.MDCAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticMDCBinderTest {
+
+    @Test
+    void singletonExposesBasicMdcAdapterInformation() {
+        StaticMDCBinder binder = StaticMDCBinder.SINGLETON;
+
+        MDCAdapter adapter = binder.getMDCA();
+        String adapterClassName = binder.getMDCAdapterClassStr();
+
+        assertThat(adapter).isNotNull();
+        assertThat(adapterClassName).isEqualTo(adapter.getClass().getName());
+    }
+}

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/StaticMarkerBinderTest.java
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/StaticMarkerBinderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_slf4j.slf4j_jdk14;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Marker;
+import org.slf4j.impl.StaticMarkerBinder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticMarkerBinderTest {
+
+    @Test
+    void singletonExposesBasicMarkerFactoryInformation() {
+        StaticMarkerBinder binder = StaticMarkerBinder.SINGLETON;
+
+        IMarkerFactory markerFactory = binder.getMarkerFactory();
+        Marker marker = markerFactory.getMarker("coverage-marker");
+        String markerFactoryClassName = binder.getMarkerFactoryClassStr();
+
+        assertThat(markerFactory).isNotNull();
+        assertThat(markerFactoryClassName).isEqualTo(markerFactory.getClass().getName());
+        assertThat(marker.getName()).isEqualTo("coverage-marker");
+        assertThat(markerFactory.getMarker("coverage-marker")).isSameAs(marker);
+    }
+}

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:38:28">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4430-b0bf9bff/tests/src/org.slf4j/slf4j-jdk14/1.6.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="locationAwareLoggingUsesCallerBoundaryForSourceInformation()" classname="org_slf4j.slf4j_jdk14.JDK14LoggerAdapterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_slf4j.slf4j_jdk14.JDK14LoggerAdapterTest]/[method:locationAwareLoggingUsesCallerBoundaryForSourceInformation()]
+display-name: locationAwareLoggingUsesCallerBoundaryForSourceInformation()
+]]></system-out>
+</testcase>
+<testcase name="loggerFactoryBridgesSlf4jCallsToJul()" classname="org_slf4j.slf4j_jdk14.JDK14LoggerAdapterTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_slf4j.slf4j_jdk14.JDK14LoggerAdapterTest]/[method:loggerFactoryBridgesSlf4jCallsToJul()]
+display-name: loggerFactoryBridgesSlf4jCallsToJul()
+]]></system-out>
+</testcase>
+<testcase name="singletonExposesBasicMarkerFactoryInformation()" classname="org_slf4j.slf4j_jdk14.StaticMarkerBinderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_slf4j.slf4j_jdk14.StaticMarkerBinderTest]/[method:singletonExposesBasicMarkerFactoryInformation()]
+display-name: singletonExposesBasicMarkerFactoryInformation()
+]]></system-out>
+</testcase>
+<testcase name="singletonExposesBasicMdcAdapterInformation()" classname="org_slf4j.slf4j_jdk14.StaticMDCBinderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_slf4j.slf4j_jdk14.StaticMDCBinderTest]/[method:singletonExposesBasicMdcAdapterInformation()]
+display-name: singletonExposesBasicMdcAdapterInformation()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:38:28">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4430-b0bf9bff/tests/src/org.slf4j/slf4j-jdk14/1.6.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.slf4j/slf4j-jdk14/1.6.0/user-code-filter.json
+++ b/tests/src/org.slf4j/slf4j-jdk14/1.6.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.slf4j.impl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4430

This PR provides test fixes and new metadata for org.slf4j:slf4j-jdk14:1.6.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 16281
- Cached input tokens: 94720
- Output tokens: 1074
- Metadata entries: 7
- Iterations: 1
- Library coverage percentage: 44.77
- Previous library version metadata entries: 5
- Previous library version coverage percentage: 44.77

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `904a573c65d2c81961aaf0615032c8b1f3f2027c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.slf4j:slf4j-jdk14:1.5.6: 4/4 covered calls (100.00%)
- org.slf4j:slf4j-jdk14:1.6.0: 4/4 covered calls (100.00%)

**Reflection:**
- org.slf4j:slf4j-jdk14:1.5.6: 4/4 covered calls (100.00%)
- org.slf4j:slf4j-jdk14:1.6.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.slf4j:slf4j-jdk14:1.5.6: 304/685 (44.38%)
- org.slf4j:slf4j-jdk14:1.6.0: 308/715 (43.08%)

**Line:**
- org.slf4j:slf4j-jdk14:1.5.6: 77/172 (44.77%)
- org.slf4j:slf4j-jdk14:1.6.0: 77/172 (44.77%)

**Method:**
- org.slf4j:slf4j-jdk14:1.5.6: 21/49 (42.86%)
- org.slf4j:slf4j-jdk14:1.6.0: 21/49 (42.86%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.slf4j/slf4j-jdk14/1.5.6/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java 2/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
index b42d00c1bd..dc2f12d437 100644
--- 1/tests/src/org.slf4j/slf4j-jdk14/1.5.6/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
+++ 2/tests/src/org.slf4j/slf4j-jdk14/1.6.0/src/test/java/org_slf4j/slf4j_jdk14/JDK14LoggerAdapterTest.java
@@ -137,7 +137,7 @@ public class JDK14LoggerAdapterTest {
     private static final class LocationAwareInvoker {
 
         private static void logWarning(LocationAwareLogger logger, String message, Throwable throwable) {
-            logger.log(null, LocationAwareInvoker.class.getName(), LocationAwareLogger.WARN_INT, message, throwable);
+            logger.log(null, LocationAwareInvoker.class.getName(), LocationAwareLogger.WARN_INT, message, null, throwable);
         }
     }
 }

```
