### PR TITLE
[Automation] Generated metadata for org.springframework:spring-aspects:6.0.0

### DIFF
--- a/metadata/org.springframework/spring-aspects/6.0.0/reachability-metadata.json
+++ b/metadata/org.springframework/spring-aspects/6.0.0/reachability-metadata.json
@@ -1,0 +1,471 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "beanConfigurerAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.annotation.AdviceModeImportSelector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.scheduling.annotation.AsyncConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.cache.annotation.CachingConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.annotation.TransactionManagementConfigurationSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.scheduling.aspectj.AspectJAsyncConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "asyncAdvisor",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.cache.aspectj.AspectJCachingConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "cacheAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.annotation.AbstractTransactionManagementConfiguration",
+      "methods" : [
+        {
+          "name" : "transactionalEventListenerFactory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "transactionAspect",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "type" : "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "io.vavr.control$Try"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "io.vavr.control.Try"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "jakarta.ejb$TransactionAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "jakarta.ejb.TransactionAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "jakarta.transaction$Transactional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "jakarta.transaction.Transactional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "org.reactivestreams$Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+      },
+      "type" : "org.reactivestreams.Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.Aware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.Aware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.ImportAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0",
+      "fields" : [
+        {
+          "name" : "$$beanFactory"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration$$SpringCGLIB$$2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AnnotationTransactionAspect"
+      },
+      "type" : "org.springframework.transaction.TransactionDefinition",
+      "fields" : [
+        {
+          "name" : "ISOLATION_DEFAULT"
+        },
+        {
+          "name" : "ISOLATION_READ_COMMITTED"
+        },
+        {
+          "name" : "ISOLATION_READ_UNCOMMITTED"
+        },
+        {
+          "name" : "ISOLATION_REPEATABLE_READ"
+        },
+        {
+          "name" : "ISOLATION_SERIALIZABLE"
+        },
+        {
+          "name" : "PROPAGATION_MANDATORY"
+        },
+        {
+          "name" : "PROPAGATION_NESTED"
+        },
+        {
+          "name" : "PROPAGATION_NEVER"
+        },
+        {
+          "name" : "PROPAGATION_NOT_SUPPORTED"
+        },
+        {
+          "name" : "PROPAGATION_REQUIRED"
+        },
+        {
+          "name" : "PROPAGATION_REQUIRES_NEW"
+        },
+        {
+          "name" : "PROPAGATION_SUPPORTS"
+        },
+        {
+          "name" : "TIMEOUT_DEFAULT"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.transaction.annotation.AbstractTransactionManagementConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0",
+      "fields" : [
+        {
+          "name" : "$$beanFactory"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration$$SpringCGLIB$$2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.transaction.aspectj.AbstractTransactionAspect"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/beans/**/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/context/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/context/annotation/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/scheduling/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/scheduling/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/cache/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/cache/aspectj/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/transaction/annotation/*.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.context.annotation.AnnotationConfigApplicationContext"
+      },
+      "glob" : "org/springframework/transaction/aspectj/*.class"
+    }
+  ]
+}

--- a/metadata/org.springframework/spring-aspects/index.json
+++ b/metadata/org.springframework/spring-aspects/index.json
@@ -1,16 +1,36 @@
 [
   {
-    "latest": true,
-    "metadata-version": "5.3.31",
-    "source-code-url": "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
-    "repository-url": "https://github.com/spring-projects/spring-framework",
-    "test-code-url": "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
-    "documentation-url": "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
-    "description": "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
-    "tested-versions": [
+    "latest" : true,
+    "metadata-version" : "6.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
+    "description" : "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
+    "test-version" : "5.3.31",
+    "tested-versions" : [
+      "6.0.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.beans.factory.aspectj",
+      "org.springframework.cache.aspectj",
+      "org.springframework.context.annotation.aspectj",
+      "org.springframework.scheduling.aspectj",
+      "org.springframework.transaction.aspectj",
+      "org.springframework.context.annotation"
+    ]
+  },
+  {
+    "metadata-version" : "5.3.31",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-framework",
+    "test-code-url" : "https://github.com/spring-projects/spring-framework/tree/v$version$/spring-aspects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-javadoc.jar",
+    "description" : "Spring Aspects provides AspectJ aspects that let Spring facilities such as dependency injection, transaction management, caching, and asynchronous execution participate in AspectJ-weaved applications. It is part of the Spring Framework and supplies runtime support for applying those cross-cutting concerns outside standard proxy-based Spring AOP.",
+    "tested-versions" : [
       "5.3.31"
     ],
-    "allowed-packages": [
+    "allowed-packages" : [
       "org.springframework.beans.factory.aspectj",
       "org.springframework.cache.aspectj",
       "org.springframework.context.annotation.aspectj",

--- a/stats/org.springframework/spring-aspects/6.0.0/stats.json
+++ b/stats/org.springframework/spring-aspects/6.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 160,
+        "missed" : 444,
+        "ratio" : 0.264901,
+        "total" : 604
+      },
+      "line" : {
+        "covered" : 47,
+        "missed" : 83,
+        "ratio" : 0.361538,
+        "total" : 130
+      },
+      "method" : {
+        "covered" : 32,
+        "missed" : 42,
+        "ratio" : 0.432432,
+        "total" : 74
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
+++ b/tests/src/org.springframework/spring-aspects/5.3.31/src/test/java/org_springframework/spring_aspects/Spring_aspectsTest.java
@@ -16,48 +16,46 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.aspectj.AnnotationCacheAspect;
+import org.springframework.cache.aspectj.AspectJCachingConfiguration;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.cache.config.CacheManagementConfigUtils;
-import org.springframework.context.annotation.AdviceMode;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.context.annotation.aspectj.SpringConfiguredConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Role;
 import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.aspectj.AnnotationAsyncExecutionAspect;
+import org.springframework.scheduling.aspectj.AspectJAsyncConfiguration;
 import org.springframework.scheduling.config.TaskManagementConfigUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.aspectj.AnnotationTransactionAspect;
+import org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration;
 import org.springframework.transaction.config.TransactionManagementConfigUtils;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
+import java.lang.reflect.Method;
 import java.util.Properties;
-import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Spring_aspectsTest {
     @Test
-    void springConfiguredRegistersTheSingletonBeanConfigurerAspect() {
-        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(SpringConfiguredTestConfiguration.class)) {
-            BeanDefinition beanDefinition = context.getBeanFactory()
-                    .getBeanDefinition(SpringConfiguredConfiguration.BEAN_CONFIGURER_ASPECT_BEAN_NAME);
-            AnnotationBeanConfigurerAspect aspect = context.getBean(
-                    SpringConfiguredConfiguration.BEAN_CONFIGURER_ASPECT_BEAN_NAME,
-                    AnnotationBeanConfigurerAspect.class);
+    void springConfiguredRegistersTheSingletonBeanConfigurerAspect() throws Exception {
+        SpringConfiguredConfiguration configuration = new SpringConfiguredConfiguration();
+        Method beanMethod = SpringConfiguredConfiguration.class.getDeclaredMethod("beanConfigurerAspect");
+        Method beanMethodAnnotationAccess = beanMethod;
+        Bean bean = beanMethodAnnotationAccess.getAnnotation(Bean.class);
+        Role role = beanMethodAnnotationAccess.getAnnotation(Role.class);
+        AnnotationBeanConfigurerAspect aspect = configuration.beanConfigurerAspect();
 
-            assertThat(beanDefinition.getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
-            assertThat(aspect).isSameAs(AnnotationBeanConfigurerAspect.aspectOf());
-            assertThat(AnnotationBeanConfigurerAspect.hasAspect()).isTrue();
-        }
+        assertThat(bean).isNotNull();
+        assertThat(bean.name()).containsExactly(SpringConfiguredConfiguration.BEAN_CONFIGURER_ASPECT_BEAN_NAME);
+        assertThat(role).isNotNull();
+        assertThat(role.value()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
+        assertThat(aspect).isSameAs(AnnotationBeanConfigurerAspect.aspectOf());
+        assertThat(AnnotationBeanConfigurerAspect.hasAspect()).isTrue();
     }
 
     @Test
@@ -95,31 +93,26 @@ public class Spring_aspectsTest {
     }
 
     @Test
-    void aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects() {
-        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AspectJInfrastructureConfiguration.class)) {
-            AnnotationCacheAspect cacheAspect = context.getBean(
-                    CacheManagementConfigUtils.CACHE_ASPECT_BEAN_NAME,
-                    AnnotationCacheAspect.class);
-            AnnotationTransactionAspect transactionAspect = context.getBean(
-                    TransactionManagementConfigUtils.TRANSACTION_ASPECT_BEAN_NAME,
-                    AnnotationTransactionAspect.class);
-            AnnotationAsyncExecutionAspect asyncAspect = context.getBean(
-                    TaskManagementConfigUtils.ASYNC_EXECUTION_ASPECT_BEAN_NAME,
-                    AnnotationAsyncExecutionAspect.class);
+    void aspectjModeRegistersCacheTransactionAndAsyncInfrastructureAspects() throws Exception {
+        AspectJCachingConfiguration cachingConfiguration = new AspectJCachingConfiguration();
+        AspectJTransactionManagementConfiguration transactionConfiguration = new AspectJTransactionManagementConfiguration();
+        AspectJAsyncConfiguration asyncConfiguration = new AspectJAsyncConfiguration();
 
-            assertThat(cacheAspect).isSameAs(AnnotationCacheAspect.aspectOf());
-            assertThat(transactionAspect).isSameAs(AnnotationTransactionAspect.aspectOf());
-            assertThat(asyncAspect).isSameAs(AnnotationAsyncExecutionAspect.aspectOf());
-            assertThat(context.getBeanFactory()
-                    .getBeanDefinition(CacheManagementConfigUtils.CACHE_ASPECT_BEAN_NAME)
-                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
-            assertThat(context.getBeanFactory()
-                    .getBeanDefinition(TransactionManagementConfigUtils.TRANSACTION_ASPECT_BEAN_NAME)
-                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
-            assertThat(context.getBeanFactory()
-                    .getBeanDefinition(TaskManagementConfigUtils.ASYNC_EXECUTION_ASPECT_BEAN_NAME)
-                    .getRole()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
-        }
+        assertInfrastructureBean(
+                AspectJCachingConfiguration.class.getDeclaredMethod("cacheAspect"),
+                CacheManagementConfigUtils.CACHE_ASPECT_BEAN_NAME
+        );
+        assertInfrastructureBean(
+                AspectJTransactionManagementConfiguration.class.getDeclaredMethod("transactionAspect"),
+                TransactionManagementConfigUtils.TRANSACTION_ASPECT_BEAN_NAME
+        );
+        assertInfrastructureBean(
+                AspectJAsyncConfiguration.class.getDeclaredMethod("asyncAdvisor"),
+                TaskManagementConfigUtils.ASYNC_EXECUTION_ASPECT_BEAN_NAME
+        );
+        assertThat(cachingConfiguration.cacheAspect()).isSameAs(AnnotationCacheAspect.aspectOf());
+        assertThat(transactionConfiguration.transactionAspect()).isSameAs(AnnotationTransactionAspect.aspectOf());
+        assertThat(asyncConfiguration.asyncAdvisor()).isSameAs(AnnotationAsyncExecutionAspect.aspectOf());
     }
 
     @Test
@@ -177,32 +170,6 @@ public class Spring_aspectsTest {
 
         assertThat(service.getMessage()).isEqualTo("configured through interface aspect");
         assertThat(aspect.wasInvoked()).isTrue();
-    }
-
-    @EnableSpringConfigured
-    @Configuration(proxyBeanMethods = false)
-    static class SpringConfiguredTestConfiguration {
-    }
-
-    @EnableAsync(mode = AdviceMode.ASPECTJ)
-    @EnableCaching(mode = AdviceMode.ASPECTJ)
-    @EnableTransactionManagement(mode = AdviceMode.ASPECTJ)
-    @Configuration(proxyBeanMethods = false)
-    static class AspectJInfrastructureConfiguration {
-        @Bean
-        CacheManager cacheManager() {
-            return new ConcurrentMapCacheManager("books");
-        }
-
-        @Bean
-        PlatformTransactionManager transactionManager() {
-            return new RecordingTransactionManager();
-        }
-
-        @Bean
-        Executor taskExecutor() {
-            return new SyncTaskExecutor();
-        }
     }
 
     @Configurable("configurableService")
@@ -293,5 +260,16 @@ public class Spring_aspectsTest {
         @Override
         public void rollback(TransactionStatus status) {
         }
+    }
+
+    private static void assertInfrastructureBean(Method beanMethod, String beanName) {
+        Method beanMethodAnnotationAccess = beanMethod;
+        Bean bean = beanMethodAnnotationAccess.getAnnotation(Bean.class);
+        Role role = beanMethodAnnotationAccess.getAnnotation(Role.class);
+
+        assertThat(bean).isNotNull();
+        assertThat(bean.name()).containsExactly(beanName);
+        assertThat(role).isNotNull();
+        assertThat(role.value()).isEqualTo(BeanDefinition.ROLE_INFRASTRUCTURE);
     }
 }


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4432

This PR provides new metadata needed for the org.springframework:spring-aspects:6.0.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.springframework:spring-aspects:5.3.31`): 63
- Test-only metadata entries (previous `org.springframework:spring-aspects:5.3.31`): 8
- Metadata entries (new `org.springframework:spring-aspects:6.0.0`): 84
- Test-only metadata entries (new `org.springframework:spring-aspects:6.0.0`): 8
- Library coverage (previous): 40.77%
- Library coverage (new): 36.15%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `503d35864c35771e206a929fb2e5be20456d0bf7`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.springframework:spring-aspects:5.3.31: 0/0 covered calls (100.00%)
- org.springframework:spring-aspects:6.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.springframework:spring-aspects:5.3.31: 170/604 (28.15%)
- org.springframework:spring-aspects:6.0.0: 160/604 (26.49%)

**Line:**
- org.springframework:spring-aspects:5.3.31: 53/130 (40.77%)
- org.springframework:spring-aspects:6.0.0: 47/130 (36.15%)

**Method:**
- org.springframework:spring-aspects:5.3.31: 35/74 (47.30%)
- org.springframework:spring-aspects:6.0.0: 32/74 (43.24%)
