### PR TITLE
Fix metadata index boundary updates

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -19,9 +19,10 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.api.logging.LogLevel;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.process.ExecOperations;
+import org.gradle.util.internal.VersionNumber;
 
 import java.io.File;
 import java.io.IOException;
@@ -293,9 +294,10 @@ public final class MetadataGenerationUtils {
             }
         }
 
-        // Add the new entry and mark it as latest
-        List<String> testedVersions = new ArrayList<>();
-        testedVersions.add(newCoords.version());
+        // Add the new entry and mark it as latest.
+        // When this creates a new metadata boundary inside an existing range,
+        // move covered tested versions to the new entry so index validation keeps passing.
+        List<String> testedVersions = moveTestedVersionsCoveredByNewMetadata(entries, newCoords.version());
         MetadataVersionsIndexEntry newEntry = new MetadataVersionsIndexEntry(
                 Boolean.TRUE, // latest
                 null, // override
@@ -325,5 +327,101 @@ public final class MetadataGenerationUtils {
             json = json + System.lineSeparator();
         }
         Files.writeString(indexFile.toPath(), json, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private static List<String> moveTestedVersionsCoveredByNewMetadata(List<MetadataVersionsIndexEntry> entries, String newVersion) {
+        VersionNumber newMetadataVersion = parseVersionOrNull(newVersion);
+        List<String> movedVersions = new ArrayList<>();
+        movedVersions.add(newVersion);
+
+        if (newMetadataVersion == null) {
+            return movedVersions;
+        }
+
+        VersionNumber nextMetadataVersion = findNextMetadataVersion(entries, newMetadataVersion);
+        for (int i = 0; i < entries.size(); i++) {
+            MetadataVersionsIndexEntry entry = entries.get(i);
+            VersionNumber entryMetadataVersion = parseVersionOrNull(entry.metadataVersion());
+            if (entryMetadataVersion == null || entryMetadataVersion.compareTo(newMetadataVersion) >= 0) {
+                continue;
+            }
+
+            List<String> testedVersions = entry.testedVersions();
+            if (testedVersions == null || testedVersions.isEmpty()) {
+                continue;
+            }
+
+            List<String> retainedVersions = new ArrayList<>();
+            boolean moved = false;
+            for (String testedVersion : testedVersions) {
+                if (isCoveredByNewMetadata(testedVersion, newMetadataVersion, nextMetadataVersion)) {
+                    movedVersions.add(testedVersion);
+                    moved = true;
+                } else {
+                    retainedVersions.add(testedVersion);
+                }
+            }
+            if (moved) {
+                entries.set(i, copyWithTestedVersions(entry, retainedVersions));
+            }
+        }
+
+        return new ArrayList<>(new LinkedHashSet<>(movedVersions));
+    }
+
+    private static VersionNumber findNextMetadataVersion(List<MetadataVersionsIndexEntry> entries, VersionNumber newMetadataVersion) {
+        VersionNumber nextMetadataVersion = null;
+        for (MetadataVersionsIndexEntry entry : entries) {
+            VersionNumber candidate = parseVersionOrNull(entry.metadataVersion());
+            if (candidate == null || candidate.compareTo(newMetadataVersion) <= 0) {
+                continue;
+            }
+            if (nextMetadataVersion == null || candidate.compareTo(nextMetadataVersion) < 0) {
+                nextMetadataVersion = candidate;
+            }
+        }
+        return nextMetadataVersion;
+    }
+
+    private static boolean isCoveredByNewMetadata(String testedVersion, VersionNumber newMetadataVersion, VersionNumber nextMetadataVersion) {
+        VersionNumber parsedTestedVersion = parseVersionOrNull(testedVersion);
+        if (parsedTestedVersion == null || parsedTestedVersion.compareTo(newMetadataVersion) < 0) {
+            return false;
+        }
+        return nextMetadataVersion == null || parsedTestedVersion.compareTo(nextMetadataVersion) < 0;
+    }
+
+    private static VersionNumber parseVersionOrNull(String version) {
+        if (version == null) {
+            return null;
+        }
+        try {
+            return VersionNumber.parse(version);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static MetadataVersionsIndexEntry copyWithTestedVersions(MetadataVersionsIndexEntry entry, List<String> testedVersions) {
+        return new MetadataVersionsIndexEntry(
+                entry.latest(),
+                entry.override(),
+                entry.defaultFor(),
+                entry.metadataVersion(),
+                entry.testVersion(),
+                entry.sourceCodeUrl(),
+                entry.repositoryUrl(),
+                entry.testCodeUrl(),
+                entry.documentationUrl(),
+                entry.description(),
+                entry.language(),
+                testedVersions,
+                entry.skippedVersions(),
+                entry.allowedPackages(),
+                entry.requires(),
+                entry.notForNativeImage(),
+                entry.reason(),
+                entry.replacement()
+        );
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graalvm.internal.tck.Coordinates;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetadataGenerationUtilsTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void makeVersionLatestInIndexJsonMovesCoveredTimestampVersionsToInsertedMetadataBoundary() throws IOException {
+        String group = "com.graphql-java";
+        String artifact = "java-dataloader";
+        String newVersion = "2021-08-19T04-04-25-efb3c9d";
+        writeIndex(
+                group,
+                artifact,
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "2021-03-30T02-06-56-9a47743",
+                    "tested-versions" : [
+                      "2021-03-30T02-06-56-9a47743"
+                    ],
+                    "allowed-packages" : [
+                      "org.dataloader"
+                    ]
+                  },
+                  {
+                    "metadata-version" : "2021-07-17T01-39-28-682c652",
+                    "tested-versions" : [
+                      "2021-07-17T01-39-28-682c652",
+                      "2021-10-29T01-57-17-4253050"
+                    ],
+                    "allowed-packages" : [
+                      "org.dataloader"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        MetadataGenerationUtils.makeVersionLatestInIndexJson(
+                createProject().getLayout(),
+                Coordinates.parse(group + ":" + artifact + ":" + newVersion),
+                null
+        );
+
+        List<Map<String, Object>> entries = readIndex(group, artifact);
+        assertThat(entries.get(0))
+                .containsEntry("latest", true)
+                .containsEntry("metadata-version", newVersion)
+                .containsEntry("tested-versions", List.of(
+                        newVersion,
+                        "2021-10-29T01-57-17-4253050"
+                ));
+        assertThat(findEntry(entries, "2021-07-17T01-39-28-682c652"))
+                .containsEntry("tested-versions", List.of("2021-07-17T01-39-28-682c652"));
+    }
+
+    @Test
+    void makeVersionLatestInIndexJsonDoesNotMoveVersionsCoveredByNextMetadataBoundary() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        writeIndex(
+                group,
+                artifact,
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "1.0.0",
+                    "tested-versions" : [
+                      "1.0.0",
+                      "1.2.0"
+                    ],
+                    "allowed-packages" : [
+                      "com.example"
+                    ]
+                  },
+                  {
+                    "metadata-version" : "2.0.0",
+                    "tested-versions" : [
+                      "2.0.0",
+                      "2.1.0"
+                    ],
+                    "allowed-packages" : [
+                      "com.example"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        MetadataGenerationUtils.makeVersionLatestInIndexJson(
+                createProject().getLayout(),
+                Coordinates.parse(group + ":" + artifact + ":1.1.0"),
+                null
+        );
+
+        List<Map<String, Object>> entries = readIndex(group, artifact);
+        assertThat(entries.get(0))
+                .containsEntry("metadata-version", "1.1.0")
+                .containsEntry("tested-versions", List.of("1.1.0", "1.2.0"));
+        assertThat(findEntry(entries, "1.0.0"))
+                .containsEntry("tested-versions", List.of("1.0.0"));
+        assertThat(findEntry(entries, "2.0.0"))
+                .containsEntry("tested-versions", List.of("2.0.0", "2.1.0"));
+    }
+
+    private Project createProject() {
+        return ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+    }
+
+    private void writeIndex(String group, String artifact, String content) throws IOException {
+        Path indexFile = tempDir.resolve("metadata").resolve(group).resolve(artifact).resolve("index.json");
+        Files.createDirectories(indexFile.getParent());
+        Files.writeString(indexFile, content, StandardCharsets.UTF_8);
+    }
+
+    private List<Map<String, Object>> readIndex(String group, String artifact) throws IOException {
+        return OBJECT_MAPPER.readValue(
+                tempDir.resolve("metadata").resolve(group).resolve(artifact).resolve("index.json").toFile(),
+                new TypeReference<>() {
+                }
+        );
+    }
+
+    private Map<String, Object> findEntry(List<Map<String, Object>> entries, String metadataVersion) {
+        return entries.stream()
+                .filter(entry -> metadataVersion.equals(entry.get("metadata-version")))
+                .findFirst()
+                .orElseThrow();
+    }
+}


### PR DESCRIPTION
### Summary
- Move existing tested versions covered by a newly inserted metadata boundary into the new `index.json` entry.
- Keep the move bounded by the next higher metadata version so later metadata entries keep their tested versions.
- Add regression coverage for the timestamp-like `java-dataloader` failure and for preserving the next metadata boundary.

Fixes #4746.

### Testing
- `./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.utils.MetadataGenerationUtilsTests --rerun-tasks`
- `./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.TestedVersionUpdaterTaskTests --rerun-tasks`
- `./gradlew :tck-build-logic:test --rerun-tasks`
- `git diff --check`
