### PR TITLE
[GenAI] Test fix for org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1 using gpt-5.5

### DIFF
--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/reachability-metadata.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryLoader"
+      },
+      "type": "java.lang.String",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]"
+          ]
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+      },
+      "type": "java.util.AbstractCollection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.DirectByteBufferDeallocator"
+      },
+      "type": "java.nio.ByteBuffer",
+      "methods": [
+        {
+          "name": "clear",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL"
+      },
+      "type": "org.wildfly.openssl.SSL$LibraryLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "load",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "org.wildfly.openssl.SSL$LibraryLoader"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL"
+      },
+      "type": "org.wildfly.openssl.SSLImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "org.wildfly.openssl.SSLImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "head"
+        },
+        {
+          "name": "tail"
+        }
+      ],
+      "methods": [
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque$Node"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque$Node",
+      "fields": [
+        {
+          "name": "item"
+        },
+        {
+          "name": "next"
+        },
+        {
+          "name": "prev"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque$Node"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque$Node"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.DirectByteBufferDeallocator"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "linux-x86_64/libwfssl.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "org/wildfly/openssl/SSL$LibraryLoader.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "org/wildfly/openssl/SSLImpl.class"
+    },
+    {
+      "bundle": "org.wildfly.openssl.OpenSSLMessages"
+    }
+  ]
+}

--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0.Alpha1",
+    "tested-versions" : [
+      "2.0.0.Alpha1"
+    ],
+    "allowed-packages" : [
+      "org.wildfly.openssl"
+    ]
+  },
+  {
     "metadata-version" : "1.0.7.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl-java/$version$/wildfly-openssl-java-$version$-sources.jar",
     "repository-url" : "https://github.com/wildfly-security/wildfly-openssl",

--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0.Alpha1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl-java/$version$/wildfly-openssl-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/wildfly-security/wildfly-openssl",
+    "test-code-url" : "https://github.com/wildfly-security/wildfly-openssl/tree/$version$/java/src/test",
+    "documentation-url" : "https://github.com/wildfly-security/wildfly-openssl/blob/$version$/README.md",
+    "description" : "WildFly OpenSSL Java provides Java bindings for OpenSSL and exposes them through JSSE-compatible SSLContext and security provider APIs. The java artifact contains the Java side of the binding and expects the native library to be supplied separately or through a platform-specific WildFly OpenSSL artifact.",
     "tested-versions" : [
       "2.0.0.Alpha1"
     ],

--- a/stats/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/execution-metrics.json
+++ b/stats/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T21:41:10.388786Z",
+    "library": "org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1",
+    "starting_commit": "b0c0bfed4b6f419fa9b0d0060c22217ff33d31aa",
+    "ending_commit": "b040fa60eb1cdd8928bd0277d903094976f08ae7",
+    "previous_library": "org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0.Alpha1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2371,
+          "missed": 16864,
+          "ratio": 0.123265,
+          "total": 19235
+        },
+        "line": {
+          "covered": 601,
+          "missed": 3281,
+          "ratio": 0.154817,
+          "total": 3882
+        },
+        "method": {
+          "covered": 112,
+          "missed": 630,
+          "ratio": 0.150943,
+          "total": 742
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.7.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2193,
+          "missed": 16424,
+          "ratio": 0.117796,
+          "total": 18617
+        },
+        "line": {
+          "covered": 563,
+          "missed": 3178,
+          "ratio": 0.150495,
+          "total": 3741
+        },
+        "method": {
+          "covered": 110,
+          "missed": 615,
+          "ratio": 0.151724,
+          "total": 725
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 39322,
+      "cached_input_tokens_used": 357376,
+      "output_tokens_used": 4023,
+      "iterations": 2,
+      "cost_usd": 0.2994,
+      "tested_library_loc": 601,
+      "metadata_entries": 51,
+      "previous_library_metadata_entries": 51,
+      "code_coverage_percent": 15.48,
+      "previous_library_coverage_percent": 15.05
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java",
+      "metadata_file": "metadata/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/stats.json
+++ b/stats/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0.Alpha1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 22,
+      "totalCalls" : 22
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2371,
+        "missed" : 16864,
+        "ratio" : 0.123265,
+        "total" : 19235
+      },
+      "line" : {
+        "covered" : 601,
+        "missed" : 3281,
+        "ratio" : 0.154817,
+        "total" : 3882
+      },
+      "method" : {
+        "covered" : 112,
+        "missed" : 630,
+        "ratio" : 0.150943,
+        "total" : 742
+      }
+    }
+  } ]
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/.gitignore
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
@@ -10,9 +10,24 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup "org.wildfly.openssl"
+        }
+    }
+}
+
 dependencies {
-    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion"
-    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion"
+    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion@jar"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/gradle.properties
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1
+library.version = 2.0.0.Alpha1
+metadata.dir = org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/settings.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.wildfly.openssl.wildfly-openssl-java_tests'

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/ConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/ConcurrentDirectDequeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.ConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentDirectDequeTest {
+    @Test
+    void newInstanceCreatesUsableDequeWithTokenRemoval() {
+        ConcurrentDirectDeque<String> deque = ConcurrentDirectDeque.newInstance();
+
+        Object firstToken = deque.offerFirstAndReturnToken("first");
+        Object lastToken = deque.offerLastAndReturnToken("last");
+
+        assertThat(firstToken).isNotNull();
+        assertThat(lastToken).isNotNull();
+        assertThat(deque).containsExactly("first", "last");
+
+        deque.removeToken(firstToken);
+        assertThat(deque).containsExactly("last");
+        assertThat(deque.pollFirst()).isEqualTo("last");
+        assertThat(deque).isEmpty();
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.DirectByteBufferDeallocator;
+
+import sun.misc.Unsafe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DirectByteBufferDeallocatorTest {
+    @Test
+    void freeReleasesDirectByteBufferThroughPublicApi() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(32);
+        buffer.putInt(0, 42);
+
+        DirectByteBufferDeallocator.free(buffer);
+
+        assertThat(buffer.isDirect()).isTrue();
+    }
+
+    @Test
+    void freeIgnoresNullAndHeapByteBuffers() {
+        ByteBuffer heapBuffer = ByteBuffer.allocate(16);
+
+        DirectByteBufferDeallocator.free(null);
+        DirectByteBufferDeallocator.free(heapBuffer);
+
+        assertThat(heapBuffer.isDirect()).isFalse();
+    }
+
+    @Test
+    void freeCanUseCleanerMethodFallback() throws ReflectiveOperationException {
+        Unsafe unsafe = getUnsafe();
+        Field unsafeField = getDirectByteBufferDeallocatorField("UNSAFE");
+        Field cleanerField = getDirectByteBufferDeallocatorField("cleaner");
+        Field cleanerCleanField = getDirectByteBufferDeallocatorField("cleanerClean");
+        Object originalUnsafe = readStaticField(unsafe, unsafeField);
+        Object originalCleaner = readStaticField(unsafe, cleanerField);
+        Object originalCleanerClean = readStaticField(unsafe, cleanerCleanField);
+        Method clear = ByteBuffer.class.getMethod("clear");
+
+        try {
+            writeStaticField(unsafe, unsafeField, null);
+            writeStaticField(unsafe, cleanerField, clear);
+            writeStaticField(unsafe, cleanerCleanField, clear);
+            assertThat(readStaticField(unsafe, unsafeField)).isNull();
+
+            ByteBuffer buffer = ByteBuffer.allocateDirect(32);
+
+            DirectByteBufferDeallocator.free(buffer);
+
+            assertThat(buffer.isDirect()).isTrue();
+        } finally {
+            writeStaticField(unsafe, unsafeField, originalUnsafe);
+            writeStaticField(unsafe, cleanerField, originalCleaner);
+            writeStaticField(unsafe, cleanerCleanField, originalCleanerClean);
+        }
+    }
+
+    private static Field getDirectByteBufferDeallocatorField(String fieldName) throws NoSuchFieldException {
+        Field field = DirectByteBufferDeallocator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static Unsafe getUnsafe() throws ReflectiveOperationException {
+        Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        return (Unsafe) theUnsafe.get(null);
+    }
+
+    private static Object readStaticField(Unsafe unsafe, Field field) {
+        return unsafe.getObject(unsafe.staticFieldBase(field), unsafe.staticFieldOffset(field));
+    }
+
+    private static void writeStaticField(Unsafe unsafe, Field field, Object value) {
+        unsafe.putObject(unsafe.staticFieldBase(field), unsafe.staticFieldOffset(field), value);
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/FastConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/FastConcurrentDirectDequeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.FastConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastConcurrentDirectDequeTest {
+    @Test
+    void serializationRoundTripPreservesElementsInDequeOrder() throws IOException, ClassNotFoundException {
+        FastConcurrentDirectDeque<String> original = new FastConcurrentDirectDeque<>();
+        original.addLast("first");
+        original.addLast("second");
+        original.addFirst("zero");
+
+        byte[] serialized = serialize(original);
+        FastConcurrentDirectDeque<String> restored = deserialize(serialized);
+
+        assertThat(restored).containsExactly("zero", "first", "second");
+        assertThat(restored.pollFirst()).isEqualTo("zero");
+        assertThat(restored.pollLast()).isEqualTo("second");
+        assertThat(restored).containsExactly("first");
+    }
+
+    private static byte[] serialize(FastConcurrentDirectDeque<String> deque) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(deque);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FastConcurrentDirectDeque<String> deserialize(byte[] serialized)
+        throws IOException, ClassNotFoundException {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (FastConcurrentDirectDeque<String>) input.readObject();
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/PortableConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/PortableConcurrentDirectDequeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.PortableConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PortableConcurrentDirectDequeTest {
+    @Test
+    void serializationRoundTripPreservesElementsInDequeOrder() throws IOException, ClassNotFoundException {
+        PortableConcurrentDirectDeque<String> original = new PortableConcurrentDirectDeque<>();
+        original.addLast("first");
+        original.addLast("second");
+        original.addFirst("zero");
+
+        byte[] serialized = serialize(original);
+        PortableConcurrentDirectDeque<String> restored = deserialize(serialized);
+
+        assertThat(restored).containsExactly("zero", "first", "second");
+        assertThat(restored.pollFirst()).isEqualTo("zero");
+        assertThat(restored.pollLast()).isEqualTo("second");
+        assertThat(restored).containsExactly("first");
+    }
+
+    private static byte[] serialize(PortableConcurrentDirectDeque<String> deque) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(deque);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PortableConcurrentDirectDeque<String> deserialize(byte[] serialized)
+        throws IOException, ClassNotFoundException {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (PortableConcurrentDirectDeque<String>) input.readObject();
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/SSLTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/src/test/java/org_wildfly_openssl/wildfly_openssl_java/SSLTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.wildfly.openssl.SSL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SSLTest {
+    @Test
+    void getInstanceUsesPackagedNativeLibraryFallback(@TempDir Path openSslDirectory) {
+        String originalOpenSslPath = System.getProperty(SSL.ORG_WILDFLY_OPENSSL_PATH);
+        String originalWfsslPath = System.getProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH);
+        try {
+            System.setProperty(SSL.ORG_WILDFLY_OPENSSL_PATH, openSslDirectory.toString());
+            System.clearProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH);
+
+            try {
+                SSL ssl = SSL.getInstance();
+
+                assertThat(ssl).isNotNull();
+            } catch (RuntimeException exception) {
+                assertThat(hasInvocationTargetExceptionCause(exception)).isFalse();
+            } catch (Error error) {
+                if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    throw error;
+                }
+            }
+        } finally {
+            setOrClearProperty(SSL.ORG_WILDFLY_OPENSSL_PATH, originalOpenSslPath);
+            setOrClearProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH, originalWfsslPath);
+        }
+    }
+
+    private static boolean hasInvocationTargetExceptionCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof InvocationTargetException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static void setOrClearProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.006" hostname="mihailo-Precision-5690" timestamp="2026-05-02T19:55:46">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3032-bd074974/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<testcase name="freeReleasesDirectByteBufferThroughPublicApi()" classname="org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest]/[method:freeReleasesDirectByteBufferThroughPublicApi()]
+display-name: freeReleasesDirectByteBufferThroughPublicApi()
+]]></system-out>
+</testcase>
+<testcase name="freeIgnoresNullAndHeapByteBuffers()" classname="org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest]/[method:freeIgnoresNullAndHeapByteBuffers()]
+display-name: freeIgnoresNullAndHeapByteBuffers()
+]]></system-out>
+</testcase>
+<testcase name="newInstanceCreatesUsableDequeWithTokenRemoval()" classname="org_wildfly_openssl.wildfly_openssl_java.ConcurrentDirectDequeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.ConcurrentDirectDequeTest]/[method:newInstanceCreatesUsableDequeWithTokenRemoval()]
+display-name: newInstanceCreatesUsableDequeWithTokenRemoval()
+]]></system-out>
+</testcase>
+<testcase name="serializationRoundTripPreservesElementsInDequeOrder()" classname="org_wildfly_openssl.wildfly_openssl_java.FastConcurrentDirectDequeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.FastConcurrentDirectDequeTest]/[method:serializationRoundTripPreservesElementsInDequeOrder()]
+display-name: serializationRoundTripPreservesElementsInDequeOrder()
+]]></system-out>
+</testcase>
+<testcase name="freeCanUseCleanerMethodFallback()" classname="org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest]/[method:freeCanUseCleanerMethodFallback()]
+display-name: freeCanUseCleanerMethodFallback()
+]]></system-out>
+</testcase>
+<testcase name="serializationRoundTripPreservesElementsInDequeOrder()" classname="org_wildfly_openssl.wildfly_openssl_java.PortableConcurrentDirectDequeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.PortableConcurrentDirectDequeTest]/[method:serializationRoundTripPreservesElementsInDequeOrder()]
+display-name: serializationRoundTripPreservesElementsInDequeOrder()
+]]></system-out>
+</testcase>
+<testcase name="getInstanceUsesPackagedNativeLibraryFallback(Path)" classname="org_wildfly_openssl.wildfly_openssl_java.SSLTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.SSLTest]/[method:getInstanceUsesPackagedNativeLibraryFallback(java.nio.file.Path)]
+display-name: getInstanceUsesPackagedNativeLibraryFallback(Path)
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.006" hostname="mihailo-Precision-5690" timestamp="2026-05-02T19:55:46">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-02T23:40:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -10,22 +10,22 @@
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
@@ -45,11 +45,11 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3032-bd074974/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final"/>
-<property name="user.home" value="/home/mihailo"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4433-9f3be350/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1"/>
+<property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
-<property name="user.name" value="mihailo"/>
-<property name="user.timezone" value="Europe/Belgrade"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <testcase name="freeReleasesDirectByteBufferThroughPublicApi()" classname="org_wildfly_openssl.wildfly_openssl_java.DirectByteBufferDeallocatorTest" time="0">
 <system-out><![CDATA[
@@ -63,13 +63,13 @@ unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_jav
 display-name: freeIgnoresNullAndHeapByteBuffers()
 ]]></system-out>
 </testcase>
-<testcase name="newInstanceCreatesUsableDequeWithTokenRemoval()" classname="org_wildfly_openssl.wildfly_openssl_java.ConcurrentDirectDequeTest" time="0.001">
+<testcase name="newInstanceCreatesUsableDequeWithTokenRemoval()" classname="org_wildfly_openssl.wildfly_openssl_java.ConcurrentDirectDequeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.ConcurrentDirectDequeTest]/[method:newInstanceCreatesUsableDequeWithTokenRemoval()]
 display-name: newInstanceCreatesUsableDequeWithTokenRemoval()
 ]]></system-out>
 </testcase>
-<testcase name="serializationRoundTripPreservesElementsInDequeOrder()" classname="org_wildfly_openssl.wildfly_openssl_java.FastConcurrentDirectDequeTest" time="0.001">
+<testcase name="serializationRoundTripPreservesElementsInDequeOrder()" classname="org_wildfly_openssl.wildfly_openssl_java.FastConcurrentDirectDequeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.FastConcurrentDirectDequeTest]/[method:serializationRoundTripPreservesElementsInDequeOrder()]
 display-name: serializationRoundTripPreservesElementsInDequeOrder()
@@ -87,7 +87,7 @@ unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_jav
 display-name: serializationRoundTripPreservesElementsInDequeOrder()
 ]]></system-out>
 </testcase>
-<testcase name="getInstanceUsesPackagedNativeLibraryFallback(Path)" classname="org_wildfly_openssl.wildfly_openssl_java.SSLTest" time="0.001">
+<testcase name="getInstanceUsesPackagedNativeLibraryFallback(Path)" classname="org_wildfly_openssl.wildfly_openssl_java.SSLTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_wildfly_openssl.wildfly_openssl_java.SSLTest]/[method:getInstanceUsesPackagedNativeLibraryFallback(java.nio.file.Path)]
 display-name: getInstanceUsesPackagedNativeLibraryFallback(Path)

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T19:55:46">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3032-bd074974/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T19:55:46">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:40:10">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -10,22 +10,22 @@
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
@@ -45,11 +45,11 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3032-bd074974/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final"/>
-<property name="user.home" value="/home/mihailo"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4433-9f3be350/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1"/>
+<property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
-<property name="user.name" value="mihailo"/>
-<property name="user.timezone" value="Europe/Belgrade"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/user-code-filter.json
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.wildfly.openssl.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4433

This PR provides test fixes and new metadata for org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 39322
- Cached input tokens: 357376
- Output tokens: 4023
- Metadata entries: 51
- Iterations: 2
- Library coverage percentage: 15.48
- Previous library version metadata entries: 51
- Previous library version coverage percentage: 15.05

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `904a573c65d2c81961aaf0615032c8b1f3f2027c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 22/22 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 22/22 covered calls (100.00%)

**Reflection:**
- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 19/19 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 19/19 covered calls (100.00%)

**Resources:**
- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 3/3 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 2193/18617 (11.78%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 2371/19235 (12.33%)

**Line:**
- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 563/3741 (15.05%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 601/3882 (15.48%)

**Method:**
- org.wildfly.openssl:wildfly-openssl-java:1.0.7.Final: 110/725 (15.17%)
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 112/742 (15.09%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final/build.gradle 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
index 158c62485a..3b477b24d8 100644
--- 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/1.0.7.Final/build.gradle
+++ 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
@@ -10,9 +10,24 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup "org.wildfly.openssl"
+        }
+    }
+}
+
 dependencies {
-    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion"
-    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion"
+    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion@jar"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

```
