### PR TITLE
[GenAI] Add support for org.jline:jline-reader:3.19.0 using gpt-5.5

### DIFF
--- a/metadata/org.jline/jline-reader/3.19.0/reachability-metadata.json
+++ b/metadata/org.jline/jline-reader/3.19.0/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.TerminalBuilder"
+      },
+      "glob": "META-INF/services/org.jline.terminal.spi.JansiSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.TerminalBuilder"
+      },
+      "glob": "META-INF/services/org.jline.terminal.spi.JnaSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.utils.InfoCmp"
+      },
+      "glob": "org/jline/utils/capabilities.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.utils.InfoCmp"
+      },
+      "glob": "org/jline/utils/xterm-256color.caps"
+    }
+  ]
+}

--- a/metadata/org.jline/jline-reader/index.json
+++ b/metadata/org.jline/jline-reader/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.19.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-reader/$version$/jline-reader-$version$-sources.jar",
+    "repository-url" : "https://github.com/jline/jline3",
+    "test-code-url" : "https://github.com/jline/jline3/tree/jline-parent-$version$/reader/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-reader/$version$/jline-reader-$version$-javadoc.jar",
+    "description" : "JLine Reader provides the line-editing, history, completion, key binding, and prompt-reading APIs used to build interactive command-line interfaces on the JVM. It sits on top of JLine terminal abstractions so Java applications can implement shell-like input behavior across supported consoles and terminal backends.",
+    "tested-versions" : [
+      "3.19.0"
+    ],
+    "allowed-packages" : [
+      "org.jline"
+    ]
+  }
+]

--- a/stats/org.jline/jline-reader/3.19.0/execution-metrics.json
+++ b/stats/org.jline/jline-reader/3.19.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T01:00:21.523788Z",
+    "library": "org.jline:jline-reader:3.19.0",
+    "starting_commit": "c274bb917e436d77b42fcde435eb15d3361cdd23",
+    "ending_commit": "333380cc9fe2da326a31947472a86444faf6282f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.19.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9743,
+          "missed": 17491,
+          "ratio": 0.357751,
+          "total": 27234
+        },
+        "line": {
+          "covered": 1781,
+          "missed": 3620,
+          "ratio": 0.329754,
+          "total": 5401
+        },
+        "method": {
+          "covered": 302,
+          "missed": 517,
+          "ratio": 0.368742,
+          "total": 819
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 228086,
+      "cached_input_tokens_used": 2331136,
+      "output_tokens_used": 28051,
+      "iterations": 7,
+      "cost_usd": 2.0071,
+      "generated_loc": 343,
+      "tested_library_loc": 1781,
+      "metadata_entries": 4,
+      "code_coverage_percent": 32.98
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java",
+      "metadata_file": "metadata/org.jline/jline-reader/3.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jline/jline-reader/3.19.0/stats.json
+++ b/stats/org.jline/jline-reader/3.19.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.19.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9743,
+        "missed" : 17491,
+        "ratio" : 0.357751,
+        "total" : 27234
+      },
+      "line" : {
+        "covered" : 1781,
+        "missed" : 3620,
+        "ratio" : 0.329754,
+        "total" : 5401
+      },
+      "method" : {
+        "covered" : 302,
+        "missed" : 517,
+        "ratio" : 0.368742,
+        "total" : 819
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jline/jline-reader/3.19.0/.gitignore
+++ b/tests/src/org.jline/jline-reader/3.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jline/jline-reader/3.19.0/build.gradle
+++ b/tests/src/org.jline/jline-reader/3.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jline:jline-reader:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jline/jline-reader/3.19.0/gradle.properties
+++ b/tests/src/org.jline/jline-reader/3.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jline:jline-reader:3.19.0
+library.version = 3.19.0
+metadata.dir = org.jline/jline-reader/3.19.0/

--- a/tests/src/org.jline/jline-reader/3.19.0/settings.gradle
+++ b/tests/src/org.jline/jline-reader/3.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jline.jline-reader_tests'

--- a/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
+++ b/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
@@ -6,11 +6,298 @@
  */
 package org_jline.jline_reader;
 
+import org.jline.keymap.BindingReader;
+import org.jline.keymap.KeyMap;
+import org.jline.reader.Candidate;
+import org.jline.reader.EOFError;
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser;
+import org.jline.reader.impl.BufferImpl;
+import org.jline.reader.impl.DefaultExpander;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.SimpleMaskingCallback;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.completer.EnumCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
+import org.jline.reader.impl.completer.StringsCompleter;
+import org.jline.reader.impl.history.DefaultHistory;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-class Jline_readerTest {
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jline_readerTest {
+    @TempDir
+    Path temporaryDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultParserHandlesQuotingEscapingAndCompletionMetadata() {
+        DefaultParser parser = new DefaultParser()
+                .quoteChars(new char[] {'\'', '"'})
+                .escapeChars(new char[] {'\\'})
+                .eofOnEscapedNewLine(true);
+        String line = "deploy \"two words\" plain\\ value";
+
+        ParsedLine parsedLine = parser.parse(line, line.length(), Parser.ParseContext.COMPLETE);
+
+        assertThat(parsedLine.line()).isEqualTo(line);
+        assertThat(parsedLine.cursor()).isEqualTo(line.length());
+        assertThat(parsedLine.words()).containsExactly("deploy", "two words", "plain value");
+        assertThat(parsedLine.wordIndex()).isEqualTo(2);
+        assertThat(parsedLine.word()).isEqualTo("plain value");
+        assertThat(parsedLine.wordCursor()).isEqualTo("plain value".length());
+        assertThat(parser.getQuoteChars()).contains('"');
+        assertThat(parser.getEscapeChars()).contains('\\');
+    }
+
+    @Test
+    void defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing() {
+        DefaultParser parser = new DefaultParser()
+                .eofOnUnclosedQuote(true)
+                .eofOnUnclosedBracket(DefaultParser.Bracket.ROUND, DefaultParser.Bracket.CURLY);
+
+        String unclosedQuote = "echo \"unterminated";
+        String unclosedBracket = "call(first, second";
+
+        assertThatThrownBy(() -> parser.parse(unclosedQuote, unclosedQuote.length(), Parser.ParseContext.ACCEPT_LINE))
+                .isInstanceOf(EOFError.class);
+        assertThatThrownBy(() -> parser.parse(unclosedBracket, unclosedBracket.length(), Parser.ParseContext.ACCEPT_LINE))
+                .isInstanceOf(EOFError.class);
+    }
+
+    @Test
+    void completersContributeCandidatesForStringsEnumsAggregateAndArguments() {
+        DefaultParser parser = new DefaultParser();
+        ParsedLine firstWord = parser.parse("", 0, Parser.ParseContext.COMPLETE);
+        List<Candidate> aggregateCandidates = new ArrayList<>();
+        AggregateCompleter aggregateCompleter = new AggregateCompleter(
+                new StringsCompleter("status", "checkout"),
+                new EnumCompleter(CommandMode.class),
+                NullCompleter.INSTANCE);
+
+        aggregateCompleter.complete(null, firstWord, aggregateCandidates);
+
+        assertThat(candidateValues(aggregateCandidates))
+                .contains("status", "checkout", "fast_mode", "safe_mode");
+
+        ParsedLine commandLine = parser.parse("git checkout ", "git checkout ".length(), Parser.ParseContext.COMPLETE);
+        List<Candidate> argumentCandidates = new ArrayList<>();
+        ArgumentCompleter argumentCompleter = new ArgumentCompleter(
+                new StringsCompleter("git"),
+                new StringsCompleter("checkout", "commit"),
+                new StringsCompleter("main", "feature/native"));
+
+        argumentCompleter.complete(null, commandLine, argumentCandidates);
+
+        assertThat(candidateValues(argumentCandidates)).containsExactly("main", "feature/native");
+        assertThat(argumentCompleter.getCompleters()).hasSize(3);
+        assertThat(argumentCompleter.isStrict()).isTrue();
+    }
+
+    @Test
+    void bufferSupportsCursorEditingDeletionAndCopying() {
+        BufferImpl buffer = new BufferImpl();
+
+        buffer.write("hello world");
+        assertThat(buffer.toString()).isEqualTo("hello world");
+        assertThat(buffer.cursor()).isEqualTo("hello world".length());
+
+        assertThat(buffer.move(-5)).isEqualTo(-5);
+        buffer.write("native ");
+        assertThat(buffer.toString()).isEqualTo("hello native world");
+        assertThat(buffer.upToCursor()).isEqualTo("hello native ");
+
+        assertThat(buffer.backspace(7)).isEqualTo(7);
+        assertThat(buffer.toString()).isEqualTo("hello world");
+        assertThat(buffer.delete(5)).isEqualTo(5);
+        assertThat(buffer.toString()).isEqualTo("hello ");
+
+        BufferImpl copy = buffer.copy();
+        buffer.write("again");
+        assertThat(copy.toString()).isEqualTo("hello ");
+        copy.copyFrom(buffer);
+        assertThat(copy.toString()).isEqualTo("hello again");
+    }
+
+    @Test
+    void historyNavigatesPersistsAndExpandsPreviousEvents() throws Exception {
+        DefaultHistory history = new DefaultHistory();
+        Instant firstTimestamp = Instant.parse("2024-01-01T00:00:00Z");
+        Instant secondTimestamp = Instant.parse("2024-01-01T00:00:01Z");
+
+        history.add(firstTimestamp, "git status");
+        history.add(secondTimestamp, "git checkout main");
+
+        assertThat(history).hasSize(2);
+        assertThat(history.first()).isZero();
+        assertThat(history.last()).isEqualTo(1);
+        assertThat(history.get(0)).isEqualTo("git status");
+        assertThat(history.moveToFirst()).isTrue();
+        assertThat(history.current()).isEqualTo("git status");
+        assertThat(history.next()).isTrue();
+        assertThat(history.current()).isEqualTo("git checkout main");
+        history.moveToEnd();
+
+        String expanded = new DefaultExpander().expandHistory(history, "sudo !!");
+        assertThat(expanded).isEqualTo("sudo git checkout main");
+
+        Path historyFile = temporaryDirectory.resolve("jline-history.txt");
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-history-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .history(history)
+                    .build();
+            history.attach(reader);
+            history.write(historyFile, false);
+        }
+
+        DefaultHistory reloaded = new DefaultHistory();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-history-reload-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .history(reloaded)
+                    .build();
+            reloaded.attach(reader);
+            reloaded.read(historyFile, false);
+        }
+
+        assertThat(historyLines(reloaded)).containsExactly("git status", "git checkout main");
+        assertThat(reloaded.iterator(0).next().time()).isNotNull();
+    }
+
+    @Test
+    void lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables() throws Exception {
+        byte[] input = "hello native image\n".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        DefaultHistory history = new DefaultHistory();
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-reader-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream(input), output)
+                .encoding(StandardCharsets.UTF_8)
+                .size(new Size(80, 24))
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("jline-reader-tests")
+                    .parser(new DefaultParser())
+                    .completer(new StringsCompleter("hello", "help"))
+                    .history(history)
+                    .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                    .variable(LineReader.SECONDARY_PROMPT_PATTERN, "%M> ")
+                    .build();
+
+            reader.setVariable(LineReader.LIST_MAX, 25);
+            reader.setTailTip("tail-tip");
+            assertThat(reader.getTailTip()).isEqualTo("tail-tip");
+            reader.setAutosuggestion(LineReader.SuggestionType.HISTORY);
+            String line = reader.readLine("prompt> ");
+
+            assertThat(line).isEqualTo("hello native image");
+            assertThat(reader.getAppName()).isEqualTo("jline-reader-tests");
+            assertThat(reader.isSet(LineReader.Option.DISABLE_EVENT_EXPANSION)).isTrue();
+            assertThat(reader.getVariable(LineReader.LIST_MAX)).isEqualTo(25);
+            assertThat(reader.getTailTip()).isEmpty();
+            assertThat(reader.getAutosuggestion()).isEqualTo(LineReader.SuggestionType.HISTORY);
+            assertThat(historyLines(history)).containsExactly("hello native image");
+        }
+
+        assertThat(output.toString(StandardCharsets.UTF_8)).contains("prompt> ");
+    }
+
+    @Test
+    void keyMapTranslatesDisplaysBindsAndReadsTerminalInput() throws Exception {
+        assertThat(KeyMap.ctrl('A')).isEqualTo("\u0001");
+        assertThat(KeyMap.alt('x')).isEqualTo("\u001Bx");
+        assertThat(KeyMap.display(KeyMap.ctrl('C'))).isEqualTo("\"^C\"");
+        assertThat(KeyMap.range("a-c")).containsExactly("a", "b", "c");
+
+        KeyMap<String> keyMap = new KeyMap<>();
+        keyMap.bind("insert-x", "x");
+        keyMap.bindIfNotBound("ignored", "x");
+        keyMap.bind("control-a", KeyMap.ctrl('A'));
+
+        assertThat(keyMap.getBound("x")).isEqualTo("insert-x");
+        assertThat(keyMap.getBound(KeyMap.ctrl('A'))).isEqualTo("control-a");
+        assertThat(keyMap.getBoundKeys()).containsEntry("x", "insert-x");
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-binding-reader-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream("x".getBytes(StandardCharsets.UTF_8)), new ByteArrayOutputStream())
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+            BindingReader bindingReader = new BindingReader(terminal.reader());
+
+            assertThat(bindingReader.readBinding(keyMap)).isEqualTo("insert-x");
+            assertThat(bindingReader.getLastBinding()).isEqualTo("x");
+        }
+    }
+
+    @Test
+    void maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata() {
+        SimpleMaskingCallback maskingCallback = new SimpleMaskingCallback('*');
+        Candidate visible = new Candidate("checkout", "checkout", "commands", "switch branches", " ", "co", true);
+        Candidate hidden = new Candidate("commit");
+        List<Candidate> candidates = new ArrayList<>(List.of(visible, hidden));
+
+        candidates.sort(Comparator.naturalOrder());
+
+        assertThat(maskingCallback.display("secret")).isEqualTo("******");
+        assertThat(maskingCallback.history("secret")).isNull();
+        assertThat(candidates).extracting(Candidate::value).containsExactly("checkout", "commit");
+        assertThat(visible.displ()).isEqualTo("checkout");
+        assertThat(visible.group()).isEqualTo("commands");
+        assertThat(visible.descr()).isEqualTo("switch branches");
+        assertThat(visible.suffix()).isEqualTo(" ");
+        assertThat(visible.key()).isEqualTo("co");
+        assertThat(visible.complete()).isTrue();
+    }
+
+    private static List<String> candidateValues(List<Candidate> candidates) {
+        return candidates.stream().map(Candidate::value).toList();
+    }
+
+    private static List<String> historyLines(History history) {
+        List<String> lines = new ArrayList<>();
+        history.forEach(entry -> lines.add(entry.line()));
+        return lines;
+    }
+
+    private enum CommandMode {
+        FAST_MODE,
+        SAFE_MODE
     }
 }

--- a/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
+++ b/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
@@ -22,6 +22,7 @@ import org.jline.reader.impl.SimpleMaskingCallback;
 import org.jline.reader.impl.completer.AggregateCompleter;
 import org.jline.reader.impl.completer.ArgumentCompleter;
 import org.jline.reader.impl.completer.EnumCompleter;
+import org.jline.reader.impl.completer.FileNameCompleter;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.reader.impl.history.DefaultHistory;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -267,6 +269,59 @@ public class Jline_readerTest {
     }
 
     @Test
+    void fileNameCompleterContributesFileAndDirectoryCandidates() throws Exception {
+        Path workingDirectory = temporaryDirectory.resolve("workspace");
+        Path scriptsDirectory = workingDirectory.resolve("scripts");
+        Files.createDirectories(scriptsDirectory);
+        Files.writeString(workingDirectory.resolve("status.txt"), "ready", StandardCharsets.UTF_8);
+        Files.writeString(scriptsDirectory.resolve("build.sh"), "echo build", StandardCharsets.UTF_8);
+
+        FileNameCompleter completer = new FileNameCompleter();
+        String separator = workingDirectory.getFileSystem().getSeparator();
+        String topLevelPrefix = workingDirectory.toString() + separator;
+        String scriptsCandidateValue = scriptsDirectory.toString() + separator;
+        String statusCandidateValue = workingDirectory.resolve("status.txt").toString();
+        String nestedCandidateValue = scriptsDirectory.resolve("build.sh").toString();
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-file-completer-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .completer(completer)
+                    .option(LineReader.Option.AUTO_PARAM_SLASH, true)
+                    .option(LineReader.Option.AUTO_REMOVE_SLASH, true)
+                    .build();
+            DefaultParser parser = new DefaultParser().escapeChars(new char[0]);
+            List<Candidate> topLevelCandidates = new ArrayList<>();
+
+            String topLevelInput = topLevelPrefix + "s";
+            completer.complete(
+                    reader,
+                    parser.parse(topLevelInput, topLevelInput.length(), Parser.ParseContext.COMPLETE),
+                    topLevelCandidates);
+
+            assertThat(candidateValues(topLevelCandidates)).contains(scriptsCandidateValue, statusCandidateValue);
+            Candidate scriptsCandidate = candidateWithValue(topLevelCandidates, scriptsCandidateValue);
+            assertThat(scriptsCandidate.complete()).isFalse();
+            assertThat(scriptsCandidate.suffix()).isEqualTo(separator);
+            assertThat(candidateWithValue(topLevelCandidates, statusCandidateValue).complete()).isTrue();
+
+            List<Candidate> nestedCandidates = new ArrayList<>();
+            completer.complete(
+                    reader,
+                    parser.parse(scriptsCandidateValue, scriptsCandidateValue.length(), Parser.ParseContext.COMPLETE),
+                    nestedCandidates);
+
+            assertThat(candidateValues(nestedCandidates)).containsExactly(nestedCandidateValue);
+            assertThat(candidateWithValue(nestedCandidates, nestedCandidateValue).complete()).isTrue();
+        }
+    }
+
+    @Test
     void maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata() {
         SimpleMaskingCallback maskingCallback = new SimpleMaskingCallback('*');
         Candidate visible = new Candidate("checkout", "checkout", "commands", "switch branches", " ", "co", true);
@@ -284,6 +339,13 @@ public class Jline_readerTest {
         assertThat(visible.suffix()).isEqualTo(" ");
         assertThat(visible.key()).isEqualTo("co");
         assertThat(visible.complete()).isTrue();
+    }
+
+    private static Candidate candidateWithValue(List<Candidate> candidates, String value) {
+        return candidates.stream()
+                .filter(candidate -> candidate.value().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing candidate: " + value));
     }
 
     private static List<String> candidateValues(List<Candidate> candidates) {

--- a/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
+++ b/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
@@ -17,6 +17,7 @@ import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.impl.BufferImpl;
 import org.jline.reader.impl.DefaultExpander;
+import org.jline.reader.impl.DefaultHighlighter;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.SimpleMaskingCallback;
 import org.jline.reader.impl.completer.AggregateCompleter;
@@ -29,6 +30,8 @@ import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Size;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -41,6 +44,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -318,6 +322,35 @@ public class Jline_readerTest {
 
             assertThat(candidateValues(nestedCandidates)).containsExactly(nestedCandidateValue);
             assertThat(candidateWithValue(nestedCandidates, nestedCandidateValue).complete()).isTrue();
+        }
+    }
+
+    @Test
+    void defaultHighlighterStylesConfiguredErrorsWithoutChangingDisplayedText() throws Exception {
+        String line = "ok ERR42 warning";
+        int errorIndex = line.indexOf("warning");
+        DefaultHighlighter highlighter = new DefaultHighlighter();
+        highlighter.setErrorPattern(Pattern.compile("\\bERR\\w+\\b"));
+        highlighter.setErrorIndex(errorIndex);
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .name("jline-highlighter-test")
+                .system(false)
+                .dumb(true)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream())
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .highlighter(highlighter)
+                    .build();
+
+            AttributedString highlighted = reader.getHighlighter().highlight(reader, line);
+
+            assertThat(highlighted.toString()).isEqualTo(line);
+            assertThat(highlighted.styleAt(line.indexOf("ERR42"))).isNotEqualTo(AttributedStyle.DEFAULT);
+            assertThat(highlighted.styleAt(errorIndex)).isNotEqualTo(AttributedStyle.DEFAULT);
+            assertThat(highlighted.styleAt(line.indexOf(' ', line.indexOf("ERR42")))).isEqualTo(AttributedStyle.DEFAULT);
         }
     }
 

--- a/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
+++ b/tests/src/org.jline/jline-reader/3.19.0/src/test/java/org_jline/jline_reader/Jline_readerTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jline.jline_reader;
+
+import org.junit.jupiter.api.Test;
+
+class Jline_readerTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.019" hostname="kung-fu-workstation" timestamp="2026-05-03T02:58:47">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.018" hostname="kung-fu-workstation" timestamp="2026-05-03T02:59:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2743-cd239124/tests/src/org.jline/jline-reader/3.19.0"/>
@@ -82,19 +81,19 @@ unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest
 display-name: maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="fileNameCompleterContributesFileAndDirectoryCandidates()" classname="org_jline.jline_reader.Jline_readerTest" time="0.003">
+<testcase name="fileNameCompleterContributesFileAndDirectoryCandidates()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:fileNameCompleterContributesFileAndDirectoryCandidates()]
 display-name: fileNameCompleterContributesFileAndDirectoryCandidates()
 ]]></system-out>
 </testcase>
-<testcase name="historyNavigatesPersistsAndExpandsPreviousEvents()" classname="org_jline.jline_reader.Jline_readerTest" time="0.006">
+<testcase name="historyNavigatesPersistsAndExpandsPreviousEvents()" classname="org_jline.jline_reader.Jline_readerTest" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:historyNavigatesPersistsAndExpandsPreviousEvents()]
 display-name: historyNavigatesPersistsAndExpandsPreviousEvents()
 ]]></system-out>
 </testcase>
-<testcase name="lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()" classname="org_jline.jline_reader.Jline_readerTest" time="0.003">
+<testcase name="lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()]
 display-name: lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.012" hostname="kung-fu-workstation" timestamp="2026-05-03T02:53:50">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2743-cd239124/tests/src/org.jline/jline-reader/3.19.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing()]
+display-name: defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing()
+]]></system-out>
+</testcase>
+<testcase name="bufferSupportsCursorEditingDeletionAndCopying()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:bufferSupportsCursorEditingDeletionAndCopying()]
+display-name: bufferSupportsCursorEditingDeletionAndCopying()
+]]></system-out>
+</testcase>
+<testcase name="defaultParserHandlesQuotingEscapingAndCompletionMetadata()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:defaultParserHandlesQuotingEscapingAndCompletionMetadata()]
+display-name: defaultParserHandlesQuotingEscapingAndCompletionMetadata()
+]]></system-out>
+</testcase>
+<testcase name="maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata()]
+display-name: maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata()
+]]></system-out>
+</testcase>
+<testcase name="historyNavigatesPersistsAndExpandsPreviousEvents()" classname="org_jline.jline_reader.Jline_readerTest" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:historyNavigatesPersistsAndExpandsPreviousEvents()]
+display-name: historyNavigatesPersistsAndExpandsPreviousEvents()
+]]></system-out>
+</testcase>
+<testcase name="lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()]
+display-name: lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()
+]]></system-out>
+</testcase>
+<testcase name="completersContributeCandidatesForStringsEnumsAggregateAndArguments()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:completersContributeCandidatesForStringsEnumsAggregateAndArguments()]
+display-name: completersContributeCandidatesForStringsEnumsAggregateAndArguments()
+]]></system-out>
+</testcase>
+<testcase name="keyMapTranslatesDisplaysBindsAndReadsTerminalInput()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:keyMapTranslatesDisplaysBindsAndReadsTerminalInput()]
+display-name: keyMapTranslatesDisplaysBindsAndReadsTerminalInput()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.016" hostname="kung-fu-workstation" timestamp="2026-05-03T02:56:59">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.019" hostname="kung-fu-workstation" timestamp="2026-05-03T02:58:47">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,6 +52,12 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
+<testcase name="defaultHighlighterStylesConfiguredErrorsWithoutChangingDisplayedText()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:defaultHighlighterStylesConfiguredErrorsWithoutChangingDisplayedText()]
+display-name: defaultHighlighterStylesConfiguredErrorsWithoutChangingDisplayedText()
+]]></system-out>
+</testcase>
 <testcase name="defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing()" classname="org_jline.jline_reader.Jline_readerTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:defaultParserReportsIncompleteInputWhenConfiguredForMultilineEditing()]

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.012" hostname="kung-fu-workstation" timestamp="2026-05-03T02:53:50">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.016" hostname="kung-fu-workstation" timestamp="2026-05-03T02:56:59">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -76,13 +76,19 @@ unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest
 display-name: maskingCallbackAndCandidatesExposeDisplayHistoryAndSortingMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="historyNavigatesPersistsAndExpandsPreviousEvents()" classname="org_jline.jline_reader.Jline_readerTest" time="0.005">
+<testcase name="fileNameCompleterContributesFileAndDirectoryCandidates()" classname="org_jline.jline_reader.Jline_readerTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:fileNameCompleterContributesFileAndDirectoryCandidates()]
+display-name: fileNameCompleterContributesFileAndDirectoryCandidates()
+]]></system-out>
+</testcase>
+<testcase name="historyNavigatesPersistsAndExpandsPreviousEvents()" classname="org_jline.jline_reader.Jline_readerTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:historyNavigatesPersistsAndExpandsPreviousEvents()]
 display-name: historyNavigatesPersistsAndExpandsPreviousEvents()
 ]]></system-out>
 </testcase>
-<testcase name="lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()" classname="org_jline.jline_reader.Jline_readerTest" time="0.002">
+<testcase name="lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()" classname="org_jline.jline_reader.Jline_readerTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jline.jline_reader.Jline_readerTest]/[method:lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()]
 display-name: lineReaderReadsScriptedInputWithConfiguredTerminalHistoryAndVariables()

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:58:47">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:59:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2743-cd239124/tests/src/org.jline/jline-reader/3.19.0"/>

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:53:50">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:56:59">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:56:59">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:58:47">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jline/jline-reader/3.19.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:53:50">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2743-cd239124/tests/src/org.jline/jline-reader/3.19.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.jline/jline-reader/3.19.0/user-code-filter.json
+++ b/tests/src/org.jline/jline-reader/3.19.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jline.**"
+    }
+  ]
+}

--- a/tests/src/org.jline/jline-reader/3.19.0/user-code-filter.json
+++ b/tests/src/org.jline/jline-reader/3.19.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jline.**"
+      "includeClasses" : "org.jline.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2743

This PR introduces tests and metadata for org.jline:jline-reader:3.19.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 228086
- Cached input tokens: 2331136
- Output tokens: 28051
- Metadata entries: 4
- Iterations: 7
- Library coverage percentage: 32.98
- Generated lines of code: 343
- Tested library lines of code: 1781

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `48228a8955a7ddf97b5729a6b4d515e4d73988de`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 9743/27234 (35.78%)
- Line: 1781/5401 (32.98%)
- Method: 302/819 (36.87%)
