### PR TITLE
[GenAI] Add support for org.apache.maven.resolver:maven-resolver-transport-file:2.0.13 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.file.FileTransporterFactory"
+      },
+      "type": "jdk.internal.jrtfs.JrtFileSystemProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.file.FileTransporterFactory"
+      },
+      "type": "org.eclipse.aether.transfer.NoTransporterException",
+      "methods": [
+        {
+          "name": "getRepository",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.file.FileTransporterFactory"
+      },
+      "glob": "META-INF/services/java.nio.file.spi.FileSystemProvider"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-file/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-file/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.13",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-file/$version$/maven-resolver-transport-file-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://github.com/apache/maven-resolver/tree/maven-resolver-$version$/maven-resolver-transport-file/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-file/$version$/maven-resolver-transport-file-$version$-javadoc.jar",
+    "description" : "Maven Artifact Resolver Transport File is a transport implementation that lets Maven Resolver access repositories addressed with file:// URLs. It integrates with the Resolver API and SPI so artifact and metadata transfers can be performed against local filesystem-backed repositories.",
+    "tested-versions" : [
+      "2.0.13"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.transport.file"
+    ]
+  }
+]

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T02:51:01.759471Z",
+    "library": "org.apache.maven.resolver:maven-resolver-transport-file:2.0.13",
+    "starting_commit": "592a6d31bd2c455b78f7ef4e6dcbd40eb8e67056",
+    "ending_commit": "12c9b675592fb7418b1449cf023708e8481a6636",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.13",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 350,
+          "missed": 60,
+          "ratio": 0.853659,
+          "total": 410
+        },
+        "line": {
+          "covered": 88,
+          "missed": 16,
+          "ratio": 0.846154,
+          "total": 104
+        },
+        "method": {
+          "covered": 14,
+          "missed": 1,
+          "ratio": 0.933333,
+          "total": 15
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 91518,
+      "cached_input_tokens_used": 729088,
+      "output_tokens_used": 13753,
+      "iterations": 3,
+      "cost_usd": 0.7771,
+      "generated_loc": 238,
+      "tested_library_loc": 88,
+      "metadata_entries": 4,
+      "code_coverage_percent": 84.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.13",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 350,
+        "missed" : 60,
+        "ratio" : 0.853659,
+        "total" : 410
+      },
+      "line" : {
+        "covered" : 88,
+        "missed" : 16,
+        "ratio" : 0.846154,
+        "total" : 104
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 1,
+        "ratio" : 0.933333,
+        "total" : 15
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-transport-file:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-transport-file:2.0.13
+library.version = 2.0.13
+metadata.dir = org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-transport-file_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_transport_file;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_resolver_transport_fileTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
@@ -6,11 +6,225 @@
  */
 package org_apache_maven_resolver.maven_resolver_transport_file;
 
-import org.junit.jupiter.api.Test;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
 
-class Maven_resolver_transport_fileTest {
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportListener;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Maven_resolver_transport_fileTest {
+
+    private static final URI ARTIFACT_URI = URI.create("org/example/demo/1.0/demo-1.0.txt");
+
+    @TempDir
+    Path temporaryDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void factoryCreatesFileTransporterAndRoundTripsStringContent() throws Exception {
+        String content = """
+                first line
+                second line
+                """;
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Files.createDirectories(repositoryBase);
+        FileTransporterFactory factory = new FileTransporterFactory().setPriority(42.5F);
+
+        assertThat(FileTransporterFactory.NAME).isEqualTo("file");
+        assertThat(factory.getPriority()).isEqualTo(42.5F);
+
+        Transporter transporter = factory.newInstance(
+                session(), repository("local", repositoryBase.toUri().toASCIIString()));
+        try {
+            RecordingTransportListener putListener = new RecordingTransportListener();
+            transporter.put(new PutTask(ARTIFACT_URI).setDataString(content).setListener(putListener));
+
+            Path storedArtifact = repositoryBase.resolve(ARTIFACT_URI.getPath());
+            assertThat(storedArtifact).exists();
+            assertThat(Files.readString(storedArtifact, StandardCharsets.UTF_8)).isEqualTo(content);
+            assertThat(putListener.startedOffset).isZero();
+            assertThat(putListener.startedLength).isEqualTo(content.getBytes(StandardCharsets.UTF_8).length);
+            assertThat(putListener.progressedBytes).isEqualTo(content.getBytes(StandardCharsets.UTF_8).length);
+
+            transporter.peek(new PeekTask(ARTIFACT_URI));
+
+            RecordingTransportListener getListener = new RecordingTransportListener();
+            GetTask getTask = new GetTask(ARTIFACT_URI).setListener(getListener);
+            transporter.get(getTask);
+
+            assertThat(getTask.getDataString()).isEqualTo(content);
+            assertThat(getTask.getDataBytes()).containsExactly(content.getBytes(StandardCharsets.UTF_8));
+            assertThat(getListener.startedOffset).isZero();
+            assertThat(getListener.startedLength).isEqualTo(content.getBytes(StandardCharsets.UTF_8).length);
+            assertThat(getListener.progressedBytes).isEqualTo(content.getBytes(StandardCharsets.UTF_8).length);
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
+    void putFromDataFileAndGetToDataFilePreservesBinaryContent() throws Exception {
+        byte[] data = new byte[] {0, 1, 2, 3, 5, 8, 13, 21, -1};
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Path sourceFile = temporaryDirectory.resolve("source.bin");
+        Path targetFile = temporaryDirectory.resolve("target.bin");
+        Files.createDirectories(repositoryBase);
+        Files.write(sourceFile, data);
+
+        Transporter transporter = newTransporter("local", repositoryBase.toUri().toASCIIString());
+        try {
+            PutTask putTask = new PutTask(ARTIFACT_URI).setDataFile(sourceFile.toFile());
+            transporter.put(putTask);
+
+            Path storedArtifact = repositoryBase.resolve(ARTIFACT_URI.getPath());
+            assertThat(storedArtifact).exists();
+            assertThat(Files.readAllBytes(storedArtifact)).containsExactly(data);
+
+            GetTask getTask = new GetTask(ARTIFACT_URI).setDataFile(targetFile.toFile());
+            transporter.get(getTask);
+
+            assertThat(targetFile).exists();
+            assertThat(Files.readAllBytes(targetFile)).containsExactly(data);
+            assertThat(getTask.getDataBytes()).isEmpty();
+            assertThat(getTask.getDataString()).isEmpty();
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
+    void missingResourcesAreClassifiedAsNotFoundAndIllegalPathsAreRejected() throws Exception {
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Files.createDirectories(repositoryBase);
+
+        Transporter transporter = newTransporter("local", repositoryBase.toUri().toASCIIString());
+        try {
+            Throwable missing = catchThrowable(() -> transporter.peek(new PeekTask(URI.create("missing.txt"))));
+            assertThat(missing).isNotNull();
+            assertThat(transporter.classify(missing)).isEqualTo(Transporter.ERROR_NOT_FOUND);
+            assertThat(missing).hasMessageContaining("Could not locate");
+
+            Throwable traversal = catchThrowable(() -> transporter.get(new GetTask(URI.create("../outside.txt"))));
+            assertThat(traversal).isInstanceOf(IllegalArgumentException.class);
+            assertThat(transporter.classify(traversal)).isEqualTo(Transporter.ERROR_OTHER);
+            assertThat(traversal).hasMessageContaining("illegal resource path");
+        } finally {
+            transporter.close();
+        }
+
+        assertThatThrownBy(() -> transporter.peek(new PeekTask(ARTIFACT_URI)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("transporter closed");
+    }
+
+    @Test
+    void hardlinkRepositoryUrlCanMaterializeDownloadedFilesAsLinks() throws Exception {
+        byte[] data = "linked artifact".getBytes(StandardCharsets.UTF_8);
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Path artifact = repositoryBase.resolve(ARTIFACT_URI.getPath());
+        Path target = temporaryDirectory.resolve("linked-target.txt");
+        Files.createDirectories(artifact.getParent());
+        Files.write(artifact, data);
+
+        Transporter transporter = newTransporter("hardlink", "hardlink+" + repositoryBase.toUri().toASCIIString());
+        try {
+            RecordingTransportListener listener = new RecordingTransportListener();
+            transporter.get(new GetTask(ARTIFACT_URI).setDataFile(target.toFile()).setListener(listener));
+
+            assertThat(target).exists();
+            assertThat(Files.readAllBytes(target)).containsExactly(data);
+            assertThat(Files.isSameFile(artifact, target)).isTrue();
+            assertThat(listener.startedOffset).isZero();
+            assertThat(listener.startedLength).isEqualTo(data.length);
+            assertThat(listener.progressedBytes).isEqualTo(data.length);
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
+    void bundleRepositoryReadsJarEntriesAndRejectsWrites() throws Exception {
+        Path archive = temporaryDirectory.resolve("repository.jar");
+        URI zipUri = URI.create("jar:" + archive.toUri().toASCIIString());
+        try (FileSystem zipFileSystem = FileSystems.newFileSystem(zipUri, Map.of("create", "true"))) {
+            Path entryDirectory = zipFileSystem.getPath("nested");
+            Files.createDirectories(entryDirectory);
+            Files.writeString(entryDirectory.resolve("entry.txt"), "from archive", StandardCharsets.UTF_8);
+        }
+
+        Transporter transporter = newTransporter("bundle", "bundle:" + archive.toUri().toASCIIString());
+        try {
+            URI entryUri = URI.create("nested/entry.txt");
+            transporter.peek(new PeekTask(entryUri));
+
+            GetTask getTask = new GetTask(entryUri);
+            transporter.get(getTask);
+            assertThat(getTask.getDataString()).isEqualTo("from archive");
+
+            assertThatThrownBy(() -> transporter.put(new PutTask(URI.create("nested/new.txt")).setDataString("new")))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("Read only FileSystem");
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
+    void unsupportedRepositoryUrlReportsNoTransporter() {
+        FileTransporterFactory factory = new FileTransporterFactory();
+        RemoteRepository repository = repository("unsupported", "unknown://example.invalid/repository");
+
+        assertThatThrownBy(() -> factory.newInstance(session(), repository))
+                .isInstanceOf(NoTransporterException.class)
+                .extracting("repository")
+                .isEqualTo(repository);
+    }
+
+    private Transporter newTransporter(String id, String url) throws NoTransporterException {
+        return new FileTransporterFactory().newInstance(session(), repository(id, url));
+    }
+
+    private static RepositorySystemSession session() {
+        return new DefaultRepositorySystemSession();
+    }
+
+    private static RemoteRepository repository(String id, String url) {
+        return new RemoteRepository.Builder(id, "default", url).build();
+    }
+
+    private static final class RecordingTransportListener extends TransportListener {
+        private long startedOffset = -1;
+        private long startedLength = -1;
+        private long progressedBytes;
+
+        @Override
+        public void transportStarted(long dataOffset, long dataLength) {
+            startedOffset = dataOffset;
+            startedLength = dataLength;
+        }
+
+        @Override
+        public void transportProgressed(ByteBuffer data) {
+            progressedBytes += data.remaining();
+        }
     }
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
@@ -162,6 +162,31 @@ public class Maven_resolver_transport_fileTest {
     }
 
     @Test
+    void linkRepositoryUrlReadsContentIntoMemoryWhenNoTargetFileIsProvided() throws Exception {
+        String content = "in-memory linked artifact";
+        byte[] data = content.getBytes(StandardCharsets.UTF_8);
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Path artifact = repositoryBase.resolve(ARTIFACT_URI.getPath());
+        Files.createDirectories(artifact.getParent());
+        Files.write(artifact, data);
+
+        Transporter transporter = newTransporter("hardlink", "hardlink+" + repositoryBase.toUri().toASCIIString());
+        try {
+            RecordingTransportListener listener = new RecordingTransportListener();
+            GetTask getTask = new GetTask(ARTIFACT_URI).setListener(listener);
+            transporter.get(getTask);
+
+            assertThat(getTask.getDataString()).isEqualTo(content);
+            assertThat(getTask.getDataBytes()).containsExactly(data);
+            assertThat(listener.startedOffset).isZero();
+            assertThat(listener.startedLength).isEqualTo(data.length);
+            assertThat(listener.progressedBytes).isEqualTo(data.length);
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
     void symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks() throws Exception {
         byte[] data = "symbolic artifact".getBytes(StandardCharsets.UTF_8);
         Path repositoryBase = temporaryDirectory.resolve("repository");

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_file/Maven_resolver_transport_fileTest.java
@@ -162,6 +162,32 @@ public class Maven_resolver_transport_fileTest {
     }
 
     @Test
+    void symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks() throws Exception {
+        byte[] data = "symbolic artifact".getBytes(StandardCharsets.UTF_8);
+        Path repositoryBase = temporaryDirectory.resolve("repository");
+        Path artifact = repositoryBase.resolve(ARTIFACT_URI.getPath());
+        Path target = temporaryDirectory.resolve("symlink-target.txt");
+        Files.createDirectories(artifact.getParent());
+        Files.write(artifact, data);
+
+        Transporter transporter = newTransporter("symlink", "symlink+" + repositoryBase.toUri().toASCIIString());
+        try {
+            RecordingTransportListener listener = new RecordingTransportListener();
+            transporter.get(new GetTask(ARTIFACT_URI).setDataFile(target.toFile()).setListener(listener));
+
+            assertThat(target).exists();
+            assertThat(Files.isSymbolicLink(target)).isTrue();
+            assertThat(Files.readSymbolicLink(target)).isEqualTo(artifact);
+            assertThat(Files.readAllBytes(target)).containsExactly(data);
+            assertThat(listener.startedOffset).isZero();
+            assertThat(listener.startedLength).isEqualTo(data.length);
+            assertThat(listener.progressedBytes).isEqualTo(data.length);
+        } finally {
+            transporter.close();
+        }
+    }
+
+    @Test
     void bundleRepositoryReadsJarEntriesAndRejectsWrites() throws Exception {
         Path archive = temporaryDirectory.resolve("repository.jar");
         URI zipUri = URI.create("jar:" + archive.toUri().toASCIIString());

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T04:45:25">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T04:46:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -69,7 +69,7 @@ Error when introspecting fields was :
 	at org.assertj.core.extractor.ByNameSingleExtractor.apply(ByNameSingleExtractor.java:29)
 	at org.assertj.core.api.AbstractAssert.extracting(AbstractAssert.java:1087)
 	at org.assertj.core.api.AbstractObjectAssert.extracting(AbstractObjectAssert.java:835)
-	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:224)
+	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:249)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -126,6 +126,12 @@ display-name: symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:factoryCreatesFileTransporterAndRoundTripsStringContent()]
 display-name: factoryCreatesFileTransporterAndRoundTripsStringContent()
+]]></system-out>
+</testcase>
+<testcase name="linkRepositoryUrlReadsContentIntoMemoryWhenNoTargetFileIsProvided()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:linkRepositoryUrlReadsContentIntoMemoryWhenNoTargetFileIsProvided()]
+display-name: linkRepositoryUrlReadsContentIntoMemoryWhenNoTargetFileIsProvided()
 ]]></system-out>
 </testcase>
 <testcase name="bundleRepositoryReadsJarEntriesAndRejectsWrites()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T04:46:48">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T04:50:23">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3778-f7ab94ae/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13"/>
@@ -53,46 +52,6 @@
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <testcase name="unsupportedRepositoryUrlReportsNoTransporter()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
-<error message="
-Can't find any field or property with name 'repository'.
-Error when introspecting properties was :
-- No getter for property 'repository' in org.eclipse.aether.transfer.NoTransporterException 
-Error when introspecting fields was :
-- Unable to obtain the value of the field &lt;'repository'&gt; from &lt;org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown&gt;" type="org.assertj.core.util.introspection.IntrospectionError"><![CDATA[org.assertj.core.util.introspection.IntrospectionError: 
-Can't find any field or property with name 'repository'.
-Error when introspecting properties was :
-- No getter for property 'repository' in org.eclipse.aether.transfer.NoTransporterException 
-Error when introspecting fields was :
-- Unable to obtain the value of the field <'repository'> from <org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown>
-	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:91)
-	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getValueOf(PropertyOrFieldSupport.java:61)
-	at org.assertj.core.extractor.ByNameSingleExtractor.apply(ByNameSingleExtractor.java:29)
-	at org.assertj.core.api.AbstractAssert.extracting(AbstractAssert.java:1087)
-	at org.assertj.core.api.AbstractObjectAssert.extracting(AbstractObjectAssert.java:835)
-	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:249)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: org.assertj.core.util.introspection.IntrospectionError: Unable to obtain the value of the field <'repository'> from <org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown>
-	at org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:248)
-	at org.assertj.core.util.introspection.FieldSupport.fieldValue(FieldSupport.java:202)
-	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:75)
-	... 17 more
-Caused by: java.lang.IllegalArgumentException: Cannot locate field repository on class org.eclipse.aether.transfer.NoTransporterException
-	at org.assertj.core.util.Preconditions.checkArgument(Preconditions.java:129)
-	at org.assertj.core.util.introspection.FieldUtils.readField(FieldUtils.java:144)
-	at org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:208)
-	... 19 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:unsupportedRepositoryUrlReportsNoTransporter()]
 display-name: unsupportedRepositoryUrlReportsNoTransporter()

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="1" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:44:08">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3778-f7ab94ae/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="unsupportedRepositoryUrlReportsNoTransporter()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<error message="
+Can't find any field or property with name 'repository'.
+Error when introspecting properties was :
+- No getter for property 'repository' in org.eclipse.aether.transfer.NoTransporterException 
+Error when introspecting fields was :
+- Unable to obtain the value of the field &lt;'repository'&gt; from &lt;org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown&gt;" type="org.assertj.core.util.introspection.IntrospectionError"><![CDATA[org.assertj.core.util.introspection.IntrospectionError: 
+Can't find any field or property with name 'repository'.
+Error when introspecting properties was :
+- No getter for property 'repository' in org.eclipse.aether.transfer.NoTransporterException 
+Error when introspecting fields was :
+- Unable to obtain the value of the field <'repository'> from <org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown>
+	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:91)
+	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getValueOf(PropertyOrFieldSupport.java:61)
+	at org.assertj.core.extractor.ByNameSingleExtractor.apply(ByNameSingleExtractor.java:29)
+	at org.assertj.core.api.AbstractAssert.extracting(AbstractAssert.java:1087)
+	at org.assertj.core.api.AbstractObjectAssert.extracting(AbstractObjectAssert.java:835)
+	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:198)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: org.assertj.core.util.introspection.IntrospectionError: Unable to obtain the value of the field <'repository'> from <org.eclipse.aether.transfer.NoTransporterException: Unsupported transport protocol unknown>
+	at org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:248)
+	at org.assertj.core.util.introspection.FieldSupport.fieldValue(FieldSupport.java:202)
+	at org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:75)
+	... 17 more
+Caused by: java.lang.IllegalArgumentException: Cannot locate field repository on class org.eclipse.aether.transfer.NoTransporterException
+	at org.assertj.core.util.Preconditions.checkArgument(Preconditions.java:129)
+	at org.assertj.core.util.introspection.FieldUtils.readField(FieldUtils.java:144)
+	at org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:208)
+	... 19 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:unsupportedRepositoryUrlReportsNoTransporter()]
+display-name: unsupportedRepositoryUrlReportsNoTransporter()
+]]></system-out>
+</testcase>
+<testcase name="missingResourcesAreClassifiedAsNotFoundAndIllegalPathsAreRejected()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:missingResourcesAreClassifiedAsNotFoundAndIllegalPathsAreRejected()]
+display-name: missingResourcesAreClassifiedAsNotFoundAndIllegalPathsAreRejected()
+]]></system-out>
+</testcase>
+<testcase name="hardlinkRepositoryUrlCanMaterializeDownloadedFilesAsLinks()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:hardlinkRepositoryUrlCanMaterializeDownloadedFilesAsLinks()]
+display-name: hardlinkRepositoryUrlCanMaterializeDownloadedFilesAsLinks()
+]]></system-out>
+</testcase>
+<testcase name="putFromDataFileAndGetToDataFilePreservesBinaryContent()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:putFromDataFileAndGetToDataFilePreservesBinaryContent()]
+display-name: putFromDataFileAndGetToDataFilePreservesBinaryContent()
+]]></system-out>
+</testcase>
+<testcase name="factoryCreatesFileTransporterAndRoundTripsStringContent()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:factoryCreatesFileTransporterAndRoundTripsStringContent()]
+display-name: factoryCreatesFileTransporterAndRoundTripsStringContent()
+]]></system-out>
+</testcase>
+<testcase name="bundleRepositoryReadsJarEntriesAndRejectsWrites()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:bundleRepositoryReadsJarEntriesAndRejectsWrites()]
+display-name: bundleRepositoryReadsJarEntriesAndRejectsWrites()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="1" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:44:08">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="1" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T04:45:25">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -69,7 +69,7 @@ Error when introspecting fields was :
 	at org.assertj.core.extractor.ByNameSingleExtractor.apply(ByNameSingleExtractor.java:29)
 	at org.assertj.core.api.AbstractAssert.extracting(AbstractAssert.java:1087)
 	at org.assertj.core.api.AbstractObjectAssert.extracting(AbstractObjectAssert.java:835)
-	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:198)
+	at org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest.unsupportedRepositoryUrlReportsNoTransporter(Maven_resolver_transport_fileTest.java:224)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -114,6 +114,12 @@ display-name: hardlinkRepositoryUrlCanMaterializeDownloadedFilesAsLinks()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:putFromDataFileAndGetToDataFilePreservesBinaryContent()]
 display-name: putFromDataFileAndGetToDataFilePreservesBinaryContent()
+]]></system-out>
+</testcase>
+<testcase name="symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest]/[method:symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks()]
+display-name: symlinkRepositoryUrlCanMaterializeDownloadedFilesAsSymbolicLinks()
 ]]></system-out>
 </testcase>
 <testcase name="factoryCreatesFileTransporterAndRoundTripsStringContent()" classname="org_apache_maven_resolver.maven_resolver_transport_file.Maven_resolver_transport_fileTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:44:08">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3778-f7ab94ae/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:44:08">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:45:25">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:45:25">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:46:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:46:48">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:50:23">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3778-f7ab94ae/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.aether.transport.file.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-file/2.0.13/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.aether.transport.file.**"
+      "includeClasses" : "org.eclipse.aether.transport.file.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3778

This PR introduces tests and metadata for org.apache.maven.resolver:maven-resolver-transport-file:2.0.13, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 91518
- Cached input tokens: 729088
- Output tokens: 13753
- Metadata entries: 4
- Iterations: 3
- Library coverage percentage: 84.62
- Generated lines of code: 238
- Tested library lines of code: 88

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `398b41f517b19a8622e482d25e9e3fbd770b2876`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 350/410 (85.37%)
- Line: 88/104 (84.62%)
- Method: 14/15 (93.33%)
