### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-io-core as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-io-core/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-io-core/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; the JVM artifact is published separately as kotlinx-io-core-jvm.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.8.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3715

This PR records `org.jetbrains.kotlinx:kotlinx-io-core` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; the JVM artifact is published separately as kotlinx-io-core-jvm.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.8.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7ee8392e3d642569a5d415f2658ea8b3469d6273`
