### PR TITLE
[GenAI] Test fix for org.jboss.weld:weld-spi:2.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.weld/weld-spi/2.1.Final/reachability-metadata.json
+++ b/metadata/org.jboss.weld/weld-spi/2.1.Final/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.weld.bootstrap.api.SingletonProvider"
+      },
+      "type": "org.jboss.weld.bootstrap.api.helpers.IsolatedStaticSingletonProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jboss.weld/weld-spi/index.json
+++ b/metadata/org.jboss.weld/weld-spi/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.1.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-sources.jar",
+    "repository-url" : "https://github.com/weld/api",
+    "test-code-url" : "https://github.com/weld/api/tree/$version$/weld-spi/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-javadoc.jar",
+    "description" : "Weld SPI provides the service-provider interfaces used to integrate Weld, the CDI reference implementation, with Java EE containers and runtime services. It defines bootstrap, deployment, resource, transaction, security, validation, EJB, injection, servlet, and serialization contracts for container integration.",
     "tested-versions" : [
       "2.1.Final"
     ],

--- a/metadata/org.jboss.weld/weld-spi/index.json
+++ b/metadata/org.jboss.weld/weld-spi/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.1.Final",
+    "tested-versions" : [
+      "2.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.weld"
+    ]
+  },
+  {
     "metadata-version" : "2.0.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-sources.jar",
     "repository-url" : "https://github.com/weld/api",

--- a/stats/org.jboss.weld/weld-spi/2.1.Final/execution-metrics.json
+++ b/stats/org.jboss.weld/weld-spi/2.1.Final/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-03": {
+    "timestamp": "2026-05-03T06:48:18.701305Z",
+    "library": "org.jboss.weld:weld-spi:2.1.Final",
+    "starting_commit": "361d02de4b4b04a51469a2f7fe62443e11baa835",
+    "ending_commit": "32997601e400a9690f2c9f343f040b6530bee3d3",
+    "previous_library": "org.jboss.weld:weld-spi:2.0.Final",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 67,
+          "missed": 1429,
+          "ratio": 0.044786,
+          "total": 1496
+        },
+        "line": {
+          "covered": 26,
+          "missed": 317,
+          "ratio": 0.075802,
+          "total": 343
+        },
+        "method": {
+          "covered": 11,
+          "missed": 190,
+          "ratio": 0.054726,
+          "total": 201
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 67,
+          "missed": 1328,
+          "ratio": 0.048029,
+          "total": 1395
+        },
+        "line": {
+          "covered": 26,
+          "missed": 289,
+          "ratio": 0.08254,
+          "total": 315
+        },
+        "method": {
+          "covered": 11,
+          "missed": 174,
+          "ratio": 0.059459,
+          "total": 185
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 14141,
+      "cached_input_tokens_used": 40960,
+      "output_tokens_used": 1072,
+      "iterations": 1,
+      "cost_usd": 0.0527,
+      "tested_library_loc": 26,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 7.58,
+      "previous_library_coverage_percent": 8.25
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java",
+      "metadata_file": "metadata/org.jboss.weld/weld-spi/2.1.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.weld/weld-spi/2.1.Final/stats.json
+++ b/stats/org.jboss.weld/weld-spi/2.1.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 67,
+        "missed" : 1429,
+        "ratio" : 0.044786,
+        "total" : 1496
+      },
+      "line" : {
+        "covered" : 26,
+        "missed" : 317,
+        "ratio" : 0.075802,
+        "total" : 343
+      },
+      "method" : {
+        "covered" : 11,
+        "missed" : 190,
+        "ratio" : 0.054726,
+        "total" : 201
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/.gitignore
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/build.gradle
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.weld:weld-spi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/gradle.properties
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.weld:weld-spi:2.1.Final
+library.version = 2.1.Final
+metadata.dir = org.jboss.weld/weld-spi/2.1.Final/

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/settings.gradle
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.weld.weld-spi_tests'

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_weld.weld_spi;
+
+import org.jboss.weld.bootstrap.api.Singleton;
+import org.jboss.weld.bootstrap.api.SingletonProvider;
+import org.jboss.weld.bootstrap.api.helpers.IsolatedStaticSingletonProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SingletonProviderTest {
+    @BeforeEach
+    void resetBeforeTest() {
+        SingletonProvider.reset();
+    }
+
+    @AfterEach
+    void resetAfterTest() {
+        SingletonProvider.reset();
+    }
+
+    @Test
+    void instanceInitializesDefaultIsolatedStaticProvider() {
+        SingletonProvider provider = SingletonProvider.instance();
+
+        assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
+
+        Singleton<String> singleton = provider.create(String.class);
+        assertThat(singleton.isSet()).isFalse();
+        assertThatThrownBy(singleton::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Singleton is not set");
+
+        singleton.set("stored value");
+        assertThat(singleton.isSet()).isTrue();
+        assertThat(singleton.get()).isEqualTo("stored value");
+
+        singleton.clear();
+        assertThat(singleton.isSet()).isFalse();
+    }
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -17,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SingletonProviderTest {
+    private static final String SINGLETON_ID = "test-deployment";
+
     @BeforeEach
     void resetBeforeTest() {
         SingletonProvider.reset();
@@ -34,16 +36,16 @@ public class SingletonProviderTest {
         assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
 
         Singleton<String> singleton = provider.create(String.class);
-        assertThat(singleton.isSet()).isFalse();
-        assertThatThrownBy(singleton::get)
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
+        assertThatThrownBy(() -> singleton.get(SINGLETON_ID))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Singleton is not set");
 
-        singleton.set("stored value");
-        assertThat(singleton.isSet()).isTrue();
-        assertThat(singleton.get()).isEqualTo("stored value");
+        singleton.set(SINGLETON_ID, "stored value");
+        assertThat(singleton.isSet(SINGLETON_ID)).isTrue();
+        assertThat(singleton.get(SINGLETON_ID)).isEqualTo("stored value");
 
-        singleton.clear();
-        assertThat(singleton.isSet()).isFalse();
+        singleton.clear(SINGLETON_ID);
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
     }
 }

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:44:18">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4427-d56562a9/tests/src/org.jboss.weld/weld-spi/2.0.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="instanceInitializesDefaultIsolatedStaticProvider()" classname="org_jboss_weld.weld_spi.SingletonProviderTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_jboss_weld.weld_spi.SingletonProviderTest]/[method:instanceInitializesDefaultIsolatedStaticProvider()]
+display-name: instanceInitializesDefaultIsolatedStaticProvider()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:44:18">
+<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-03T08:47:02">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,13 +45,13 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4427-d56562a9/tests/src/org.jboss.weld/weld-spi/2.0.Final"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4842-b9ebde69/tests/src/org.jboss.weld/weld-spi/2.1.Final"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="instanceInitializesDefaultIsolatedStaticProvider()" classname="org_jboss_weld.weld_spi.SingletonProviderTest" time="0">
+<testcase name="instanceInitializesDefaultIsolatedStaticProvider()" classname="org_jboss_weld.weld_spi.SingletonProviderTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_jboss_weld.weld_spi.SingletonProviderTest]/[method:instanceInitializesDefaultIsolatedStaticProvider()]
 display-name: instanceInitializesDefaultIsolatedStaticProvider()

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:44:18">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4427-d56562a9/tests/src/org.jboss.weld/weld-spi/2.0.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-02T23:44:18">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:47:02">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4427-d56562a9/tests/src/org.jboss.weld/weld-spi/2.0.Final"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4842-b9ebde69/tests/src/org.jboss.weld/weld-spi/2.1.Final"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/org.jboss.weld/weld-spi/2.1.Final/user-code-filter.json
+++ b/tests/src/org.jboss.weld/weld-spi/2.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.weld.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4842

This PR provides test fixes and new metadata for org.jboss.weld:weld-spi:2.1.Final, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 14141
- Cached input tokens: 40960
- Output tokens: 1072
- Metadata entries: 2
- Iterations: 1
- Library coverage percentage: 7.58
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 8.25

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.weld:weld-spi:2.0.Final: 1/1 covered calls (100.00%)
- org.jboss.weld:weld-spi:2.1.Final: 1/1 covered calls (100.00%)

**Reflection:**
- org.jboss.weld:weld-spi:2.0.Final: 1/1 covered calls (100.00%)
- org.jboss.weld:weld-spi:2.1.Final: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.weld:weld-spi:2.0.Final: 67/1395 (4.80%)
- org.jboss.weld:weld-spi:2.1.Final: 67/1496 (4.48%)

**Line:**
- org.jboss.weld:weld-spi:2.0.Final: 26/315 (8.25%)
- org.jboss.weld:weld-spi:2.1.Final: 26/343 (7.58%)

**Method:**
- org.jboss.weld:weld-spi:2.0.Final: 11/185 (5.95%)
- org.jboss.weld:weld-spi:2.1.Final: 11/201 (5.47%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.weld/weld-spi/2.0.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java 2/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
index 5444cfbf65..a48d03e82c 100644
--- 1/tests/src/org.jboss.weld/weld-spi/2.0.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ 2/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -17,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SingletonProviderTest {
+    private static final String SINGLETON_ID = "test-deployment";
+
     @BeforeEach
     void resetBeforeTest() {
         SingletonProvider.reset();
@@ -34,16 +36,16 @@ public class SingletonProviderTest {
         assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
 
         Singleton<String> singleton = provider.create(String.class);
-        assertThat(singleton.isSet()).isFalse();
-        assertThatThrownBy(singleton::get)
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
+        assertThatThrownBy(() -> singleton.get(SINGLETON_ID))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Singleton is not set");
 
-        singleton.set("stored value");
-        assertThat(singleton.isSet()).isTrue();
-        assertThat(singleton.get()).isEqualTo("stored value");
+        singleton.set(SINGLETON_ID, "stored value");
+        assertThat(singleton.isSet(SINGLETON_ID)).isTrue();
+        assertThat(singleton.get(SINGLETON_ID)).isEqualTo("stored value");
 
-        singleton.clear();
-        assertThat(singleton.isSet()).isFalse();
+        singleton.clear(SINGLETON_ID);
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
     }
 }

```
