### PR TITLE
[GenAI] Test fix for org.apache.lucene:lucene-core:5.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.lucene/lucene-core/5.0.0/reachability-metadata.json
+++ b/metadata/org.apache.lucene/lucene-core/5.0.0/reachability-metadata.json
@@ -1,0 +1,359 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.HotSpotDiagnosticMXBean",
+      "methods" : [
+        {
+          "name" : "getVMOption",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.VMOption",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.VMOption$Origin",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "ATTACH_ON_DEMAND"
+        },
+        {
+          "name" : "CONFIG_FILE"
+        },
+        {
+          "name" : "DEFAULT"
+        },
+        {
+          "name" : "ENVIRON_VAR"
+        },
+        {
+          "name" : "ERGONOMIC"
+        },
+        {
+          "name" : "MANAGEMENT"
+        },
+        {
+          "name" : "OTHER"
+        },
+        {
+          "name" : "VM_CREATION"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.internal.Flag",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object",
+            "boolean",
+            "boolean",
+            "com.sun.management.VMOption$Origin"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Long",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "value"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$1$1"
+      },
+      "type" : "java.nio.DirectByteBuffer",
+      "methods" : [
+        {
+          "name" : "cleaner",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$1$1"
+      },
+      "type" : "java.nio.DirectByteBufferR"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$1$1"
+      },
+      "type" : "jdk.internal.ref.Cleaner",
+      "methods" : [
+        {
+          "name" : "clean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeFactory"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeImpl"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl",
+      "fields" : [
+        {
+          "name" : "flags"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.NamedSPILoader"
+      },
+      "type" : "org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.MMapDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.NIOFSDirectory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.nio.file.Path",
+            "org.apache.lucene.store.LockFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.RAMDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.SimpleFSDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.LockStressTest"
+      },
+      "type" : "org.apache.lucene.store.SimpleFSLockFactory",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "org.apache.lucene.util.BytesRef",
+      "fields" : [
+        {
+          "name" : "bytes"
+        },
+        {
+          "name" : "offset"
+        },
+        {
+          "name" : "length"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "org.apache.lucene.util.RamUsageEstimator$DummyOneFieldObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "org.apache.lucene.util.RamUsageEstimator$DummyTwoLongObject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory"
+      },
+      "type" : "sun.misc.Cleaner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.Constants"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "addressSize",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "arrayBaseOffset",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "arrayIndexScale",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "objectFieldOffset",
+          "parameterTypes" : [
+            "java.lang.reflect.Field"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.IOUtils"
+      },
+      "glob" : "META-INF/LICENSE.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.NamedSPILoader"
+      },
+      "glob" : "META-INF/services/org.apache.lucene.codecs.PostingsFormat"
+    }
+  ]
+}

--- a/metadata/org.apache.lucene/lucene-core/index.json
+++ b/metadata/org.apache.lucene/lucene-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "5.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/lucene-solr",
+    "test-code-url" : "https://github.com/apache/lucene-solr/tree/releases/lucene-solr/$version$/lucene/core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-javadoc.jar",
+    "description" : "Apache Lucene Core provides the core indexing, search, storage, and query APIs for the Lucene full-text search engine. It lets JVM applications create and query inverted indexes with analyzers, codecs, scoring, and low-level index management primitives.",
     "tested-versions" : [
       "5.0.0"
     ],

--- a/metadata/org.apache.lucene/lucene-core/index.json
+++ b/metadata/org.apache.lucene/lucene-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "5.0.0",
+    "tested-versions" : [
+      "5.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.lucene"
+    ]
+  },
+  {
     "metadata-version" : "4.10.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/lucene-solr",

--- a/stats/org.apache.lucene/lucene-core/5.0.0/execution-metrics.json
+++ b/stats/org.apache.lucene/lucene-core/5.0.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-02": {
+    "timestamp": "2026-05-02T21:58:57.761555Z",
+    "library": "org.apache.lucene:lucene-core:5.0.0",
+    "starting_commit": "130d44843fc1a22577ea765203e8261088c519f8",
+    "ending_commit": "75a56d42ae52ef9baaa5b893ef1e158a72cddb24",
+    "previous_library": "org.apache.lucene:lucene-core:4.10.4",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 34,
+            "totalCalls": 34
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 37,
+        "totalCalls": 37
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4234,
+          "missed": 259232,
+          "ratio": 0.01607,
+          "total": 263466
+        },
+        "line": {
+          "covered": 703,
+          "missed": 47062,
+          "ratio": 0.014718,
+          "total": 47765
+        },
+        "method": {
+          "covered": 164,
+          "missed": 8410,
+          "ratio": 0.019128,
+          "total": 8574
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.10.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 31,
+            "totalCalls": 31
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 34,
+        "totalCalls": 34
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4425,
+          "missed": 294325,
+          "ratio": 0.014812,
+          "total": 298750
+        },
+        "line": {
+          "covered": 767,
+          "missed": 54217,
+          "ratio": 0.01395,
+          "total": 54984
+        },
+        "method": {
+          "covered": 169,
+          "missed": 9453,
+          "ratio": 0.017564,
+          "total": 9622
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 97258,
+      "cached_input_tokens_used": 752128,
+      "output_tokens_used": 12536,
+      "iterations": 4,
+      "cost_usd": 0.7522,
+      "tested_library_loc": 703,
+      "metadata_entries": 69,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 71,
+      "previous_library_test_only_metadata_entries": 9,
+      "code_coverage_percent": 1.47,
+      "previous_library_coverage_percent": 1.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java",
+      "metadata_file": "metadata/org.apache.lucene/lucene-core/5.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.lucene/lucene-core/5.0.0/stats.json
+++ b/stats/org.apache.lucene/lucene-core/5.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 34,
+          "totalCalls" : 34
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 37,
+      "totalCalls" : 37
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4234,
+        "missed" : 259232,
+        "ratio" : 0.01607,
+        "total" : 263466
+      },
+      "line" : {
+        "covered" : 703,
+        "missed" : 47062,
+        "ratio" : 0.014718,
+        "total" : 47765
+      },
+      "method" : {
+        "covered" : 164,
+        "missed" : 8410,
+        "ratio" : 0.019128,
+        "total" : 8574
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/.gitignore
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/build.gradle
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import org.gradle.api.tasks.testing.Test
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.lucene:lucene-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/gradle.properties
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.lucene:lucene-core:5.0.0
+library.version = 5.0.0
+metadata.dir = org.apache.lucene/lucene-core/5.0.0/

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/settings.gradle
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.lucene.lucene-core_tests'

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeSupportTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeSupportTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import org.apache.lucene.analysis.tokenattributes.FlagsAttribute;
+import org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl;
+import org.apache.lucene.util.AttributeFactory;
+import org.apache.lucene.util.AttributeImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeSupportTest {
+    @Test
+    void reflectsFieldsFromAttributeImplementation() {
+        FlagsAttributeImpl attribute = new FlagsAttributeImpl();
+        attribute.setFlags(7);
+
+        assertThat(attribute.reflectAsString(false)).contains("flags=7");
+    }
+
+    @Test
+    void createsAttributeImplementationFromDefaultFactory() {
+        AttributeFactory factory = AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY;
+        AttributeImpl attribute = factory.createAttributeInstance(FlagsAttribute.class);
+
+        assertThat(attribute).isInstanceOf(FlagsAttributeImpl.class);
+        assertThat(((FlagsAttribute) attribute).getFlags()).isZero();
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.util.CommandLineUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CommandLineUtilTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames() throws ClassNotFoundException {
+        Class<? extends Directory> simpleNameClass = CommandLineUtil.loadDirectoryClass("RAMDirectory");
+        Class<? extends Directory> fullyQualifiedClass =
+                CommandLineUtil.loadDirectoryClass("org.apache.lucene.store.MMapDirectory");
+
+        assertThat(simpleNameClass).isEqualTo(RAMDirectory.class);
+        assertThat(fullyQualifiedClass).isEqualTo(MMapDirectory.class);
+    }
+
+    @Test
+    void loadsFSDirectoryImplementationFromSimpleName() throws ClassNotFoundException {
+        Class<? extends FSDirectory> fsDirectoryClass = CommandLineUtil.loadFSDirectoryClass("SimpleFSDirectory");
+
+        assertThat(fsDirectoryClass).isEqualTo(SimpleFSDirectory.class);
+    }
+
+    @Test
+    void createsFSDirectoryByClassNameUsingFileConstructor() throws IOException {
+        File directoryPath = temporaryDirectory.toFile();
+
+        FSDirectory directory = CommandLineUtil.newFSDirectory("NIOFSDirectory", directoryPath);
+        try {
+            assertThat(directory).isInstanceOf(NIOFSDirectory.class);
+            assertThat(directory.getDirectory()).isEqualTo(directoryPath.getCanonicalFile());
+        } finally {
+            directory.close();
+        }
+    }
+
+    @Test
+    void reportsNonFSDirectoryClassNames() {
+        assertThatThrownBy(() -> CommandLineUtil.loadFSDirectoryClass("RAMDirectory"))
+                .isInstanceOf(ClassCastException.class);
+        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory.toFile()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RAMDirectory is not a FSDirectory implementation");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
@@ -6,7 +6,6 @@
  */
 package org_apache_lucene.lucene_core;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -45,13 +44,13 @@ public class CommandLineUtilTest {
     }
 
     @Test
-    void createsFSDirectoryByClassNameUsingFileConstructor() throws IOException {
-        File directoryPath = temporaryDirectory.toFile();
+    void createsFSDirectoryByClassNameUsingPathConstructor() throws IOException {
+        Path directoryPath = temporaryDirectory;
 
         FSDirectory directory = CommandLineUtil.newFSDirectory("NIOFSDirectory", directoryPath);
         try {
             assertThat(directory).isInstanceOf(NIOFSDirectory.class);
-            assertThat(directory.getDirectory()).isEqualTo(directoryPath.getCanonicalFile());
+            assertThat(directory.getDirectory()).isEqualTo(directoryPath.toRealPath());
         } finally {
             directory.close();
         }
@@ -61,7 +60,7 @@ public class CommandLineUtilTest {
     void reportsNonFSDirectoryClassNames() {
         assertThatThrownBy(() -> CommandLineUtil.loadFSDirectoryClass("RAMDirectory"))
                 .isInstanceOf(ClassCastException.class);
-        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory.toFile()))
+        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RAMDirectory is not a FSDirectory implementation");
     }

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.util.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IOUtilsAndNamedSPILoaderTest {
+    @Test
+    void readsClasspathResourceWithExplicitCharsetDecoder() throws Exception {
+        try (Reader reader = IOUtils.getDecodingReader(IOUtils.class, "/META-INF/LICENSE.txt", StandardCharsets.UTF_8)) {
+            char[] buffer = new char[192];
+            int read = reader.read(buffer);
+
+            assertThat(read).isPositive();
+            assertThat(new String(buffer, 0, read)).contains("Apache License");
+        }
+    }
+
+    @Test
+    void loadsBuiltInPostingsFormatsThroughNamedSpiLookup() {
+        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene41");
+
+        assertThat(postingsFormat.getClass().getName())
+                .isEqualTo("org.apache.lucene.codecs.lucene41.Lucene41PostingsFormat");
+        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene40", "Lucene41");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
@@ -29,10 +29,10 @@ public class IOUtilsAndNamedSPILoaderTest {
 
     @Test
     void loadsBuiltInPostingsFormatsThroughNamedSpiLookup() {
-        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene41");
+        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene50");
 
         assertThat(postingsFormat.getClass().getName())
-                .isEqualTo("org.apache.lucene.codecs.lucene41.Lucene41PostingsFormat");
-        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene40", "Lucene41");
+                .isEqualTo("org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat");
+        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene50");
     }
 }

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.store.LockStressTest;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LockStressTestTest {
+    private static final int CLIENT_ID = 17;
+    private static final int STARTING_GUN = 43;
+    private static final int LOCKED = 1;
+    private static final int UNLOCKED = 0;
+
+    @TempDir
+    Path lockDirectory;
+
+    @Test
+    void instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle() throws Exception {
+        try (LockVerificationServer server = LockVerificationServer.start()) {
+            LockStressTest.main(new String[] {
+                    Integer.toString(CLIENT_ID),
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    Integer.toString(server.port()),
+                    SimpleFSLockFactory.class.getName(),
+                    lockDirectory.toString(),
+                    "0",
+                    "1"
+            });
+
+            server.awaitCompletion();
+        }
+    }
+
+    private static final class LockVerificationServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final ExecutorService executorService;
+        private final Future<?> serverFuture;
+
+        private LockVerificationServer(
+                ServerSocket serverSocket,
+                ExecutorService executorService,
+                Future<?> serverFuture) {
+            this.serverSocket = serverSocket;
+            this.executorService = executorService;
+            this.serverFuture = serverFuture;
+        }
+
+        private static LockVerificationServer start() throws Exception {
+            ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+            ExecutorService executorService = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "lock-stress-test-verifier");
+                thread.setDaemon(true);
+                return thread;
+            });
+            Future<?> serverFuture = executorService.submit(() -> {
+                serveSingleClient(serverSocket);
+                return null;
+            });
+            return new LockVerificationServer(serverSocket, executorService, serverFuture);
+        }
+
+        private int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        private void awaitCompletion() throws Exception {
+            serverFuture.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+            executorService.shutdownNow();
+            assertThat(executorService.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        private static void serveSingleClient(ServerSocket serverSocket) throws Exception {
+            try (Socket socket = serverSocket.accept();
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream()) {
+                assertThat(inputStream.read()).isEqualTo(CLIENT_ID);
+                outputStream.write(STARTING_GUN);
+                outputStream.flush();
+
+                boolean locked = false;
+                int transitions = 0;
+                int command;
+                while ((command = inputStream.read()) >= 0) {
+                    if (command == LOCKED) {
+                        assertThat(locked).isFalse();
+                        locked = true;
+                    } else {
+                        assertThat(command).isEqualTo(UNLOCKED);
+                        assertThat(locked).isTrue();
+                        locked = false;
+                    }
+                    transitions++;
+                    outputStream.write(command);
+                    outputStream.flush();
+                }
+
+                assertThat(locked).isFalse();
+                assertThat(transitions).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
@@ -17,6 +17,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockStressTest;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.junit.jupiter.api.Test;
@@ -47,6 +50,33 @@ public class LockStressTestTest {
             });
 
             server.awaitCompletion();
+        }
+    }
+
+    @Test
+    void instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle() throws Exception {
+        try (LockVerificationServer server = LockVerificationServer.start()) {
+            LockStressTest.main(new String[] {
+                    Integer.toString(CLIENT_ID),
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    Integer.toString(server.port()),
+                    ConstructibleFSLockFactory.class.getName(),
+                    lockDirectory.toString(),
+                    "0",
+                    "1"
+            });
+
+            server.awaitCompletion();
+        }
+    }
+
+    public static final class ConstructibleFSLockFactory extends FSLockFactory {
+        public ConstructibleFSLockFactory() {
+        }
+
+        @Override
+        protected Lock makeFSLock(FSDirectory dir, String lockName) {
+            return SimpleFSLockFactory.INSTANCE.makeLock(dir, lockName);
         }
     }
 

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InaccessibleObjectException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.RandomAccessInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MMapDirectoryAnonymous1Anonymous1Test {
+    private static final String INDEX_FILE_NAME = "mapped-input.bin";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void closingMappedInputUsesCleanerWhenUnmapIsEnabled() throws IOException {
+        byte[] content = new byte[] {10, 20, 30, 40, 50, 60, 70, 80};
+        Files.write(temporaryDirectory.resolve(INDEX_FILE_NAME), content);
+
+        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory.toFile());
+        try {
+            IndexInput input = directory.openInput(INDEX_FILE_NAME, IOContext.DEFAULT);
+            try {
+                RandomAccessInput randomAccessInput = (RandomAccessInput) input;
+
+                assertThat(input.length()).isEqualTo(content.length);
+                assertThat(input.readByte()).isEqualTo(content[0]);
+                assertThat(randomAccessInput.readLong(0)).isEqualTo(0x0A141E28323C4650L);
+            } finally {
+                closeMappedInput(input);
+            }
+        } finally {
+            directory.close();
+        }
+    }
+
+    private static void closeMappedInput(IndexInput input) throws IOException {
+        try {
+            input.close();
+        } catch (IOException e) {
+            assertThat(e).hasMessageContaining("Unable to unmap the mapped buffer");
+            assertThat(e.getCause())
+                    .isInstanceOfAny(IllegalAccessException.class, NoSuchMethodException.class);
+        } catch (InaccessibleObjectException e) {
+            assertThat(e).hasMessageContaining("java.nio");
+        }
+    }
+
+    private static final class AlwaysUnmappingMMapDirectory extends MMapDirectory {
+        private AlwaysUnmappingMMapDirectory(File path) throws IOException {
+            super(path);
+        }
+
+        @Override
+        public boolean getUseUnmap() {
+            return true;
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
@@ -6,7 +6,6 @@
  */
 package org_apache_lucene.lucene_core;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InaccessibleObjectException;
 import java.nio.file.Files;
@@ -32,7 +31,7 @@ public class MMapDirectoryAnonymous1Anonymous1Test {
         byte[] content = new byte[] {10, 20, 30, 40, 50, 60, 70, 80};
         Files.write(temporaryDirectory.resolve(INDEX_FILE_NAME), content);
 
-        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory.toFile());
+        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory);
         try {
             IndexInput input = directory.openInput(INDEX_FILE_NAME, IOContext.DEFAULT);
             try {
@@ -62,7 +61,7 @@ public class MMapDirectoryAnonymous1Anonymous1Test {
     }
 
     private static final class AlwaysUnmappingMMapDirectory extends MMapDirectory {
-        private AlwaysUnmappingMMapDirectory(File path) throws IOException {
+        private AlwaysUnmappingMMapDirectory(Path path) throws IOException {
             super(path);
         }
 

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/RamUsageEstimatorTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/RamUsageEstimatorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.util.Collections;
+import java.util.EnumSet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RamUsageEstimatorTest {
+    @Test
+    void initializesJvmMemoryConstantsAndFeatureSets() {
+        EnumSet<RamUsageEstimator.JvmFeature> supportedFeatures = RamUsageEstimator.getSupportedFeatures();
+        EnumSet<RamUsageEstimator.JvmFeature> unsupportedFeatures = RamUsageEstimator.getUnsupportedFeatures();
+        EnumSet<RamUsageEstimator.JvmFeature> allFeatures = EnumSet.allOf(RamUsageEstimator.JvmFeature.class);
+        EnumSet<RamUsageEstimator.JvmFeature> detectedFeatures = EnumSet.copyOf(supportedFeatures);
+        detectedFeatures.addAll(unsupportedFeatures);
+
+        assertThat(detectedFeatures).containsExactlyInAnyOrderElementsOf(allFeatures);
+        assertThat(Collections.disjoint(supportedFeatures, unsupportedFeatures)).isTrue();
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_REF).isPositive();
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_HEADER).isPositive();
+        assertThat(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER).isPositive();
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT).isPositive();
+        assertThat(RamUsageEstimator.JVM_INFO_STRING).startsWith("[JVM: ").endsWith("]");
+    }
+
+    @Test
+    void estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields() {
+        BytesRef bytesRef = new BytesRef("dynamic-access");
+
+        long sizeFromClass = RamUsageEstimator.shallowSizeOfInstance(BytesRef.class);
+        long sizeFromObject = RamUsageEstimator.shallowSizeOf(bytesRef);
+
+        assertThat(sizeFromClass).isEqualTo(sizeFromObject);
+        assertThat(sizeFromClass).isGreaterThanOrEqualTo(RamUsageEstimator.NUM_BYTES_OBJECT_HEADER);
+        assertThat(sizeFromClass % RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT).isZero();
+    }
+
+    @Test
+    void estimatesArraySizesUsingPublicHelpers() {
+        byte[] bytes = new byte[] {1, 2, 3, 4};
+        int[] ints = new int[] {1, 2, 3};
+        Object[] references = new Object[] {new BytesRef("one"), new BytesRef("two")};
+
+        assertThat(RamUsageEstimator.sizeOf(bytes))
+                .isEqualTo(RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + bytes.length));
+        assertThat(RamUsageEstimator.sizeOf(ints))
+                .isEqualTo(RamUsageEstimator.alignObjectSize(
+                        RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
+                                + (long) RamUsageEstimator.NUM_BYTES_INT * ints.length));
+        assertThat(RamUsageEstimator.shallowSizeOf(references))
+                .isEqualTo(RamUsageEstimator.shallowSizeOf(new Object[references.length]));
+    }
+
+    @Test
+    void reportsLongAndHumanReadableSizes() {
+        long uncachedLong = Long.MAX_VALUE;
+
+        assertThat(RamUsageEstimator.sizeOf(Long.valueOf(uncachedLong)))
+                .isEqualTo(RamUsageEstimator.shallowSizeOfInstance(Long.class));
+        assertThat(RamUsageEstimator.humanReadableUnits(RamUsageEstimator.ONE_KB)).isEqualTo("1 KB");
+        assertThat(RamUsageEstimator.humanReadableUnits(RamUsageEstimator.ONE_MB)).isEqualTo("1 MB");
+        assertThat(RamUsageEstimator.humanReadableUnits(512)).isEqualTo("512 bytes");
+    }
+
+    @Test
+    void rejectsArrayClassesForInstanceSizing() {
+        assertThatThrownBy(() -> RamUsageEstimator.shallowSizeOfInstance(byte[].class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("array classes");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.util.NoSuchElementException;
+
+import org.apache.lucene.util.SPIClassIterator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SPIClassIteratorTest {
+    @Test
+    void findsServiceDefinitionWithExplicitClassLoader() {
+        ClassLoader classLoader = SPIClassIteratorTest.class.getClassLoader();
+        SPIClassIterator<SPIClassIteratorService> iterator = SPIClassIterator.get(
+                SPIClassIteratorService.class,
+                classLoader);
+
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(SPIClassIteratorServiceImplementation.class);
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void findsServiceDefinitionWithSystemClassLoaderResources() {
+        SPIClassIterator<SPIClassIteratorSystemService> iterator = SPIClassIterator.get(
+                SPIClassIteratorSystemService.class,
+                null);
+
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(SPIClassIteratorSystemServiceImplementation.class);
+        assertThat(iterator.hasNext()).isFalse();
+    }
+}
+
+interface SPIClassIteratorService {
+}
+
+class SPIClassIteratorServiceImplementation implements SPIClassIteratorService {
+}
+
+interface SPIClassIteratorSystemService {
+}
+
+class SPIClassIteratorSystemServiceImplementation implements SPIClassIteratorSystemService {
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/VirtualMethodTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/VirtualMethodTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import org.apache.lucene.util.VirtualMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VirtualMethodTest {
+    private static final VirtualMethod<BaseDescription> DESCRIPTION_METHOD =
+            new VirtualMethod<>(BaseDescription.class, "describe");
+
+    @Test
+    void reportsOverrideDistanceAcrossInheritanceHierarchy() {
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(BaseDescription.class)).isZero();
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(DerivedDescription.class)).isEqualTo(1);
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(FurtherDerivedDescription.class)).isEqualTo(1);
+        assertThat(DESCRIPTION_METHOD.isOverriddenAsOf(FurtherDerivedDescription.class)).isTrue();
+    }
+
+    public static class BaseDescription {
+        public String describe() {
+            return "base";
+        }
+    }
+
+    public static class DerivedDescription extends BaseDescription {
+        @Override
+        public String describe() {
+            return "derived";
+        }
+    }
+
+    public static class FurtherDerivedDescription extends DerivedDescription {
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,58 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$BaseDescription",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$DerivedDescription",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.SPIClassIterator"
+      },
+      "type" : "org_apache_lucene.lucene_core.SPIClassIteratorServiceImplementation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.SPIClassIterator"
+      },
+      "type" : "org_apache_lucene.lucene_core.SPIClassIteratorSystemServiceImplementation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$BaseDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$DerivedDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$FurtherDerivedDescription"
+    }
+  ]
+}

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -53,6 +53,18 @@
         "typeReached" : "org.apache.lucene.util.VirtualMethod"
       },
       "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$FurtherDerivedDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.LockStressTest"
+      },
+      "type" : "org_apache_lucene.lucene_core.LockStressTestTest$ConstructibleFSLockFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ]
 }

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorService
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorService
@@ -1,0 +1,3 @@
+# comments and surrounding whitespace are ignored by SPIClassIterator
+  org_apache_lucene.lucene_core.SPIClassIteratorServiceImplementation  
+

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorSystemService
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorSystemService
@@ -1,0 +1,1 @@
+org_apache_lucene.lucene_core.SPIClassIteratorSystemServiceImplementation

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="18" skipped="0" failures="0" errors="0" time="0.035" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:38">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3612-634ecf23/tests/src/org.apache.lucene/lucene-core/4.10.4"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="reflectsFieldsFromAttributeImplementation()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.007">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:reflectsFieldsFromAttributeImplementation()]
+display-name: reflectsFieldsFromAttributeImplementation()
+]]></system-out>
+</testcase>
+<testcase name="estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields()]
+display-name: estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields()
+]]></system-out>
+</testcase>
+<testcase name="loadsFSDirectoryImplementationFromSimpleName()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsFSDirectoryImplementationFromSimpleName()]
+display-name: loadsFSDirectoryImplementationFromSimpleName()
+]]></system-out>
+</testcase>
+<testcase name="instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.LockStressTestTest]/[method:instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()]
+display-name: instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()
+]]></system-out>
+</testcase>
+<testcase name="estimatesArraySizesUsingPublicHelpers()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:estimatesArraySizesUsingPublicHelpers()]
+display-name: estimatesArraySizesUsingPublicHelpers()
+]]></system-out>
+</testcase>
+<testcase name="reportsLongAndHumanReadableSizes()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:reportsLongAndHumanReadableSizes()]
+display-name: reportsLongAndHumanReadableSizes()
+]]></system-out>
+</testcase>
+<testcase name="findsServiceDefinitionWithExplicitClassLoader()" classname="org_apache_lucene.lucene_core.SPIClassIteratorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.SPIClassIteratorTest]/[method:findsServiceDefinitionWithExplicitClassLoader()]
+display-name: findsServiceDefinitionWithExplicitClassLoader()
+]]></system-out>
+</testcase>
+<testcase name="reportsOverrideDistanceAcrossInheritanceHierarchy()" classname="org_apache_lucene.lucene_core.VirtualMethodTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.VirtualMethodTest]/[method:reportsOverrideDistanceAcrossInheritanceHierarchy()]
+display-name: reportsOverrideDistanceAcrossInheritanceHierarchy()
+]]></system-out>
+</testcase>
+<testcase name="createsAttributeImplementationFromDefaultFactory()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:createsAttributeImplementationFromDefaultFactory()]
+display-name: createsAttributeImplementationFromDefaultFactory()
+]]></system-out>
+</testcase>
+<testcase name="initializesJvmMemoryConstantsAndFeatureSets()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:initializesJvmMemoryConstantsAndFeatureSets()]
+display-name: initializesJvmMemoryConstantsAndFeatureSets()
+]]></system-out>
+</testcase>
+<testcase name="closingMappedInputUsesCleanerWhenUnmapIsEnabled()" classname="org_apache_lucene.lucene_core.MMapDirectoryAnonymous1Anonymous1Test" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.MMapDirectoryAnonymous1Anonymous1Test]/[method:closingMappedInputUsesCleanerWhenUnmapIsEnabled()]
+display-name: closingMappedInputUsesCleanerWhenUnmapIsEnabled()
+]]></system-out>
+</testcase>
+<testcase name="findsServiceDefinitionWithSystemClassLoaderResources()" classname="org_apache_lucene.lucene_core.SPIClassIteratorTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.SPIClassIteratorTest]/[method:findsServiceDefinitionWithSystemClassLoaderResources()]
+display-name: findsServiceDefinitionWithSystemClassLoaderResources()
+]]></system-out>
+</testcase>
+<testcase name="reportsNonFSDirectoryClassNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:reportsNonFSDirectoryClassNames()]
+display-name: reportsNonFSDirectoryClassNames()
+]]></system-out>
+</testcase>
+<testcase name="createsFSDirectoryByClassNameUsingFileConstructor()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:createsFSDirectoryByClassNameUsingFileConstructor()]
+display-name: createsFSDirectoryByClassNameUsingFileConstructor()
+]]></system-out>
+</testcase>
+<testcase name="loadsBuiltInPostingsFormatsThroughNamedSpiLookup()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest]/[method:loadsBuiltInPostingsFormatsThroughNamedSpiLookup()]
+display-name: loadsBuiltInPostingsFormatsThroughNamedSpiLookup()
+]]></system-out>
+</testcase>
+<testcase name="rejectsArrayClassesForInstanceSizing()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:rejectsArrayClassesForInstanceSizing()]
+display-name: rejectsArrayClassesForInstanceSizing()
+]]></system-out>
+</testcase>
+<testcase name="loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()]
+display-name: loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()
+]]></system-out>
+</testcase>
+<testcase name="readsClasspathResourceWithExplicitCharsetDecoder()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest]/[method:readsClasspathResourceWithExplicitCharsetDecoder()]
+display-name: readsClasspathResourceWithExplicitCharsetDecoder()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="19" skipped="0" failures="2" errors="6" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-02T23:52:38">
+<testsuite name="JUnit Jupiter" tests="19" skipped="0" failures="0" errors="0" time="0.015" hostname="kung-fu-workstation" timestamp="2026-05-02T23:58:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4423-1ead607d/tests/src/org.apache.lucene/lucene-core/5.0.0"/>
@@ -52,61 +51,13 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="createsFSDirectoryByClassNameUsingPathConstructor()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
-<error message="FSDirectory implementation not found: NIOFSDirectory" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: FSDirectory implementation not found: NIOFSDirectory
-	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:61)
-	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:46)
-	at org_apache_lucene.lucene_core.CommandLineUtilTest.createsFSDirectoryByClassNameUsingPathConstructor(CommandLineUtilTest.java:50)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.ClassNotFoundException: org.apache.lucene.store.NIOFSDirectory
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
-	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
-	at org.apache.lucene.util.CommandLineUtil.loadFSDirectoryClass(CommandLineUtil.java:93)
-	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:58)
-	... 14 more
-]]></error>
+<testcase name="createsFSDirectoryByClassNameUsingPathConstructor()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:createsFSDirectoryByClassNameUsingPathConstructor()]
 display-name: createsFSDirectoryByClassNameUsingPathConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="reflectsFieldsFromAttributeImplementation()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0">
-<failure message="
-Expecting actual:
-  &quot;&quot;
-to contain:
-  &quot;flags=7&quot; " type="java.lang.AssertionError"><![CDATA[java.lang.AssertionError: 
-Expecting actual:
-  ""
-to contain:
-  "flags=7" 
-	at org_apache_lucene.lucene_core.AttributeSupportTest.reflectsFieldsFromAttributeImplementation(AttributeSupportTest.java:23)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></failure>
+<testcase name="reflectsFieldsFromAttributeImplementation()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:reflectsFieldsFromAttributeImplementation()]
 display-name: reflectsFieldsFromAttributeImplementation()
@@ -119,49 +70,12 @@ display-name: estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields(
 ]]></system-out>
 </testcase>
 <testcase name="loadsFSDirectoryImplementationFromSimpleName()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
-<error message="org.apache.lucene.store.SimpleFSDirectory" type="java.lang.ClassNotFoundException"><![CDATA[java.lang.ClassNotFoundException: org.apache.lucene.store.SimpleFSDirectory
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
-	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
-	at org.apache.lucene.util.CommandLineUtil.loadFSDirectoryClass(CommandLineUtil.java:93)
-	at org_apache_lucene.lucene_core.CommandLineUtilTest.loadsFSDirectoryImplementationFromSimpleName(CommandLineUtilTest.java:41)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsFSDirectoryImplementationFromSimpleName()]
 display-name: loadsFSDirectoryImplementationFromSimpleName()
 ]]></system-out>
 </testcase>
-<testcase name="instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0">
-<error message="Cannot get lock factory singleton of org.apache.lucene.store.SimpleFSLockFactory" type="java.io.IOException"><![CDATA[java.io.IOException: Cannot get lock factory singleton of org.apache.lucene.store.SimpleFSLockFactory
-	at org.apache.lucene.store.LockStressTest.getNewLockFactory(LockStressTest.java:146)
-	at org.apache.lucene.store.LockStressTest.main(LockStressTest.java:76)
-	at org_apache_lucene.lucene_core.LockStressTestTest.instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle(LockStressTestTest.java:42)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.LockStressTestTest]/[method:instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()]
 display-name: instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()
@@ -191,28 +105,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.VirtualMe
 display-name: reportsOverrideDistanceAcrossInheritanceHierarchy()
 ]]></system-out>
 </testcase>
-<testcase name="createsAttributeImplementationFromDefaultFactory()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0">
-<error message="Cannot find implementing class for: org.apache.lucene.analysis.tokenattributes.FlagsAttribute" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Cannot find implementing class for: org.apache.lucene.analysis.tokenattributes.FlagsAttribute
-	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.findImplClass(AttributeFactory.java:79)
-	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.access$000(AttributeFactory.java:55)
-	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory$1.computeValue(AttributeFactory.java:59)
-	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory$1.computeValue(AttributeFactory.java:56)
-	at java.base@25.0.2/java.lang.ClassValue.get(JavaLangSubstitutions.java:587)
-	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.createAttributeInstance(AttributeFactory.java:68)
-	at org_apache_lucene.lucene_core.AttributeSupportTest.createsAttributeImplementationFromDefaultFactory(AttributeSupportTest.java:29)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="createsAttributeImplementationFromDefaultFactory()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:createsAttributeImplementationFromDefaultFactory()]
 display-name: createsAttributeImplementationFromDefaultFactory()
@@ -237,43 +130,12 @@ display-name: findsServiceDefinitionWithSystemClassLoaderResources()
 ]]></system-out>
 </testcase>
 <testcase name="reportsNonFSDirectoryClassNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
-<failure message="
-Expecting actual throwable to be an instance of:
-  java.lang.ClassCastException
-but was:
-  java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
-	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
-	...(20 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)" type="java.lang.AssertionError"><![CDATA[java.lang.AssertionError: 
-Expecting actual throwable to be an instance of:
-  java.lang.ClassCastException
-but was:
-  java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
-	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
-	...(20 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
-	at org_apache_lucene.lucene_core.CommandLineUtilTest.reportsNonFSDirectoryClassNames(CommandLineUtilTest.java:62)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></failure>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:reportsNonFSDirectoryClassNames()]
 display-name: reportsNonFSDirectoryClassNames()
 ]]></system-out>
 </testcase>
-<testcase name="instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.001">
+<testcase name="instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.LockStressTestTest]/[method:instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()]
 display-name: instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()
@@ -292,51 +154,12 @@ display-name: rejectsArrayClassesForInstanceSizing()
 ]]></system-out>
 </testcase>
 <testcase name="loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
-<error message="org.apache.lucene.store.RAMDirectory" type="java.lang.ClassNotFoundException"><![CDATA[java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
-	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
-	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
-	at org.apache.lucene.util.CommandLineUtil.loadDirectoryClass(CommandLineUtil.java:82)
-	at org_apache_lucene.lucene_core.CommandLineUtilTest.loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames(CommandLineUtilTest.java:31)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()]
 display-name: loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()
 ]]></system-out>
 </testcase>
 <testcase name="readsClasspathResourceWithExplicitCharsetDecoder()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0">
-<error type="java.lang.NullPointerException"><![CDATA[java.lang.NullPointerException
-	at java.base@25.0.2/java.io.Reader.<init>(Reader.java:286)
-	at java.base@25.0.2/java.io.InputStreamReader.<init>(InputStreamReader.java:135)
-	at org.apache.lucene.util.IOUtils.getDecodingReader(IOUtils.java:162)
-	at org.apache.lucene.util.IOUtils.getDecodingReader(IOUtils.java:185)
-	at org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest.readsClasspathResourceWithExplicitCharsetDecoder(IOUtilsAndNamedSPILoaderTest.java:21)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest]/[method:readsClasspathResourceWithExplicitCharsetDecoder()]
 display-name: readsClasspathResourceWithExplicitCharsetDecoder()

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="18" skipped="0" failures="0" errors="0" time="0.035" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:38">
+<testsuite name="JUnit Jupiter" tests="19" skipped="0" failures="2" errors="6" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-02T23:52:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,15 +43,70 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3612-634ecf23/tests/src/org.apache.lucene/lucene-core/4.10.4"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4423-1ead607d/tests/src/org.apache.lucene/lucene-core/5.0.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="reflectsFieldsFromAttributeImplementation()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.007">
+<testcase name="createsFSDirectoryByClassNameUsingPathConstructor()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
+<error message="FSDirectory implementation not found: NIOFSDirectory" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: FSDirectory implementation not found: NIOFSDirectory
+	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:61)
+	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:46)
+	at org_apache_lucene.lucene_core.CommandLineUtilTest.createsFSDirectoryByClassNameUsingPathConstructor(CommandLineUtilTest.java:50)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.ClassNotFoundException: org.apache.lucene.store.NIOFSDirectory
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
+	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
+	at org.apache.lucene.util.CommandLineUtil.loadFSDirectoryClass(CommandLineUtil.java:93)
+	at org.apache.lucene.util.CommandLineUtil.newFSDirectory(CommandLineUtil.java:58)
+	... 14 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:createsFSDirectoryByClassNameUsingPathConstructor()]
+display-name: createsFSDirectoryByClassNameUsingPathConstructor()
+]]></system-out>
+</testcase>
+<testcase name="reflectsFieldsFromAttributeImplementation()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0">
+<failure message="
+Expecting actual:
+  &quot;&quot;
+to contain:
+  &quot;flags=7&quot; " type="java.lang.AssertionError"><![CDATA[java.lang.AssertionError: 
+Expecting actual:
+  ""
+to contain:
+  "flags=7" 
+	at org_apache_lucene.lucene_core.AttributeSupportTest.reflectsFieldsFromAttributeImplementation(AttributeSupportTest.java:23)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></failure>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:reflectsFieldsFromAttributeImplementation()]
 display-name: reflectsFieldsFromAttributeImplementation()
@@ -63,13 +118,50 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageE
 display-name: estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields()
 ]]></system-out>
 </testcase>
-<testcase name="loadsFSDirectoryImplementationFromSimpleName()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.002">
+<testcase name="loadsFSDirectoryImplementationFromSimpleName()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
+<error message="org.apache.lucene.store.SimpleFSDirectory" type="java.lang.ClassNotFoundException"><![CDATA[java.lang.ClassNotFoundException: org.apache.lucene.store.SimpleFSDirectory
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
+	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
+	at org.apache.lucene.util.CommandLineUtil.loadFSDirectoryClass(CommandLineUtil.java:93)
+	at org_apache_lucene.lucene_core.CommandLineUtilTest.loadsFSDirectoryImplementationFromSimpleName(CommandLineUtilTest.java:41)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsFSDirectoryImplementationFromSimpleName()]
 display-name: loadsFSDirectoryImplementationFromSimpleName()
 ]]></system-out>
 </testcase>
-<testcase name="instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.006">
+<testcase name="instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0">
+<error message="Cannot get lock factory singleton of org.apache.lucene.store.SimpleFSLockFactory" type="java.io.IOException"><![CDATA[java.io.IOException: Cannot get lock factory singleton of org.apache.lucene.store.SimpleFSLockFactory
+	at org.apache.lucene.store.LockStressTest.getNewLockFactory(LockStressTest.java:146)
+	at org.apache.lucene.store.LockStressTest.main(LockStressTest.java:76)
+	at org_apache_lucene.lucene_core.LockStressTestTest.instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle(LockStressTestTest.java:42)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.LockStressTestTest]/[method:instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()]
 display-name: instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle()
@@ -99,19 +191,40 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.VirtualMe
 display-name: reportsOverrideDistanceAcrossInheritanceHierarchy()
 ]]></system-out>
 </testcase>
-<testcase name="createsAttributeImplementationFromDefaultFactory()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0.003">
+<testcase name="createsAttributeImplementationFromDefaultFactory()" classname="org_apache_lucene.lucene_core.AttributeSupportTest" time="0">
+<error message="Cannot find implementing class for: org.apache.lucene.analysis.tokenattributes.FlagsAttribute" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Cannot find implementing class for: org.apache.lucene.analysis.tokenattributes.FlagsAttribute
+	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.findImplClass(AttributeFactory.java:79)
+	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.access$000(AttributeFactory.java:55)
+	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory$1.computeValue(AttributeFactory.java:59)
+	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory$1.computeValue(AttributeFactory.java:56)
+	at java.base@25.0.2/java.lang.ClassValue.get(JavaLangSubstitutions.java:587)
+	at org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory.createAttributeInstance(AttributeFactory.java:68)
+	at org_apache_lucene.lucene_core.AttributeSupportTest.createsAttributeImplementationFromDefaultFactory(AttributeSupportTest.java:29)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.AttributeSupportTest]/[method:createsAttributeImplementationFromDefaultFactory()]
 display-name: createsAttributeImplementationFromDefaultFactory()
 ]]></system-out>
 </testcase>
-<testcase name="initializesJvmMemoryConstantsAndFeatureSets()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0.001">
+<testcase name="initializesJvmMemoryConstantsAndFeatureSets()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:initializesJvmMemoryConstantsAndFeatureSets()]
 display-name: initializesJvmMemoryConstantsAndFeatureSets()
 ]]></system-out>
 </testcase>
-<testcase name="closingMappedInputUsesCleanerWhenUnmapIsEnabled()" classname="org_apache_lucene.lucene_core.MMapDirectoryAnonymous1Anonymous1Test" time="0.002">
+<testcase name="closingMappedInputUsesCleanerWhenUnmapIsEnabled()" classname="org_apache_lucene.lucene_core.MMapDirectoryAnonymous1Anonymous1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.MMapDirectoryAnonymous1Anonymous1Test]/[method:closingMappedInputUsesCleanerWhenUnmapIsEnabled()]
 display-name: closingMappedInputUsesCleanerWhenUnmapIsEnabled()
@@ -123,37 +236,107 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.SPIClassI
 display-name: findsServiceDefinitionWithSystemClassLoaderResources()
 ]]></system-out>
 </testcase>
-<testcase name="reportsNonFSDirectoryClassNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.001">
+<testcase name="reportsNonFSDirectoryClassNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
+<failure message="
+Expecting actual throwable to be an instance of:
+  java.lang.ClassCastException
+but was:
+  java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
+	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
+	...(20 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)" type="java.lang.AssertionError"><![CDATA[java.lang.AssertionError: 
+Expecting actual throwable to be an instance of:
+  java.lang.ClassCastException
+but was:
+  java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
+	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
+	...(20 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
+	at org_apache_lucene.lucene_core.CommandLineUtilTest.reportsNonFSDirectoryClassNames(CommandLineUtilTest.java:62)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></failure>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:reportsNonFSDirectoryClassNames()]
 display-name: reportsNonFSDirectoryClassNames()
 ]]></system-out>
 </testcase>
-<testcase name="createsFSDirectoryByClassNameUsingFileConstructor()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0.002">
+<testcase name="instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()" classname="org_apache_lucene.lucene_core.LockStressTestTest" time="0.001">
 <system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:createsFSDirectoryByClassNameUsingFileConstructor()]
-display-name: createsFSDirectoryByClassNameUsingFileConstructor()
+unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.LockStressTestTest]/[method:instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()]
+display-name: instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle()
 ]]></system-out>
 </testcase>
-<testcase name="loadsBuiltInPostingsFormatsThroughNamedSpiLookup()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0.001">
+<testcase name="loadsBuiltInPostingsFormatsThroughNamedSpiLookup()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest]/[method:loadsBuiltInPostingsFormatsThroughNamedSpiLookup()]
 display-name: loadsBuiltInPostingsFormatsThroughNamedSpiLookup()
 ]]></system-out>
 </testcase>
-<testcase name="rejectsArrayClassesForInstanceSizing()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0.002">
+<testcase name="rejectsArrayClassesForInstanceSizing()" classname="org_apache_lucene.lucene_core.RamUsageEstimatorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.RamUsageEstimatorTest]/[method:rejectsArrayClassesForInstanceSizing()]
 display-name: rejectsArrayClassesForInstanceSizing()
 ]]></system-out>
 </testcase>
 <testcase name="loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()" classname="org_apache_lucene.lucene_core.CommandLineUtilTest" time="0">
+<error message="org.apache.lucene.store.RAMDirectory" type="java.lang.ClassNotFoundException"><![CDATA[java.lang.ClassNotFoundException: org.apache.lucene.store.RAMDirectory
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.registry.ClassRegistries.forName(ClassRegistries.java:263)
+	at java.base@25.0.2/java.lang.Class.forName0(DynamicHub.java:1975)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:467)
+	at java.base@25.0.2/java.lang.Class.forName(DynamicHub.java:458)
+	at org.apache.lucene.util.CommandLineUtil.loadDirectoryClass(CommandLineUtil.java:82)
+	at org_apache_lucene.lucene_core.CommandLineUtilTest.loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames(CommandLineUtilTest.java:31)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.CommandLineUtilTest]/[method:loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()]
 display-name: loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames()
 ]]></system-out>
 </testcase>
 <testcase name="readsClasspathResourceWithExplicitCharsetDecoder()" classname="org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest" time="0">
+<error type="java.lang.NullPointerException"><![CDATA[java.lang.NullPointerException
+	at java.base@25.0.2/java.io.Reader.<init>(Reader.java:286)
+	at java.base@25.0.2/java.io.InputStreamReader.<init>(InputStreamReader.java:135)
+	at org.apache.lucene.util.IOUtils.getDecodingReader(IOUtils.java:162)
+	at org.apache.lucene.util.IOUtils.getDecodingReader(IOUtils.java:185)
+	at org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest.readsClasspathResourceWithExplicitCharsetDecoder(IOUtilsAndNamedSPILoaderTest.java:21)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_lucene.lucene_core.IOUtilsAndNamedSPILoaderTest]/[method:readsClasspathResourceWithExplicitCharsetDecoder()]
 display-name: readsClasspathResourceWithExplicitCharsetDecoder()

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:38">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3612-634ecf23/tests/src/org.apache.lucene/lucene-core/4.10.4"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T21:26:38">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:52:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,9 +43,10 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3612-634ecf23/tests/src/org.apache.lucene/lucene-core/4.10.4"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4423-1ead607d/tests/src/org.apache.lucene/lucene-core/5.0.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:52:38">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:58:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4423-1ead607d/tests/src/org.apache.lucene/lucene-core/5.0.0"/>

--- a/tests/src/org.apache.lucene/lucene-core/5.0.0/user-code-filter.json
+++ b/tests/src/org.apache.lucene/lucene-core/5.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.lucene.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4423

This PR provides test fixes and new metadata for org.apache.lucene:lucene-core:5.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 97258
- Cached input tokens: 752128
- Output tokens: 12536
- Metadata entries: 69
- Test-only metadata entries: 11
- Iterations: 4
- Library coverage percentage: 1.47
- Previous library version metadata entries: 71
- Previous library version test-only metadata entries: 9
- Previous library version coverage percentage: 1.4

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7f4efb65e78d4a230fe29b794639ec01a1996d8d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.lucene:lucene-core:4.10.4: 34/34 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.0.0: 37/37 covered calls (100.00%)

**Reflection:**
- org.apache.lucene:lucene-core:4.10.4: 31/31 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.0.0: 34/34 covered calls (100.00%)

**Resources:**
- org.apache.lucene:lucene-core:4.10.4: 3/3 covered calls (100.00%)
- org.apache.lucene:lucene-core:5.0.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.lucene:lucene-core:4.10.4: 4425/298750 (1.48%)
- org.apache.lucene:lucene-core:5.0.0: 4234/263466 (1.61%)

**Line:**
- org.apache.lucene:lucene-core:4.10.4: 767/54984 (1.40%)
- org.apache.lucene:lucene-core:5.0.0: 703/47765 (1.47%)

**Method:**
- org.apache.lucene:lucene-core:4.10.4: 169/9622 (1.76%)
- org.apache.lucene:lucene-core:5.0.0: 164/8574 (1.91%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
index 33c68588b8..3bd8c2eb88 100644
--- 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
+++ 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
@@ -6,7 +6,6 @@
  */
 package org_apache_lucene.lucene_core;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -45,13 +44,13 @@ public class CommandLineUtilTest {
     }
 
     @Test
-    void createsFSDirectoryByClassNameUsingFileConstructor() throws IOException {
-        File directoryPath = temporaryDirectory.toFile();
+    void createsFSDirectoryByClassNameUsingPathConstructor() throws IOException {
+        Path directoryPath = temporaryDirectory;
 
         FSDirectory directory = CommandLineUtil.newFSDirectory("NIOFSDirectory", directoryPath);
         try {
             assertThat(directory).isInstanceOf(NIOFSDirectory.class);
-            assertThat(directory.getDirectory()).isEqualTo(directoryPath.getCanonicalFile());
+            assertThat(directory.getDirectory()).isEqualTo(directoryPath.toRealPath());
         } finally {
             directory.close();
         }
@@ -61,7 +60,7 @@ public class CommandLineUtilTest {
     void reportsNonFSDirectoryClassNames() {
         assertThatThrownBy(() -> CommandLineUtil.loadFSDirectoryClass("RAMDirectory"))
                 .isInstanceOf(ClassCastException.class);
-        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory.toFile()))
+        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("RAMDirectory is not a FSDirectory implementation");
     }
diff --git 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
index a15f5a53b8..14701fea97 100644
--- 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
+++ 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
@@ -29,10 +29,10 @@ public class IOUtilsAndNamedSPILoaderTest {
 
     @Test
     void loadsBuiltInPostingsFormatsThroughNamedSpiLookup() {
-        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene41");
+        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene50");
 
         assertThat(postingsFormat.getClass().getName())
-                .isEqualTo("org.apache.lucene.codecs.lucene41.Lucene41PostingsFormat");
-        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene40", "Lucene41");
+                .isEqualTo("org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat");
+        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene50");
     }
 }
diff --git 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
index 0c86fc2984..e0a8b87a4d 100644
--- 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
+++ 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
@@ -17,6 +17,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockStressTest;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.junit.jupiter.api.Test;
@@ -50,6 +53,33 @@ public class LockStressTestTest {
         }
     }
 
+    @Test
+    void instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle() throws Exception {
+        try (LockVerificationServer server = LockVerificationServer.start()) {
+            LockStressTest.main(new String[] {
+                    Integer.toString(CLIENT_ID),
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    Integer.toString(server.port()),
+                    ConstructibleFSLockFactory.class.getName(),
+                    lockDirectory.toString(),
+                    "0",
+                    "1"
+            });
+
+            server.awaitCompletion();
+        }
+    }
+
+    public static final class ConstructibleFSLockFactory extends FSLockFactory {
+        public ConstructibleFSLockFactory() {
+        }
+
+        @Override
+        protected Lock makeFSLock(FSDirectory dir, String lockName) {
+            return SimpleFSLockFactory.INSTANCE.makeLock(dir, lockName);
+        }
+    }
+
     private static final class LockVerificationServer implements AutoCloseable {
         private final ServerSocket serverSocket;
         private final ExecutorService executorService;
diff --git 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
index 1fc09cd0a0..83829f93db 100644
--- 1/tests/src/org.apache.lucene/lucene-core/4.10.4/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
+++ 2/tests/src/org.apache.lucene/lucene-core/5.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
@@ -6,7 +6,6 @@
  */
 package org_apache_lucene.lucene_core;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InaccessibleObjectException;
 import java.nio.file.Files;
@@ -32,7 +31,7 @@ public class MMapDirectoryAnonymous1Anonymous1Test {
         byte[] content = new byte[] {10, 20, 30, 40, 50, 60, 70, 80};
         Files.write(temporaryDirectory.resolve(INDEX_FILE_NAME), content);
 
-        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory.toFile());
+        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory);
         try {
             IndexInput input = directory.openInput(INDEX_FILE_NAME, IOContext.DEFAULT);
             try {
@@ -62,7 +61,7 @@ public class MMapDirectoryAnonymous1Anonymous1Test {
     }
 
     private static final class AlwaysUnmappingMMapDirectory extends MMapDirectory {
-        private AlwaysUnmappingMMapDirectory(File path) throws IOException {
+        private AlwaysUnmappingMMapDirectory(Path path) throws IOException {
             super(path);
         }
 

```
