### PR TITLE
Clean up unchanged scaffold placeholder tests during generation

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -557,7 +557,7 @@ def main(argv=None):
         for removed_file in placeholder_cleanup.removed_files:
             log_stage(
                 "scaffold-cleanup",
-                f"Removed scaffold placeholder test {os.path.relpath(removed_file, reachability_repo_path)}",
+                f"Removed unchanged scaffold placeholder test {os.path.relpath(removed_file, reachability_repo_path)}",
             )
         if placeholder_cleanup.remaining_placeholders:
             for occurrence in placeholder_cleanup.remaining_placeholders:

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -33,8 +33,6 @@ from utility_scripts.metrics_writer import (
 )
 from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART, LargeLibraryProgressState
 from utility_scripts.library_stats import stats_artifact_dir
-from utility_scripts.source_context import resolve_test_source_layout
-from utility_scripts.test_quality_checks import cleanup_scaffold_placeholder_tests, format_placeholder_occurrence
 from utility_scripts.repo_path_resolver import (
     add_in_metadata_repo_argument,
     resolve_repo_roots,
@@ -425,26 +423,6 @@ def validate_run_quality(coordinates: str, metrics_repo_path: str) -> None:
         raise ValueError(f"Refusing to create PR for {coordinates}: {details}")
 
 
-def cleanup_generated_test_scaffold(coordinates: str, repo_path: str, metrics_repo_path: str) -> None:
-    """Remove untouched scaffold placeholder tests before opening a PR."""
-    run_metrics = read_pending_metrics(metrics_repo_path)
-    scaffold_commit_hash = run_metrics.get("starting_commit")
-    if not scaffold_commit_hash:
-        raise ValueError(f"Refusing to create PR for {coordinates}: missing scaffold commit in run metrics")
-    group, artifact, library_version = parse_coordinate_parts(coordinates)
-    module_dir = os.path.join(repo_path, "tests", "src", group, artifact, library_version)
-    test_source_layout = resolve_test_source_layout(repo_path, coordinates, module_dir)
-    cleanup_result = cleanup_scaffold_placeholder_tests(test_source_layout.source_root, repo_path, scaffold_commit_hash)
-    for removed_file in cleanup_result.removed_files:
-        print(f"Removed scaffold placeholder test: {os.path.relpath(removed_file, repo_path)}")
-    if cleanup_result.remaining_placeholders:
-        details = "; ".join(
-            format_placeholder_occurrence(occurrence, repo_path)
-            for occurrence in cleanup_result.remaining_placeholders
-        )
-        print(f"WARNING: Scaffold placeholder remains in {details} for {coordinates}")
-
-
 def main(argv=None):
     (
         coordinates,
@@ -460,7 +438,6 @@ def main(argv=None):
 
     ensure_gh_authenticated()
     validate_run_quality(coordinates, metrics_repo_path)
-    cleanup_generated_test_scaffold(coordinates, repo_path, metrics_repo_path)
 
     branch = push_current_branch_to_origin(
         coordinates=coordinates,

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -47,7 +47,7 @@ class RealTest {
             self.assertTrue(os.path.exists(real_test_file))
             self.assertEqual(result.remaining_placeholders, [])
 
-    def test_keeps_and_reports_placeholder_when_no_real_test_exists(self) -> None:
+    def test_removes_untouched_scaffold_when_no_real_test_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._init_git_repo(tmp_dir)
             placeholder_file = os.path.join(tmp_dir, "ExampleTest.java")
@@ -70,13 +70,9 @@ class ExampleTest {
 
             result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
 
-            self.assertEqual(result.removed_files, [])
-            self.assertTrue(os.path.exists(placeholder_file))
-            self.assertEqual(len(result.remaining_placeholders), 1)
-            self.assertEqual(
-                format_placeholder_occurrence(result.remaining_placeholders[0], tmp_dir),
-                "ExampleTest.java:8",
-            )
+            self.assertEqual(result.removed_files, [placeholder_file])
+            self.assertFalse(os.path.exists(placeholder_file))
+            self.assertEqual(result.remaining_placeholders, [])
 
     def test_reports_placeholder_when_scaffold_file_changed_but_placeholder_remains(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -33,21 +33,20 @@ def cleanup_scaffold_placeholder_tests(
     if not os.path.isdir(test_source_root):
         return ScaffoldPlaceholderCleanupResult([], [])
 
-    placeholder_files = _find_placeholder_test_files(test_source_root)
+    scaffold_test_files = _find_scaffold_test_files(test_source_root, repo_path, scaffold_commit_hash)
+    placeholder_files = [
+        file_path for file_path in scaffold_test_files
+        if _file_contains_placeholder(file_path)
+    ]
     scaffold_files = [
         file_path for file_path in placeholder_files
         if _is_unchanged_since_commit(file_path, repo_path, scaffold_commit_hash)
     ]
-    non_placeholder_files = [
-        file_path for file_path in _list_test_source_files(test_source_root)
-        if file_path not in placeholder_files
-    ]
 
     removed_files: list[str] = []
-    if non_placeholder_files:
-        for file_path in scaffold_files:
-            os.remove(file_path)
-            removed_files.append(file_path)
+    for file_path in scaffold_files:
+        os.remove(file_path)
+        removed_files.append(file_path)
 
     remaining_placeholders: list[PlaceholderOccurrence] = []
     removed_file_set = set(removed_files)
@@ -66,20 +65,34 @@ def format_placeholder_occurrence(occurrence: PlaceholderOccurrence, repo_path: 
     return f"{display_path}:{occurrence.line_number}"
 
 
-def _find_placeholder_test_files(test_source_root: str) -> list[str]:
+def _find_scaffold_test_files(test_source_root: str, repo_path: str, scaffold_commit_hash: str) -> list[str]:
+    relative_source_root = os.path.relpath(test_source_root, repo_path)
+    result = subprocess.run(
+        [
+            "git",
+            "diff-tree",
+            "--root",
+            "--no-commit-id",
+            "--name-only",
+            "--diff-filter=A",
+            "-r",
+            scaffold_commit_hash,
+            "--",
+            relative_source_root,
+        ],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
     return [
-        file_path for file_path in _list_test_source_files(test_source_root)
-        if _file_contains_placeholder(file_path)
+        os.path.join(repo_path, relative_path)
+        for relative_path in result.stdout.splitlines()
+        if relative_path.endswith(TEST_SOURCE_EXTENSIONS)
     ]
-
-
-def _list_test_source_files(test_source_root: str) -> list[str]:
-    test_files: list[str] = []
-    for root_dir, _, file_names in os.walk(test_source_root):
-        for file_name in file_names:
-            if file_name.endswith(TEST_SOURCE_EXTENSIONS):
-                test_files.append(os.path.join(root_dir, file_name))
-    return sorted(test_files)
 
 
 def _file_contains_placeholder(file_path: str) -> bool:


### PR DESCRIPTION
## Summary
- remove unchanged scaffold-added placeholder test files during new-library generation
- limit cleanup candidates to test source files added by the scaffold commit
- remove the PR-creation scaffold cleanup backstop so cleanup is owned by generation

Fixes #4454
