### PR TITLE
[GenAI] Add support for org.apache.maven.resolver:maven-resolver-connector-basic:1.9.25 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.connector.basic.BasicRepositoryConnector"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-connector-basic/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-connector-basic/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.25",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/$version$/maven-resolver-connector-basic-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://github.com/apache/maven-resolver/tree/maven-resolver-$version$/maven-resolver-connector-basic/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-connector-basic/$version$/maven-resolver-connector-basic-$version$-javadoc.jar",
+    "description" : "Maven Resolver Connector Basic provides the standard repository connector implementation for Maven Artifact Resolver repositories that use URI-based layouts. It coordinates artifact and metadata transfers through the Resolver connector SPI and configured transport implementations.",
+    "tested-versions" : [
+      "1.9.25"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.connector.basic"
+    ]
+  }
+]

--- a/stats/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T02:59:56.246302Z",
+    "library": "org.apache.maven.resolver:maven-resolver-connector-basic:1.9.25",
+    "starting_commit": "c90339a34bfcd0bb1a4a5413159fab77428b29ba",
+    "ending_commit": "8cc795ffd7d0745a333d1dcbe426d0ed22ced7d7",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.25",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1261,
+          "missed": 869,
+          "ratio": 0.592019,
+          "total": 2130
+        },
+        "line": {
+          "covered": 293,
+          "missed": 203,
+          "ratio": 0.590726,
+          "total": 496
+        },
+        "method": {
+          "covered": 50,
+          "missed": 22,
+          "ratio": 0.694444,
+          "total": 72
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 251282,
+      "cached_input_tokens_used": 1825792,
+      "output_tokens_used": 26332,
+      "iterations": 5,
+      "cost_usd": 1.7029,
+      "generated_loc": 603,
+      "tested_library_loc": 293,
+      "metadata_entries": 1,
+      "code_coverage_percent": 59.07
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.9.25",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1261,
+        "missed" : 869,
+        "ratio" : 0.592019,
+        "total" : 2130
+      },
+      "line" : {
+        "covered" : 293,
+        "missed" : 203,
+        "ratio" : 0.590726,
+        "total" : 496
+      },
+      "method" : {
+        "covered" : 50,
+        "missed" : 22,
+        "ratio" : 0.694444,
+        "total" : 72
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-connector-basic:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-connector-basic:1.9.25
+library.version = 1.9.25
+metadata.dir = org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-connector-basic_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
@@ -6,11 +6,550 @@
  */
 package org_apache_maven_resolver.maven_resolver_connector_basic;
 
-import org.junit.jupiter.api.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
-class Maven_resolver_connector_basicTest {
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.checksums.ProvidedChecksumsSource;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.ArtifactUpload;
+import org.eclipse.aether.spi.connector.MetadataDownload;
+import org.eclipse.aether.spi.connector.MetadataUpload;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportListener;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.spi.connector.transport.TransporterProvider;
+import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
+import org.eclipse.aether.transfer.NoRepositoryConnectorException;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transfer.TransferResource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Maven_resolver_connector_basicTest {
+    @TempDir
+    Path tempDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void downloadsArtifactsMetadataAndPerformsExistenceChecks() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        Artifact artifact = artifact();
+        Metadata metadata = metadata();
+        transporter.putBytes(
+                SimpleRepositoryLayout.locationFor(artifact), "artifact-content".getBytes(StandardCharsets.UTF_8));
+        transporter.putBytes(
+                SimpleRepositoryLayout.locationFor(metadata), "metadata-content".getBytes(StandardCharsets.UTF_8));
+        RecordingTransferListener listener = new RecordingTransferListener();
+        AtomicInteger providedChecksumsCalls = new AtomicInteger();
+        ProvidedChecksumsSource checksumSource = (session, download, repository, algorithms) -> {
+            providedChecksumsCalls.incrementAndGet();
+            assertThat(repository.getId()).isEqualTo("central");
+            assertThat(algorithms).isEmpty();
+            return Collections.emptyMap();
+        };
+
+        RepositoryConnector connector = newConnector(transporter, Map.of("test", checksumSource));
+        try {
+            Path artifactTarget = tempDirectory.resolve("downloaded-artifact.jar");
+            Path metadataTarget = tempDirectory.resolve("downloaded-metadata.xml");
+            Path existenceTarget = tempDirectory.resolve("existence-check.jar");
+            ArtifactDownload artifactDownload = new ArtifactDownload(artifact, "resolve", artifactTarget.toFile(), null)
+                    .setListener(listener);
+            MetadataDownload metadataDownload = new MetadataDownload(metadata, "resolve", metadataTarget.toFile(), null)
+                    .setListener(listener);
+            ArtifactDownload existenceCheck = new ArtifactDownload(artifact, "resolve", existenceTarget.toFile(), null)
+                    .setExistenceCheck(true)
+                    .setListener(listener);
+
+            connector.get(List.of(artifactDownload, existenceCheck), List.of(metadataDownload));
+
+            assertThat(Files.readString(artifactTarget)).isEqualTo("artifact-content");
+            assertThat(Files.readString(metadataTarget)).isEqualTo("metadata-content");
+            assertThat(existenceTarget).doesNotExist();
+            assertThat(artifactDownload.getException()).isNull();
+            assertThat(metadataDownload.getException()).isNull();
+            assertThat(existenceCheck.getException()).isNull();
+            assertThat(transporter.getLocations()).containsExactly(
+                    SimpleRepositoryLayout.locationFor(metadata),
+                    SimpleRepositoryLayout.locationFor(artifact));
+            assertThat(transporter.peekLocations()).containsExactly(SimpleRepositoryLayout.locationFor(artifact));
+            assertThat(providedChecksumsCalls).hasValue(2);
+            assertThat(listener.events()).anySatisfy(event -> {
+                assertThat(event.getType()).isEqualTo(TransferEvent.EventType.SUCCEEDED);
+                assertThat(event.getRequestType()).isEqualTo(TransferEvent.RequestType.GET);
+                assertThat(event.getResource().getRepositoryId()).isEqualTo("central");
+            });
+            assertThat(listener.events()).anySatisfy(event -> {
+                assertThat(event.getType()).isEqualTo(TransferEvent.EventType.SUCCEEDED);
+                assertThat(event.getRequestType()).isEqualTo(TransferEvent.RequestType.GET_EXISTENCE);
+            });
+        } finally {
+            connector.close();
+        }
+    }
+
+    @Test
+    void uploadsArtifactsAndMetadataToTransportLocations() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        Artifact artifact = artifact();
+        Metadata metadata = metadata();
+        Path artifactSource = tempDirectory.resolve("artifact.jar");
+        Path metadataSource = tempDirectory.resolve("maven-metadata.xml");
+        Files.writeString(artifactSource, "uploaded-artifact");
+        Files.writeString(metadataSource, "uploaded-metadata");
+        RecordingTransferListener listener = new RecordingTransferListener();
+
+        RepositoryConnector connector = newConnector(transporter, Collections.emptyMap());
+        try {
+            ArtifactUpload artifactUpload = new ArtifactUpload(artifact, artifactSource.toFile()).setListener(listener);
+            MetadataUpload metadataUpload = new MetadataUpload(metadata, metadataSource.toFile()).setListener(listener);
+
+            connector.put(List.of(artifactUpload), List.of(metadataUpload));
+
+            assertThat(artifactUpload.getException()).isNull();
+            assertThat(metadataUpload.getException()).isNull();
+            assertThat(transporter.putLocations()).containsExactly(
+                    SimpleRepositoryLayout.locationFor(artifact),
+                    SimpleRepositoryLayout.locationFor(metadata));
+            assertThat(transporter.content(SimpleRepositoryLayout.locationFor(artifact)))
+                    .isEqualTo("uploaded-artifact");
+            assertThat(transporter.content(SimpleRepositoryLayout.locationFor(metadata)))
+                    .isEqualTo("uploaded-metadata");
+            assertThat(listener.events()).anySatisfy(event -> {
+                assertThat(event.getType()).isEqualTo(TransferEvent.EventType.SUCCEEDED);
+                assertThat(event.getRequestType()).isEqualTo(TransferEvent.RequestType.PUT);
+                assertThat(event.getResource().getRepositoryUrl()).isEqualTo(repository().getUrl() + "/");
+            });
+        } finally {
+            connector.close();
+        }
+    }
+
+    @Test
+    void transportNotFoundIsReportedOnArtifactDownload() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        ArtifactDownload download = new ArtifactDownload(
+                artifact(), "resolve", tempDirectory.resolve("missing.jar").toFile(), null)
+                .setListener(new RecordingTransferListener());
+
+        RepositoryConnector connector = newConnector(transporter, Collections.emptyMap());
+        try {
+            connector.get(List.of(download), null);
+
+            assertThat(download.getException()).isInstanceOf(ArtifactNotFoundException.class);
+            assertThat(download.getException().getRepository()).isEqualTo(repository());
+            assertThat(download.getException().getArtifact()).isEqualTo(artifact());
+        } finally {
+            connector.close();
+        }
+    }
+
+    @Test
+    void connectorClosesTransporterAndRejectsFurtherTransfers() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        RepositoryConnector connector = newConnector(transporter, Collections.emptyMap());
+
+        assertThat(connector.toString()).isEqualTo(repository().toString());
+
+        connector.close();
+        connector.close();
+
+        assertThat(transporter.closeCalls()).hasValue(1);
+        assertThatThrownBy(() -> connector.get(null, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("connector already closed");
+    }
+
+    @Test
+    void factoryConfigurationIsFluentAndWrapsProviderFailures() {
+        BasicRepositoryConnectorFactory factory = configuredFactory(new InMemoryTransporter(), Collections.emptyMap());
+
+        assertThat(factory.setPriority(3.5f)).isSameAs(factory);
+        assertThat(factory.getPriority()).isEqualTo(3.5f);
+        assertThatNullPointerException().isThrownBy(() -> factory.setTransporterProvider(null));
+        assertThatNullPointerException().isThrownBy(() -> factory.setRepositoryLayoutProvider(null));
+        assertThatNullPointerException().isThrownBy(() -> factory.setChecksumPolicyProvider(null));
+        assertThatNullPointerException().isThrownBy(() -> factory.setFileProcessor(null));
+        assertThatNullPointerException().isThrownBy(() -> factory.setProvidedChecksumSources(null));
+
+        RepositoryLayoutProvider failingLayoutProvider = (session, remoteRepository) -> {
+            throw new NoRepositoryLayoutException(remoteRepository, "unsupported layout");
+        };
+        BasicRepositoryConnectorFactory layoutFailureFactory = configuredFactory(
+                (session, remoteRepository) -> new InMemoryTransporter(),
+                failingLayoutProvider,
+                Collections.emptyMap());
+        assertThatExceptionOfType(NoRepositoryConnectorException.class)
+                .isThrownBy(() -> layoutFailureFactory.newInstance(session(), repository()))
+                .withMessageContaining("unsupported layout")
+                .withCauseInstanceOf(NoRepositoryLayoutException.class);
+
+        TransporterProvider failingTransporterProvider = (session, remoteRepository) -> {
+            throw new NoTransporterException(remoteRepository, "unsupported transport");
+        };
+        BasicRepositoryConnectorFactory transportFailureFactory = configuredFactory(
+                failingTransporterProvider,
+                (session, remoteRepository) -> new SimpleRepositoryLayout(),
+                Collections.emptyMap());
+        assertThatExceptionOfType(NoRepositoryConnectorException.class)
+                .isThrownBy(() -> transportFailureFactory.newInstance(session(), repository()))
+                .withMessageContaining("unsupported transport")
+                .withCauseInstanceOf(NoTransporterException.class);
+    }
+
+    private static RepositoryConnector newConnector(
+            InMemoryTransporter transporter, Map<String, ProvidedChecksumsSource> checksumSources)
+            throws NoRepositoryConnectorException {
+        return configuredFactory(transporter, checksumSources).newInstance(session(), repository());
+    }
+
+    private static BasicRepositoryConnectorFactory configuredFactory(
+            InMemoryTransporter transporter, Map<String, ProvidedChecksumsSource> checksumSources) {
+        return configuredFactory((session, repository) -> transporter,
+                (session, repository) -> new SimpleRepositoryLayout(), checksumSources);
+    }
+
+    private static BasicRepositoryConnectorFactory configuredFactory(
+            TransporterProvider transporterProvider,
+            RepositoryLayoutProvider layoutProvider,
+            Map<String, ProvidedChecksumsSource> checksumSources) {
+        return new BasicRepositoryConnectorFactory()
+                .setTransporterProvider(transporterProvider)
+                .setRepositoryLayoutProvider(layoutProvider)
+                .setChecksumPolicyProvider(new NoChecksumPolicyProvider())
+                .setFileProcessor(new NioFileProcessor())
+                .setProvidedChecksumSources(checksumSources);
+    }
+
+    private static RepositorySystemSession session() {
+        return new DefaultRepositorySystemSession()
+                .setConfigProperty("aether.connector.basic.threads", Integer.valueOf(1))
+                .setConfigProperty("aether.connector.basic.parallelPut", Boolean.FALSE);
+    }
+
+    private static RemoteRepository repository() {
+        return new RemoteRepository.Builder("central", "default", "https://repo.example.test/repository").build();
+    }
+
+    private static Artifact artifact() {
+        return new DefaultArtifact("com.acme", "demo", "", "jar", "1.0");
+    }
+
+    private static Metadata metadata() {
+        return new DefaultMetadata("com.acme", "demo", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+    }
+
+    private static final class SimpleRepositoryLayout implements RepositoryLayout {
+        static URI locationFor(Artifact artifact) {
+            return URI.create("artifacts/"
+                    + artifact.getGroupId().replace('.', '/') + "/"
+                    + artifact.getArtifactId() + "/"
+                    + artifact.getVersion() + "/"
+                    + artifact.getArtifactId() + "-" + artifact.getVersion() + "." + artifact.getExtension());
+        }
+
+        static URI locationFor(Metadata metadata) {
+            StringBuilder path = new StringBuilder("metadata/")
+                    .append(metadata.getGroupId().replace('.', '/'));
+            if (!metadata.getArtifactId().isEmpty()) {
+                path.append('/').append(metadata.getArtifactId());
+            }
+            if (!metadata.getVersion().isEmpty()) {
+                path.append('/').append(metadata.getVersion());
+            }
+            return URI.create(path.append('/').append(metadata.getType()).toString());
+        }
+
+        @Override
+        public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean hasChecksums(Artifact artifact) {
+            return false;
+        }
+
+        @Override
+        public URI getLocation(Artifact artifact, boolean upload) {
+            return locationFor(artifact);
+        }
+
+        @Override
+        public URI getLocation(Metadata metadata, boolean upload) {
+            return locationFor(metadata);
+        }
+
+        @Override
+        public List<ChecksumLocation> getChecksumLocations(Artifact artifact, boolean upload, URI location) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<ChecksumLocation> getChecksumLocations(Metadata metadata, boolean upload, URI location) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class InMemoryTransporter implements Transporter {
+        private final Map<String, byte[]> contents = new ConcurrentHashMap<>();
+        private final List<URI> getLocations = new ArrayList<>();
+        private final List<URI> putLocations = new ArrayList<>();
+        private final List<URI> peekLocations = new ArrayList<>();
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final AtomicInteger closeCalls = new AtomicInteger();
+
+        void putBytes(URI location, byte[] bytes) {
+            contents.put(location.toString(), bytes.clone());
+        }
+
+        String content(URI location) {
+            return new String(contents.get(location.toString()), StandardCharsets.UTF_8);
+        }
+
+        List<URI> getLocations() {
+            return List.copyOf(getLocations);
+        }
+
+        List<URI> putLocations() {
+            return List.copyOf(putLocations);
+        }
+
+        List<URI> peekLocations() {
+            return List.copyOf(peekLocations);
+        }
+
+        AtomicInteger closeCalls() {
+            return closeCalls;
+        }
+
+        @Override
+        public int classify(Throwable error) {
+            return error instanceof FileNotFoundException ? ERROR_NOT_FOUND : ERROR_OTHER;
+        }
+
+        @Override
+        public void peek(PeekTask task) throws Exception {
+            failIfClosed();
+            peekLocations.add(task.getLocation());
+            if (!contents.containsKey(task.getLocation().toString())) {
+                throw new FileNotFoundException(task.getLocation().toString());
+            }
+        }
+
+        @Override
+        public void get(GetTask task) throws Exception {
+            failIfClosed();
+            getLocations.add(task.getLocation());
+            byte[] bytes = contents.get(task.getLocation().toString());
+            if (bytes == null) {
+                throw new FileNotFoundException(task.getLocation().toString());
+            }
+            notifyProgress(task.getListener(), bytes);
+            try (OutputStream output = task.newOutputStream()) {
+                output.write(bytes);
+            }
+        }
+
+        @Override
+        public void put(PutTask task) throws Exception {
+            failIfClosed();
+            putLocations.add(task.getLocation());
+            byte[] bytes;
+            try (InputStream input = task.newInputStream();
+                    ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+                input.transferTo(output);
+                bytes = output.toByteArray();
+            }
+            notifyProgress(task.getListener(), bytes);
+            contents.put(task.getLocation().toString(), bytes);
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                closeCalls.incrementAndGet();
+            }
+        }
+
+        private void failIfClosed() throws IOException {
+            if (closed.get()) {
+                throw new IOException("transporter is closed");
+            }
+        }
+
+        private void notifyProgress(TransportListener listener, byte[] bytes) throws Exception {
+            if (listener != null) {
+                listener.transportStarted(0L, bytes.length);
+                listener.transportProgressed(ByteBuffer.wrap(bytes));
+            }
+        }
+    }
+
+    private static final class NoChecksumPolicyProvider implements ChecksumPolicyProvider {
+        @Override
+        public ChecksumPolicy newChecksumPolicy(
+                RepositorySystemSession session,
+                RemoteRepository repository,
+                TransferResource resource,
+                String policy) {
+            return null;
+        }
+
+        @Override
+        public String getEffectiveChecksumPolicy(
+                RepositorySystemSession session, String policy1, String policy2) {
+            return policy1 != null ? policy1 : policy2;
+        }
+    }
+
+    private static final class NioFileProcessor implements FileProcessor {
+        @Override
+        public boolean mkdirs(File directory) {
+            try {
+                Files.createDirectories(directory.toPath());
+                return true;
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public void write(File target, String data) throws IOException {
+            createParentDirectories(target);
+            Files.writeString(target.toPath(), data);
+        }
+
+        @Override
+        public void write(File target, InputStream data) throws IOException {
+            createParentDirectories(target);
+            Files.copy(data, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        @Override
+        public void move(File source, File target) throws IOException {
+            createParentDirectories(target);
+            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        @Override
+        public void copy(File source, File target) throws IOException {
+            createParentDirectories(target);
+            Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        @Override
+        public long copy(File source, File target, ProgressListener listener) throws IOException {
+            createParentDirectories(target);
+            long bytes = Files.size(source.toPath());
+            try (InputStream input = Files.newInputStream(source.toPath());
+                    OutputStream output = Files.newOutputStream(target.toPath())) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) >= 0) {
+                    output.write(buffer, 0, read);
+                    if (listener != null && read > 0) {
+                        listener.progressed(ByteBuffer.wrap(buffer, 0, read));
+                    }
+                }
+            }
+            return bytes;
+        }
+
+        @Override
+        public String readChecksum(File checksumFile) throws IOException {
+            return Files.readString(checksumFile.toPath()).trim();
+        }
+
+        @Override
+        public void writeChecksum(File checksumFile, String checksum) throws IOException {
+            write(checksumFile, checksum);
+        }
+
+        private static void createParentDirectories(File file) throws IOException {
+            Path parent = file.toPath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+        }
+    }
+
+    private static final class RecordingTransferListener implements TransferListener {
+        private final List<TransferEvent> events = new ArrayList<>();
+
+        List<TransferEvent> events() {
+            return List.copyOf(events);
+        }
+
+        @Override
+        public void transferInitiated(TransferEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void transferStarted(TransferEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void transferProgressed(TransferEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void transferCorrupted(TransferEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void transferSucceeded(TransferEvent event) {
+            events.add(event);
+        }
+
+        @Override
+        public void transferFailed(TransferEvent event) {
+            events.add(event);
+        }
     }
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
@@ -40,6 +40,7 @@ import org.eclipse.aether.spi.connector.ArtifactUpload;
 import org.eclipse.aether.spi.connector.MetadataDownload;
 import org.eclipse.aether.spi.connector.MetadataUpload;
 import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithm;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
@@ -167,6 +168,50 @@ public class Maven_resolver_connector_basicTest {
     }
 
     @Test
+    void uploadsGeneratedChecksumsWhenLayoutProvidesChecksumLocations() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        Artifact artifact = artifact();
+        Metadata metadata = metadata();
+        Path artifactSource = tempDirectory.resolve("checksummed-artifact.jar");
+        Path metadataSource = tempDirectory.resolve("checksummed-metadata.xml");
+        Files.writeString(artifactSource, "artifact-payload");
+        Files.writeString(metadataSource, "metadata-payload");
+
+        RepositoryConnector connector = configuredFactory(
+                        (session, repository) -> transporter,
+                        (session, repository) -> new SimpleRepositoryLayout(
+                                List.of(LengthChecksumAlgorithmFactory.INSTANCE)),
+                        Collections.emptyMap())
+                .newInstance(session(), repository());
+        try {
+            ArtifactUpload artifactUpload = new ArtifactUpload(artifact, artifactSource.toFile());
+            MetadataUpload metadataUpload = new MetadataUpload(metadata, metadataSource.toFile());
+
+            connector.put(List.of(artifactUpload), List.of(metadataUpload));
+
+            URI artifactLocation = SimpleRepositoryLayout.locationFor(artifact);
+            URI artifactChecksumLocation = SimpleRepositoryLayout.checksumLocationFor(
+                    artifactLocation, LengthChecksumAlgorithmFactory.INSTANCE);
+            URI metadataLocation = SimpleRepositoryLayout.locationFor(metadata);
+            URI metadataChecksumLocation = SimpleRepositoryLayout.checksumLocationFor(
+                    metadataLocation, LengthChecksumAlgorithmFactory.INSTANCE);
+            assertThat(artifactUpload.getException()).isNull();
+            assertThat(metadataUpload.getException()).isNull();
+            assertThat(transporter.putLocations()).containsExactly(
+                    artifactLocation,
+                    artifactChecksumLocation,
+                    metadataLocation,
+                    metadataChecksumLocation);
+            assertThat(transporter.content(artifactChecksumLocation))
+                    .isEqualTo(Long.toString(Files.size(artifactSource)));
+            assertThat(transporter.content(metadataChecksumLocation))
+                    .isEqualTo(Long.toString(Files.size(metadataSource)));
+        } finally {
+            connector.close();
+        }
+    }
+
+    @Test
     void transportNotFoundIsReportedOnArtifactDownload() throws Exception {
         InMemoryTransporter transporter = new InMemoryTransporter();
         ArtifactDownload download = new ArtifactDownload(
@@ -281,6 +326,16 @@ public class Maven_resolver_connector_basicTest {
     }
 
     private static final class SimpleRepositoryLayout implements RepositoryLayout {
+        private final List<ChecksumAlgorithmFactory> checksumAlgorithmFactories;
+
+        SimpleRepositoryLayout() {
+            this(Collections.emptyList());
+        }
+
+        SimpleRepositoryLayout(List<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+            this.checksumAlgorithmFactories = List.copyOf(checksumAlgorithmFactories);
+        }
+
         static URI locationFor(Artifact artifact) {
             return URI.create("artifacts/"
                     + artifact.getGroupId().replace('.', '/') + "/"
@@ -301,14 +356,18 @@ public class Maven_resolver_connector_basicTest {
             return URI.create(path.append('/').append(metadata.getType()).toString());
         }
 
+        static URI checksumLocationFor(URI location, ChecksumAlgorithmFactory checksumAlgorithmFactory) {
+            return URI.create(location + "." + checksumAlgorithmFactory.getFileExtension());
+        }
+
         @Override
         public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories() {
-            return Collections.emptyList();
+            return checksumAlgorithmFactories;
         }
 
         @Override
         public boolean hasChecksums(Artifact artifact) {
-            return false;
+            return !checksumAlgorithmFactories.isEmpty();
         }
 
         @Override
@@ -323,12 +382,51 @@ public class Maven_resolver_connector_basicTest {
 
         @Override
         public List<ChecksumLocation> getChecksumLocations(Artifact artifact, boolean upload, URI location) {
-            return Collections.emptyList();
+            return checksumLocationsFor(location);
         }
 
         @Override
         public List<ChecksumLocation> getChecksumLocations(Metadata metadata, boolean upload, URI location) {
-            return Collections.emptyList();
+            return checksumLocationsFor(location);
+        }
+
+        private List<ChecksumLocation> checksumLocationsFor(URI location) {
+            return checksumAlgorithmFactories.stream()
+                    .map(factory -> ChecksumLocation.forLocation(location, factory))
+                    .toList();
+        }
+    }
+
+    private static final class LengthChecksumAlgorithmFactory implements ChecksumAlgorithmFactory {
+        private static final LengthChecksumAlgorithmFactory INSTANCE = new LengthChecksumAlgorithmFactory();
+
+        @Override
+        public String getName() {
+            return "length";
+        }
+
+        @Override
+        public String getFileExtension() {
+            return "len";
+        }
+
+        @Override
+        public ChecksumAlgorithm getAlgorithm() {
+            return new LengthChecksumAlgorithm();
+        }
+    }
+
+    private static final class LengthChecksumAlgorithm implements ChecksumAlgorithm {
+        private long byteCount;
+
+        @Override
+        public void update(ByteBuffer buffer) {
+            byteCount += buffer.remaining();
+        }
+
+        @Override
+        public String checksum() {
+            return Long.toString(byteCount);
         }
     }
 

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
@@ -6,6 +6,7 @@
  */
 package org_apache_maven_resolver.maven_resolver_connector_basic;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -21,6 +22,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,6 +61,7 @@ import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transform.FileTransformer;
 import org.eclipse.aether.transfer.TransferResource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -162,6 +165,45 @@ public class Maven_resolver_connector_basicTest {
                 assertThat(event.getRequestType()).isEqualTo(TransferEvent.RequestType.PUT);
                 assertThat(event.getResource().getRepositoryUrl()).isEqualTo(repository().getUrl() + "/");
             });
+        } finally {
+            connector.close();
+        }
+    }
+
+    @Test
+    void uploadsTransformedArtifactDataWhenFileTransformerIsConfigured() throws Exception {
+        InMemoryTransporter transporter = new InMemoryTransporter();
+        Artifact artifact = artifact();
+        Path artifactSource = tempDirectory.resolve("transformable-artifact.jar");
+        Files.writeString(artifactSource, "original-artifact");
+        AtomicBoolean transformed = new AtomicBoolean();
+        FileTransformer transformer = new FileTransformer() {
+            @Override
+            public Artifact transformArtifact(Artifact artifact) {
+                return artifact;
+            }
+
+            @Override
+            public InputStream transformData(File file) throws IOException {
+                transformed.set(true);
+                String originalContent = Files.readString(file.toPath());
+                String transformedContent = "transformed:" + originalContent.toUpperCase(Locale.ROOT);
+                return new ByteArrayInputStream(transformedContent.getBytes(StandardCharsets.UTF_8));
+            }
+        };
+
+        RepositoryConnector connector = newConnector(transporter, Collections.emptyMap());
+        try {
+            ArtifactUpload artifactUpload = new ArtifactUpload(artifact, artifactSource.toFile(), transformer);
+
+            connector.put(List.of(artifactUpload), null);
+
+            assertThat(artifactUpload.getException()).isNull();
+            assertThat(transformed).isTrue();
+            assertThat(transporter.putLocations()).containsExactly(SimpleRepositoryLayout.locationFor(artifact));
+            assertThat(transporter.content(SimpleRepositoryLayout.locationFor(artifact)))
+                    .isEqualTo("transformed:ORIGINAL-ARTIFACT");
+            assertThat(Files.readString(artifactSource)).isEqualTo("original-artifact");
         } finally {
             connector.close();
         }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/src/test/java/org_apache_maven_resolver/maven_resolver_connector_basic/Maven_resolver_connector_basicTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_connector_basic;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_resolver_connector_basicTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:20">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:09">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3768-ca291ee1/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:57:07">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -80,6 +80,12 @@ display-name: transportNotFoundIsReportedOnArtifactDownload()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:connectorClosesTransporterAndRejectsFurtherTransfers()]
 display-name: connectorClosesTransporterAndRejectsFurtherTransfers()
+]]></system-out>
+</testcase>
+<testcase name="uploadsTransformedArtifactDataWhenFileTransformerIsConfigured()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:uploadsTransformedArtifactDataWhenFileTransformerIsConfigured()]
+display-name: uploadsTransformedArtifactDataWhenFileTransformerIsConfigured()
 ]]></system-out>
 </testcase>
 <testcase name="uploadsArtifactsAndMetadataToTransportLocations()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T04:54:27">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3768-ca291ee1/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="downloadsArtifactsMetadataAndPerformsExistenceChecks()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:downloadsArtifactsMetadataAndPerformsExistenceChecks()]
+display-name: downloadsArtifactsMetadataAndPerformsExistenceChecks()
+]]></system-out>
+</testcase>
+<testcase name="factoryConfigurationIsFluentAndWrapsProviderFailures()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:factoryConfigurationIsFluentAndWrapsProviderFailures()]
+display-name: factoryConfigurationIsFluentAndWrapsProviderFailures()
+]]></system-out>
+</testcase>
+<testcase name="transportNotFoundIsReportedOnArtifactDownload()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:transportNotFoundIsReportedOnArtifactDownload()]
+display-name: transportNotFoundIsReportedOnArtifactDownload()
+]]></system-out>
+</testcase>
+<testcase name="connectorClosesTransporterAndRejectsFurtherTransfers()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:connectorClosesTransporterAndRejectsFurtherTransfers()]
+display-name: connectorClosesTransporterAndRejectsFurtherTransfers()
+]]></system-out>
+</testcase>
+<testcase name="uploadsArtifactsAndMetadataToTransportLocations()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:uploadsArtifactsAndMetadataToTransportLocations()]
+display-name: uploadsArtifactsAndMetadataToTransportLocations()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T04:54:27">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T04:57:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -62,6 +62,12 @@ display-name: downloadsArtifactsMetadataAndPerformsExistenceChecks()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:factoryConfigurationIsFluentAndWrapsProviderFailures()]
 display-name: factoryConfigurationIsFluentAndWrapsProviderFailures()
+]]></system-out>
+</testcase>
+<testcase name="uploadsGeneratedChecksumsWhenLayoutProvidesChecksumLocations()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest]/[method:uploadsGeneratedChecksumsWhenLayoutProvidesChecksumLocations()]
+display-name: uploadsGeneratedChecksumsWhenLayoutProvidesChecksumLocations()
 ]]></system-out>
 </testcase>
 <testcase name="transportNotFoundIsReportedOnArtifactDownload()" classname="org_apache_maven_resolver.maven_resolver_connector_basic.Maven_resolver_connector_basicTest" time="0">

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:57:07">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:54:27">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3768-ca291ee1/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:20">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:09">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3768-ca291ee1/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:54:27">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:57:07">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.aether.connector.basic.**"
+      "includeClasses" : "org.eclipse.aether.connector.basic.**"
     }
   ]
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-connector-basic/1.9.25/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.aether.connector.basic.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3768

This PR introduces tests and metadata for org.apache.maven.resolver:maven-resolver-connector-basic:1.9.25, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 251282
- Cached input tokens: 1825792
- Output tokens: 26332
- Metadata entries: 1
- Iterations: 5
- Library coverage percentage: 59.07
- Generated lines of code: 603
- Tested library lines of code: 293

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `398b41f517b19a8622e482d25e9e3fbd770b2876`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1261/2130 (59.20%)
- Line: 293/496 (59.07%)
- Method: 50/72 (69.44%)
