### PR TITLE
[GenAI] Test fix for org.junit.platform:junit-platform-engine:1.10.4 using gpt-5.5

### DIFF
--- a/metadata/org.junit.platform/junit-platform-engine/1.10.4/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-engine/1.10.4/reachability-metadata.json
@@ -1,0 +1,27 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService"
+      },
+      "type" : "java.util.concurrent.ForkJoinPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int",
+            "java.util.concurrent.ForkJoinPool$ForkJoinWorkerThreadFactory",
+            "java.lang.Thread$UncaughtExceptionHandler",
+            "boolean",
+            "int",
+            "int",
+            "int",
+            "java.util.function.Predicate",
+            "long",
+            "java.util.concurrent.TimeUnit"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.junit.platform/junit-platform-engine/index.json
+++ b/metadata/org.junit.platform/junit-platform-engine/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.10.4",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/$version$/junit-platform-engine-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit-framework",
+    "test-code-url" : "https://github.com/junit-team/junit-framework/tree/r5.10.4/platform-tests/src/test/java/org/junit/platform/engine",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/$version$/junit-platform-engine-$version$-javadoc.jar",
+    "description" : "JUnit Platform Engine defines the API and support classes for test engines that plug into the JUnit Platform. It provides discovery selectors, filters, test descriptors, execution listeners, reporting types, and hierarchical execution support used by engines to discover and run tests.",
     "tested-versions" : [
       "1.10.4"
     ],

--- a/metadata/org.junit.platform/junit-platform-engine/index.json
+++ b/metadata/org.junit.platform/junit-platform-engine/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.10.4",
+    "tested-versions" : [
+      "1.10.4"
+    ],
+    "allowed-packages" : [
+      "org.junit.platform.engine"
+    ]
+  },
+  {
     "metadata-version" : "1.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/$version$/junit-platform-engine-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/stats/org.junit.platform/junit-platform-engine/1.10.4/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-engine/1.10.4/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-03": {
+    "timestamp": "2026-05-03T06:49:21.241482Z",
+    "library": "org.junit.platform:junit-platform-engine:1.10.4",
+    "starting_commit": "67f860979076f11ff8de2d215de860b81db11937",
+    "ending_commit": "aec47befe009695b7194664136682cadff34fd80",
+    "previous_library": "org.junit.platform:junit-platform-engine:1.8.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.10.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2999,
+          "missed": 6965,
+          "ratio": 0.300984,
+          "total": 9964
+        },
+        "line": {
+          "covered": 703,
+          "missed": 1428,
+          "ratio": 0.329892,
+          "total": 2131
+        },
+        "method": {
+          "covered": 285,
+          "missed": 545,
+          "ratio": 0.343373,
+          "total": 830
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.8.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2415,
+          "missed": 6273,
+          "ratio": 0.27797,
+          "total": 8688
+        },
+        "line": {
+          "covered": 573,
+          "missed": 1276,
+          "ratio": 0.309897,
+          "total": 1849
+        },
+        "method": {
+          "covered": 241,
+          "missed": 494,
+          "ratio": 0.327891,
+          "total": 735
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 22974,
+      "cached_input_tokens_used": 59904,
+      "output_tokens_used": 1141,
+      "iterations": 1,
+      "cost_usd": 0.0642,
+      "tested_library_loc": 703,
+      "metadata_entries": 2,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 32.99,
+      "previous_library_coverage_percent": 30.99
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java",
+      "metadata_file": "metadata/org.junit.platform/junit-platform-engine/1.10.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.junit.platform/junit-platform-engine/1.10.4/stats.json
+++ b/stats/org.junit.platform/junit-platform-engine/1.10.4/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.10.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2999,
+        "missed" : 6965,
+        "ratio" : 0.300984,
+        "total" : 9964
+      },
+      "line" : {
+        "covered" : 703,
+        "missed" : 1428,
+        "ratio" : 0.329892,
+        "total" : 2131
+      },
+      "method" : {
+        "covered" : 285,
+        "missed" : 545,
+        "ratio" : 0.343373,
+        "total" : 830
+      }
+    }
+  } ]
+}

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/.gitignore
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.platform:junit-platform-engine:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/gradle.properties
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.platform:junit-platform-engine:1.10.4
+library.version = 1.10.4
+metadata.dir = org.junit.platform/junit-platform-engine/1.10.4/

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/settings.gradle
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.platform.junit-platform-engine_tests'

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService;
+import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService.TestTask;
+import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
+import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfiguration;
+import org.junit.platform.engine.support.hierarchical.ResourceLock;
+
+public class ForkJoinPoolHierarchicalTestExecutorServiceTest {
+
+    @Test
+    void createsForkJoinPoolAndExecutesSubmittedTask() throws Exception {
+        AtomicBoolean executed = new AtomicBoolean(false);
+
+        try (ForkJoinPoolHierarchicalTestExecutorService executorService =
+                new ForkJoinPoolHierarchicalTestExecutorService(new FixedParallelExecutionConfiguration())) {
+            Future<Void> future = executorService.submit(new RecordingTestTask(executed));
+
+            assertThat(future.get(5, TimeUnit.SECONDS)).isNull();
+        }
+
+        assertThat(executed).isTrue();
+    }
+
+    private static final class FixedParallelExecutionConfiguration implements ParallelExecutionConfiguration {
+
+        @Override
+        public int getParallelism() {
+            return 2;
+        }
+
+        @Override
+        public int getMinimumRunnable() {
+            return 1;
+        }
+
+        @Override
+        public int getMaxPoolSize() {
+            return 4;
+        }
+
+        @Override
+        public int getCorePoolSize() {
+            return 2;
+        }
+
+        @Override
+        public int getKeepAliveSeconds() {
+            return 30;
+        }
+    }
+
+    private static final class RecordingTestTask implements TestTask {
+
+        private static final ResourceLock NO_OP_RESOURCE_LOCK = new NoOpResourceLock();
+
+        private final AtomicBoolean executed;
+
+        private RecordingTestTask(AtomicBoolean executed) {
+            this.executed = executed;
+        }
+
+        @Override
+        public ExecutionMode getExecutionMode() {
+            return CONCURRENT;
+        }
+
+        @Override
+        public ResourceLock getResourceLock() {
+            return NO_OP_RESOURCE_LOCK;
+        }
+
+        @Override
+        public void execute() {
+            executed.set(true);
+        }
+    }
+
+    private static final class NoOpResourceLock implements ResourceLock {
+
+        @Override
+        public ResourceLock acquire() {
+            return this;
+        }
+
+        @Override
+        public void release() {
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
@@ -9,11 +9,13 @@ package org_junit_platform.junit_platform_engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
 
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
 import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService.TestTask;
 import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
@@ -99,6 +101,16 @@ public class ForkJoinPoolHierarchicalTestExecutorServiceTest {
 
         @Override
         public void release() {
+        }
+
+        @Override
+        public List<ExclusiveResource> getResources() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isExclusive() {
+            return false;
         }
     }
 }

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution"
+      },
+      "type" : "org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.engine.support.discovery.SelectorResolver$Match"
+      },
+      "type" : "org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest"
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:24:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2234-744af6d0/tests/src/org.junit.platform/junit-platform-engine/1.8.2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="createsForkJoinPoolAndExecutesSubmittedTask()" classname="org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest]/[method:createsForkJoinPoolAndExecutesSubmittedTask()]
+display-name: createsForkJoinPoolAndExecutesSubmittedTask()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:24:32">
+<testsuite name="JUnit Jupiter" tests="1" skipped="0" failures="0" errors="0" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-03T08:47:26">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,13 +45,13 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2234-744af6d0/tests/src/org.junit.platform/junit-platform-engine/1.8.2"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4844-09d0fb68/tests/src/org.junit.platform/junit-platform-engine/1.10.4"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="createsForkJoinPoolAndExecutesSubmittedTask()" classname="org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest" time="0">
+<testcase name="createsForkJoinPoolAndExecutesSubmittedTask()" classname="org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_junit_platform.junit_platform_engine.ForkJoinPoolHierarchicalTestExecutorServiceTest]/[method:createsForkJoinPoolAndExecutesSubmittedTask()]
 display-name: createsForkJoinPoolAndExecutesSubmittedTask()

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:24:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2234-744af6d0/tests/src/org.junit.platform/junit-platform-engine/1.8.2"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T02:24:32">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:47:26">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -45,7 +45,7 @@
 <property name="sun.arch.data.model" value="64"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge9/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2234-744af6d0/tests/src/org.junit.platform/junit-platform-engine/1.8.2"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4844-09d0fb68/tests/src/org.junit.platform/junit-platform-engine/1.10.4"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/org.junit.platform/junit-platform-engine/1.10.4/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-engine/1.10.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.junit.platform.engine.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4844

This PR provides test fixes and new metadata for org.junit.platform:junit-platform-engine:1.10.4, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 22974
- Cached input tokens: 59904
- Output tokens: 1141
- Metadata entries: 2
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 32.99
- Previous library version metadata entries: 2
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 30.99

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.junit.platform:junit-platform-engine:1.8.2: 1/1 covered calls (100.00%)
- org.junit.platform:junit-platform-engine:1.10.4: 1/1 covered calls (100.00%)

**Reflection:**
- org.junit.platform:junit-platform-engine:1.8.2: 1/1 covered calls (100.00%)
- org.junit.platform:junit-platform-engine:1.10.4: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.junit.platform:junit-platform-engine:1.8.2: 2415/8688 (27.80%)
- org.junit.platform:junit-platform-engine:1.10.4: 2999/9964 (30.10%)

**Line:**
- org.junit.platform:junit-platform-engine:1.8.2: 573/1849 (30.99%)
- org.junit.platform:junit-platform-engine:1.10.4: 703/2131 (32.99%)

**Method:**
- org.junit.platform:junit-platform-engine:1.8.2: 241/735 (32.79%)
- org.junit.platform:junit-platform-engine:1.10.4: 285/830 (34.34%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.junit.platform/junit-platform-engine/1.8.2/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java 2/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
index 85e9b66025..6bf59d774e 100644
--- 1/tests/src/org.junit.platform/junit-platform-engine/1.8.2/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
+++ 2/tests/src/org.junit.platform/junit-platform-engine/1.10.4/src/test/java/org_junit_platform/junit_platform_engine/ForkJoinPoolHierarchicalTestExecutorServiceTest.java
@@ -9,11 +9,13 @@ package org_junit_platform.junit_platform_engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
 
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
 import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService.TestTask;
 import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
@@ -100,5 +102,15 @@ public class ForkJoinPoolHierarchicalTestExecutorServiceTest {
         @Override
         public void release() {
         }
+
+        @Override
+        public List<ExclusiveResource> getResources() {
+            return List.of();
+        }
+
+        @Override
+        public boolean isExclusive() {
+            return false;
+        }
     }
 }

```
