### PR TITLE
[GenAI] Add support for org.eclipse.jetty:jetty-ee:12.0.10 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-ee/12.0.10/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-ee/12.0.10/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.ee.WebAppClassLoading"
+      },
+      "type": "org.eclipse.jetty.util.ClassMatcher$ByLocationOrModule",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.ee.WebAppClassLoading"
+      },
+      "type": "org.eclipse.jetty.util.ClassMatcher$ByPackageOrName",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-ee/index.json
+++ b/metadata/org.eclipse.jetty/jetty-ee/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "12.0.10",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-ee/$version$/jetty-ee-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-$version$/jetty-core/jetty-ee/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-ee/$version$/jetty-ee-$version$-javadoc.jar",
+    "description" : "Jetty EE provides common Eclipse Jetty support for enterprise web application class loading. It defines defaults and helper methods for protected and hidden class patterns used by Jetty web application environments and server instances.",
+    "tested-versions" : [
+      "12.0.10"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.ee"
+    ]
+  }
+]

--- a/stats/org.eclipse.jetty/jetty-ee/12.0.10/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-ee/12.0.10/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-02": {
+    "timestamp": "2026-05-02T21:47:48.926158Z",
+    "library": "org.eclipse.jetty:jetty-ee:12.0.10",
+    "starting_commit": "35ed45359ce33905f5a92c08c6b1e7401993a285",
+    "ending_commit": "74831ebdcd76c8d91eca59820d5e4938b8e93c56",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "12.0.10",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 165,
+          "missed": 13,
+          "ratio": 0.926966,
+          "total": 178
+        },
+        "line": {
+          "covered": 33,
+          "missed": 3,
+          "ratio": 0.916667,
+          "total": 36
+        },
+        "method": {
+          "covered": 14,
+          "missed": 1,
+          "ratio": 0.933333,
+          "total": 15
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 209764,
+      "cached_input_tokens_used": 1903104,
+      "output_tokens_used": 23498,
+      "iterations": 5,
+      "cost_usd": 1.6565,
+      "generated_loc": 193,
+      "tested_library_loc": 33,
+      "metadata_entries": 4,
+      "code_coverage_percent": 91.67
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-ee/12.0.10/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-ee/12.0.10/stats.json
+++ b/stats/org.eclipse.jetty/jetty-ee/12.0.10/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "12.0.10",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 165,
+        "missed" : 13,
+        "ratio" : 0.926966,
+        "total" : 178
+      },
+      "line" : {
+        "covered" : 33,
+        "missed" : 3,
+        "ratio" : 0.916667,
+        "total" : 36
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 1,
+        "ratio" : 0.933333,
+        "total" : 15
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-ee:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-ee:12.0.10
+library.version = 12.0.10
+metadata.dir = org.eclipse.jetty/jetty-ee/12.0.10/

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-ee_tests'

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
@@ -120,6 +120,24 @@ public class Jetty_eeTest {
     }
 
     @Test
+    void serverMatchersStartWithoutEnvironmentDefaultPatterns() {
+        Server server = new Server();
+        try {
+            ClassMatcher protectedMatcher = WebAppClassLoading.getProtectedClasses(server);
+            ClassMatcher hiddenMatcher = WebAppClassLoading.getHiddenClasses(server);
+
+            assertThat(protectedMatcher.getPatterns()).isEmpty();
+            assertThat(hiddenMatcher.getPatterns()).isEmpty();
+            assertThat(protectedMatcher).isNotSameAs(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES);
+            assertThat(hiddenMatcher).isNotSameAs(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES);
+            assertThat(WebAppClassLoading.getProtectedClasses(server)).isSameAs(protectedMatcher);
+            assertThat(WebAppClassLoading.getHiddenClasses(server)).isSameAs(hiddenMatcher);
+        } finally {
+            server.destroy();
+        }
+    }
+
+    @Test
     void serverMatchersAreStoredAsIndependentServerAttributes() {
         Server server = new Server();
         try {

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
@@ -8,6 +8,7 @@ package org_eclipse_jetty.jetty_ee;
 
 import org.eclipse.jetty.ee.WebAppClassLoading;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.AttributesMap;
 import org.eclipse.jetty.util.ClassMatcher;
 import org.eclipse.jetty.util.component.Environment;
@@ -99,6 +100,22 @@ public class Jetty_eeTest {
         WebAppClassLoading.addHiddenClasses((Environment) attributes);
 
         assertThat(attributes.getAttribute(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE)).isNull();
+        assertThat(attributes.getAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    void genericAttributesStoreProtectedClassMatcherWithoutEnvironmentDefaults() {
+        Attributes attributes = new AttributesMap();
+
+        WebAppClassLoading.addProtectedClasses(attributes, "com.attributes.protected.");
+
+        ClassMatcher protectedMatcher = (ClassMatcher) attributes.getAttribute(
+                WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE);
+
+        assertThat(protectedMatcher).isNotNull();
+        assertThat(protectedMatcher.match("com.attributes.protected.Endpoint")).isTrue();
+        assertThat(protectedMatcher.match("com.attributes.public.Endpoint")).isFalse();
+        assertThat(protectedMatcher.match("java.lang.String")).isFalse();
         assertThat(attributes.getAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE)).isNull();
     }
 

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_ee;
+
+import org.junit.jupiter.api.Test;
+
+class Jetty_eeTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/src/test/java/org_eclipse_jetty/jetty_ee/Jetty_eeTest.java
@@ -6,11 +6,192 @@
  */
 package org_eclipse_jetty.jetty_ee;
 
+import org.eclipse.jetty.ee.WebAppClassLoading;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.AttributesMap;
+import org.eclipse.jetty.util.ClassMatcher;
+import org.eclipse.jetty.util.component.Environment;
 import org.junit.jupiter.api.Test;
 
-class Jetty_eeTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jetty_eeTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces() {
+        assertThat(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE)
+                .isEqualTo("org.eclipse.jetty.webapp.systemClasses");
+        assertThat(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE)
+                .isEqualTo("org.eclipse.jetty.webapp.serverClasses");
+
+        assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match(String.class)).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match("jakarta.servlet.Servlet")).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match("org.xml.sax.SAXException")).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match("com.example.Application")).isFalse();
+
+        assertThat(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.match(WebAppClassLoading.class)).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.match("org.eclipse.jetty.server.Server")).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.match("com.example.Application")).isFalse();
+
+        assertThat(new WebAppClassLoading()).isNotNull();
+    }
+
+    @Test
+    void environmentAttributesWithStringArraysAreConvertedToReusableClassMatchers() {
+        TestEnvironment attributes = new TestEnvironment("array-backed-environment");
+        attributes.setAttribute(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE, new String[] {
+                "com.acme.protected.",
+                "-com.acme.protected.open."
+        });
+        attributes.setAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE, new String[] {
+                "com.acme.internal.",
+                "-com.acme.internal.public."
+        });
+
+        ClassMatcher protectedMatcher = WebAppClassLoading.getProtectedClasses(attributes);
+        ClassMatcher hiddenMatcher = WebAppClassLoading.getHiddenClasses(attributes);
+
+        assertThat(attributes.getAttribute(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE)).isSameAs(protectedMatcher);
+        assertThat(WebAppClassLoading.getProtectedClasses(attributes)).isSameAs(protectedMatcher);
+        assertThat(protectedMatcher.match("com.acme.protected.SecretService")).isTrue();
+        assertThat(protectedMatcher.match("com.acme.protected.open.Controller")).isFalse();
+        assertThat(protectedMatcher.match("com.acme.other.Component")).isFalse();
+
+        assertThat(attributes.getAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE)).isSameAs(hiddenMatcher);
+        assertThat(WebAppClassLoading.getHiddenClasses(attributes)).isSameAs(hiddenMatcher);
+        assertThat(hiddenMatcher.match("com.acme.internal.DatabasePassword")).isTrue();
+        assertThat(hiddenMatcher.match("com.acme.internal.public.StatusEndpoint")).isFalse();
+        assertThat(hiddenMatcher.match("com.acme.public.Api")).isFalse();
+    }
+
+    @Test
+    void existingEnvironmentAttributeMatchersAreReusedAndExtendedInPlace() {
+        TestEnvironment attributes = new TestEnvironment("existing-matcher-environment");
+        ClassMatcher existingProtectedMatcher = new ClassMatcher("com.example.base.");
+        ClassMatcher existingHiddenMatcher = new ClassMatcher("com.example.secret.");
+        attributes.setAttribute(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE, existingProtectedMatcher);
+        attributes.setAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE, existingHiddenMatcher);
+
+        WebAppClassLoading.addProtectedClasses((Environment) attributes, (String[]) null);
+        WebAppClassLoading.addProtectedClasses((Environment) attributes);
+        WebAppClassLoading.addProtectedClasses((Environment) attributes, "com.example.added.");
+        WebAppClassLoading.addHiddenClasses((Environment) attributes, (String[]) null);
+        WebAppClassLoading.addHiddenClasses((Environment) attributes);
+        WebAppClassLoading.addHiddenClasses((Environment) attributes, "com.example.hidden.");
+
+        assertThat(WebAppClassLoading.getProtectedClasses(attributes)).isSameAs(existingProtectedMatcher);
+        assertThat(existingProtectedMatcher.match("com.example.base.Component")).isTrue();
+        assertThat(existingProtectedMatcher.match("com.example.added.Component")).isTrue();
+        assertThat(existingProtectedMatcher.match("com.example.secret.Component")).isFalse();
+
+        assertThat(WebAppClassLoading.getHiddenClasses(attributes)).isSameAs(existingHiddenMatcher);
+        assertThat(existingHiddenMatcher.match("com.example.secret.Component")).isTrue();
+        assertThat(existingHiddenMatcher.match("com.example.hidden.Component")).isTrue();
+        assertThat(existingHiddenMatcher.match("com.example.added.Component")).isFalse();
+    }
+
+    @Test
+    void nullAndEmptyAdditionsDoNotCreateEnvironmentAttributeMatchers() {
+        TestEnvironment attributes = new TestEnvironment("empty-additions-environment");
+
+        WebAppClassLoading.addProtectedClasses((Environment) attributes, (String[]) null);
+        WebAppClassLoading.addProtectedClasses((Environment) attributes);
+        WebAppClassLoading.addHiddenClasses((Environment) attributes, (String[]) null);
+        WebAppClassLoading.addHiddenClasses((Environment) attributes);
+
+        assertThat(attributes.getAttribute(WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE)).isNull();
+        assertThat(attributes.getAttribute(WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    void serverMatchersAreStoredAsIndependentServerAttributes() {
+        Server server = new Server();
+        try {
+            ClassMatcher protectedMatcher = WebAppClassLoading.getProtectedClasses(server);
+            ClassMatcher hiddenMatcher = WebAppClassLoading.getHiddenClasses(server);
+
+            assertThat(protectedMatcher).isNotSameAs(hiddenMatcher);
+
+            WebAppClassLoading.addProtectedClasses(server, "com.server.protected.");
+            WebAppClassLoading.addHiddenClasses(server, "com.server.hidden.");
+
+            assertThat(WebAppClassLoading.getProtectedClasses(server)).isSameAs(protectedMatcher);
+            assertThat(WebAppClassLoading.getHiddenClasses(server)).isSameAs(hiddenMatcher);
+            assertThat(server.getAttributeNameSet())
+                    .contains(
+                            WebAppClassLoading.PROTECTED_CLASSES_ATTRIBUTE,
+                            WebAppClassLoading.HIDDEN_CLASSES_ATTRIBUTE);
+            assertThat(protectedMatcher.match("com.server.protected.Endpoint")).isTrue();
+            assertThat(protectedMatcher.match("com.server.hidden.Endpoint")).isFalse();
+            assertThat(hiddenMatcher.match("com.server.hidden.Endpoint")).isTrue();
+            assertThat(hiddenMatcher.match("com.server.protected.Endpoint")).isFalse();
+        } finally {
+            server.destroy();
+        }
+    }
+
+    @Test
+    void environmentMatchersStartAsCopiesOfDefaultsAndCanBeCustomized() {
+        TestEnvironment environment = new TestEnvironment("custom-ee-environment");
+
+        ClassMatcher protectedMatcher = WebAppClassLoading.getProtectedClasses(environment);
+        ClassMatcher hiddenMatcher = WebAppClassLoading.getHiddenClasses(environment);
+
+        assertThat(protectedMatcher).isNotSameAs(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES);
+        assertThat(hiddenMatcher).isNotSameAs(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES);
+        assertThat(protectedMatcher.match("java.lang.String")).isTrue();
+        assertThat(protectedMatcher.match("jakarta.servlet.Servlet")).isTrue();
+        assertThat(hiddenMatcher.match("org.eclipse.jetty.ee.WebAppClassLoading")).isTrue();
+
+        WebAppClassLoading.addProtectedClasses((Environment) environment, "com.environment.protected.");
+        WebAppClassLoading.addHiddenClasses((Environment) environment, "com.environment.hidden.");
+
+        assertThat(WebAppClassLoading.getProtectedClasses(environment)).isSameAs(protectedMatcher);
+        assertThat(WebAppClassLoading.getHiddenClasses(environment)).isSameAs(hiddenMatcher);
+        assertThat(protectedMatcher.match("com.environment.protected.Model")).isTrue();
+        assertThat(hiddenMatcher.match("com.environment.hidden.Model")).isTrue();
+        assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match("com.environment.protected.Model")).isFalse();
+        assertThat(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.match("com.environment.hidden.Model")).isFalse();
+    }
+
+    @Test
+    void staticAdditionsUpdateDefaultMatchersAndFutureEnvironmentCopies() {
+        String protectedPattern = "org.eclipse.jetty.ee.test.default.protected.";
+        String hiddenPattern = "org.eclipse.jetty.ee.test.default.hidden.";
+        try {
+            WebAppClassLoading.addProtectedClasses(protectedPattern);
+            WebAppClassLoading.addHiddenClasses(hiddenPattern);
+
+            assertThat(WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.match(protectedPattern + "Component")).isTrue();
+            assertThat(WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.match(hiddenPattern + "Component")).isTrue();
+
+            TestEnvironment environment = new TestEnvironment("environment-after-default-additions");
+            assertThat(WebAppClassLoading.getProtectedClasses(environment).match(protectedPattern + "Component"))
+                    .isTrue();
+            assertThat(WebAppClassLoading.getHiddenClasses(environment).match(hiddenPattern + "Component"))
+                    .isTrue();
+        } finally {
+            WebAppClassLoading.DEFAULT_PROTECTED_CLASSES.remove(protectedPattern);
+            WebAppClassLoading.DEFAULT_HIDDEN_CLASSES.remove(hiddenPattern);
+        }
+    }
+
+    private static final class TestEnvironment extends AttributesMap implements Environment {
+        private final String name;
+        private final ClassLoader classLoader;
+
+        private TestEnvironment(String name) {
+            this.name = name;
+            this.classLoader = Jetty_eeTest.class.getClassLoader();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return classLoader;
+        }
     }
 }

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.005" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:32:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="jetty.git.hash" value="26106dfc84a03ddb6216062fe33b047fc332d0ce"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3737-34ddd928/tests/src/org.eclipse.jetty/jetty-ee/12.0.10"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<testcase name="nullAndEmptyAdditionsDoNotCreateEnvironmentAttributeMatchers()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:nullAndEmptyAdditionsDoNotCreateEnvironmentAttributeMatchers()]
+display-name: nullAndEmptyAdditionsDoNotCreateEnvironmentAttributeMatchers()
+]]></system-out>
+</testcase>
+<testcase name="staticAdditionsUpdateDefaultMatchersAndFutureEnvironmentCopies()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:staticAdditionsUpdateDefaultMatchersAndFutureEnvironmentCopies()]
+display-name: staticAdditionsUpdateDefaultMatchersAndFutureEnvironmentCopies()
+]]></system-out>
+</testcase>
+<testcase name="defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()]
+display-name: defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()
+]]></system-out>
+</testcase>
+<testcase name="environmentMatchersStartAsCopiesOfDefaultsAndCanBeCustomized()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:environmentMatchersStartAsCopiesOfDefaultsAndCanBeCustomized()]
+display-name: environmentMatchersStartAsCopiesOfDefaultsAndCanBeCustomized()
+]]></system-out>
+</testcase>
+<testcase name="environmentAttributesWithStringArraysAreConvertedToReusableClassMatchers()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:environmentAttributesWithStringArraysAreConvertedToReusableClassMatchers()]
+display-name: environmentAttributesWithStringArraysAreConvertedToReusableClassMatchers()
+]]></system-out>
+</testcase>
+<testcase name="serverMatchersAreStoredAsIndependentServerAttributes()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:serverMatchersAreStoredAsIndependentServerAttributes()]
+display-name: serverMatchersAreStoredAsIndependentServerAttributes()
+]]></system-out>
+</testcase>
+<testcase name="existingEnvironmentAttributeMatchersAreReusedAndExtendedInPlace()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:existingEnvironmentAttributeMatchersAreReusedAndExtendedInPlace()]
+display-name: existingEnvironmentAttributeMatchersAreReusedAndExtendedInPlace()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:36:38">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.008" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:41:34">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -87,6 +87,12 @@ display-name: environmentAttributesWithStringArraysAreConvertedToReusableClassMa
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:serverMatchersAreStoredAsIndependentServerAttributes()]
 display-name: serverMatchersAreStoredAsIndependentServerAttributes()
+]]></system-out>
+</testcase>
+<testcase name="serverMatchersStartWithoutEnvironmentDefaultPatterns()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:serverMatchersStartWithoutEnvironmentDefaultPatterns()]
+display-name: serverMatchersStartWithoutEnvironmentDefaultPatterns()
 ]]></system-out>
 </testcase>
 <testcase name="genericAttributesStoreProtectedClassMatcherWithoutEnvironmentDefaults()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.005" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:32:03">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:36:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -87,6 +87,12 @@ display-name: environmentAttributesWithStringArraysAreConvertedToReusableClassMa
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:serverMatchersAreStoredAsIndependentServerAttributes()]
 display-name: serverMatchersAreStoredAsIndependentServerAttributes()
+]]></system-out>
+</testcase>
+<testcase name="genericAttributesStoreProtectedClassMatcherWithoutEnvironmentDefaults()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:genericAttributesStoreProtectedClassMatcherWithoutEnvironmentDefaults()]
+display-name: genericAttributesStoreProtectedClassMatcherWithoutEnvironmentDefaults()
 ]]></system-out>
 </testcase>
 <testcase name="existingEnvironmentAttributeMatchersAreReusedAndExtendedInPlace()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.008" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:41:34">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.005" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:45:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -25,7 +27,6 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="jetty.git.hash" value="26106dfc84a03ddb6216062fe33b047fc332d0ce"/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
@@ -33,7 +34,6 @@
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -44,7 +44,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3737-34ddd928/tests/src/org.eclipse.jetty/jetty-ee/12.0.10"/>
@@ -65,7 +64,7 @@ unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest
 display-name: staticAdditionsUpdateDefaultMatchersAndFutureEnvironmentCopies()
 ]]></system-out>
 </testcase>
-<testcase name="defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0.001">
+<testcase name="defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()" classname="org_eclipse_jetty.jetty_ee.Jetty_eeTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty.jetty_ee.Jetty_eeTest]/[method:defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()]
 display-name: defaultMatchersRecognizeProtectedAndHiddenJettyClassSpaces()

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:36:38">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:41:34">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:41:34">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:45:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -25,14 +27,12 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3737-34ddd928/tests/src/org.eclipse.jetty/jetty-ee/12.0.10"/>

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:32:03">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:36:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T23:32:03">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3737-34ddd928/tests/src/org.eclipse.jetty/jetty-ee/12.0.10"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.ee.**"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-ee/12.0.10/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.jetty.ee.**"
+      "includeClasses" : "org.eclipse.jetty.ee.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3737

This PR introduces tests and metadata for org.eclipse.jetty:jetty-ee:12.0.10, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 209764
- Cached input tokens: 1903104
- Output tokens: 23498
- Metadata entries: 4
- Iterations: 5
- Library coverage percentage: 91.67
- Generated lines of code: 193
- Tested library lines of code: 33

### Metadata Forge

- Forge monitored branch: `mm/scope-native-trace-exact-metadata`
- Forge branch: `mm/scope-native-trace-exact-metadata`
- Forge commit hash: `fa047a9def7868e4861545511a01dd47712ffa3f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 165/178 (92.70%)
- Line: 33/36 (91.67%)
- Method: 14/15 (93.33%)
