### PR TITLE
[Automation] Generated metadata for org.xerial:sqlite-jdbc:3.40.0.0

### DIFF
--- a/metadata/org.xerial/sqlite-jdbc/3.40.0.0/reachability-metadata.json
+++ b/metadata/org.xerial/sqlite-jdbc/3.40.0.0/reachability-metadata.json
@@ -1,0 +1,266 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "java.lang.Throwable",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "toString",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.javax.SQLitePooledConnection$1"
+      },
+      "type" : "java.sql.Connection",
+      "methods" : [
+        {
+          "name" : "createStatement",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getAutoCommit",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "isClosed",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.Collation",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "xCompare",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.Function",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "args"
+        },
+        {
+          "name" : "context"
+        },
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "xFunc",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.Function$Aggregate",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "clone",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xFinal",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xStep",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.Function$Window",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "xInverse",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "xValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.ProgressHandler",
+      "jniAccessible" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.core.DB",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "throwex",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "throwex",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.core.DB$ProgressObserver",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "progress",
+          "parameterTypes" : [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "org.sqlite.core.NativeDB",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "pointer"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "stringToUtf8ByteArray",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "throwex",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.core.NativeDB"
+      },
+      "type" : "org.sqlite.core.NativeDB",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "busyHandler"
+        },
+        {
+          "name" : "commitListener"
+        },
+        {
+          "name" : "progressHandler"
+        },
+        {
+          "name" : "updateListener"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.javax.SQLitePooledConnection"
+      },
+      "type" : {
+        "proxy" : [
+          "java.sql.Connection"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.util.ResourceFinder"
+      },
+      "glob" : "/org_xerial/sqlite_jdbc/resource_finder_missing_resource.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "glob" : "META-INF/maven/org.xerial/sqlite-jdbc/pom.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.SQLiteJDBCLoader"
+      },
+      "glob" : "org/sqlite/native/Linux/x86_64/libsqlitejdbc.so"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.sqlite.jdbc3.JDBC3DatabaseMetaData"
+      },
+      "glob" : "sqlite-jdbc.properties"
+    }
+  ]
+}

--- a/metadata/org.xerial/sqlite-jdbc/index.json
+++ b/metadata/org.xerial/sqlite-jdbc/index.json
@@ -1,13 +1,28 @@
 [
   {
     "latest" : true,
-    "metadata-version" : "3.39.2.1",
+    "metadata-version" : "3.40.0.0",
+    "test-version" : "3.36.0.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-sources.jar",
     "repository-url" : "https://github.com/xerial/sqlite-jdbc",
     "test-code-url" : "https://github.com/xerial/sqlite-jdbc/tree/$version$/src/test",
     "documentation-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-javadoc.jar",
     "description" : "SQLite JDBC is a JDBC driver for accessing and creating SQLite database files from Java applications. It packages native SQLite libraries for major operating systems into a single JAR so applications can use SQLite without separate native setup.",
+    "tested-versions" : [
+      "3.40.0.0"
+    ],
+    "allowed-packages" : [
+      "org.sqlite"
+    ]
+  },
+  {
+    "metadata-version" : "3.39.2.1",
     "test-version" : "3.36.0.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-sources.jar",
+    "repository-url" : "https://github.com/xerial/sqlite-jdbc",
+    "test-code-url" : "https://github.com/xerial/sqlite-jdbc/tree/$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/xerial/sqlite-jdbc/$version$/sqlite-jdbc-$version$-javadoc.jar",
+    "description" : "SQLite JDBC is a JDBC driver for accessing and creating SQLite database files from Java applications. It packages native SQLite libraries for major operating systems into a single JAR so applications can use SQLite without separate native setup.",
     "tested-versions" : [
       "3.39.2.1"
     ],

--- a/stats/org.xerial/sqlite-jdbc/3.40.0.0/stats.json
+++ b/stats/org.xerial/sqlite-jdbc/3.40.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.40.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 8,
+      "totalCalls" : 8
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5746,
+        "missed" : 15635,
+        "ratio" : 0.268743,
+        "total" : 21381
+      },
+      "line" : {
+        "covered" : 1262,
+        "missed" : 3559,
+        "ratio" : 0.261771,
+        "total" : 4821
+      },
+      "method" : {
+        "covered" : 264,
+        "missed" : 1106,
+        "ratio" : 0.192701,
+        "total" : 1370
+      }
+    }
+  } ]
+}

--- a/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/build.gradle
+++ b/tests/src/org.xerial/sqlite-jdbc/3.36.0.3/build.gradle
@@ -24,4 +24,14 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        all {
+            // sqlite-jdbc 3.40.x loads a JNI library that expects libm symbols at runtime.
+            buildArgs.addAll([
+                '-H:NativeLinkerOption=-Wl,--no-as-needed',
+                '-H:NativeLinkerOption=-lm',
+                '-H:NativeLinkerOption=-Wl,--as-needed'
+            ])
+        }
+    }
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4434

This PR provides new metadata needed for the org.xerial:sqlite-jdbc:3.40.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 32
- Test-only metadata entries (previous `org.xerial:sqlite-jdbc:3.36.0.3`): 1
- Metadata entries (new `org.xerial:sqlite-jdbc:3.40.0.0`): 54
- Test-only metadata entries (new `org.xerial:sqlite-jdbc:3.40.0.0`): 1
- Library coverage (previous): 26.55%
- Library coverage (new): 26.18%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a758056b19dbb8f8b60efbcc3641b8b9192af511`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.xerial:sqlite-jdbc:3.36.0.3: 8/8 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 8/8 covered calls (100.00%)

**Reflection:**
- org.xerial:sqlite-jdbc:3.36.0.3: 3/3 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 3/3 covered calls (100.00%)

**Resources:**
- org.xerial:sqlite-jdbc:3.36.0.3: 5/5 covered calls (100.00%)
- org.xerial:sqlite-jdbc:3.40.0.0: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.xerial:sqlite-jdbc:3.36.0.3: 5428/19427 (27.94%)
- org.xerial:sqlite-jdbc:3.40.0.0: 5746/21381 (26.87%)

**Line:**
- org.xerial:sqlite-jdbc:3.36.0.3: 1132/4264 (26.55%)
- org.xerial:sqlite-jdbc:3.40.0.0: 1262/4821 (26.18%)

**Method:**
- org.xerial:sqlite-jdbc:3.36.0.3: 236/1277 (18.48%)
- org.xerial:sqlite-jdbc:3.40.0.0: 264/1370 (19.27%)
