### PR TITLE
Fix Forge indexed coverage path resolution

### DIFF
--- a/forge/ai_workflows/improve_library_coverage.py
+++ b/forge/ai_workflows/improve_library_coverage.py
@@ -37,6 +37,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated, load_library_stats
 from utility_scripts import metrics_writer
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
+from utility_scripts.metadata_index import resolve_test_dir, resolve_test_version
 from utility_scripts.metrics_writer import count_metadata_entries, count_test_only_metadata_entries, create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
@@ -251,7 +252,27 @@ def main(argv=None) -> int:
     subprocess.run(["git", "switch", "-C", new_branch], check=True)
 
     # Commit existing state as checkpoint
-    tests_dir = os.path.join(reachability_repo_path, "tests", "src", group, artifact, version)
+    test_version = resolve_test_version(reachability_repo_path, group, artifact, version)
+    tests_dir = resolve_test_dir(reachability_repo_path, group, artifact, version)
+    if not os.path.isdir(tests_dir):
+        print(
+            "ERROR: Test directory for {library} does not exist: {path}".format(
+                library=library,
+                path=os.path.relpath(tests_dir, reachability_repo_path),
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    if test_version != version:
+        log_stage(
+            "setup",
+            "Using indexed test directory tests/src/{group}/{artifact}/{test_version} for {library}".format(
+                group=group,
+                artifact=artifact,
+                test_version=test_version,
+                library=library,
+            ),
+        )
     index_json = os.path.join(reachability_repo_path, "metadata", group, artifact, "index.json")
     subprocess.run(["git", "add", tests_dir, index_json], check=False)
     subprocess.run(
@@ -302,6 +323,7 @@ def main(argv=None) -> int:
         strategy_obj=strategy,
         reachability_repo_path=reachability_repo_path,
         library=library,
+        test_version=test_version,
         build_gradle_file=build_gradle_file,
         source_context_overview=prepared_source_context.to_prompt_overview(),
         source_context_available=prepared_source_context.is_available,

--- a/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
@@ -19,6 +19,7 @@ from utility_scripts.dynamic_access_report import (
     load_dynamic_access_coverage_report,
 )
 from utility_scripts.large_library_progress import LargeLibraryProgressState
+from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import (
     STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
     per_class_output_dir,
@@ -51,6 +52,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         self.keep_tests_without_dynamic_access = bool(self.context.get("keep_tests_without_dynamic_access", False))
         self._last_dynamic_access_report_issue = "not_run"
         self.group, self.artifact, self.version = self.library.split(":")
+        self.test_version = str(
+            self.context.get("test_version")
+            or resolve_test_version(self.reachability_repo_path, self.group, self.artifact, self.version)
+        )
         self.package = self.group
         self.max_class_iterations = self.parameters["max-iterations"]
         self.max_class_test_iterations = self.parameters["max-class-test-iterations"]
@@ -75,7 +80,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             "src",
             self.group,
             self.artifact,
-            self.version,
+            self.test_version,
             "build",
             "reports",
             "dynamic-access",
@@ -429,7 +434,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
     def _run_native_test_verification_gate(self, class_name: str) -> bool:
         """Run the per-class native-test verification gate; return True if PASSED."""
         output_dir = per_class_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.version, class_name,
+            self.reachability_repo_path, self.group, self.artifact, self.test_version, class_name,
         )
         self._print_dynamic_access_detail(
             f"native-test gate: starting class={class_name} output_dir={output_dir} "
@@ -618,7 +623,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
 
     def _library_test_change_signature(self) -> str:
         """Capture tracked and untracked changes under the generated library test tree."""
-        test_dir = os.path.join("tests", "src", self.group, self.artifact, self.version)
+        test_dir = os.path.join("tests", "src", self.group, self.artifact, self.test_version)
         tracked_diff = subprocess.run(
             ["git", "diff", "--no-ext-diff", "HEAD", "--", test_dir],
             cwd=self.reachability_repo_path,
@@ -641,7 +646,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         """Stage and commit test sources so the next class has a clean checkpoint."""
         tests_dir = os.path.join(
             self.reachability_repo_path, "tests", "src",
-            self.group, self.artifact, self.version,
+            self.group, self.artifact, self.test_version,
         )
         subprocess.run(
             ["git", "add", "-A", tests_dir],

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -84,6 +84,8 @@ from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
     get_not_for_native_image_marker,
     is_not_for_native_image,
+    resolve_metadata_version,
+    resolve_test_dir,
 )
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import (
@@ -1860,12 +1862,7 @@ def _resolve_dynamic_access_report_path(claimed_issue: ClaimedIssue) -> str:
     """Resolve the dynamic-access coverage report path for a new-library issue."""
     group, artifact, version = claimed_issue.issue_coordinates.split(":")
     return os.path.join(
-        claimed_issue.worktree_path,
-        "tests",
-        "src",
-        group,
-        artifact,
-        version,
+        resolve_test_dir(claimed_issue.worktree_path, group, artifact, version),
         "build",
         "reports",
         "dynamic-access",
@@ -1961,10 +1958,11 @@ def resolve_human_intervention_candidate(
 def _collect_human_intervention_read_only_files(claimed_issue: ClaimedIssue) -> list[str]:
     """Collect the key generated files that help the analysis agent explain the gap."""
     group, artifact, version = claimed_issue.issue_coordinates.split(":")
+    metadata_version = resolve_metadata_version(claimed_issue.worktree_path, group, artifact, version)
     candidate_paths = [
-        os.path.join(claimed_issue.worktree_path, "tests", "src", group, artifact, version),
+        resolve_test_dir(claimed_issue.worktree_path, group, artifact, version),
         os.path.join(claimed_issue.worktree_path, "metadata", group, artifact, "index.json"),
-        os.path.join(claimed_issue.worktree_path, "metadata", group, artifact, version),
+        os.path.join(claimed_issue.worktree_path, "metadata", group, artifact, metadata_version),
         resolve_stats_file_path(claimed_issue.worktree_path, group, artifact, version),
         _resolve_dynamic_access_report_path(claimed_issue),
     ]

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -28,6 +28,7 @@ from git_scripts.common_git import (
     get_configured_reviewers,
 )
 from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.metrics_writer import (
     commit_run_metrics_with_retry,
     count_metadata_entries,
@@ -128,7 +129,8 @@ Summary:
 
 def load_and_remove_baseline_snapshot(repo_path: str, group: str, artifact: str, version: str) -> dict | None:
     """Load baseline snapshot written by improve_library_coverage.py and delete the file."""
-    baseline_path = os.path.join(repo_path, "tests", "src", group, artifact, version, BASELINE_STATS_FILENAME)
+    test_version = resolve_test_version(repo_path, group, artifact, version)
+    baseline_path = os.path.join(repo_path, "tests", "src", group, artifact, test_version, BASELINE_STATS_FILENAME)
     if not os.path.isfile(baseline_path):
         return None
     try:
@@ -148,16 +150,18 @@ def stage_and_commit(
         repo_path: str,
 ) -> None:
     """Stage the expected files/directories and commit."""
+    test_version = resolve_test_version(repo_path, group, artifact, library_version)
+    metadata_version = resolve_metadata_version(repo_path, group, artifact, library_version)
     # Remove baseline stats snapshot before staging so it is not committed
     baseline_path = os.path.join(
-        repo_path, "tests", "src", group, artifact, library_version, BASELINE_STATS_FILENAME,
+        repo_path, "tests", "src", group, artifact, test_version, BASELINE_STATS_FILENAME,
     )
     if os.path.isfile(baseline_path):
         os.remove(baseline_path)
     candidate_paths = [
-        str(os.path.join("tests", "src", group, artifact, library_version)),
+        str(os.path.join("tests", "src", group, artifact, test_version)),
         str(os.path.join("metadata", group, artifact, "index.json")),
-        str(os.path.join("metadata", group, artifact, library_version)),
+        str(os.path.join("metadata", group, artifact, metadata_version)),
         str(os.path.relpath(stats_artifact_dir(repo_path, group, artifact), repo_path)),
     ]
     candidate_paths = [path for path in candidate_paths if os.path.exists(os.path.join(repo_path, path))]

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -4,6 +4,8 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import io
+import json
+import os
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -99,6 +101,31 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         )
 
         self.assertEqual(strategy._initial_part_covered_calls(report), 67)
+
+    def test_report_path_uses_indexed_test_version_for_reused_test_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_dir = os.path.join(tmpdir, "metadata", "org.example", "lib")
+            os.makedirs(metadata_dir)
+            with open(os.path.join(metadata_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "tested-versions": ["1.0.0", "1.0.1"],
+                        }
+                    ],
+                    index_file,
+                )
+
+            strategy = self._strategy(
+                library="org.example:lib:1.0.1",
+                reachability_repo_path=tmpdir,
+            )
+
+        self.assertIn(
+            os.path.join("tests", "src", "org.example", "lib", "1.0.0", "build", "reports"),
+            strategy.dynamic_access_report_path,
+        )
 
     def test_partially_covered_exhausted_class_is_persisted_for_continuation(self) -> None:
         class FakeAgent:
@@ -381,6 +408,8 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
 
     @staticmethod
     def _strategy(**context) -> DynamicAccessIterativeStrategy:
+        library = context.pop("library", "org.example:lib:1.0.0")
+        reachability_repo_path = context.pop("reachability_repo_path", "/tmp/reachability")
         return DynamicAccessIterativeStrategy(
             {
                 "model": "test-model",
@@ -390,8 +419,8 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                     "max-class-test-iterations": 1,
                 },
             },
-            library="org.example:lib:1.0.0",
-            reachability_repo_path="/tmp/reachability",
+            library=library,
+            reachability_repo_path=reachability_repo_path,
             **context,
         )
 

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -13,7 +13,13 @@ from ai_workflows.add_new_library_support import (
     write_add_new_library_support_metrics,
 )
 from ai_workflows.java_fail_workflow import JAVAC_CONFIG, resolve_fix_metrics_json, write_fix_metrics
-from utility_scripts.metrics_writer import count_test_only_metadata_entries, create_run_metrics_output_json
+from utility_scripts.library_stats import load_library_stats_entry, resolve_stats_file_path
+from utility_scripts.metrics_writer import (
+    count_metadata_entries,
+    count_test_only_metadata_entries,
+    create_run_metrics_output_json,
+    resolve_artifact_paths,
+)
 
 
 def _minimal_run_metrics(library: str = "org.example:demo:1.0.0") -> dict:
@@ -61,6 +67,225 @@ class DummyAgent:
 
 
 class MetricsPathTests(unittest.TestCase):
+    def test_count_metadata_entries_uses_metadata_version_for_tested_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo", "1.0.0")
+            metadata_index_dir = os.path.dirname(metadata_dir)
+            os.makedirs(metadata_dir)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "tested-versions": ["1.0.0", "1.0.1"],
+                        }
+                    ],
+                    file,
+                )
+            with open(os.path.join(metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "reflection": [
+                            {
+                                "type": "org.example.Demo",
+                                "methods": [{"name": "create"}],
+                            }
+                        ]
+                    },
+                    file,
+                )
+
+            self.assertEqual(count_metadata_entries(temp_dir, "org.example", "demo", "1.0.1"), 2)
+
+    def test_resolve_artifact_paths_uses_metadata_version_for_tested_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo", "1.0.0")
+            metadata_index_dir = os.path.dirname(metadata_dir)
+            tests_root = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "java",
+            )
+            os.makedirs(metadata_dir)
+            os.makedirs(tests_root)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "tested-versions": ["1.0.0", "1.0.1"],
+                        }
+                    ],
+                    file,
+                )
+            with open(os.path.join(metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump({"reflection": [{"type": "org.example.Demo"}]}, file)
+            with open(os.path.join(tests_root, "DemoTest.java"), "w", encoding="utf-8") as file:
+                file.write("class DemoTest {}\n")
+
+            _test_file, metadata_file = resolve_artifact_paths(
+                temp_dir,
+                "org.example",
+                "demo",
+                "1.0.1",
+                tests_root,
+            )
+
+            self.assertEqual(
+                metadata_file,
+                os.path.join("metadata", "org.example", "demo", "1.0.0", "reachability-metadata.json"),
+            )
+
+    def test_test_version_resolution_uses_first_tested_versions_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_index_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            shared_metadata_dir = os.path.join(metadata_index_dir, "11.14.1")
+            exact_metadata_dir = os.path.join(metadata_index_dir, "10.20.1")
+            shared_test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "11.14.1",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            exact_test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "10.20.1",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(shared_metadata_dir)
+            os.makedirs(exact_metadata_dir)
+            os.makedirs(shared_test_metadata_dir)
+            os.makedirs(exact_test_metadata_dir)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "11.14.1",
+                            "tested-versions": ["10.20.1", "11.14.1"],
+                        },
+                        {
+                            "metadata-version": "10.20.1",
+                            "tested-versions": ["10.20.1"],
+                        },
+                    ],
+                    file,
+                )
+            with open(
+                    os.path.join(shared_test_metadata_dir, "reachability-metadata.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as file:
+                json.dump({"reflection": [{"type": "org.example.Shared"}]}, file)
+            with open(
+                    os.path.join(shared_metadata_dir, "reachability-metadata.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as file:
+                json.dump({"reflection": [{"type": "org.example.Shared"}]}, file)
+            with open(
+                    os.path.join(exact_test_metadata_dir, "reachability-metadata.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as file:
+                json.dump({"reflection": [{"type": "org.example.Exact"}, {"type": "org.example.Other"}]}, file)
+            with open(
+                    os.path.join(exact_metadata_dir, "reachability-metadata.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as file:
+                json.dump({"reflection": [{"type": "org.example.Exact"}, {"type": "org.example.Other"}]}, file)
+
+            self.assertEqual(count_metadata_entries(temp_dir, "org.example", "demo", "10.20.1"), 1)
+            self.assertEqual(count_test_only_metadata_entries(temp_dir, "org.example", "demo", "10.20.1"), 1)
+
+    def test_stats_resolution_uses_first_tested_versions_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_index_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            shared_metadata_dir = os.path.join(metadata_index_dir, "11.14.1")
+            exact_metadata_dir = os.path.join(metadata_index_dir, "10.20.1")
+            shared_stats_dir = os.path.join(temp_dir, "stats", "org.example", "demo", "11.14.1")
+            exact_stats_dir = os.path.join(temp_dir, "stats", "org.example", "demo", "10.20.1")
+            os.makedirs(shared_metadata_dir)
+            os.makedirs(exact_metadata_dir)
+            os.makedirs(shared_stats_dir)
+            os.makedirs(exact_stats_dir)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "11.14.1",
+                            "tested-versions": ["10.20.1", "11.14.1"],
+                        },
+                        {
+                            "metadata-version": "10.20.1",
+                            "tested-versions": ["10.20.1"],
+                        },
+                    ],
+                    file,
+                )
+            with open(os.path.join(shared_stats_dir, "stats.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "versions": [
+                            {
+                                "version": "10.20.1",
+                                "dynamicAccess": {
+                                    "coveredCalls": 1,
+                                    "totalCalls": 4,
+                                    "coverageRatio": 0.25,
+                                    "breakdown": {},
+                                },
+                            }
+                        ]
+                    },
+                    file,
+                )
+            with open(os.path.join(exact_stats_dir, "stats.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "versions": [
+                            {
+                                "version": "10.20.1",
+                                "dynamicAccess": {
+                                    "coveredCalls": 9,
+                                    "totalCalls": 9,
+                                    "coverageRatio": 1.0,
+                                    "breakdown": {},
+                                },
+                            }
+                        ]
+                    },
+                    file,
+                )
+
+            self.assertEqual(
+                resolve_stats_file_path(temp_dir, "org.example", "demo", "10.20.1"),
+                os.path.join(shared_stats_dir, "stats.json"),
+            )
+            stats_entry = load_library_stats_entry(temp_dir, "org.example", "demo", "10.20.1")
+            self.assertEqual(stats_entry["dynamicAccess"]["coveredCalls"], 1)
+
     def test_count_test_only_metadata_entries_counts_direct_native_image_reachability_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             test_metadata_dir = os.path.join(

--- a/forge/utility_scripts/library_stats.py
+++ b/forge/utility_scripts/library_stats.py
@@ -10,43 +10,12 @@ Helpers for working with exploded library stats files under `stats/<group>/<arti
 import json
 import os
 
-
-def _load_index_entries(repo_path: str, group: str, artifact: str) -> list[dict] | None:
-    """Load `metadata/<group>/<artifact>/index.json` when present and valid."""
-    index_path = os.path.join(repo_path, "metadata", group, artifact, "index.json")
-    if not os.path.isfile(index_path):
-        return None
-
-    try:
-        with open(index_path, "r", encoding="utf-8") as index_file:
-            index_entries = json.load(index_file)
-    except (OSError, json.JSONDecodeError):
-        return None
-
-    if not isinstance(index_entries, list):
-        return None
-    return index_entries
+from utility_scripts.metadata_index import resolve_metadata_version
 
 
 def resolve_stats_metadata_version(repo_path: str, group: str, artifact: str, library_version: str) -> str:
     """Resolve the metadata-version directory that owns stats for a requested library version."""
-    index_entries = _load_index_entries(repo_path, group, artifact)
-    if not index_entries:
-        return library_version
-
-    for entry in index_entries:
-        metadata_version = str(entry.get("metadata-version") or "")
-        if metadata_version == library_version:
-            return metadata_version
-
-    for entry in index_entries:
-        tested_versions = entry.get("tested-versions") or []
-        if library_version in tested_versions:
-            metadata_version = str(entry.get("metadata-version") or "")
-            if metadata_version:
-                return metadata_version
-
-    return library_version
+    return resolve_metadata_version(repo_path, group, artifact, library_version)
 
 
 def stats_artifact_dir(repo_path: str, group: str, artifact: str) -> str:

--- a/forge/utility_scripts/metadata_index.py
+++ b/forge/utility_scripts/metadata_index.py
@@ -43,6 +43,64 @@ def load_index_entries(repo_path: str, group: str, artifact: str) -> list[dict[s
     return entries
 
 
+def find_index_entry_for_version(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        library_version: str,
+) -> dict[str, Any] | None:
+    """Return the index entry that declares support for a library version."""
+    entries = load_index_entries(repo_path, group, artifact)
+    if not entries:
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        tested_versions = entry.get("tested-versions") or []
+        if isinstance(tested_versions, list) and library_version in tested_versions:
+            return entry
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        metadata_version = entry.get("metadata-version")
+        if metadata_version == library_version:
+            return entry
+
+    return None
+
+
+def resolve_test_version(repo_path: str, group: str, artifact: str, library_version: str) -> str:
+    """Resolve the tests/src version directory for a supported library version."""
+    entry = find_index_entry_for_version(repo_path, group, artifact, library_version)
+    if entry is None:
+        return library_version
+
+    test_version = entry.get("test-version") or entry.get("metadata-version")
+    if isinstance(test_version, str) and test_version:
+        return test_version
+    return library_version
+
+
+def resolve_metadata_version(repo_path: str, group: str, artifact: str, library_version: str) -> str:
+    """Resolve the metadata version directory for a supported library version."""
+    entry = find_index_entry_for_version(repo_path, group, artifact, library_version)
+    if entry is None:
+        return library_version
+
+    metadata_version = entry.get("metadata-version")
+    if isinstance(metadata_version, str) and metadata_version:
+        return metadata_version
+    return library_version
+
+
+def resolve_test_dir(repo_path: str, group: str, artifact: str, library_version: str) -> str:
+    """Resolve the tests/src directory path for a supported library version."""
+    test_version = resolve_test_version(repo_path, group, artifact, library_version)
+    return os.path.join(repo_path, "tests", "src", group, artifact, test_version)
+
+
 def is_not_for_native_image_entry(entry: dict[str, Any]) -> bool:
     """Return true when an index entry is the marker entry."""
     return entry.get(NOT_FOR_NATIVE_IMAGE_FIELD) is True

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -18,6 +18,7 @@ import tempfile
 import utility_scripts.count_reachability_entries as reachability_metadata_count
 import utility_scripts.count_native_image_config_entries as legacy_metadata_count
 from utility_scripts.library_stats import load_library_stats_entry
+from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.source_context import resolve_test_source_layout
 from utility_scripts.strategy_loader import load_strategy_by_name
 from git_scripts.common_git import git_remote_exists
@@ -222,7 +223,8 @@ def count_generated_loc(root_dir: str) -> int:
 
 
 def count_metadata_entries(repo_path: str, package: str, artifact: str, library_version: str):
-    metadata_dir = os.path.join(repo_path, "metadata", package, artifact, library_version)
+    metadata_version = resolve_metadata_version(repo_path, package, artifact, library_version)
+    metadata_dir = os.path.join(repo_path, "metadata", package, artifact, metadata_version)
     reach_json = os.path.join(metadata_dir, "reachability-metadata.json")
 
     if os.path.isfile(reach_json):
@@ -267,34 +269,7 @@ def _get_repo_root() -> str:
 
 def _resolve_test_version_dir(repo_path: str, package: str, artifact: str, library_version: str) -> str:
     """Resolve the tests/src directory name for a library version using metadata index.json."""
-    index_path = os.path.join(repo_path, "metadata", package, artifact, "index.json")
-    if os.path.isfile(index_path):
-        try:
-            with open(index_path, "r", encoding="utf-8") as f:
-                entries = json.load(f)
-            for entry in entries:
-                tested = entry.get("tested-versions") or []
-                metadata_version = entry.get("metadata-version")
-                if library_version != metadata_version and library_version not in tested:
-                    continue
-
-                test_version = entry.get("test-version") or metadata_version
-                if not test_version:
-                    break
-
-                indexed_module_dir = os.path.join(repo_path, "tests", "src", package, artifact, str(test_version))
-                if os.path.isdir(indexed_module_dir):
-                    return str(test_version)
-
-                print(
-                    f"ERROR: Test directory specified in index.json (`{indexed_module_dir}`) is missing for "
-                    f"{package}:{artifact}:{library_version}.",
-                    file=sys.stderr,
-                )
-                break
-        except Exception:
-            pass
-    return library_version
+    return resolve_test_version(repo_path, package, artifact, library_version)
 
 
 def collect_version_coverage_metrics(repo_path: str, package: str, artifact: str, library_version: str):
@@ -479,12 +454,13 @@ def resolve_artifact_paths(repo_path, package, artifact, library_version, tests_
             break
 
     # Determine metadata_file path (either reachability-metadata.json or the metadata dir)
-    reach_json = os.path.join(repo_path, "metadata", package, artifact, library_version, "reachability-metadata.json")
+    metadata_version = resolve_metadata_version(repo_path, package, artifact, library_version)
+    reach_json = os.path.join(repo_path, "metadata", package, artifact, metadata_version, "reachability-metadata.json")
     if os.path.isfile(reach_json):
         metadata_file_path = os.path.relpath(reach_json, repo_path)
     else:
         metadata_file_path = os.path.relpath(
-            os.path.join(repo_path, "metadata", package, artifact, library_version),
+            os.path.join(repo_path, "metadata", package, artifact, metadata_version),
             repo_path,
         )
 


### PR DESCRIPTION
## Summary

Fixes #5085

- Resolve Forge metadata/test paths from `metadata/<group>/<artifact>/index.json` using the same first matching `tested-versions` entry as the Gradle harness.
- Apply the indexed test/metadata version consistently across `improve_library_coverage`, dynamic-access report paths, native-test output paths, metrics, stats lookup, human-intervention context, and improve-coverage PR creation.
- Add regressions for reused test projects and overlapping index entries like `org.flywaydb:flyway-core:10.20.1`.

## Testing

- `python3 -m unittest tests.test_metrics_paths tests.test_dynamic_access_iterative_strategy`
- `python3 -m py_compile utility_scripts/library_stats.py utility_scripts/metadata_index.py utility_scripts/metrics_writer.py tests/test_metrics_paths.py`
- `git diff --check`
- Direct resolver checks for `org.thymeleaf:thymeleaf:3.1.5.RELEASE` and `org.flywaydb:flyway-core:10.20.1`