### PR TITLE
[GenAI] Add support for org.apache.maven.resolver:maven-resolver-transport-apache:2.0.13 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/reachability-metadata.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/reachability-metadata.json
@@ -1,0 +1,374 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.NetscapeCertTypeExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.PrivateKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.ApacheTransporter"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.GlobalState"
+      },
+      "glob": "mozilla/public-suffix-list.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.aether.transport.apache.ApacheTransporter"
+      },
+      "glob": "org/slf4j/impl/StaticLoggerBinder.class"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.resolver/maven-resolver-transport-apache/index.json
+++ b/metadata/org.apache.maven.resolver/maven-resolver-transport-apache/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.13",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-apache/$version$/maven-resolver-transport-apache-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-resolver",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/$version$/maven-resolver-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-transport-apache/$version$/maven-resolver-transport-apache-$version$-javadoc.jar",
+    "description" : "Maven Resolver Transport Apache provides an HTTP and HTTPS repository transport implementation for Maven Artifact Resolver using Apache HttpClient. It lets resolver-based applications transfer artifacts and metadata from remote Maven repositories through the resolver transport SPI.",
+    "tested-versions" : [
+      "2.0.13"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.aether.transport.apache"
+    ]
+  }
+]

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/execution-metrics.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T03:02:28.194543Z",
+    "library": "org.apache.maven.resolver:maven-resolver-transport-apache:2.0.13",
+    "starting_commit": "8e82be5d9107c9efe2d5ed8e83af5a420c9f5986",
+    "ending_commit": "27f097a56069baf1df8591936717fc8eecc69dcd",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.13",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2168,
+          "missed": 1265,
+          "ratio": 0.631518,
+          "total": 3433
+        },
+        "line": {
+          "covered": 471,
+          "missed": 269,
+          "ratio": 0.636486,
+          "total": 740
+        },
+        "method": {
+          "covered": 78,
+          "missed": 42,
+          "ratio": 0.65,
+          "total": 120
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 148428,
+      "cached_input_tokens_used": 2081280,
+      "output_tokens_used": 20103,
+      "iterations": 3,
+      "cost_usd": 1.6437,
+      "generated_loc": 410,
+      "tested_library_loc": 471,
+      "metadata_entries": 56,
+      "code_coverage_percent": 63.65
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java",
+      "metadata_file": "metadata/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/stats.json
+++ b/stats/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.13",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2168,
+        "missed" : 1265,
+        "ratio" : 0.631518,
+        "total" : 3433
+      },
+      "line" : {
+        "covered" : 471,
+        "missed" : 269,
+        "ratio" : 0.636486,
+        "total" : 740
+      },
+      "method" : {
+        "covered" : 78,
+        "missed" : 42,
+        "ratio" : 0.65,
+        "total" : 120
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/.gitignore
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/build.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.resolver:maven-resolver-transport-apache:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/gradle.properties
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.resolver:maven-resolver-transport-apache:2.0.13
+library.version = 2.0.13
+metadata.dir = org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/settings.gradle
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.resolver.maven-resolver-transport-apache_tests'

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
@@ -6,11 +6,359 @@
  */
 package org_apache_maven_resolver.maven_resolver_transport_apache;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Maven_resolver_transport_apacheTest {
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransporter;
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys;
+import org.eclipse.aether.transport.apache.ApacheTransporterFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Maven_resolver_transport_apacheTest {
+    private static final String FIXED_LAST_MODIFIED = DateTimeFormatter.RFC_1123_DATE_TIME
+            .format(Instant.parse("2024-01-02T03:04:05Z").atOffset(ZoneOffset.UTC));
+    private static final ChecksumExtractor RESPONSE_CHECKSUMS = headers -> {
+        String sha1 = headers.apply("X-Checksum-Sha1");
+        if (sha1 == null) {
+            return Map.of();
+        }
+        return Map.of("SHA-1", sha1);
+    };
+
+    @TempDir
+    private Path tempDirectory;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void factoryExposesPriorityAndRejectsUnsupportedRepositories() {
+        ApacheTransporterFactory factory = newFactory();
+
+        assertThat(ApacheTransporterFactory.NAME).isEqualTo("apache");
+        assertThat(factory.getPriority()).isEqualTo(5.0f);
+        assertThat(factory.setPriority(7.25f)).isSameAs(factory);
+        assertThat(factory.getPriority()).isEqualTo(7.25f);
+        assertThatNullPointerException().isThrownBy(() -> new ApacheTransporterFactory(null, new SimplePathProcessor()))
+                .withMessageContaining("checksumExtractor");
+        assertThatNullPointerException().isThrownBy(() -> new ApacheTransporterFactory(RESPONSE_CHECKSUMS, null))
+                .withMessageContaining("pathProcessor");
+
+        RemoteRepository fileRepository = new RemoteRepository.Builder("local", "default", "file:/tmp/repository")
+                .build();
+        assertThatExceptionOfType(NoTransporterException.class)
+                .isThrownBy(() -> factory.newInstance(newSession(), fileRepository))
+                .satisfies(error -> assertThat(error.getRepository()).isSameAs(fileRepository));
+    }
+
+    @Test
+    void getPeekAndPutExchangeDataHeadersAndChecksums() throws Exception {
+        byte[] payload = "resolver transport payload".getBytes(StandardCharsets.UTF_8);
+        AtomicReference<String> downloadedHeader = new AtomicReference<>();
+        AtomicReference<String> uploadedBody = new AtomicReference<>();
+        AtomicReference<String> uploadedHeader = new AtomicReference<>();
+        AtomicReference<String> uploadedPath = new AtomicReference<>();
+        List<String> methods = new ArrayList<>();
+
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            methods.add(exchange.getRequestMethod() + " " + exchange.getRequestURI().getPath());
+            if ("/repo/artifact.txt".equals(exchange.getRequestURI().getPath())) {
+                downloadedHeader.set(exchange.getRequestHeaders().getFirst("X-Resolver-Test"));
+                Headers headers = exchange.getResponseHeaders();
+                headers.add("Last-Modified", FIXED_LAST_MODIFIED);
+                headers.add("X-Checksum-Sha1", "6b61b6f78d4a6ebf01e4ee71dbba9b4d8a01f3c4");
+                if ("HEAD".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(200, -1);
+                } else if ("GET".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(200, payload.length);
+                    exchange.getResponseBody().write(payload);
+                } else {
+                    exchange.sendResponseHeaders(405, -1);
+                }
+                return;
+            }
+            if ("/repo/uploads/metadata.xml".equals(exchange.getRequestURI().getPath())
+                    && "PUT".equals(exchange.getRequestMethod())) {
+                uploadedPath.set(exchange.getRequestURI().getPath());
+                uploadedHeader.set(exchange.getRequestHeaders().getFirst("X-Resolver-Test"));
+                uploadedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+                exchange.sendResponseHeaders(201, -1);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+        })) {
+            try (HttpTransporter transporter = newTransporter(server)) {
+                PeekTask peekTask = new PeekTask(URI.create("artifact.txt"));
+                transporter.peek(peekTask);
+
+                GetTask getTask = new GetTask(URI.create("artifact.txt"));
+                transporter.get(getTask);
+
+                Path uploadSource = tempDirectory.resolve("metadata.xml");
+                Files.writeString(uploadSource, "<metadata>uploaded</metadata>", StandardCharsets.UTF_8);
+                transporter.put(new PutTask(URI.create("uploads/metadata.xml")).setDataPath(uploadSource));
+
+                assertThat(getTask.getDataString()).isEqualTo("resolver transport payload");
+                assertThat(getTask.getChecksums()).containsEntry("SHA-1", "6b61b6f78d4a6ebf01e4ee71dbba9b4d8a01f3c4");
+                assertThat(downloadedHeader.get()).isEqualTo("enabled");
+                assertThat(uploadedBody.get()).isEqualTo("<metadata>uploaded</metadata>");
+                assertThat(uploadedHeader.get()).isEqualTo("enabled");
+                assertThat(uploadedPath.get()).isEqualTo("/repo/uploads/metadata.xml");
+                assertThat(methods).containsExactly(
+                        "HEAD /repo/artifact.txt", "GET /repo/artifact.txt", "PUT /repo/uploads/metadata.xml");
+            }
+        }
+    }
+
+    @Test
+    void getCanResumeIntoAFileAndApplyServerTimestamp() throws Exception {
+        AtomicReference<String> rangeHeader = new AtomicReference<>();
+        AtomicReference<String> ifUnmodifiedSinceHeader = new AtomicReference<>();
+
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            if ("/repo/resumable.bin".equals(exchange.getRequestURI().getPath())
+                    && "GET".equals(exchange.getRequestMethod())) {
+                rangeHeader.set(exchange.getRequestHeaders().getFirst("Range"));
+                ifUnmodifiedSinceHeader.set(exchange.getRequestHeaders().getFirst("If-Unmodified-Since"));
+                byte[] suffix = "def".getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Range", "bytes 3-5/6");
+                exchange.getResponseHeaders().add("Last-Modified", FIXED_LAST_MODIFIED);
+                exchange.sendResponseHeaders(206, suffix.length);
+                exchange.getResponseBody().write(suffix);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+        })) {
+            Path target = tempDirectory.resolve("resumable.bin");
+            Files.writeString(target, "abc", StandardCharsets.UTF_8);
+            Files.setLastModifiedTime(target, FileTime.from(Instant.parse("2024-01-02T03:04:05Z")));
+
+            try (HttpTransporter transporter = newTransporter(server)) {
+                GetTask getTask = new GetTask(URI.create("resumable.bin")).setDataPath(target, true);
+                transporter.get(getTask);
+
+                assertThat(Files.readString(target, StandardCharsets.UTF_8)).isEqualTo("abcdef");
+                assertThat(rangeHeader.get()).isEqualTo("bytes=3-");
+                assertThat(ifUnmodifiedSinceHeader.get()).isNotBlank();
+                assertThat(Files.getLastModifiedTime(target).toMillis())
+                        .isEqualTo(Instant.parse("2024-01-02T03:04:05Z").toEpochMilli());
+            }
+        }
+    }
+
+    @Test
+    void classifyDistinguishesMissingHttpResourcesFromOtherErrors() throws Exception {
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            if ("/repo/missing.txt".equals(exchange.getRequestURI().getPath())) {
+                exchange.sendResponseHeaders(404, -1);
+                return;
+            }
+            exchange.sendResponseHeaders(500, -1);
+        })) {
+            try (HttpTransporter transporter = newTransporter(server)) {
+                assertThatThrownBy(() -> transporter.peek(new PeekTask(URI.create("missing.txt"))))
+                        .satisfies(error -> assertThat(transporter.classify(error))
+                                .isEqualTo(Transporter.ERROR_NOT_FOUND));
+                assertThatThrownBy(() -> transporter.peek(new PeekTask(URI.create("server-error.txt"))))
+                        .satisfies(error -> assertThat(transporter.classify(error)).isEqualTo(Transporter.ERROR_OTHER));
+            }
+        }
+    }
+
+    private static ApacheTransporterFactory newFactory() {
+        return new ApacheTransporterFactory(RESPONSE_CHECKSUMS, new SimplePathProcessor());
+    }
+
+    private static HttpTransporter newTransporter(TestHttpServer server) throws NoTransporterException {
+        RemoteRepository repository = new RemoteRepository.Builder(
+                "test-repository", "default", server.repositoryUrl()).build();
+        return newFactory().newInstance(newSession(), repository);
+    }
+
+    private static RepositorySystemSession newSession() {
+        return new DefaultRepositorySystemSession()
+                .setConfigProperty("aether.transport.http.connectTimeout", 2_000)
+                .setConfigProperty("aether.transport.http.requestTimeout", 2_000)
+                .setConfigProperty("aether.transport.http.retryHandler.count", 0)
+                .setConfigProperty("aether.transport.http.expectContinue", false)
+                .setConfigProperty("aether.transport.http.headers", Map.of("X-Resolver-Test", "enabled"))
+                .setConfigProperty(ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_REDIRECTS, false);
+    }
+
+    private static final class TestHttpServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private TestHttpServer(HttpServer server, ExecutorService executor) {
+            this.server = server;
+            this.executor = executor;
+        }
+
+        static TestHttpServer create(HttpHandler handler) throws IOException {
+            HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "resolver-apache-transport-test-server");
+                thread.setDaemon(true);
+                return thread;
+            });
+            server.createContext("/", exchange -> {
+                try (exchange) {
+                    handler.handle(exchange);
+                }
+            });
+            server.setExecutor(executor);
+            server.start();
+            return new TestHttpServer(server, executor);
+        }
+
+        String repositoryUrl() {
+            return "http://" + server.getAddress().getHostString() + ":" + server.getAddress().getPort() + "/repo/";
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            server.stop(0);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static final class SimplePathProcessor implements PathProcessor {
+        @Override
+        public boolean setLastModified(Path path, long millis) throws IOException {
+            Files.setLastModifiedTime(path, FileTime.fromMillis(millis));
+            return true;
+        }
+
+        @Override
+        public void write(Path target, String data) throws IOException {
+            Files.writeString(target, data, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void write(Path target, InputStream source) throws IOException {
+            try (source) {
+                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+
+        @Override
+        public void writeWithBackup(Path target, String data) throws IOException {
+            write(target, data);
+        }
+
+        @Override
+        public void writeWithBackup(Path target, InputStream source) throws IOException {
+            write(target, source);
+        }
+
+        @Override
+        public void move(Path source, Path target) throws IOException {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        @Override
+        public long copy(Path source, Path target, ProgressListener listener) throws IOException {
+            long bytes = 0L;
+            try (InputStream input = Files.newInputStream(source);
+                    OutputStream output = Files.newOutputStream(target)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) >= 0) {
+                    output.write(buffer, 0, read);
+                    bytes += read;
+                    if (listener != null) {
+                        listener.progressed(ByteBuffer.wrap(buffer, 0, read));
+                    }
+                }
+            }
+            return bytes;
+        }
+
+        @Override
+        public TempFile newTempFile() throws IOException {
+            return new SimpleTempFile(Files.createTempFile("resolver-apache", ".tmp"));
+        }
+
+        @Override
+        public CollocatedTempFile newTempFile(Path target) throws IOException {
+            Path parent = target.toAbsolutePath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Path tempFile = Files.createTempFile(parent, target.getFileName() + ".", ".tmp");
+            return new SimpleCollocatedTempFile(tempFile, target);
+        }
+    }
+
+    private static class SimpleTempFile implements PathProcessor.TempFile {
+        private final Path path;
+
+        SimpleTempFile(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public Path getPath() {
+            return path;
+        }
+
+        @Override
+        public void close() throws IOException {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    private static final class SimpleCollocatedTempFile extends SimpleTempFile
+            implements PathProcessor.CollocatedTempFile {
+        private final Path path;
+        private final Path target;
+
+        SimpleCollocatedTempFile(Path path, Path target) {
+            super(path);
+            this.path = path;
+            this.target = target;
+        }
+
+        @Override
+        public void move() throws IOException {
+            Files.move(path, target, StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 }

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
@@ -183,6 +183,42 @@ public class Maven_resolver_transport_apacheTest {
     }
 
     @Test
+    void getFollowsConfiguredRedirectsToDownloadRelocatedResource() throws Exception {
+        byte[] payload = "relocated resolver payload".getBytes(StandardCharsets.UTF_8);
+        List<String> methods = new ArrayList<>();
+
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            String method = exchange.getRequestMethod();
+            String path = exchange.getRequestURI().getPath();
+            methods.add(method + " " + path);
+            if ("GET".equals(method) && "/repo/redirected.txt".equals(path)) {
+                exchange.getResponseHeaders().add("Location", "/repo/relocated/artifact.txt");
+                exchange.sendResponseHeaders(302, -1);
+                return;
+            }
+            if ("GET".equals(method) && "/repo/relocated/artifact.txt".equals(path)) {
+                exchange.sendResponseHeaders(200, payload.length);
+                exchange.getResponseBody().write(payload);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+        })) {
+            RepositorySystemSession session = newSession()
+                    .setConfigProperty(ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_REDIRECTS, true)
+                    .setConfigProperty(ApacheTransporterConfigurationKeys.CONFIG_PROP_MAX_REDIRECTS, 2);
+
+            try (HttpTransporter transporter = newTransporter(server, session)) {
+                GetTask getTask = new GetTask(URI.create("redirected.txt"));
+                transporter.get(getTask);
+
+                assertThat(getTask.getDataString()).isEqualTo("relocated resolver payload");
+                assertThat(methods).containsExactly(
+                        "GET /repo/redirected.txt", "GET /repo/relocated/artifact.txt");
+            }
+        }
+    }
+
+    @Test
     void classifyDistinguishesMissingHttpResourcesFromOtherErrors() throws Exception {
         try (TestHttpServer server = TestHttpServer.create(exchange -> {
             if ("/repo/missing.txt".equals(exchange.getRequestURI().getPath())) {

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
@@ -201,17 +201,78 @@ public class Maven_resolver_transport_apacheTest {
         }
     }
 
+    @Test
+    void putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact() throws Exception {
+        List<String> methods = new ArrayList<>();
+        List<String> createdDirectories = new ArrayList<>();
+        AtomicReference<String> uploadedBody = new AtomicReference<>();
+
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            String method = exchange.getRequestMethod();
+            String path = exchange.getRequestURI().getPath();
+            methods.add(method + " " + path);
+            if ("OPTIONS".equals(method) && "/repo/releases/snapshots/metadata.xml".equals(path)) {
+                exchange.getResponseHeaders().add("Dav", "1,2");
+                exchange.sendResponseHeaders(200, -1);
+                return;
+            }
+            if ("MKCOL".equals(method) && "/repo/releases/snapshots/".equals(path)) {
+                if (createdDirectories.contains("/repo/releases/")) {
+                    createdDirectories.add(path);
+                    exchange.sendResponseHeaders(201, -1);
+                } else {
+                    exchange.sendResponseHeaders(409, -1);
+                }
+                return;
+            }
+            if ("MKCOL".equals(method) && "/repo/releases/".equals(path)) {
+                createdDirectories.add(path);
+                exchange.sendResponseHeaders(201, -1);
+                return;
+            }
+            if ("PUT".equals(method) && "/repo/releases/snapshots/metadata.xml".equals(path)) {
+                uploadedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+                exchange.sendResponseHeaders(201, -1);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+        })) {
+            Path uploadSource = tempDirectory.resolve("nested-metadata.xml");
+            Files.writeString(uploadSource, "<metadata>webdav</metadata>", StandardCharsets.UTF_8);
+            RepositorySystemSession session = newSession()
+                    .setConfigProperty("aether.transport.http.supportWebDav", true);
+
+            try (HttpTransporter transporter = newTransporter(server, session)) {
+                transporter.put(new PutTask(URI.create("releases/snapshots/metadata.xml")).setDataPath(uploadSource));
+
+                assertThat(uploadedBody.get()).isEqualTo("<metadata>webdav</metadata>");
+                assertThat(createdDirectories).containsExactly("/repo/releases/", "/repo/releases/snapshots/");
+                assertThat(methods).containsExactly(
+                        "OPTIONS /repo/releases/snapshots/metadata.xml",
+                        "MKCOL /repo/releases/snapshots/",
+                        "MKCOL /repo/releases/",
+                        "MKCOL /repo/releases/snapshots/",
+                        "PUT /repo/releases/snapshots/metadata.xml");
+            }
+        }
+    }
+
     private static ApacheTransporterFactory newFactory() {
         return new ApacheTransporterFactory(RESPONSE_CHECKSUMS, new SimplePathProcessor());
     }
 
     private static HttpTransporter newTransporter(TestHttpServer server) throws NoTransporterException {
-        RemoteRepository repository = new RemoteRepository.Builder(
-                "test-repository", "default", server.repositoryUrl()).build();
-        return newFactory().newInstance(newSession(), repository);
+        return newTransporter(server, newSession());
     }
 
-    private static RepositorySystemSession newSession() {
+    private static HttpTransporter newTransporter(TestHttpServer server, RepositorySystemSession session)
+            throws NoTransporterException {
+        RemoteRepository repository = new RemoteRepository.Builder(
+                "test-repository", "default", server.repositoryUrl()).build();
+        return newFactory().newInstance(session, repository);
+    }
+
+    private static DefaultRepositorySystemSession newSession() {
         return new DefaultRepositorySystemSession()
                 .setConfigProperty("aether.transport.http.connectTimeout", 2_000)
                 .setConfigProperty("aether.transport.http.requestTimeout", 2_000)

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/src/test/java/org_apache_maven_resolver/maven_resolver_transport_apache/Maven_resolver_transport_apacheTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_resolver.maven_resolver_transport_apache;
+
+import org.junit.jupiter.api.Test;
+
+class Maven_resolver_transport_apacheTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.012" hostname="kung-fu-workstation" timestamp="2026-05-03T05:00:50">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-03T05:01:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3777-ae3b5b5f/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13"/>
@@ -58,31 +57,31 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolve
 display-name: factoryExposesPriorityAndRejectsUnsupportedRepositories()
 ]]></system-out>
 </testcase>
-<testcase name="getFollowsConfiguredRedirectsToDownloadRelocatedResource()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
+<testcase name="getFollowsConfiguredRedirectsToDownloadRelocatedResource()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getFollowsConfiguredRedirectsToDownloadRelocatedResource()]
 display-name: getFollowsConfiguredRedirectsToDownloadRelocatedResource()
 ]]></system-out>
 </testcase>
-<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.004">
+<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:classifyDistinguishesMissingHttpResourcesFromOtherErrors()]
 display-name: classifyDistinguishesMissingHttpResourcesFromOtherErrors()
 ]]></system-out>
 </testcase>
-<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getCanResumeIntoAFileAndApplyServerTimestamp()]
 display-name: getCanResumeIntoAFileAndApplyServerTimestamp()
 ]]></system-out>
 </testcase>
-<testcase name="getPeekAndPutExchangeDataHeadersAndChecksums()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
+<testcase name="getPeekAndPutExchangeDataHeadersAndChecksums()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getPeekAndPutExchangeDataHeadersAndChecksums()]
 display-name: getPeekAndPutExchangeDataHeadersAndChecksums()
 ]]></system-out>
 </testcase>
-<testcase name="putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<testcase name="putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()]
 display-name: putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:01">
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:44">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,22 +58,28 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolve
 display-name: factoryExposesPriorityAndRejectsUnsupportedRepositories()
 ]]></system-out>
 </testcase>
-<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.004">
+<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:classifyDistinguishesMissingHttpResourcesFromOtherErrors()]
 display-name: classifyDistinguishesMissingHttpResourcesFromOtherErrors()
 ]]></system-out>
 </testcase>
-<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getCanResumeIntoAFileAndApplyServerTimestamp()]
 display-name: getCanResumeIntoAFileAndApplyServerTimestamp()
 ]]></system-out>
 </testcase>
-<testcase name="getPeekAndPutExchangeDataHeadersAndChecksums()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<testcase name="getPeekAndPutExchangeDataHeadersAndChecksums()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getPeekAndPutExchangeDataHeadersAndChecksums()]
 display-name: getPeekAndPutExchangeDataHeadersAndChecksums()
+]]></system-out>
+</testcase>
+<testcase name="putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()]
+display-name: putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:44">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="0" time="0.012" hostname="kung-fu-workstation" timestamp="2026-05-03T05:00:50">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,13 +58,19 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolve
 display-name: factoryExposesPriorityAndRejectsUnsupportedRepositories()
 ]]></system-out>
 </testcase>
-<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.005">
+<testcase name="getFollowsConfiguredRedirectsToDownloadRelocatedResource()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getFollowsConfiguredRedirectsToDownloadRelocatedResource()]
+display-name: getFollowsConfiguredRedirectsToDownloadRelocatedResource()
+]]></system-out>
+</testcase>
+<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:classifyDistinguishesMissingHttpResourcesFromOtherErrors()]
 display-name: classifyDistinguishesMissingHttpResourcesFromOtherErrors()
 ]]></system-out>
 </testcase>
-<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.003">
+<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getCanResumeIntoAFileAndApplyServerTimestamp()]
 display-name: getCanResumeIntoAFileAndApplyServerTimestamp()
@@ -76,7 +82,7 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolve
 display-name: getPeekAndPutExchangeDataHeadersAndChecksums()
 ]]></system-out>
 </testcase>
-<testcase name="putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.001">
+<testcase name="putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()]
 display-name: putCreatesWebDavDirectoriesBeforeUploadingNestedArtifact()

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="4" skipped="0" failures="0" errors="0" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:01">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3777-ae3b5b5f/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="factoryExposesPriorityAndRejectsUnsupportedRepositories()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:factoryExposesPriorityAndRejectsUnsupportedRepositories()]
+display-name: factoryExposesPriorityAndRejectsUnsupportedRepositories()
+]]></system-out>
+</testcase>
+<testcase name="classifyDistinguishesMissingHttpResourcesFromOtherErrors()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.004">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:classifyDistinguishesMissingHttpResourcesFromOtherErrors()]
+display-name: classifyDistinguishesMissingHttpResourcesFromOtherErrors()
+]]></system-out>
+</testcase>
+<testcase name="getCanResumeIntoAFileAndApplyServerTimestamp()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getCanResumeIntoAFileAndApplyServerTimestamp()]
+display-name: getCanResumeIntoAFileAndApplyServerTimestamp()
+]]></system-out>
+</testcase>
+<testcase name="getPeekAndPutExchangeDataHeadersAndChecksums()" classname="org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_maven_resolver.maven_resolver_transport_apache.Maven_resolver_transport_apacheTest]/[method:getPeekAndPutExchangeDataHeadersAndChecksums()]
+display-name: getPeekAndPutExchangeDataHeadersAndChecksums()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:01">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3777-ae3b5b5f/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:44">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T05:00:50">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:58:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T04:59:44">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T05:00:50">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T05:01:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge8/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3777-ae3b5b5f/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13"/>

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.aether.transport.apache.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/user-code-filter.json
+++ b/tests/src/org.apache.maven.resolver/maven-resolver-transport-apache/2.0.13/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.aether.transport.apache.**"
+      "includeClasses" : "org.eclipse.aether.transport.apache.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3777

This PR introduces tests and metadata for org.apache.maven.resolver:maven-resolver-transport-apache:2.0.13, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 148428
- Cached input tokens: 2081280
- Output tokens: 20103
- Metadata entries: 56
- Iterations: 3
- Library coverage percentage: 63.65
- Generated lines of code: 410
- Tested library lines of code: 471

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `398b41f517b19a8622e482d25e9e3fbd770b2876`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2168/3433 (63.15%)
- Line: 471/740 (63.65%)
- Method: 78/120 (65.00%)
