### PR TITLE
[GenAI] Add support for org.apache.maven.resolver:maven-resolver-transport-http:1.9.25 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/reachability-metadata.json
@@ -1,0 +1,386 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.RFC9457.RFC9457Parser"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.RFC9457.RFC9457Parser"
+      },
+      "type": "java.lang.reflect.RecordComponent"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.RFC9457.RFC9457Parser"
+      },
+      "type": "java.sql.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.NetscapeCertTypeExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.PrivateKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.GlobalState"
+      },
+      "glob": "mozilla/public-suffix-list.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.http.HttpTransporter"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-http/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-http/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.25",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-http/$version$/maven-resolver-transport-http-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/$version$/maven-resolver-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-http/$version$/maven-resolver-transport-http-$version$-javadoc.jar",
+    "description" : "Maven Artifact Resolver Transport HTTP provides an HTTP and HTTPS transport implementation for Maven Resolver repositories. It lets Maven Resolver clients transfer artifacts and metadata over HTTP-based repository URLs.",
+    "tested-versions" : [
+      "1.9.25"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.transport.http"
+    ]
+  }
+]

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T02:37:38.154001Z",
+    "library": "org.apache.maven.resolver:maven-resolver-transport-http:1.9.25",
+    "starting_commit": "b031a7fb18a8cfa939a6024f863c9223657110e4",
+    "ending_commit": "0bf3210b1b4089a380b8f37295ba7e3c28c5cd62",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.25",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2304,
+          "missed": 1563,
+          "ratio": 0.595811,
+          "total": 3867
+        },
+        "line": {
+          "covered": 503,
+          "missed": 340,
+          "ratio": 0.596679,
+          "total": 843
+        },
+        "method": {
+          "covered": 98,
+          "missed": 51,
+          "ratio": 0.657718,
+          "total": 149
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 224757,
+      "cached_input_tokens_used": 2914816,
+      "output_tokens_used": 25746,
+      "iterations": 4,
+      "cost_usd": 2.2298,
+      "generated_loc": 482,
+      "tested_library_loc": 503,
+      "metadata_entries": 58,
+      "code_coverage_percent": 59.67
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.9.25",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2304,
+        "missed" : 1563,
+        "ratio" : 0.595811,
+        "total" : 3867
+      },
+      "line" : {
+        "covered" : 503,
+        "missed" : 340,
+        "ratio" : 0.596679,
+        "total" : 843
+      },
+      "method" : {
+        "covered" : 98,
+        "missed" : 51,
+        "ratio" : 0.657718,
+        "total" : 149
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-transport-http:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-transport-http:1.9.25
+library.version = 1.9.25
+metadata.dir = org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-transport-http_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_transport_http;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_resolver_transport_httpTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
@@ -6,11 +6,333 @@
  */
 package org_apache_maven_resolver.maven_resolver_transport_http;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.transport.http.ChecksumExtractor;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.transport.http.Nexus2ChecksumExtractor;
+import org.eclipse.aether.transport.http.RFC9457.HttpRFC9457Exception;
+import org.eclipse.aether.transport.http.RFC9457.RFC9457Parser;
+import org.eclipse.aether.transport.http.RFC9457.RFC9457Payload;
+import org.eclipse.aether.transport.http.RFC9457.RFC9457Reporter;
+import org.eclipse.aether.transport.http.XChecksumChecksumExtractor;
 import org.junit.jupiter.api.Test;
 
-class Maven_resolver_transport_httpTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Maven_resolver_transport_httpTest {
+    private static final String ARTIFACT_PATH = "/repository/com/example/demo/1.0/demo-1.0.jar";
+    private static final String ARTIFACT_BODY = "resolved artifact contents";
+    private static final String SHA1 = "0123456789abcdef0123456789abcdef01234567";
+    private static final String MD5 = "0123456789abcdef0123456789abcdef";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void checksumExtractorsReadNexusAndStandardHttpHeaders() {
+        BasicHttpResponse centralResponse = response(200, "OK");
+        centralResponse.addHeader("x-checksum-sha1", SHA1);
+        centralResponse.addHeader("x-checksum-md5", MD5);
+        centralResponse.addHeader("x-goog-meta-checksum-sha1", "ignored-when-central-headers-exist");
+
+        Map<String, String> centralChecksums = new XChecksumChecksumExtractor().extractChecksums(centralResponse);
+        assertThat(centralChecksums).containsEntry("SHA-1", SHA1).containsEntry("MD5", MD5).hasSize(2);
+
+        BasicHttpResponse googleStorageResponse = response(200, "OK");
+        googleStorageResponse.addHeader("x-goog-meta-checksum-sha1", SHA1);
+        googleStorageResponse.addHeader("x-goog-meta-checksum-md5", MD5);
+        assertThat(new XChecksumChecksumExtractor().extractChecksums(googleStorageResponse))
+                .containsEntry("SHA-1", SHA1)
+                .containsEntry("MD5", MD5)
+                .hasSize(2);
+
+        BasicHttpResponse nexusResponse = response(200, "OK");
+        nexusResponse.addHeader(HttpHeaders.ETAG, "\"{SHA1{" + SHA1 + "}}\"");
+        assertThat(new Nexus2ChecksumExtractor().extractChecksums(nexusResponse))
+                .containsExactly(Map.entry("SHA-1", SHA1));
+
+        ChecksumExtractor extractor = new XChecksumChecksumExtractor();
+        HttpGet request = new HttpGet("http://localhost/artifact.jar");
+        extractor.prepareRequest(request);
+        assertThat(request.getAllHeaders()).isEmpty();
+        assertThat(extractor.retryWithoutExtractor(new HttpResponseException(400, "Bad Request"))).isFalse();
+        assertThat(extractor.extractChecksums(response(200, "OK"))).isNull();
+    }
+
+    @Test
+    void rfc9457ParserAndReporterExposeProblemDetails() throws Exception {
+        String problem = """
+                {
+                  "type": "https://example.invalid/problems/quota",
+                  "title": "Quota exceeded",
+                  "status": 429,
+                  "detail": "Too many artifact requests",
+                  "instance": "urn:request:123"
+                }
+                """;
+
+        RFC9457Payload parsed = RFC9457Parser.parse(problem);
+        assertThat(parsed.getType()).isEqualTo(URI.create("https://example.invalid/problems/quota"));
+        assertThat(parsed.getStatus()).isEqualTo(429);
+        assertThat(parsed.getTitle()).isEqualTo("Quota exceeded");
+        assertThat(parsed.getDetail()).isEqualTo("Too many artifact requests");
+        assertThat(parsed.getInstance()).isEqualTo(URI.create("urn:request:123"));
+        assertThat(parsed.toString()).contains("Quota exceeded", "Too many artifact requests");
+
+        CloseableBasicHttpResponse response = closeableResponse(429, "Too Many Requests");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "application/problem+json");
+        response.setEntity(new StringEntity(problem, StandardCharsets.UTF_8));
+
+        RFC9457Reporter reporter = RFC9457Reporter.INSTANCE;
+        assertThat(reporter.isRFC9457Message(response)).isTrue();
+        assertThatExceptionOfType(HttpRFC9457Exception.class)
+                .isThrownBy(() -> reporter.generateException(response))
+                .satisfies(exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(429);
+                    assertThat(exception.getReasonPhrase()).isEqualTo("Too Many Requests (429)");
+                    assertThat(exception.getPayload().getTitle()).isEqualTo("Quota exceeded");
+                    assertThat(exception.getMessage()).contains("Quota exceeded");
+                });
+
+        CloseableBasicHttpResponse emptyProblemResponse = closeableResponse(503, "");
+        emptyProblemResponse.addHeader(HttpHeaders.CONTENT_TYPE, "application/problem+json");
+        emptyProblemResponse.setEntity(new StringEntity("", StandardCharsets.UTF_8));
+        assertThatExceptionOfType(HttpRFC9457Exception.class)
+                .isThrownBy(() -> reporter.generateException(emptyProblemResponse))
+                .satisfies(exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(503);
+                    assertThat(exception.getReasonPhrase()).isEmpty();
+                    assertThat(exception.getPayload()).isSameAs(RFC9457Payload.INSTANCE);
+                });
+
+        CloseableBasicHttpResponse ordinaryJsonResponse = closeableResponse(500, "Server Error");
+        ordinaryJsonResponse.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        assertThat(reporter.isRFC9457Message(ordinaryJsonResponse)).isFalse();
+    }
+
+    @Test
+    void factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter() throws Exception {
+        HttpTransporterFactory factory = new HttpTransporterFactory(checksumExtractors());
+        assertThat(factory.getPriority()).isEqualTo(5.0f);
+        assertThat(factory.setPriority(9.5f)).isSameAs(factory);
+        assertThat(factory.getPriority()).isEqualTo(9.5f);
+
+        DefaultRepositorySystemSession session = session();
+        RemoteRepository repository = new RemoteRepository.Builder("repo", "default", "http://127.0.0.1/repository/")
+                .build();
+        Transporter transporter = factory.newInstance(session, repository);
+        try {
+            assertThat(transporter.classify(new HttpResponseException(404, "Not Found")))
+                    .isEqualTo(Transporter.ERROR_NOT_FOUND);
+            assertThat(transporter.classify(new IOException("boom"))).isEqualTo(Transporter.ERROR_OTHER);
+        } finally {
+            transporter.close();
+        }
+
+        RemoteRepository fileRepository = new RemoteRepository.Builder("repo", "default", "file:/tmp/repository/")
+                .build();
+        assertThatExceptionOfType(NoTransporterException.class)
+                .isThrownBy(() -> factory.newInstance(session, fileRepository));
+        assertThatThrownBy(() -> factory.newInstance(null, repository)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> factory.newInstance(session, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void transporterPerformsPeekGetPutAndReportsProblemJson() throws Exception {
+        AtomicReference<String> uploadedBody = new AtomicReference<>();
+        try (TestRepositoryServer server = TestRepositoryServer.start(uploadedBody)) {
+            HttpTransporterFactory factory = new HttpTransporterFactory(checksumExtractors());
+            RemoteRepository repository = new RemoteRepository.Builder("local", "default", server.repositoryUrl())
+                    .build();
+            Transporter transporter = factory.newInstance(session(), repository);
+            try {
+                transporter.peek(new PeekTask(URI.create("com/example/demo/1.0/demo-1.0.jar")));
+
+                GetTask getTask = new GetTask(URI.create("com/example/demo/1.0/demo-1.0.jar"));
+                transporter.get(getTask);
+                assertThat(getTask.getDataString()).isEqualTo(ARTIFACT_BODY);
+                assertThat(getTask.getChecksums()).containsEntry("SHA-1", SHA1).containsEntry("MD5", MD5);
+
+                PutTask putTask = new PutTask(URI.create("uploads/new-artifact.txt"))
+                        .setDataString("uploaded by resolver");
+                transporter.put(putTask);
+                assertThat(uploadedBody).hasValue("uploaded by resolver");
+
+                assertThatExceptionOfType(HttpResponseException.class)
+                        .isThrownBy(() -> transporter.peek(new PeekTask(URI.create("missing.txt"))))
+                        .satisfies(exception -> {
+                            assertThat(exception.getStatusCode()).isEqualTo(404);
+                            assertThat(transporter.classify(exception)).isEqualTo(Transporter.ERROR_NOT_FOUND);
+                        });
+
+                assertThatExceptionOfType(HttpRFC9457Exception.class)
+                        .isThrownBy(() -> transporter.get(new GetTask(URI.create("problem.json"))))
+                        .satisfies(exception -> {
+                            assertThat(exception.getStatusCode()).isEqualTo(422);
+                            assertThat(exception.getPayload().getTitle()).isEqualTo("Invalid artifact");
+                            assertThat(exception.getPayload().getDetail())
+                                    .isEqualTo("The requested artifact is malformed");
+                            assertThat(transporter.classify(exception)).isEqualTo(Transporter.ERROR_OTHER);
+                        });
+            } finally {
+                transporter.close();
+            }
+        }
+    }
+
+    private static DefaultRepositorySystemSession session() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        session.setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, 2_000);
+        session.setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, 2_000);
+        session.setConfigProperty(ConfigurationProperties.HTTP_RETRY_HANDLER_COUNT, 0);
+        session.setConfigProperty(ConfigurationProperties.HTTP_EXPECT_CONTINUE, "false");
+        return session;
+    }
+
+    private static Map<String, ChecksumExtractor> checksumExtractors() {
+        Map<String, ChecksumExtractor> extractors = new LinkedHashMap<>();
+        extractors.put(XChecksumChecksumExtractor.NAME, new XChecksumChecksumExtractor());
+        extractors.put(Nexus2ChecksumExtractor.NAME, new Nexus2ChecksumExtractor());
+        return extractors;
+    }
+
+    private static BasicHttpResponse response(int statusCode, String reasonPhrase) {
+        return new BasicHttpResponse(HttpVersion.HTTP_1_1, statusCode, reasonPhrase);
+    }
+
+    private static CloseableBasicHttpResponse closeableResponse(int statusCode, String reasonPhrase) {
+        return new CloseableBasicHttpResponse(HttpVersion.HTTP_1_1, statusCode, reasonPhrase);
+    }
+
+    private static final class CloseableBasicHttpResponse extends BasicHttpResponse implements CloseableHttpResponse {
+        private CloseableBasicHttpResponse(ProtocolVersion version, int statusCode, String reasonPhrase) {
+            super(version, statusCode, reasonPhrase);
+        }
+
+        @Override
+        public void close() {
+            EntityUtils.consumeQuietly(getEntity());
+        }
+    }
+
+    private static final class TestRepositoryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private TestRepositoryServer(HttpServer server, ExecutorService executor) {
+            this.server = server;
+            this.executor = executor;
+        }
+
+        static TestRepositoryServer start(AtomicReference<String> uploadedBody) throws IOException {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "resolver-http-test-server");
+                thread.setDaemon(true);
+                return thread;
+            });
+            TestRepositoryServer repositoryServer = new TestRepositoryServer(server, executor);
+            server.createContext("/", exchange -> repositoryServer.handle(exchange, uploadedBody));
+            server.setExecutor(executor);
+            server.start();
+            return repositoryServer;
+        }
+
+        String repositoryUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/repository/";
+        }
+
+        private void handle(HttpExchange exchange, AtomicReference<String> uploadedBody) throws IOException {
+            try {
+                String path = exchange.getRequestURI().getPath();
+                if (ARTIFACT_PATH.equals(path)) {
+                    handleArtifact(exchange);
+                } else if ("/repository/uploads/new-artifact.txt".equals(path)
+                        && "PUT".equals(exchange.getRequestMethod())) {
+                    uploadedBody.set(readRequestBody(exchange));
+                    exchange.sendResponseHeaders(201, -1);
+                } else if ("/repository/problem.json".equals(path)) {
+                    byte[] body = """
+                            {
+                              "type": "https://example.invalid/problems/invalid-artifact",
+                              "title": "Invalid artifact",
+                              "status": 422,
+                              "detail": "The requested artifact is malformed"
+                            }
+                            """.getBytes(StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, "application/problem+json");
+                    exchange.sendResponseHeaders(422, body.length);
+                    try (OutputStream outputStream = exchange.getResponseBody()) {
+                        outputStream.write(body);
+                    }
+                } else {
+                    exchange.sendResponseHeaders(404, -1);
+                }
+            } finally {
+                exchange.close();
+            }
+        }
+
+        private void handleArtifact(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().add("x-checksum-sha1", SHA1);
+            exchange.getResponseHeaders().add("x-checksum-md5", MD5);
+            if ("HEAD".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(200, -1);
+                return;
+            }
+            if ("GET".equals(exchange.getRequestMethod())) {
+                byte[] body = ARTIFACT_BODY.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream outputStream = exchange.getResponseBody()) {
+                    outputStream.write(body);
+                }
+                return;
+            }
+            exchange.sendResponseHeaders(405, -1);
+        }
+
+        private String readRequestBody(HttpExchange exchange) throws IOException {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            exchange.getRequestBody().transferTo(buffer);
+            return buffer.toString(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            server.stop(0);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(Duration.ofSeconds(1).toMillis(), TimeUnit.MILLISECONDS)).isTrue();
+        }
     }
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -173,6 +174,35 @@ public class Maven_resolver_transport_httpTest {
     }
 
     @Test
+    void transporterAppliesConfiguredUserAgentAndRequestHeaders() throws Exception {
+        AtomicReference<Map<String, String>> requestHeaders = new AtomicReference<>();
+        try (HeaderCaptureServer server = HeaderCaptureServer.start(requestHeaders)) {
+            DefaultRepositorySystemSession session = session();
+            String userAgent = "resolver-http-functional-test";
+            Map<String, String> configuredHeaders = new LinkedHashMap<>();
+            configuredHeaders.put("X-Resolver-Test", "configured header");
+            configuredHeaders.put("X-Resolver-Trace", "trace-token");
+            session.setConfigProperty(ConfigurationProperties.USER_AGENT, userAgent);
+            session.setConfigProperty(ConfigurationProperties.HTTP_HEADERS, configuredHeaders);
+
+            HttpTransporterFactory factory = new HttpTransporterFactory(checksumExtractors());
+            RemoteRepository repository = new RemoteRepository.Builder("local", "default", server.repositoryUrl())
+                    .build();
+            Transporter transporter = factory.newInstance(session, repository);
+            try {
+                transporter.peek(new PeekTask(URI.create("headers/artifact.txt")));
+
+                assertThat(requestHeaders.get())
+                        .containsEntry(HttpHeaders.USER_AGENT.toLowerCase(Locale.ROOT), userAgent)
+                        .containsEntry("x-resolver-test", "configured header")
+                        .containsEntry("x-resolver-trace", "trace-token");
+            } finally {
+                transporter.close();
+            }
+        }
+    }
+
+    @Test
     void transporterResumesFileDownloadUsingHttpRange(@TempDir Path tempDir) throws Exception {
         String localPrefix = RESUMABLE_ARTIFACT_BODY.substring(0, "already-downloaded".length());
         Path artifactFile = tempDir.resolve("artifact.txt");
@@ -275,6 +305,59 @@ public class Maven_resolver_transport_httpTest {
         @Override
         public void close() {
             EntityUtils.consumeQuietly(getEntity());
+        }
+    }
+
+    private static final class HeaderCaptureServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private HeaderCaptureServer(HttpServer server, ExecutorService executor) {
+            this.server = server;
+            this.executor = executor;
+        }
+
+        static HeaderCaptureServer start(AtomicReference<Map<String, String>> requestHeaders) throws IOException {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "resolver-http-headers-test-server");
+                thread.setDaemon(true);
+                return thread;
+            });
+            HeaderCaptureServer repositoryServer = new HeaderCaptureServer(server, executor);
+            server.createContext("/", exchange -> repositoryServer.handle(exchange, requestHeaders));
+            server.setExecutor(executor);
+            server.start();
+            return repositoryServer;
+        }
+
+        String repositoryUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/repository/";
+        }
+
+        private void handle(HttpExchange exchange, AtomicReference<Map<String, String>> requestHeaders)
+                throws IOException {
+            try {
+                if (!"/repository/headers/artifact.txt".equals(exchange.getRequestURI().getPath())
+                        || !"HEAD".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(404, -1);
+                    return;
+                }
+                Map<String, String> capturedHeaders = new LinkedHashMap<>();
+                exchange.getRequestHeaders().forEach((name, values) -> capturedHeaders.put(
+                        name.toLowerCase(Locale.ROOT), String.join(",", values)));
+                requestHeaders.set(capturedHeaders);
+                exchange.sendResponseHeaders(200, -1);
+            } finally {
+                exchange.close();
+            }
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            server.stop(0);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(Duration.ofSeconds(1).toMillis(), TimeUnit.MILLISECONDS)).isTrue();
         }
     }
 

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_transport_http/Maven_resolver_transport_httpTest.java
@@ -12,6 +12,8 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -48,6 +50,7 @@ import org.eclipse.aether.transport.http.RFC9457.RFC9457Payload;
 import org.eclipse.aether.transport.http.RFC9457.RFC9457Reporter;
 import org.eclipse.aether.transport.http.XChecksumChecksumExtractor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -56,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class Maven_resolver_transport_httpTest {
     private static final String ARTIFACT_PATH = "/repository/com/example/demo/1.0/demo-1.0.jar";
     private static final String ARTIFACT_BODY = "resolved artifact contents";
+    private static final String RESUMABLE_ARTIFACT_BODY = "already-downloaded remainder fetched over HTTP range";
     private static final String SHA1 = "0123456789abcdef0123456789abcdef01234567";
     private static final String MD5 = "0123456789abcdef0123456789abcdef";
 
@@ -169,6 +173,34 @@ public class Maven_resolver_transport_httpTest {
     }
 
     @Test
+    void transporterResumesFileDownloadUsingHttpRange(@TempDir Path tempDir) throws Exception {
+        String localPrefix = RESUMABLE_ARTIFACT_BODY.substring(0, "already-downloaded".length());
+        Path artifactFile = tempDir.resolve("artifact.txt");
+        Files.writeString(artifactFile, localPrefix, StandardCharsets.UTF_8);
+
+        try (ResumableDownloadServer server = ResumableDownloadServer.start()) {
+            HttpTransporterFactory factory = new HttpTransporterFactory(checksumExtractors());
+            RemoteRepository repository = new RemoteRepository.Builder("local", "default", server.repositoryUrl())
+                    .build();
+            Transporter transporter = factory.newInstance(session(), repository);
+            try {
+                GetTask getTask = new GetTask(URI.create("resumable/artifact.txt"))
+                        .setDataFile(artifactFile.toFile(), true);
+                transporter.get(getTask);
+
+                assertThat(Files.readString(artifactFile, StandardCharsets.UTF_8))
+                        .isEqualTo(RESUMABLE_ARTIFACT_BODY);
+                assertThat(server.rangeHeader()).isEqualTo("bytes=" + localPrefix.length() + "-");
+                assertThat(server.acceptEncodingHeader()).isEqualTo("identity");
+                assertThat(server.ifUnmodifiedSinceHeader()).isNotBlank();
+                assertThat(getTask.getChecksums()).containsEntry("SHA-1", SHA1).containsEntry("MD5", MD5);
+            } finally {
+                transporter.close();
+            }
+        }
+    }
+
+    @Test
     void transporterPerformsPeekGetPutAndReportsProblemJson() throws Exception {
         AtomicReference<String> uploadedBody = new AtomicReference<>();
         try (TestRepositoryServer server = TestRepositoryServer.start(uploadedBody)) {
@@ -243,6 +275,97 @@ public class Maven_resolver_transport_httpTest {
         @Override
         public void close() {
             EntityUtils.consumeQuietly(getEntity());
+        }
+    }
+
+    private static final class ResumableDownloadServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+        private final AtomicReference<String> rangeHeader = new AtomicReference<>();
+        private final AtomicReference<String> acceptEncodingHeader = new AtomicReference<>();
+        private final AtomicReference<String> ifUnmodifiedSinceHeader = new AtomicReference<>();
+
+        private ResumableDownloadServer(HttpServer server, ExecutorService executor) {
+            this.server = server;
+            this.executor = executor;
+        }
+
+        static ResumableDownloadServer start() throws IOException {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "resolver-http-resume-test-server");
+                thread.setDaemon(true);
+                return thread;
+            });
+            ResumableDownloadServer repositoryServer = new ResumableDownloadServer(server, executor);
+            server.createContext("/", repositoryServer::handle);
+            server.setExecutor(executor);
+            server.start();
+            return repositoryServer;
+        }
+
+        String repositoryUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/repository/";
+        }
+
+        String rangeHeader() {
+            return rangeHeader.get();
+        }
+
+        String acceptEncodingHeader() {
+            return acceptEncodingHeader.get();
+        }
+
+        String ifUnmodifiedSinceHeader() {
+            return ifUnmodifiedSinceHeader.get();
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            try {
+                if (!"/repository/resumable/artifact.txt".equals(exchange.getRequestURI().getPath())
+                        || !"GET".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(404, -1);
+                    return;
+                }
+
+                rangeHeader.set(exchange.getRequestHeaders().getFirst("Range"));
+                acceptEncodingHeader.set(exchange.getRequestHeaders().getFirst("Accept-Encoding"));
+                ifUnmodifiedSinceHeader.set(exchange.getRequestHeaders().getFirst("If-Unmodified-Since"));
+
+                long offset = parseRangeOffset(rangeHeader.get());
+                byte[] fullBody = RESUMABLE_ARTIFACT_BODY.getBytes(StandardCharsets.UTF_8);
+                if (offset <= 0 || offset >= fullBody.length) {
+                    exchange.sendResponseHeaders(416, -1);
+                    return;
+                }
+
+                byte[] remainingBody = RESUMABLE_ARTIFACT_BODY.substring((int) offset)
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Range",
+                        "bytes " + offset + "-" + (fullBody.length - 1) + "/" + fullBody.length);
+                exchange.getResponseHeaders().add("x-checksum-sha1", SHA1);
+                exchange.getResponseHeaders().add("x-checksum-md5", MD5);
+                exchange.sendResponseHeaders(206, remainingBody.length);
+                try (OutputStream outputStream = exchange.getResponseBody()) {
+                    outputStream.write(remainingBody);
+                }
+            } finally {
+                exchange.close();
+            }
+        }
+
+        private long parseRangeOffset(String range) {
+            if (range == null || !range.startsWith("bytes=") || !range.endsWith("-")) {
+                return -1;
+            }
+            return Long.parseLong(range.substring("bytes=".length(), range.length() - 1));
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            server.stop(0);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(Duration.ofSeconds(1).toMillis(), TimeUnit.MILLISECONDS)).isTrue();
         }
     }
 

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T04:31:46">
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-03T04:34:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -56,6 +56,12 @@
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()]
 display-name: factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()
+]]></system-out>
+</testcase>
+<testcase name="transporterResumesFileDownloadUsingHttpRange(Path)" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:transporterResumesFileDownloadUsingHttpRange(java.nio.file.Path)]
+display-name: transporterResumesFileDownloadUsingHttpRange(Path)
 ]]></system-out>
 </testcase>
 <testcase name="checksumExtractorsReadNexusAndStandardHttpHeaders()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T04:31:46">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3780-2c4b6d2c/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()]
+display-name: factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()
+]]></system-out>
+</testcase>
+<testcase name="checksumExtractorsReadNexusAndStandardHttpHeaders()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:checksumExtractorsReadNexusAndStandardHttpHeaders()]
+display-name: checksumExtractorsReadNexusAndStandardHttpHeaders()
+]]></system-out>
+</testcase>
+<testcase name="transporterPerformsPeekGetPutAndReportsProblemJson()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:transporterPerformsPeekGetPutAndReportsProblemJson()]
+display-name: transporterPerformsPeekGetPutAndReportsProblemJson()
+]]></system-out>
+</testcase>
+<testcase name="rfc9457ParserAndReporterExposeProblemDetails()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:rfc9457ParserAndReporterExposeProblemDetails()]
+display-name: rfc9457ParserAndReporterExposeProblemDetails()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-03T04:35:58">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-03T04:36:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3780-2c4b6d2c/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25"/>
@@ -58,7 +57,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolve
 display-name: factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()
 ]]></system-out>
 </testcase>
-<testcase name="transporterResumesFileDownloadUsingHttpRange(Path)" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0.002">
+<testcase name="transporterResumesFileDownloadUsingHttpRange(Path)" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:transporterResumesFileDownloadUsingHttpRange(java.nio.file.Path)]
 display-name: transporterResumesFileDownloadUsingHttpRange(Path)

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-03T04:34:03">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-03T04:35:58">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -62,6 +62,12 @@ display-name: factoryValidatesRepositoryAndCreatesConfiguredHttpTransporter()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:transporterResumesFileDownloadUsingHttpRange(java.nio.file.Path)]
 display-name: transporterResumesFileDownloadUsingHttpRange(Path)
+]]></system-out>
+</testcase>
+<testcase name="transporterAppliesConfiguredUserAgentAndRequestHeaders()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest]/[method:transporterAppliesConfiguredUserAgentAndRequestHeaders()]
+display-name: transporterAppliesConfiguredUserAgentAndRequestHeaders()
 ]]></system-out>
 </testcase>
 <testcase name="checksumExtractorsReadNexusAndStandardHttpHeaders()" classname="org_apache_maven_resolver.maven_resolver_transport_http.Maven_resolver_transport_httpTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:35:58">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:36:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3780-2c4b6d2c/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:31:46">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3780-2c4b6d2c/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:34:03">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:35:58">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:31:46">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:34:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.aether.transport.http.**"
+      "includeClasses" : "org.eclipse.aether.transport.http.**"
     }
   ]
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-http/1.9.25/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.aether.transport.http.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3780

This PR introduces tests and metadata for org.apache.maven.resolver:maven-resolver-transport-http:1.9.25, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 224757
- Cached input tokens: 2914816
- Output tokens: 25746
- Metadata entries: 58
- Iterations: 4
- Library coverage percentage: 59.67
- Generated lines of code: 482
- Tested library lines of code: 503

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `398b41f517b19a8622e482d25e9e3fbd770b2876`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2304/3867 (59.58%)
- Line: 503/843 (59.67%)
- Method: 98/149 (65.77%)
