### PR TITLE
[GenAI] Add support for org.eclipse.jetty.http2:http2-hpack:11.0.24 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty.http2/http2-hpack/11.0.24/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty.http2/http2-hpack/11.0.24/reachability-metadata.json
@@ -1,0 +1,110 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Boolean"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Byte"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Double"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Float"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Long"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "java.lang.Short"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackEncoder"
+      },
+      "type": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackEncoder"
+      },
+      "type": "org.eclipse.jetty.http2.hpack.HpackFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry"
+      },
+      "type": "org.eclipse.jetty.util.TypeUtil",
+      "methods": [
+        {
+          "name": "getClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getCodeSourceLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getModuleLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "getSystemClassLoaderLocation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackEncoder"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackDecoder"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.http2.hpack.HpackDecoder"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty.http2/http2-hpack/index.json
+++ b/metadata/org.eclipse.jetty.http2/http2-hpack/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "11.0.24",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/http2/http2-hpack/$version$/http2-hpack-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "https://github.com/jetty/jetty.project/tree/jetty-$version$/jetty-http2/http2-hpack/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/http2/http2-hpack/$version$/http2-hpack-$version$-javadoc.jar",
+    "description" : "Jetty HTTP2 HPACK provides Jetty's implementation of HPACK header compression for HTTP/2. It encodes and decodes HTTP header fields using the HPACK dynamic and static table mechanisms used by Jetty's HTTP/2 client and server components.",
+    "tested-versions" : [
+      "11.0.24"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.http2.hpack"
+    ]
+  }
+]

--- a/stats/org.eclipse.jetty.http2/http2-hpack/11.0.24/execution-metrics.json
+++ b/stats/org.eclipse.jetty.http2/http2-hpack/11.0.24/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T00:58:10.506124Z",
+    "library": "org.eclipse.jetty.http2:http2-hpack:11.0.24",
+    "starting_commit": "d0254d8c0d1e592887706573afacadb9e6de016c",
+    "ending_commit": "d633c0c91853fdb6c732acb5f17adf70ee60545c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.0.24",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3134,
+          "missed": 1194,
+          "ratio": 0.724122,
+          "total": 4328
+        },
+        "line": {
+          "covered": 545,
+          "missed": 191,
+          "ratio": 0.740489,
+          "total": 736
+        },
+        "method": {
+          "covered": 72,
+          "missed": 16,
+          "ratio": 0.818182,
+          "total": 88
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 242013,
+      "cached_input_tokens_used": 1606656,
+      "output_tokens_used": 19332,
+      "iterations": 6,
+      "cost_usd": 1.3833,
+      "generated_loc": 247,
+      "tested_library_loc": 545,
+      "metadata_entries": 17,
+      "code_coverage_percent": 74.05
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty.http2/http2-hpack/11.0.24/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty.http2/http2-hpack/11.0.24/stats.json
+++ b/stats/org.eclipse.jetty.http2/http2-hpack/11.0.24/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "11.0.24",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3134,
+        "missed" : 1194,
+        "ratio" : 0.724122,
+        "total" : 4328
+      },
+      "line" : {
+        "covered" : 545,
+        "missed" : 191,
+        "ratio" : 0.740489,
+        "total" : 736
+      },
+      "method" : {
+        "covered" : 72,
+        "missed" : 16,
+        "ratio" : 0.818182,
+        "total" : 88
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/.gitignore
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/build.gradle
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty.http2:http2-hpack:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/gradle.properties
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty.http2:http2-hpack:11.0.24
+library.version = 11.0.24
+metadata.dir = org.eclipse.jetty.http2/http2-hpack/11.0.24/

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/settings.gradle
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.http2.http2-hpack_tests'

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
@@ -6,11 +6,220 @@
  */
 package org_eclipse_jetty_http2.http2_hpack;
 
+import java.nio.ByteBuffer;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.hpack.AuthorityHttpField;
+import org.eclipse.jetty.http2.hpack.HpackContext;
+import org.eclipse.jetty.http2.hpack.HpackDecoder;
+import org.eclipse.jetty.http2.hpack.HpackEncoder;
+import org.eclipse.jetty.http2.hpack.HpackException;
+import org.eclipse.jetty.http2.hpack.HpackFieldPreEncoder;
+import org.eclipse.jetty.http2.hpack.StaticTableHttpField;
 import org.junit.jupiter.api.Test;
 
-class Http2_hpackTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Http2_hpackTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void encodesAndDecodesRequestMetadataWithDynamicTableReuse() throws Exception {
+        HpackEncoder encoder = new HpackEncoder();
+        HpackDecoder decoder = new HpackDecoder(4096, () -> 12345L);
+        MetaData.Request request = newRequest("same-dynamic-value");
+
+        ByteBuffer firstBlock = encode(encoder, request);
+        int firstSize = firstBlock.remaining();
+        MetaData firstDecoded = decoder.decode(firstBlock);
+
+        assertThat(firstDecoded).isInstanceOf(MetaData.Request.class);
+        MetaData.Request decodedRequest = (MetaData.Request)firstDecoded;
+        assertThat(decodedRequest.getBeginNanoTime()).isEqualTo(12345L);
+        assertThat(decodedRequest.getMethod()).isEqualTo("GET");
+        assertThat(decodedRequest.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
+        assertThat(decodedRequest.getURI().getScheme()).isEqualTo("https");
+        assertThat(decodedRequest.getURI().getHost()).isEqualTo("example.com");
+        assertThat(decodedRequest.getURI().getPort()).isEqualTo(8443);
+        assertThat(decodedRequest.getURI().getPathQuery()).isEqualTo("/items/1?expand=true");
+        assertThat(decodedRequest.getFields().get(HttpHeader.ACCEPT)).isEqualTo("application/json");
+        assertThat(decodedRequest.getFields().get(HttpHeader.USER_AGENT)).isEqualTo("reachability-hpack-test");
+        assertThat(decodedRequest.getFields().get("x-repeatable")).isEqualTo("same-dynamic-value");
+        assertThat(decodedRequest.getContentLength()).isEqualTo(7L);
+
+        HttpField dynamicField = new HttpField("x-repeatable", "same-dynamic-value");
+        HpackContext.Entry encoderEntry = encoder.getHpackContext().get(dynamicField);
+        HpackContext.Entry decoderEntry = decoder.getHpackContext().get(dynamicField);
+        assertThat(encoderEntry).isNotNull();
+        assertThat(encoderEntry.isStatic()).isFalse();
+        assertThat(decoderEntry).isNotNull();
+        assertThat(decoderEntry.isStatic()).isFalse();
+
+        ByteBuffer secondBlock = encode(encoder, request);
+        assertThat(secondBlock.remaining()).isLessThan(firstSize);
+        MetaData secondDecoded = decoder.decode(secondBlock);
+        assertThat(secondDecoded.getFields().get("x-repeatable")).isEqualTo("same-dynamic-value");
+    }
+
+    @Test
+    void encodesAndDecodesResponseMetadataAndPreEncodedFields() throws Exception {
+        HpackEncoder encoder = new HpackEncoder();
+        HpackFieldPreEncoder preEncoder = new HpackFieldPreEncoder();
+        ByteBuffer block = ByteBuffer.allocate(512);
+
+        encoder.encode(block, new MetaData.Response(HttpVersion.HTTP_2, 204, HttpFields.EMPTY));
+        byte[] preEncodedContentType = preEncoder.getEncodedField(
+                HttpHeader.CONTENT_TYPE,
+                HttpHeader.CONTENT_TYPE.asString(),
+                "text/plain;charset=utf-8");
+        byte[] preEncodedServer = preEncoder.getEncodedField(
+                HttpHeader.SERVER,
+                HttpHeader.SERVER.asString(),
+                "jetty-test");
+        block.put(preEncodedContentType);
+        block.put(preEncodedServer);
+        block.flip();
+
+        HpackDecoder decoder = new HpackDecoder(4096, System::nanoTime);
+        MetaData decoded = decoder.decode(block);
+
+        assertThat(preEncoder.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
+        assertThat(preEncodedContentType).isNotEmpty();
+        assertThat(preEncodedServer).isNotEmpty();
+        assertThat(decoded).isInstanceOf(MetaData.Response.class);
+        MetaData.Response response = (MetaData.Response)decoded;
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(response.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
+        assertThat(response.getFields().get(HttpHeader.CONTENT_TYPE)).isEqualTo("text/plain;charset=utf-8");
+        assertThat(response.getFields().get(HttpHeader.SERVER)).isEqualTo("jetty-test");
+    }
+
+    @Test
+    void exposesStaticAndDynamicHpackContextEntries() {
+        HpackEncoder encoder = new HpackEncoder();
+        HpackContext context = encoder.getHpackContext();
+
+        HpackContext.Entry methodEntry = context.get(HttpHeader.C_METHOD);
+        HpackContext.Entry pathEntry = HpackContext.getStatic(HttpHeader.C_PATH);
+        assertThat(methodEntry).isNotNull();
+        assertThat(methodEntry.isStatic()).isTrue();
+        assertThat(methodEntry.getHttpField().getName()).isEqualTo(":method");
+        assertThat(pathEntry).isNotNull();
+        assertThat(HpackContext.staticIndex(HttpHeader.C_PATH)).isGreaterThan(0);
+        assertThat(context.index(pathEntry)).isEqualTo(HpackContext.staticIndex(HttpHeader.C_PATH));
+
+        HttpField customField = new HttpField("x-context", "context-value");
+        HpackContext.Entry dynamicEntry = context.add(customField);
+        assertThat(dynamicEntry).isNotNull();
+        assertThat(dynamicEntry.isStatic()).isFalse();
+        assertThat(dynamicEntry.getHttpField()).isEqualTo(customField);
+        assertThat(dynamicEntry.getSize()).isEqualTo(32 + "x-context".length() + "context-value".length());
+        assertThat(context.get(customField)).isSameAs(dynamicEntry);
+        assertThat(context.get("x-context")).isSameAs(dynamicEntry);
+        assertThat(context.get(context.index(dynamicEntry))).isSameAs(dynamicEntry);
+        assertThat(context.size()).isEqualTo(1);
+        assertThat(context.getDynamicTableSize()).isEqualTo(dynamicEntry.getSize());
+
+        context.resize(0);
+        assertThat(context.getMaxDynamicTableSize()).isZero();
+        assertThat(context.size()).isZero();
+        assertThat(context.getDynamicTableSize()).isZero();
+        assertThat(context.get(customField)).isNull();
+    }
+
+    @Test
+    void validatesTableCapacityConfigurationAndDynamicTableSizeUpdates() throws Exception {
+        HpackEncoder encoder = new HpackEncoder();
+        assertThat(encoder.isValidateEncoding()).isTrue();
+
+        encoder.setValidateEncoding(false);
+        encoder.setLocalMaxDynamicTableSize(128);
+        encoder.setRemoteMaxDynamicTableSize(64);
+        assertThat(encoder.isValidateEncoding()).isFalse();
+        assertThat(encoder.getMaxTableCapacity()).isEqualTo(128);
+        assertThat(encoder.getTableCapacity()).isEqualTo(64);
+        assertThatThrownBy(() -> encoder.setTableCapacity(129))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Max table capacity");
+
+        ByteBuffer dynamicTableSizeUpdate = ByteBuffer.allocate(16);
+        encoder.encodeMaxDynamicTableSize(dynamicTableSizeUpdate, 32);
+        dynamicTableSizeUpdate.flip();
+        assertThat(dynamicTableSizeUpdate.remaining()).isGreaterThan(0);
+
+        HpackDecoder decoder = new HpackDecoder(4096, System::nanoTime);
+        assertThat(decoder.getMaxTableCapacity()).isEqualTo(HpackContext.DEFAULT_MAX_TABLE_CAPACITY);
+        decoder.setLocalMaxDynamicTableSize(128);
+        assertThat(decoder.getMaxTableCapacity()).isEqualTo(128);
+        decoder.getHpackContext().resize(32);
+        assertThat(decoder.getHpackContext().getMaxDynamicTableSize()).isEqualTo(32);
+    }
+
+    @Test
+    void representsAuthorityAndStaticTableFields() {
+        AuthorityHttpField authority = new AuthorityHttpField("example.org:9443");
+        assertThat(AuthorityHttpField.AUTHORITY).isEqualTo(":authority");
+        assertThat(authority.getHeader()).isEqualTo(HttpHeader.C_AUTHORITY);
+        assertThat(authority.getName()).isEqualTo(":authority");
+        assertThat(authority.getValue()).isEqualTo("example.org:9443");
+        assertThat(authority.getHost()).isEqualTo("example.org");
+        assertThat(authority.getPort()).isEqualTo(9443);
+        assertThat(authority.toString()).contains(":authority", "example.org:9443");
+
+        StaticTableHttpField status = new StaticTableHttpField(HttpHeader.C_STATUS, ":status", "204", 204);
+        assertThat(status.getHeader()).isEqualTo(HttpHeader.C_STATUS);
+        assertThat(status.getName()).isEqualTo(":status");
+        assertThat(status.getValue()).isEqualTo("204");
+        assertThat(status.getStaticValue()).isEqualTo(204);
+        assertThat(status.getIntValue()).isEqualTo(204);
+        assertThat(status.toString()).contains(":status", "204");
+    }
+
+    @Test
+    void rejectsInvalidOrOversizedHeaderBlocks() throws Exception {
+        HpackDecoder invalidIndexDecoder = new HpackDecoder(4096, System::nanoTime);
+        assertThatThrownBy(() -> invalidIndexDecoder.decode(ByteBuffer.wrap(new byte[] {(byte)0x80})))
+                .isInstanceOf(HpackException.class);
+
+        HpackEncoder encoder = new HpackEncoder();
+        ByteBuffer encoded = encode(encoder, newRequest("value-that-will-exceed-a-small-limit"));
+        HpackDecoder sizeLimitedDecoder = new HpackDecoder(8, System::nanoTime);
+        assertThat(sizeLimitedDecoder.getMaxHeaderListSize()).isEqualTo(8);
+        assertThatThrownBy(() -> sizeLimitedDecoder.decode(encoded))
+                .isInstanceOf(HpackException.class)
+                .hasMessageContaining("Header");
+    }
+
+    @Test
+    void decodesIso88591StringFromByteBuffer() {
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {'J', 'e', 't', 't', 'y', '-', (byte)0xE9});
+
+        assertThat(HpackDecoder.toISO88591String(bytes, bytes.remaining())).isEqualTo("Jetty-?");
+        assertThat(bytes.position()).isEqualTo(bytes.limit());
+    }
+
+    private static MetaData.Request newRequest(String repeatableValue) {
+        HttpFields.Mutable fields = HttpFields.build();
+        fields.add(HttpHeader.ACCEPT, "application/json");
+        fields.add(HttpHeader.USER_AGENT, "reachability-hpack-test");
+        fields.add("x-repeatable", repeatableValue);
+        fields.putLongField(HttpHeader.CONTENT_LENGTH, 7L);
+
+        return new MetaData.Request(
+                "GET",
+                HttpURI.from("https://example.com:8443/items/1?expand=true"),
+                HttpVersion.HTTP_2,
+                fields);
+    }
+
+    private static ByteBuffer encode(HpackEncoder encoder, MetaData metadata) throws HpackException {
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        encoder.encode(buffer, metadata);
+        buffer.flip();
+        return buffer;
     }
 }

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
@@ -8,9 +8,11 @@ package org_eclipse_jetty_http2.http2_hpack;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.jetty.http.HostPortHttpField;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
@@ -63,6 +65,36 @@ public class Http2_hpackTest {
         assertThat(secondBlock.remaining()).isLessThan(firstSize);
         MetaData secondDecoded = decoder.decode(secondBlock);
         assertThat(secondDecoded.getFields().get("x-repeatable")).isEqualTo("same-dynamic-value");
+    }
+
+    @Test
+    void encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader() throws Exception {
+        HpackEncoder encoder = new HpackEncoder();
+        HpackDecoder decoder = new HpackDecoder(4096, () -> 67890L);
+        HttpFields.Mutable fields = HttpFields.build();
+        fields.add("sec-websocket-protocol", "chat");
+        fields.add("x-connect-test", "extended-connect");
+        MetaData.ConnectRequest request = new MetaData.ConnectRequest(
+                HttpScheme.HTTPS,
+                new HostPortHttpField("example.com", 8443),
+                "/socket?room=blue",
+                fields,
+                "websocket");
+
+        MetaData decoded = decoder.decode(encode(encoder, request));
+
+        assertThat(decoded).isInstanceOf(MetaData.ConnectRequest.class);
+        MetaData.ConnectRequest decodedRequest = (MetaData.ConnectRequest)decoded;
+        assertThat(decodedRequest.getBeginNanoTime()).isEqualTo(67890L);
+        assertThat(decodedRequest.getMethod()).isEqualTo("CONNECT");
+        assertThat(decodedRequest.getProtocol()).isEqualTo("websocket");
+        assertThat(decodedRequest.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
+        assertThat(decodedRequest.getURI().getScheme()).isEqualTo("https");
+        assertThat(decodedRequest.getURI().getHost()).isEqualTo("example.com");
+        assertThat(decodedRequest.getURI().getPort()).isEqualTo(8443);
+        assertThat(decodedRequest.getURI().getPathQuery()).isEqualTo("/socket?room=blue");
+        assertThat(decodedRequest.getFields().get("sec-websocket-protocol")).isEqualTo("chat");
+        assertThat(decodedRequest.getFields().get("x-connect-test")).isEqualTo("extended-connect");
     }
 
     @Test

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
@@ -131,6 +131,31 @@ public class Http2_hpackTest {
     }
 
     @Test
+    void encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable() throws Exception {
+        HpackEncoder encoder = new HpackEncoder();
+        HpackDecoder decoder = new HpackDecoder(4096, () -> 24680L);
+        HttpField contentType = new HttpField(HttpHeader.CONTENT_TYPE, "text/plain");
+        HttpField setCookie = new HttpField(HttpHeader.SET_COOKIE, "session=secret");
+        ByteBuffer block = ByteBuffer.allocate(512);
+
+        encoder.encode(block, new HttpField(HttpHeader.C_STATUS, "200"));
+        encoder.encode(block, contentType);
+        encoder.encode(block, setCookie);
+        block.flip();
+        MetaData decoded = decoder.decode(block);
+
+        assertThat(decoded).isInstanceOf(MetaData.Response.class);
+        MetaData.Response response = (MetaData.Response)decoded;
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getFields().get(HttpHeader.CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(response.getFields().get(HttpHeader.SET_COOKIE)).isEqualTo("session=secret");
+        assertThat(encoder.getHpackContext().get(contentType)).isNotNull();
+        assertThat(decoder.getHpackContext().get(contentType)).isNotNull();
+        assertThat(encoder.getHpackContext().get(setCookie)).isNull();
+        assertThat(decoder.getHpackContext().get(setCookie)).isNull();
+    }
+
+    @Test
     void exposesStaticAndDynamicHpackContextEntries() {
         HpackEncoder encoder = new HpackEncoder();
         HpackContext context = encoder.getHpackContext();

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
@@ -40,7 +40,7 @@ public class Http2_hpackTest {
         MetaData firstDecoded = decoder.decode(firstBlock);
 
         assertThat(firstDecoded).isInstanceOf(MetaData.Request.class);
-        MetaData.Request decodedRequest = (MetaData.Request)firstDecoded;
+        MetaData.Request decodedRequest = (MetaData.Request) firstDecoded;
         assertThat(decodedRequest.getBeginNanoTime()).isEqualTo(12345L);
         assertThat(decodedRequest.getMethod()).isEqualTo("GET");
         assertThat(decodedRequest.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
@@ -84,7 +84,7 @@ public class Http2_hpackTest {
         MetaData decoded = decoder.decode(encode(encoder, request));
 
         assertThat(decoded).isInstanceOf(MetaData.ConnectRequest.class);
-        MetaData.ConnectRequest decodedRequest = (MetaData.ConnectRequest)decoded;
+        MetaData.ConnectRequest decodedRequest = (MetaData.ConnectRequest) decoded;
         assertThat(decodedRequest.getBeginNanoTime()).isEqualTo(67890L);
         assertThat(decodedRequest.getMethod()).isEqualTo("CONNECT");
         assertThat(decodedRequest.getProtocol()).isEqualTo("websocket");
@@ -123,7 +123,7 @@ public class Http2_hpackTest {
         assertThat(preEncodedContentType).isNotEmpty();
         assertThat(preEncodedServer).isNotEmpty();
         assertThat(decoded).isInstanceOf(MetaData.Response.class);
-        MetaData.Response response = (MetaData.Response)decoded;
+        MetaData.Response response = (MetaData.Response) decoded;
         assertThat(response.getStatus()).isEqualTo(204);
         assertThat(response.getHttpVersion()).isEqualTo(HttpVersion.HTTP_2);
         assertThat(response.getFields().get(HttpHeader.CONTENT_TYPE)).isEqualTo("text/plain;charset=utf-8");
@@ -145,7 +145,7 @@ public class Http2_hpackTest {
         MetaData decoded = decoder.decode(block);
 
         assertThat(decoded).isInstanceOf(MetaData.Response.class);
-        MetaData.Response response = (MetaData.Response)decoded;
+        MetaData.Response response = (MetaData.Response) decoded;
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getFields().get(HttpHeader.CONTENT_TYPE)).isEqualTo("text/plain");
         assertThat(response.getFields().get(HttpHeader.SET_COOKIE)).isEqualTo("session=secret");
@@ -239,7 +239,7 @@ public class Http2_hpackTest {
     @Test
     void rejectsInvalidOrOversizedHeaderBlocks() throws Exception {
         HpackDecoder invalidIndexDecoder = new HpackDecoder(4096, System::nanoTime);
-        assertThatThrownBy(() -> invalidIndexDecoder.decode(ByteBuffer.wrap(new byte[] {(byte)0x80})))
+        assertThatThrownBy(() -> invalidIndexDecoder.decode(ByteBuffer.wrap(new byte[] {(byte) 0x80})))
                 .isInstanceOf(HpackException.class);
 
         HpackEncoder encoder = new HpackEncoder();
@@ -253,7 +253,7 @@ public class Http2_hpackTest {
 
     @Test
     void decodesIso88591StringFromByteBuffer() {
-        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {'J', 'e', 't', 't', 'y', '-', (byte)0xE9});
+        ByteBuffer bytes = ByteBuffer.wrap(new byte[] {'J', 'e', 't', 't', 'y', '-', (byte) 0xE9});
 
         assertThat(HpackDecoder.toISO88591String(bytes, bytes.remaining())).isEqualTo("Jetty-?");
         assertThat(bytes.position()).isEqualTo(bytes.limit());

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/src/test/java/org_eclipse_jetty_http2/http2_hpack/Http2_hpackTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty_http2.http2_hpack;
+
+import org.junit.jupiter.api.Test;
+
+class Http2_hpackTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:52:32">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="8" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:54:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -55,7 +55,7 @@
 <testcase name="representsAuthorityAndStaticTableFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext
 	at org.eclipse.jetty.http2.hpack.AuthorityHttpField.<clinit>(AuthorityHttpField.java:21)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:164)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:196)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -77,7 +77,7 @@ display-name: representsAuthorityAndStaticTableFields()
 <testcase name="decodesIso88591StringFromByteBuffer()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http.HttpTokens" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http.HttpTokens
 	at org.eclipse.jetty.http2.hpack.HpackDecoder.toISO88591String(HpackDecoder.java:369)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:201)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:233)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -98,7 +98,7 @@ display-name: decodesIso88591StringFromByteBuffer()
 </testcase>
 <testcase name="exposesStaticAndDynamicHpackContextEntries()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:103)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:135)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -119,7 +119,7 @@ display-name: exposesStaticAndDynamicHpackContextEntries()
 </testcase>
 <testcase name="encodesAndDecodesResponseMetadataAndPreEncodedFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesResponseMetadataAndPreEncodedFields(Http2_hpackTest.java:70)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesResponseMetadataAndPreEncodedFields(Http2_hpackTest.java:102)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -139,10 +139,8 @@ display-name: encodesAndDecodesResponseMetadataAndPreEncodedFields()
 ]]></system-out>
 </testcase>
 <testcase name="encodesAndDecodesRequestMetadataWithDynamicTableReuse()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.util.TypeUtil" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.util.TypeUtil
-	at org.eclipse.jetty.http.PreEncodedHttpField.<clinit>(PreEncodedHttpField.java:42)
-	at org.eclipse.jetty.http2.hpack.HpackEncoder.<clinit>(HpackEncoder.java:78)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesRequestMetadataWithDynamicTableReuse(Http2_hpackTest.java:32)
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesRequestMetadataWithDynamicTableReuse(Http2_hpackTest.java:34)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -163,7 +161,7 @@ display-name: encodesAndDecodesRequestMetadataWithDynamicTableReuse()
 </testcase>
 <testcase name="validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:136)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:168)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -182,6 +180,29 @@ unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Htt
 display-name: validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()
 ]]></system-out>
 </testcase>
+<testcase name="encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.util.TypeUtil" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.util.TypeUtil
+	at org.eclipse.jetty.http.PreEncodedHttpField.<clinit>(PreEncodedHttpField.java:42)
+	at org.eclipse.jetty.http2.hpack.HpackEncoder.<clinit>(HpackEncoder.java:78)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader(Http2_hpackTest.java:72)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()]
+display-name: encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()
+]]></system-out>
+</testcase>
 <testcase name="rejectsInvalidOrOversizedHeaderBlocks()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)" type="java.lang.Error"><![CDATA[java.lang.Error: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)
 	at org.eclipse.jetty.util.TypeUtil.<clinit>(TypeUtil.java:178)
@@ -192,7 +213,7 @@ display-name: validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()
 	at org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry.<init>(HpackContext.java:463)
 	at org.eclipse.jetty.http2.hpack.HpackContext.<clinit>(HpackContext.java:139)
 	at org.eclipse.jetty.http2.hpack.HpackDecoder.<init>(HpackDecoder.java:58)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:184)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:216)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="8" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:54:20">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="9" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:55:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -55,7 +55,7 @@
 <testcase name="representsAuthorityAndStaticTableFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext
 	at org.eclipse.jetty.http2.hpack.AuthorityHttpField.<clinit>(AuthorityHttpField.java:21)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:196)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:221)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -77,7 +77,7 @@ display-name: representsAuthorityAndStaticTableFields()
 <testcase name="decodesIso88591StringFromByteBuffer()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http.HttpTokens" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http.HttpTokens
 	at org.eclipse.jetty.http2.hpack.HpackDecoder.toISO88591String(HpackDecoder.java:369)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:233)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:258)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -98,7 +98,7 @@ display-name: decodesIso88591StringFromByteBuffer()
 </testcase>
 <testcase name="exposesStaticAndDynamicHpackContextEntries()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:135)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:160)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -138,6 +138,27 @@ unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Htt
 display-name: encodesAndDecodesResponseMetadataAndPreEncodedFields()
 ]]></system-out>
 </testcase>
+<testcase name="encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable(Http2_hpackTest.java:135)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()]
+display-name: encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()
+]]></system-out>
+</testcase>
 <testcase name="encodesAndDecodesRequestMetadataWithDynamicTableReuse()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
 	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesRequestMetadataWithDynamicTableReuse(Http2_hpackTest.java:34)
@@ -161,7 +182,7 @@ display-name: encodesAndDecodesRequestMetadataWithDynamicTableReuse()
 </testcase>
 <testcase name="validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
 <error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:168)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:193)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -213,7 +234,7 @@ display-name: encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()
 	at org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry.<init>(HpackContext.java:463)
 	at org.eclipse.jetty.http2.hpack.HpackContext.<clinit>(HpackContext.java:139)
 	at org.eclipse.jetty.http2.hpack.HpackDecoder.<init>(HpackDecoder.java:58)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:216)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:241)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:52:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2783-51411f37/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="representsAuthorityAndStaticTableFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext
+	at org.eclipse.jetty.http2.hpack.AuthorityHttpField.<clinit>(AuthorityHttpField.java:21)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:164)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:representsAuthorityAndStaticTableFields()]
+display-name: representsAuthorityAndStaticTableFields()
+]]></system-out>
+</testcase>
+<testcase name="decodesIso88591StringFromByteBuffer()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http.HttpTokens" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http.HttpTokens
+	at org.eclipse.jetty.http2.hpack.HpackDecoder.toISO88591String(HpackDecoder.java:369)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:201)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:decodesIso88591StringFromByteBuffer()]
+display-name: decodesIso88591StringFromByteBuffer()
+]]></system-out>
+</testcase>
+<testcase name="exposesStaticAndDynamicHpackContextEntries()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:103)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:exposesStaticAndDynamicHpackContextEntries()]
+display-name: exposesStaticAndDynamicHpackContextEntries()
+]]></system-out>
+</testcase>
+<testcase name="encodesAndDecodesResponseMetadataAndPreEncodedFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesResponseMetadataAndPreEncodedFields(Http2_hpackTest.java:70)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesResponseMetadataAndPreEncodedFields()]
+display-name: encodesAndDecodesResponseMetadataAndPreEncodedFields()
+]]></system-out>
+</testcase>
+<testcase name="encodesAndDecodesRequestMetadataWithDynamicTableReuse()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.util.TypeUtil" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.util.TypeUtil
+	at org.eclipse.jetty.http.PreEncodedHttpField.<clinit>(PreEncodedHttpField.java:42)
+	at org.eclipse.jetty.http2.hpack.HpackEncoder.<clinit>(HpackEncoder.java:78)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesRequestMetadataWithDynamicTableReuse(Http2_hpackTest.java:32)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesRequestMetadataWithDynamicTableReuse()]
+display-name: encodesAndDecodesRequestMetadataWithDynamicTableReuse()
+]]></system-out>
+</testcase>
+<testcase name="validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:136)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()]
+display-name: validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()
+]]></system-out>
+</testcase>
+<testcase name="rejectsInvalidOrOversizedHeaderBlocks()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
+<error message="java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)" type="java.lang.Error"><![CDATA[java.lang.Error: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)
+	at org.eclipse.jetty.util.TypeUtil.<clinit>(TypeUtil.java:178)
+	at org.eclipse.jetty.http.HttpTokens$Token.<init>(HttpTokens.java:77)
+	at org.eclipse.jetty.http.HttpTokens.<clinit>(HttpTokens.java:220)
+	at org.eclipse.jetty.http.compression.HuffmanEncoder.octetsNeeded(HuffmanEncoder.java:93)
+	at org.eclipse.jetty.http.compression.HuffmanEncoder.octetsNeeded(HuffmanEncoder.java:41)
+	at org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry.<init>(HpackContext.java:463)
+	at org.eclipse.jetty.http2.hpack.HpackContext.<clinit>(HpackContext.java:139)
+	at org.eclipse.jetty.http2.hpack.HpackDecoder.<init>(HpackDecoder.java:58)
+	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:184)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1649)
+	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1643)
+	at org.eclipse.jetty.util.TypeUtil.<clinit>(TypeUtil.java:149)
+	... 20 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:rejectsInvalidOrOversizedHeaderBlocks()]
+display-name: rejectsInvalidOrOversizedHeaderBlocks()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="9" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T02:55:48">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T02:57:50">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -53,206 +53,54 @@
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <testcase name="representsAuthorityAndStaticTableFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackContext
-	at org.eclipse.jetty.http2.hpack.AuthorityHttpField.<clinit>(AuthorityHttpField.java:21)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.representsAuthorityAndStaticTableFields(Http2_hpackTest.java:221)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:representsAuthorityAndStaticTableFields()]
 display-name: representsAuthorityAndStaticTableFields()
 ]]></system-out>
 </testcase>
 <testcase name="decodesIso88591StringFromByteBuffer()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http.HttpTokens" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http.HttpTokens
-	at org.eclipse.jetty.http2.hpack.HpackDecoder.toISO88591String(HpackDecoder.java:369)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.decodesIso88591StringFromByteBuffer(Http2_hpackTest.java:258)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:decodesIso88591StringFromByteBuffer()]
 display-name: decodesIso88591StringFromByteBuffer()
 ]]></system-out>
 </testcase>
 <testcase name="exposesStaticAndDynamicHpackContextEntries()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.exposesStaticAndDynamicHpackContextEntries(Http2_hpackTest.java:160)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:exposesStaticAndDynamicHpackContextEntries()]
 display-name: exposesStaticAndDynamicHpackContextEntries()
 ]]></system-out>
 </testcase>
 <testcase name="encodesAndDecodesResponseMetadataAndPreEncodedFields()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesResponseMetadataAndPreEncodedFields(Http2_hpackTest.java:102)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesResponseMetadataAndPreEncodedFields()]
 display-name: encodesAndDecodesResponseMetadataAndPreEncodedFields()
 ]]></system-out>
 </testcase>
 <testcase name="encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable(Http2_hpackTest.java:135)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()]
 display-name: encodesIndividualFieldsAndKeepsNeverIndexedHeadersOutOfDynamicTable()
 ]]></system-out>
 </testcase>
 <testcase name="encodesAndDecodesRequestMetadataWithDynamicTableReuse()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesRequestMetadataWithDynamicTableReuse(Http2_hpackTest.java:34)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesRequestMetadataWithDynamicTableReuse()]
 display-name: encodesAndDecodesRequestMetadataWithDynamicTableReuse()
 ]]></system-out>
 </testcase>
 <testcase name="validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.http2.hpack.HpackEncoder
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.validatesTableCapacityConfigurationAndDynamicTableSizeUpdates(Http2_hpackTest.java:193)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()]
 display-name: validatesTableCapacityConfigurationAndDynamicTableSizeUpdates()
 ]]></system-out>
 </testcase>
 <testcase name="encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="Could not initialize class org.eclipse.jetty.util.TypeUtil" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class org.eclipse.jetty.util.TypeUtil
-	at org.eclipse.jetty.http.PreEncodedHttpField.<clinit>(PreEncodedHttpField.java:42)
-	at org.eclipse.jetty.http2.hpack.HpackEncoder.<clinit>(HpackEncoder.java:78)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader(Http2_hpackTest.java:72)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()]
 display-name: encodesAndDecodesExtendedConnectRequestWithProtocolPseudoHeader()
 ]]></system-out>
 </testcase>
 <testcase name="rejectsInvalidOrOversizedHeaderBlocks()" classname="org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest" time="0">
-<error message="java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)" type="java.lang.Error"><![CDATA[java.lang.Error: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)
-	at org.eclipse.jetty.util.TypeUtil.<clinit>(TypeUtil.java:178)
-	at org.eclipse.jetty.http.HttpTokens$Token.<init>(HttpTokens.java:77)
-	at org.eclipse.jetty.http.HttpTokens.<clinit>(HttpTokens.java:220)
-	at org.eclipse.jetty.http.compression.HuffmanEncoder.octetsNeeded(HuffmanEncoder.java:93)
-	at org.eclipse.jetty.http.compression.HuffmanEncoder.octetsNeeded(HuffmanEncoder.java:41)
-	at org.eclipse.jetty.http2.hpack.HpackContext$StaticEntry.<init>(HpackContext.java:463)
-	at org.eclipse.jetty.http2.hpack.HpackContext.<clinit>(HpackContext.java:139)
-	at org.eclipse.jetty.http2.hpack.HpackDecoder.<init>(HpackDecoder.java:58)
-	at org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest.rejectsInvalidOrOversizedHeaderBlocks(Http2_hpackTest.java:241)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.NoSuchMethodException: java.lang.Byte.valueOf(java.lang.String)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1649)
-	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1643)
-	at org.eclipse.jetty.util.TypeUtil.<clinit>(TypeUtil.java:149)
-	... 20 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_eclipse_jetty_http2.http2_hpack.Http2_hpackTest]/[method:rejectsInvalidOrOversizedHeaderBlocks()]
 display-name: rejectsInvalidOrOversizedHeaderBlocks()

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:54:20">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:55:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:55:48">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:57:50">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:52:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2783-51411f37/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:52:32">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:54:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.http2.hpack.**"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty.http2/http2-hpack/11.0.24/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.jetty.http2.hpack.**"
+      "includeClasses" : "org.eclipse.jetty.http2.hpack.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2783

This PR introduces tests and metadata for org.eclipse.jetty.http2:http2-hpack:11.0.24, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 242013
- Cached input tokens: 1606656
- Output tokens: 19332
- Metadata entries: 17
- Iterations: 6
- Library coverage percentage: 74.05
- Generated lines of code: 247
- Tested library lines of code: 545

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a68934aa7c95dba0f2baa122ed30350cf01b2da1`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3134/4328 (72.41%)
- Line: 545/736 (74.05%)
- Method: 72/88 (81.82%)
