### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:6.116.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/reachability-metadata.json
@@ -1,0 +1,116 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnforceNamingStyle"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$VisibilityFeature$DefaultSymbolVisibility"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.ReplicaInfo"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.ReplicaInfo"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.ReplicaInfo"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.116.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-cloud-spanner-admin-instance-v1/$version$/proto-google-cloud-spanner-admin-instance-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/google-cloud-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-cloud-spanner-admin-instance-v1/$version$/proto-google-cloud-spanner-admin-instance-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-cloud-spanner-admin-instance-v1/$version$/proto-google-cloud-spanner-admin-instance-v1-$version$-javadoc.jar",
+    "description" : "This artifact contains the generated Java Protocol Buffer model classes for the Cloud Spanner Instance Admin v1 API. It provides message types, resource-name helpers, and protobuf descriptors used by higher-level Spanner admin gRPC and client libraries to create, list, update, and delete instances, instance configs, and instance partitions.",
+    "tested-versions" : [
+      "6.116.1"
+    ],
+    "allowed-packages" : [
+      "com.google.spanner.admin.instance.v1"
+    ]
+  }
+]

--- a/stats/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T07:02:06.702584Z",
+    "library": "com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:6.116.1",
+    "starting_commit": "1b15d2cafac2a99104a1c33cc91f5f34588109d7",
+    "ending_commit": "054b70104261bfc8ed43babc9b1a8c97478b0b1b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.116.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 13660,
+          "missed": 50909,
+          "ratio": 0.211557,
+          "total": 64569
+        },
+        "line": {
+          "covered": 3665,
+          "missed": 13625,
+          "ratio": 0.211972,
+          "total": 17290
+        },
+        "method": {
+          "covered": 911,
+          "missed": 3052,
+          "ratio": 0.229876,
+          "total": 3963
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 128289,
+      "cached_input_tokens_used": 1921024,
+      "output_tokens_used": 21585,
+      "iterations": 3,
+      "cost_usd": 1.608,
+      "generated_loc": 534,
+      "tested_library_loc": 3665,
+      "metadata_entries": 19,
+      "code_coverage_percent": 21.2
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.116.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 13660,
+        "missed" : 50909,
+        "ratio" : 0.211557,
+        "total" : 64569
+      },
+      "line" : {
+        "covered" : 3665,
+        "missed" : 13625,
+        "ratio" : 0.211972,
+        "total" : 17290
+      },
+      "method" : {
+        "covered" : 911,
+        "missed" : 3052,
+        "ratio" : 0.229876,
+        "total" : 3963
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:6.116.1
+library.version = 6.116.1
+metadata.dir = com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-cloud-spanner-admin-instance-v1_tests'

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
@@ -8,7 +8,15 @@ package com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1;
 
 import java.util.List;
 
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
@@ -59,6 +67,7 @@ import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
 import com.google.spanner.admin.instance.v1.UpdateInstancePartitionMetadata;
 import com.google.spanner.admin.instance.v1.UpdateInstancePartitionRequest;
 import com.google.spanner.admin.instance.v1.UpdateInstanceRequest;
+import com.google.type.Expr;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -360,6 +369,66 @@ public class Proto_google_cloud_spanner_admin_instance_v1Test {
                 .isEqualTo(FulfillmentPeriod.FULFILLMENT_PERIOD_NORMAL);
         assertThat(updateInstanceMetadata.getExpectedFulfillmentPeriod())
                 .isEqualTo(FulfillmentPeriod.FULFILLMENT_PERIOD_EXTENDED);
+    }
+
+    @Test
+    void createsIamPolicyRequestsForInstanceAdminResources() {
+        String instanceResource = InstanceName.format(PROJECT, INSTANCE_ID);
+        Binding adminBinding = Binding.newBuilder()
+                .setRole("roles/spanner.admin")
+                .addMembers("user:admin@example.com")
+                .build();
+        Binding conditionalReaderBinding = Binding.newBuilder()
+                .setRole("roles/spanner.viewer")
+                .addMembers("group:readers@example.com")
+                .setCondition(Expr.newBuilder()
+                        .setTitle("limited-access")
+                        .setDescription("Only grant viewer access for approved requests.")
+                        .setExpression("request.auth.claims.approved == true"))
+                .build();
+        Policy policy = Policy.newBuilder()
+                .setVersion(3)
+                .addBindings(adminBinding)
+                .addBindings(conditionalReaderBinding)
+                .setEtag(ByteString.copyFromUtf8("policy-etag"))
+                .build();
+
+        SetIamPolicyRequest setPolicy = SetIamPolicyRequest.newBuilder()
+                .setResource(instanceResource)
+                .setPolicy(policy)
+                .setUpdateMask(FieldMask.newBuilder().addPaths("bindings").addPaths("etag"))
+                .build();
+        GetIamPolicyRequest getPolicy = GetIamPolicyRequest.newBuilder()
+                .setResource(instanceResource)
+                .setOptions(GetPolicyOptions.newBuilder().setRequestedPolicyVersion(3))
+                .build();
+        TestIamPermissionsRequest testPermissions = TestIamPermissionsRequest.newBuilder()
+                .setResource(instanceResource)
+                .addPermissions("spanner.instances.get")
+                .addPermissions("spanner.instances.update")
+                .build();
+        TestIamPermissionsResponse permissionsResponse = TestIamPermissionsResponse.newBuilder()
+                .addPermissions("spanner.instances.get")
+                .build();
+        Descriptors.ServiceDescriptor instanceAdminService =
+                SpannerInstanceAdminProto.getDescriptor().findServiceByName("InstanceAdmin");
+
+        assertThat(setPolicy.getResource()).isEqualTo(instanceResource);
+        assertThat(setPolicy.getPolicy().getVersion()).isEqualTo(3);
+        assertThat(setPolicy.getPolicy().getBindingsList()).containsExactly(adminBinding, conditionalReaderBinding);
+        assertThat(setPolicy.getPolicy().getBindings(1).getCondition().getExpression())
+                .isEqualTo("request.auth.claims.approved == true");
+        assertThat(setPolicy.getUpdateMask().getPathsList()).containsExactly("bindings", "etag");
+        assertThat(getPolicy.getOptions().getRequestedPolicyVersion()).isEqualTo(3);
+        assertThat(testPermissions.getPermissionsList())
+                .containsExactly("spanner.instances.get", "spanner.instances.update");
+        assertThat(permissionsResponse.getPermissionsList()).containsExactly("spanner.instances.get");
+        assertThat(instanceAdminService.findMethodByName("SetIamPolicy").getInputType().getFullName())
+                .isEqualTo("google.iam.v1.SetIamPolicyRequest");
+        assertThat(instanceAdminService.findMethodByName("GetIamPolicy").getOutputType().getFullName())
+                .isEqualTo("google.iam.v1.Policy");
+        assertThat(instanceAdminService.findMethodByName("TestIamPermissions").getOutputType().getFullName())
+                .isEqualTo("google.iam.v1.TestIamPermissionsResponse");
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
@@ -363,6 +363,45 @@ public class Proto_google_cloud_spanner_admin_instance_v1Test {
     }
 
     @Test
+    void buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences() {
+        AutoscalingConfig autoscalingConfig = AutoscalingConfig.newBuilder()
+                .setAutoscalingLimits(AutoscalingConfig.AutoscalingLimits.newBuilder()
+                        .setMinProcessingUnits(300)
+                        .setMaxProcessingUnits(1_200))
+                .setAutoscalingTargets(AutoscalingConfig.AutoscalingTargets.newBuilder()
+                        .setHighPriorityCpuUtilizationPercent(60)
+                        .setStorageUtilizationPercent(85))
+                .build();
+        String backup = "projects/sample-project/instances/test-instance/backups/nightly";
+
+        InstancePartition partition = InstancePartition.newBuilder()
+                .setName(InstancePartitionName.format(PROJECT, INSTANCE_ID, PARTITION_ID))
+                .setConfig(InstanceConfigName.format(PROJECT, CONFIG_ID))
+                .setDisplayName("Autoscaled Partition")
+                .setProcessingUnits(600)
+                .setAutoscalingConfig(autoscalingConfig)
+                .setState(InstancePartition.State.READY)
+                .addReferencingBackups(backup)
+                .build();
+        InstancePartition capacityCleared = partition.toBuilder().clearProcessingUnits().build();
+
+        assertThat(partition.getComputeCapacityCase())
+                .isEqualTo(InstancePartition.ComputeCapacityCase.PROCESSING_UNITS);
+        assertThat(partition.hasProcessingUnits()).isTrue();
+        assertThat(partition.hasNodeCount()).isFalse();
+        assertThat(partition.getProcessingUnits()).isEqualTo(600);
+        assertThat(partition.hasAutoscalingConfig()).isTrue();
+        assertThat(partition.getAutoscalingConfig().getAutoscalingLimits().getMaxLimitCase())
+                .isEqualTo(AutoscalingConfig.AutoscalingLimits.MaxLimitCase.MAX_PROCESSING_UNITS);
+        assertThat(partition.getAutoscalingConfig().getAutoscalingTargets().getStorageUtilizationPercent())
+                .isEqualTo(85);
+        assertThat(partition.getReferencingBackupsList()).containsExactly(backup);
+        assertThat(capacityCleared.getComputeCapacityCase())
+                .isEqualTo(InstancePartition.ComputeCapacityCase.COMPUTECAPACITY_NOT_SET);
+        assertThat(capacityCleared.hasAutoscalingConfig()).isTrue();
+    }
+
+    @Test
     void createsInstancePartitionMessagesAndMoveInstanceMetadata() {
         FieldMask partitionMask = FieldMask.newBuilder().addPaths("display_name").addPaths("node_count").build();
         Timestamp startTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).build();

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
@@ -6,11 +6,452 @@
  */
 package com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1;
 
+import java.util.List;
+
+import com.google.longrunning.Operation;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
+import com.google.spanner.admin.instance.v1.AutoscalingConfig;
+import com.google.spanner.admin.instance.v1.CommonProto;
+import com.google.spanner.admin.instance.v1.CreateInstanceConfigMetadata;
+import com.google.spanner.admin.instance.v1.CreateInstanceConfigRequest;
+import com.google.spanner.admin.instance.v1.CreateInstanceMetadata;
+import com.google.spanner.admin.instance.v1.CreateInstancePartitionMetadata;
+import com.google.spanner.admin.instance.v1.CreateInstancePartitionRequest;
+import com.google.spanner.admin.instance.v1.CreateInstanceRequest;
+import com.google.spanner.admin.instance.v1.DeleteInstanceConfigRequest;
+import com.google.spanner.admin.instance.v1.DeleteInstancePartitionRequest;
+import com.google.spanner.admin.instance.v1.DeleteInstanceRequest;
+import com.google.spanner.admin.instance.v1.FreeInstanceMetadata;
+import com.google.spanner.admin.instance.v1.FulfillmentPeriod;
+import com.google.spanner.admin.instance.v1.GetInstanceConfigRequest;
+import com.google.spanner.admin.instance.v1.GetInstancePartitionRequest;
+import com.google.spanner.admin.instance.v1.GetInstanceRequest;
+import com.google.spanner.admin.instance.v1.Instance;
+import com.google.spanner.admin.instance.v1.InstanceConfig;
+import com.google.spanner.admin.instance.v1.InstanceConfigName;
+import com.google.spanner.admin.instance.v1.InstanceName;
+import com.google.spanner.admin.instance.v1.InstancePartition;
+import com.google.spanner.admin.instance.v1.InstancePartitionName;
+import com.google.spanner.admin.instance.v1.ListInstanceConfigOperationsRequest;
+import com.google.spanner.admin.instance.v1.ListInstanceConfigOperationsResponse;
+import com.google.spanner.admin.instance.v1.ListInstanceConfigsRequest;
+import com.google.spanner.admin.instance.v1.ListInstanceConfigsResponse;
+import com.google.spanner.admin.instance.v1.ListInstancePartitionOperationsRequest;
+import com.google.spanner.admin.instance.v1.ListInstancePartitionOperationsResponse;
+import com.google.spanner.admin.instance.v1.ListInstancePartitionsRequest;
+import com.google.spanner.admin.instance.v1.ListInstancePartitionsResponse;
+import com.google.spanner.admin.instance.v1.ListInstancesRequest;
+import com.google.spanner.admin.instance.v1.ListInstancesResponse;
+import com.google.spanner.admin.instance.v1.MoveInstanceMetadata;
+import com.google.spanner.admin.instance.v1.MoveInstanceRequest;
+import com.google.spanner.admin.instance.v1.MoveInstanceResponse;
+import com.google.spanner.admin.instance.v1.OperationProgress;
+import com.google.spanner.admin.instance.v1.ProjectName;
+import com.google.spanner.admin.instance.v1.ReplicaComputeCapacity;
+import com.google.spanner.admin.instance.v1.ReplicaInfo;
+import com.google.spanner.admin.instance.v1.ReplicaSelection;
+import com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto;
+import com.google.spanner.admin.instance.v1.UpdateInstanceConfigMetadata;
+import com.google.spanner.admin.instance.v1.UpdateInstanceConfigRequest;
+import com.google.spanner.admin.instance.v1.UpdateInstanceMetadata;
+import com.google.spanner.admin.instance.v1.UpdateInstancePartitionMetadata;
+import com.google.spanner.admin.instance.v1.UpdateInstancePartitionRequest;
+import com.google.spanner.admin.instance.v1.UpdateInstanceRequest;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_spanner_admin_instance_v1Test {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Proto_google_cloud_spanner_admin_instance_v1Test {
+    private static final String PROJECT = "sample-project";
+    private static final String INSTANCE_ID = "test-instance";
+    private static final String CONFIG_ID = "regional-us-central1";
+    private static final String PARTITION_ID = "read-only-partition";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void resourceNamesRoundTripThroughGeneratedHelpers() {
+        ProjectName projectName = ProjectName.of(PROJECT);
+        InstanceConfigName configName = InstanceConfigName.of(PROJECT, CONFIG_ID);
+        InstanceName instanceName = InstanceName.of(PROJECT, INSTANCE_ID);
+        InstancePartitionName partitionName = InstancePartitionName.of(PROJECT, INSTANCE_ID, PARTITION_ID);
+
+        assertThat(projectName.toString()).isEqualTo("projects/" + PROJECT);
+        assertThat(ProjectName.parse(projectName.toString())).isEqualTo(projectName);
+        assertThat(projectName.toBuilder().setProject("other-project").build().toString())
+                .isEqualTo("projects/other-project");
+
+        assertThat(InstanceConfigName.isParsableFrom(configName.toString())).isTrue();
+        assertThat(InstanceConfigName.parse(configName.toString()).getFieldValuesMap())
+                .containsEntry("project", PROJECT)
+                .containsEntry("instance_config", CONFIG_ID);
+        assertThat(InstanceConfigName.format(PROJECT, CONFIG_ID)).isEqualTo(configName.toString());
+
+        assertThat(InstanceName.parse(instanceName.toString()).getInstance()).isEqualTo(INSTANCE_ID);
+        assertThat(InstanceName.toStringList(List.of(instanceName))).containsExactly(instanceName.toString());
+        assertThat(InstanceName.parseList(List.of(instanceName.toString()))).containsExactly(instanceName);
+
+        assertThat(InstancePartitionName.parse(partitionName.toString()).getInstancePartition())
+                .isEqualTo(PARTITION_ID);
+        assertThat(partitionName.getFieldValue("instance_partition")).isEqualTo(PARTITION_ID);
+    }
+
+    @Test
+    void descriptorsExposeCommonMessagesAndInstanceAdminService() {
+        Descriptors.FileDescriptor commonDescriptor = CommonProto.getDescriptor();
+        Descriptors.FileDescriptor adminDescriptor = SpannerInstanceAdminProto.getDescriptor();
+
+        assertThat(commonDescriptor.findMessageTypeByName("OperationProgress").getFields())
+                .extracting(Descriptors.FieldDescriptor::getName)
+                .containsExactly("progress_percent", "start_time", "end_time");
+        assertThat(adminDescriptor.findMessageTypeByName("Instance")
+                .findFieldByName("autoscaling_config")
+                .getMessageType()
+                .getFullName())
+                .isEqualTo("google.spanner.admin.instance.v1.AutoscalingConfig");
+        assertThat(adminDescriptor.findServiceByName("InstanceAdmin").getMethods())
+                .extracting(Descriptors.MethodDescriptor::getName)
+                .contains(
+                        "ListInstanceConfigs",
+                        "CreateInstanceConfig",
+                        "ListInstances",
+                        "CreateInstance",
+                        "CreateInstancePartition",
+                        "MoveInstance");
+    }
+
+    @Test
+    void buildsInstanceConfigWithReplicasLabelsAndEnumFields() {
+        ReplicaInfo leaderReplica = ReplicaInfo.newBuilder()
+                .setLocation("us-central1")
+                .setType(ReplicaInfo.ReplicaType.READ_WRITE)
+                .setDefaultLeaderLocation(true)
+                .build();
+        ReplicaInfo readOnlyReplica = ReplicaInfo.newBuilder()
+                .setLocation("us-east1")
+                .setType(ReplicaInfo.ReplicaType.READ_ONLY)
+                .build();
+
+        InstanceConfig instanceConfig = InstanceConfig.newBuilder()
+                .setName(InstanceConfigName.format(PROJECT, CONFIG_ID))
+                .setDisplayName("Regional test config")
+                .setConfigType(InstanceConfig.Type.USER_MANAGED)
+                .addReplicas(leaderReplica)
+                .addOptionalReplicas(readOnlyReplica)
+                .setBaseConfig(InstanceConfigName.format(PROJECT, "regional-us-east1"))
+                .putLabels("env", "test")
+                .putLabels("team", "spanner")
+                .setEtag("config-etag")
+                .addLeaderOptions("us-central1")
+                .setReconciling(true)
+                .setState(InstanceConfig.State.CREATING)
+                .setFreeInstanceAvailability(InstanceConfig.FreeInstanceAvailability.AVAILABLE)
+                .setQuorumType(InstanceConfig.QuorumType.REGION)
+                .setStorageLimitPerProcessingUnit(1024L)
+                .build();
+
+        assertThat(instanceConfig.getName()).isEqualTo(InstanceConfigName.format(PROJECT, CONFIG_ID));
+        assertThat(instanceConfig.getReplicasList()).containsExactly(leaderReplica);
+        assertThat(instanceConfig.getOptionalReplicas(0).getType()).isEqualTo(ReplicaInfo.ReplicaType.READ_ONLY);
+        assertThat(instanceConfig.getLabelsMap()).containsEntry("env", "test").containsEntry("team", "spanner");
+        assertThat(instanceConfig.getLeaderOptionsList()).containsExactly("us-central1");
+        assertThat(instanceConfig.getState()).isEqualTo(InstanceConfig.State.CREATING);
+        assertThat(instanceConfig.getConfigTypeValue()).isEqualTo(InstanceConfig.Type.USER_MANAGED.getNumber());
+        assertThat(instanceConfig.toBuilder().setState(InstanceConfig.State.READY).build().getState())
+                .isEqualTo(InstanceConfig.State.READY);
+    }
+
+    @Test
+    void buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata() {
+        Timestamp createdAt = Timestamp.newBuilder().setSeconds(1_700_000_000L).build();
+        Timestamp updatedAt = Timestamp.newBuilder().setSeconds(1_700_000_100L).build();
+        AutoscalingConfig.AutoscalingLimits limits = AutoscalingConfig.AutoscalingLimits.newBuilder()
+                .setMinProcessingUnits(1_000)
+                .setMaxProcessingUnits(4_000)
+                .build();
+        AutoscalingConfig.AutoscalingTargets targets = AutoscalingConfig.AutoscalingTargets.newBuilder()
+                .setHighPriorityCpuUtilizationPercent(65)
+                .setTotalCpuUtilizationPercent(75)
+                .setStorageUtilizationPercent(80)
+                .build();
+        ReplicaSelection selection = ReplicaSelection.newBuilder().setLocation("us-east1").build();
+        AutoscalingConfig.AsymmetricAutoscalingOption.AutoscalingConfigOverrides overrides =
+                AutoscalingConfig.AsymmetricAutoscalingOption.AutoscalingConfigOverrides.newBuilder()
+                        .setAutoscalingLimits(AutoscalingConfig.AutoscalingLimits.newBuilder()
+                                .setMinProcessingUnits(500)
+                                .setMaxProcessingUnits(2_000))
+                        .setAutoscalingTargetHighPriorityCpuUtilizationPercent(55)
+                        .setAutoscalingTargetTotalCpuUtilizationPercent(60)
+                        .setDisableHighPriorityCpuAutoscaling(false)
+                        .setDisableTotalCpuAutoscaling(false)
+                        .build();
+        AutoscalingConfig autoscalingConfig = AutoscalingConfig.newBuilder()
+                .setAutoscalingLimits(limits)
+                .setAutoscalingTargets(targets)
+                .addAsymmetricAutoscalingOptions(AutoscalingConfig.AsymmetricAutoscalingOption.newBuilder()
+                        .setReplicaSelection(selection)
+                        .setOverrides(overrides))
+                .build();
+        ReplicaComputeCapacity replicaCapacity = ReplicaComputeCapacity.newBuilder()
+                .setReplicaSelection(selection)
+                .setProcessingUnits(1_000)
+                .build();
+        FreeInstanceMetadata freeMetadata = FreeInstanceMetadata.newBuilder()
+                .setExpireTime(updatedAt)
+                .setUpgradeTime(updatedAt)
+                .setExpireBehavior(FreeInstanceMetadata.ExpireBehavior.FREE_TO_PROVISIONED)
+                .build();
+
+        Instance instance = Instance.newBuilder()
+                .setName(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setConfig(InstanceConfigName.format(PROJECT, CONFIG_ID))
+                .setDisplayName("Integration Test")
+                .setProcessingUnits(1_000)
+                .addReplicaComputeCapacity(replicaCapacity)
+                .setAutoscalingConfig(autoscalingConfig)
+                .setState(Instance.State.READY)
+                .putLabels("component", "admin")
+                .setInstanceType(Instance.InstanceType.FREE_INSTANCE)
+                .setCreateTime(createdAt)
+                .setUpdateTime(updatedAt)
+                .setFreeInstanceMetadata(freeMetadata)
+                .setEdition(Instance.Edition.ENTERPRISE)
+                .setDefaultBackupScheduleType(Instance.DefaultBackupScheduleType.NONE)
+                .build();
+
+        assertThat(instance.getProcessingUnits()).isEqualTo(1_000);
+        assertThat(instance.getAutoscalingConfig().getAutoscalingLimits().getMinLimitCase())
+                .isEqualTo(AutoscalingConfig.AutoscalingLimits.MinLimitCase.MIN_PROCESSING_UNITS);
+        assertThat(instance.getAutoscalingConfig().getAutoscalingLimits().getMaxLimitCase())
+                .isEqualTo(AutoscalingConfig.AutoscalingLimits.MaxLimitCase.MAX_PROCESSING_UNITS);
+        assertThat(instance.getAutoscalingConfig().getAsymmetricAutoscalingOptions(0).getOverrides()
+                .getAutoscalingTargetTotalCpuUtilizationPercent())
+                .isEqualTo(60);
+        assertThat(instance.getReplicaComputeCapacity(0).getComputeCapacityCase())
+                .isEqualTo(ReplicaComputeCapacity.ComputeCapacityCase.PROCESSING_UNITS);
+        assertThat(instance.getLabelsMap()).containsEntry("component", "admin");
+        assertThat(instance.getFreeInstanceMetadata().getExpireBehavior())
+                .isEqualTo(FreeInstanceMetadata.ExpireBehavior.FREE_TO_PROVISIONED);
+        assertThat(instance.getDefaultBackupScheduleType()).isEqualTo(Instance.DefaultBackupScheduleType.NONE);
+    }
+
+    @Test
+    void createsInstanceAdminRequestsResponsesAndOperationMetadata() {
+        InstanceConfig config = InstanceConfig.newBuilder()
+                .setName(InstanceConfigName.format(PROJECT, CONFIG_ID))
+                .setDisplayName("Regional test config")
+                .build();
+        Instance instance = Instance.newBuilder()
+                .setName(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setConfig(config.getName())
+                .setDisplayName("Integration Test")
+                .setNodeCount(1)
+                .build();
+        FieldMask displayNameMask = FieldMask.newBuilder().addPaths("display_name").build();
+        Timestamp startTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).build();
+        OperationProgress progress = OperationProgress.newBuilder()
+                .setProgressPercent(42)
+                .setStartTime(startTime)
+                .setEndTime(Timestamp.newBuilder().setSeconds(1_700_000_060L))
+                .build();
+        Operation operation = Operation.newBuilder()
+                .setName(config.getName() + "/operations/create-config")
+                .setDone(false)
+                .build();
+
+        ListInstanceConfigsRequest listConfigs = ListInstanceConfigsRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setPageSize(10)
+                .setPageToken("next-config-page")
+                .build();
+        ListInstanceConfigsResponse listConfigsResponse = ListInstanceConfigsResponse.newBuilder()
+                .addInstanceConfigs(config)
+                .setNextPageToken("next-config-page")
+                .build();
+        CreateInstanceConfigRequest createConfig = CreateInstanceConfigRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setInstanceConfig(config)
+                .setInstanceConfigId(CONFIG_ID)
+                .setValidateOnly(true)
+                .build();
+        UpdateInstanceConfigRequest updateConfig = UpdateInstanceConfigRequest.newBuilder()
+                .setInstanceConfig(config)
+                .setUpdateMask(displayNameMask)
+                .setValidateOnly(true)
+                .build();
+        DeleteInstanceConfigRequest deleteConfig = DeleteInstanceConfigRequest.newBuilder()
+                .setName(config.getName())
+                .setEtag("config-etag")
+                .setValidateOnly(true)
+                .build();
+        ListInstanceConfigOperationsRequest listConfigOperations = ListInstanceConfigOperationsRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setFilter("done=false")
+                .setPageSize(5)
+                .build();
+        ListInstanceConfigOperationsResponse listConfigOperationsResponse =
+                ListInstanceConfigOperationsResponse.newBuilder()
+                        .addOperations(operation)
+                        .setNextPageToken("next-operation-page")
+                        .build();
+        GetInstanceConfigRequest getConfig = GetInstanceConfigRequest.newBuilder().setName(config.getName()).build();
+        CreateInstanceConfigMetadata createConfigMetadata = CreateInstanceConfigMetadata.newBuilder()
+                .setInstanceConfig(config)
+                .setProgress(progress)
+                .setCancelTime(startTime)
+                .build();
+        UpdateInstanceConfigMetadata updateConfigMetadata = UpdateInstanceConfigMetadata.newBuilder()
+                .setInstanceConfig(config)
+                .setProgress(progress)
+                .setCancelTime(startTime)
+                .build();
+
+        ListInstancesRequest listInstances = ListInstancesRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setFilter("labels.component:admin")
+                .setInstanceDeadline(Timestamp.newBuilder().setSeconds(30L))
+                .build();
+        ListInstancesResponse listInstancesResponse = ListInstancesResponse.newBuilder()
+                .addInstances(instance)
+                .addUnreachable("projects/other-project")
+                .setNextPageToken("next-instance-page")
+                .build();
+        CreateInstanceRequest createInstance = CreateInstanceRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setInstance(instance)
+                .setInstanceId(INSTANCE_ID)
+                .build();
+        UpdateInstanceRequest updateInstance = UpdateInstanceRequest.newBuilder()
+                .setInstance(instance)
+                .setFieldMask(displayNameMask)
+                .build();
+        DeleteInstanceRequest deleteInstance = DeleteInstanceRequest.newBuilder().setName(instance.getName()).build();
+        GetInstanceRequest getInstance = GetInstanceRequest.newBuilder().setName(instance.getName()).build();
+        CreateInstanceMetadata createInstanceMetadata = CreateInstanceMetadata.newBuilder()
+                .setInstance(instance)
+                .setStartTime(startTime)
+                .setExpectedFulfillmentPeriod(FulfillmentPeriod.FULFILLMENT_PERIOD_NORMAL)
+                .build();
+        UpdateInstanceMetadata updateInstanceMetadata = UpdateInstanceMetadata.newBuilder()
+                .setInstance(instance)
+                .setStartTime(startTime)
+                .setExpectedFulfillmentPeriod(FulfillmentPeriod.FULFILLMENT_PERIOD_EXTENDED)
+                .build();
+
+        assertThat(listConfigs.getParent()).isEqualTo(ProjectName.format(PROJECT));
+        assertThat(listConfigsResponse.getInstanceConfigsList()).containsExactly(config);
+        assertThat(createConfig.getInstanceConfigId()).isEqualTo(CONFIG_ID);
+        assertThat(updateConfig.getUpdateMask().getPathsList()).containsExactly("display_name");
+        assertThat(deleteConfig.getEtag()).isEqualTo("config-etag");
+        assertThat(listConfigOperations.getFilter()).isEqualTo("done=false");
+        assertThat(listConfigOperationsResponse.getOperations(0).getName()).contains("create-config");
+        assertThat(getConfig.getName()).isEqualTo(config.getName());
+        assertThat(createConfigMetadata.getProgress().getProgressPercent()).isEqualTo(42);
+        assertThat(updateConfigMetadata.getInstanceConfig()).isEqualTo(config);
+
+        assertThat(listInstances.getInstanceDeadline().getSeconds()).isEqualTo(30L);
+        assertThat(listInstancesResponse.getInstancesList()).containsExactly(instance);
+        assertThat(listInstancesResponse.getUnreachableList()).containsExactly("projects/other-project");
+        assertThat(createInstance.getInstanceId()).isEqualTo(INSTANCE_ID);
+        assertThat(updateInstance.getFieldMask()).isEqualTo(displayNameMask);
+        assertThat(deleteInstance.getName()).isEqualTo(instance.getName());
+        assertThat(getInstance.getName()).isEqualTo(instance.getName());
+        assertThat(createInstanceMetadata.getExpectedFulfillmentPeriod())
+                .isEqualTo(FulfillmentPeriod.FULFILLMENT_PERIOD_NORMAL);
+        assertThat(updateInstanceMetadata.getExpectedFulfillmentPeriod())
+                .isEqualTo(FulfillmentPeriod.FULFILLMENT_PERIOD_EXTENDED);
+    }
+
+    @Test
+    void createsInstancePartitionMessagesAndMoveInstanceMetadata() {
+        FieldMask partitionMask = FieldMask.newBuilder().addPaths("display_name").addPaths("node_count").build();
+        Timestamp startTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).build();
+        InstancePartition partition = InstancePartition.newBuilder()
+                .setName(InstancePartitionName.format(PROJECT, INSTANCE_ID, PARTITION_ID))
+                .setConfig(InstanceConfigName.format(PROJECT, CONFIG_ID))
+                .setDisplayName("Read Only Partition")
+                .setNodeCount(2)
+                .setState(InstancePartition.State.READY)
+                .setCreateTime(startTime)
+                .setUpdateTime(Timestamp.newBuilder().setSeconds(1_700_000_100L))
+                .addReferencingDatabases("projects/sample-project/instances/test-instance/databases/app")
+                .setEtag("partition-etag")
+                .build();
+        Operation partitionOperation = Operation.newBuilder()
+                .setName(partition.getName() + "/operations/create-partition")
+                .setDone(true)
+                .build();
+
+        CreateInstancePartitionRequest createPartition = CreateInstancePartitionRequest.newBuilder()
+                .setParent(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setInstancePartitionId(PARTITION_ID)
+                .setInstancePartition(partition)
+                .build();
+        UpdateInstancePartitionRequest updatePartition = UpdateInstancePartitionRequest.newBuilder()
+                .setInstancePartition(partition)
+                .setFieldMask(partitionMask)
+                .build();
+        DeleteInstancePartitionRequest deletePartition = DeleteInstancePartitionRequest.newBuilder()
+                .setName(partition.getName())
+                .setEtag("partition-etag")
+                .build();
+        GetInstancePartitionRequest getPartition = GetInstancePartitionRequest.newBuilder()
+                .setName(partition.getName())
+                .build();
+        ListInstancePartitionsRequest listPartitions = ListInstancePartitionsRequest.newBuilder()
+                .setParent(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setPageSize(3)
+                .setPageToken("partition-token")
+                .build();
+        ListInstancePartitionsResponse listPartitionsResponse = ListInstancePartitionsResponse.newBuilder()
+                .addInstancePartitions(partition)
+                .setNextPageToken("next-partition-page")
+                .build();
+        ListInstancePartitionOperationsRequest listPartitionOperations =
+                ListInstancePartitionOperationsRequest.newBuilder()
+                .setParent(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setFilter("metadata.instance_partition.name:" + PARTITION_ID)
+                .setPageSize(2)
+                .build();
+        ListInstancePartitionOperationsResponse listPartitionOperationsResponse =
+                ListInstancePartitionOperationsResponse.newBuilder()
+                        .addOperations(partitionOperation)
+                        .setNextPageToken("next-partition-operation-page")
+                        .build();
+        CreateInstancePartitionMetadata createPartitionMetadata = CreateInstancePartitionMetadata.newBuilder()
+                .setInstancePartition(partition)
+                .setStartTime(startTime)
+                .setCancelTime(startTime)
+                .setEndTime(Timestamp.newBuilder().setSeconds(1_700_000_300L))
+                .build();
+        UpdateInstancePartitionMetadata updatePartitionMetadata = UpdateInstancePartitionMetadata.newBuilder()
+                .setInstancePartition(partition)
+                .setStartTime(startTime)
+                .build();
+        MoveInstanceRequest moveRequest = MoveInstanceRequest.newBuilder()
+                .setName(InstanceName.format(PROJECT, INSTANCE_ID))
+                .setTargetConfig(InstanceConfigName.format(PROJECT, "regional-us-east1"))
+                .build();
+        MoveInstanceMetadata moveMetadata = MoveInstanceMetadata.newBuilder()
+                .setTargetConfig(moveRequest.getTargetConfig())
+                .setProgress(OperationProgress.newBuilder().setProgressPercent(100))
+                .setCancelTime(startTime)
+                .build();
+        MoveInstanceResponse moveResponse = MoveInstanceResponse.newBuilder().build();
+
+        assertThat(partition.getComputeCapacityCase()).isEqualTo(InstancePartition.ComputeCapacityCase.NODE_COUNT);
+        assertThat(createPartition.getInstancePartitionId()).isEqualTo(PARTITION_ID);
+        assertThat(updatePartition.getFieldMask().getPathsList()).containsExactly("display_name", "node_count");
+        assertThat(deletePartition.getEtag()).isEqualTo("partition-etag");
+        assertThat(getPartition.getName()).isEqualTo(partition.getName());
+        assertThat(listPartitions.getPageToken()).isEqualTo("partition-token");
+        assertThat(listPartitionsResponse.getInstancePartitionsList()).containsExactly(partition);
+        assertThat(listPartitionOperations.getFilter()).contains(PARTITION_ID);
+        assertThat(listPartitionOperationsResponse.getOperations(0)).isEqualTo(partitionOperation);
+        assertThat(createPartitionMetadata.getEndTime().getSeconds()).isEqualTo(1_700_000_300L);
+        assertThat(updatePartitionMetadata.getInstancePartition()).isEqualTo(partition);
+        assertThat(moveRequest.getTargetConfig()).endsWith("regional-us-east1");
+        assertThat(moveMetadata.getProgress().getProgressPercent()).isEqualTo(100);
+        assertThat(moveResponse).isEqualTo(MoveInstanceResponse.getDefaultInstance());
     }
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/src/test/java/com_google_api_grpc/proto_google_cloud_spanner_admin_instance_v1/Proto_google_cloud_spanner_admin_instance_v1Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_spanner_admin_instance_v1Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="3" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-03T08:55:40">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="4" time="0.031" hostname="kung-fu-workstation" timestamp="2026-05-03T08:57:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,18 +52,18 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="resourceNamesRoundTripThroughGeneratedHelpers()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<testcase name="resourceNamesRoundTripThroughGeneratedHelpers()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:resourceNamesRoundTripThroughGeneratedHelpers()]
 display-name: resourceNamesRoundTripThroughGeneratedHelpers()
 ]]></system-out>
 </testcase>
-<testcase name="buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<testcase name="buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <error message="Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto
 	at com.google.spanner.admin.instance.v1.Instance$LabelsDefaultEntryHolder.<clinit>(Instance.java:1293)
 	at com.google.spanner.admin.instance.v1.Instance$Builder.internalGetMutableLabels(Instance.java:4106)
 	at com.google.spanner.admin.instance.v1.Instance$Builder.putLabels(Instance.java:4366)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata(Proto_google_cloud_spanner_admin_instance_v1Test.java:213)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata(Proto_google_cloud_spanner_admin_instance_v1Test.java:222)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -82,13 +82,13 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="buildsInstanceConfigWithReplicasLabelsAndEnumFields()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.005">
+<testcase name="buildsInstanceConfigWithReplicasLabelsAndEnumFields()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.003">
 <error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
 	at com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto.<clinit>(SpannerInstanceAdminProto.java:684)
 	at com.google.spanner.admin.instance.v1.InstanceConfig$LabelsDefaultEntryHolder.<clinit>(InstanceConfig.java:1301)
 	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.internalGetMutableLabels(InstanceConfig.java:3979)
 	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.putLabels(InstanceConfig.java:4239)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsInstanceConfigWithReplicasLabelsAndEnumFields(Proto_google_cloud_spanner_admin_instance_v1Test.java:142)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsInstanceConfigWithReplicasLabelsAndEnumFields(Proto_google_cloud_spanner_admin_instance_v1Test.java:151)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -119,7 +119,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: buildsInstanceConfigWithReplicasLabelsAndEnumFields()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.005">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstancePartitionMessagesAndMoveInstanceMetadata()]
 display-name: createsInstancePartitionMessagesAndMoveInstanceMetadata()
@@ -128,7 +128,7 @@ display-name: createsInstancePartitionMessagesAndMoveInstanceMetadata()
 <testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
 	at com.google.spanner.admin.instance.v1.CommonProto.<clinit>(CommonProto.java:84)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.descriptorsExposeCommonMessagesAndInstanceAdminService(Proto_google_cloud_spanner_admin_instance_v1Test.java:101)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.descriptorsExposeCommonMessagesAndInstanceAdminService(Proto_google_cloud_spanner_admin_instance_v1Test.java:110)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -153,10 +153,31 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
+<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstanceAdminRequestsResponsesAndOperationMetadata()]
 display-name: createsInstanceAdminRequestsResponsesAndOperationMetadata()
+]]></system-out>
+</testcase>
+<testcase name="createsIamPolicyRequestsForInstanceAdminResources()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<error message="Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.createsIamPolicyRequestsForInstanceAdminResources(Proto_google_cloud_spanner_admin_instance_v1Test.java:414)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsIamPolicyRequestsForInstanceAdminResources()]
+display-name: createsIamPolicyRequestsForInstanceAdminResources()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="3" time="0.018" hostname="kung-fu-workstation" timestamp="2026-05-03T08:53:45">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4709-74082d54/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="resourceNamesRoundTripThroughGeneratedHelpers()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:resourceNamesRoundTripThroughGeneratedHelpers()]
+display-name: resourceNamesRoundTripThroughGeneratedHelpers()
+]]></system-out>
+</testcase>
+<testcase name="buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<error message="Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto
+	at com.google.spanner.admin.instance.v1.Instance$LabelsDefaultEntryHolder.<clinit>(Instance.java:1293)
+	at com.google.spanner.admin.instance.v1.Instance$Builder.internalGetMutableLabels(Instance.java:4106)
+	at com.google.spanner.admin.instance.v1.Instance$Builder.putLabels(Instance.java:4366)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata(Proto_google_cloud_spanner_admin_instance_v1Test.java:213)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()]
+display-name: buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()
+]]></system-out>
+</testcase>
+<testcase name="buildsInstanceConfigWithReplicasLabelsAndEnumFields()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.005">
+<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
+	at com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto.<clinit>(SpannerInstanceAdminProto.java:684)
+	at com.google.spanner.admin.instance.v1.InstanceConfig$LabelsDefaultEntryHolder.<clinit>(InstanceConfig.java:1301)
+	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.internalGetMutableLabels(InstanceConfig.java:3979)
+	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.putLabels(InstanceConfig.java:4239)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsInstanceConfigWithReplicasLabelsAndEnumFields(Proto_google_cloud_spanner_admin_instance_v1Test.java:142)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.IllegalStateException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:2140)
+	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:55)
+	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1964)
+	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1884)
+	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:71)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
+	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:2137)
+	... 21 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsInstanceConfigWithReplicasLabelsAndEnumFields()]
+display-name: buildsInstanceConfigWithReplicasLabelsAndEnumFields()
+]]></system-out>
+</testcase>
+<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.004">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstancePartitionMessagesAndMoveInstanceMetadata()]
+display-name: createsInstancePartitionMessagesAndMoveInstanceMetadata()
+]]></system-out>
+</testcase>
+<testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
+	at com.google.spanner.admin.instance.v1.CommonProto.<clinit>(CommonProto.java:84)
+	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.descriptorsExposeCommonMessagesAndInstanceAdminService(Proto_google_cloud_spanner_admin_instance_v1Test.java:101)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:descriptorsExposeCommonMessagesAndInstanceAdminService()]
+display-name: descriptorsExposeCommonMessagesAndInstanceAdminService()
+]]></system-out>
+</testcase>
+<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstanceAdminRequestsResponsesAndOperationMetadata()]
+display-name: createsInstanceAdminRequestsResponsesAndOperationMetadata()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="3" time="0.018" hostname="kung-fu-workstation" timestamp="2026-05-03T08:53:45">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="3" time="0.014" hostname="kung-fu-workstation" timestamp="2026-05-03T08:55:40">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -119,13 +119,13 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: buildsInstanceConfigWithReplicasLabelsAndEnumFields()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.004">
+<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstancePartitionMessagesAndMoveInstanceMetadata()]
 display-name: createsInstancePartitionMessagesAndMoveInstanceMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
+<testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
 	at com.google.spanner.admin.instance.v1.CommonProto.<clinit>(CommonProto.java:84)
 	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.descriptorsExposeCommonMessagesAndInstanceAdminService(Proto_google_cloud_spanner_admin_instance_v1Test.java:101)
@@ -147,7 +147,13 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: descriptorsExposeCommonMessagesAndInstanceAdminService()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.006">
+<testcase name="buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()]
+display-name: buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()
+]]></system-out>
+</testcase>
+<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstanceAdminRequestsResponsesAndOperationMetadata()]
 display-name: createsInstanceAdminRequestsResponsesAndOperationMetadata()

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="4" time="0.031" hostname="kung-fu-workstation" timestamp="2026-05-03T08:57:48">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.019" hostname="kung-fu-workstation" timestamp="2026-05-03T09:01:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4709-74082d54/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1"/>
@@ -52,129 +51,49 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="resourceNamesRoundTripThroughGeneratedHelpers()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.006">
+<testcase name="resourceNamesRoundTripThroughGeneratedHelpers()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:resourceNamesRoundTripThroughGeneratedHelpers()]
 display-name: resourceNamesRoundTripThroughGeneratedHelpers()
 ]]></system-out>
 </testcase>
 <testcase name="buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
-<error message="Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto
-	at com.google.spanner.admin.instance.v1.Instance$LabelsDefaultEntryHolder.<clinit>(Instance.java:1293)
-	at com.google.spanner.admin.instance.v1.Instance$Builder.internalGetMutableLabels(Instance.java:4106)
-	at com.google.spanner.admin.instance.v1.Instance$Builder.putLabels(Instance.java:4366)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata(Proto_google_cloud_spanner_admin_instance_v1Test.java:222)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()]
 display-name: buildsAutoscaledInstanceWithOneofComputeCapacityAndFreeMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="buildsInstanceConfigWithReplicasLabelsAndEnumFields()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.003">
-<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
-	at com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto.<clinit>(SpannerInstanceAdminProto.java:684)
-	at com.google.spanner.admin.instance.v1.InstanceConfig$LabelsDefaultEntryHolder.<clinit>(InstanceConfig.java:1301)
-	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.internalGetMutableLabels(InstanceConfig.java:3979)
-	at com.google.spanner.admin.instance.v1.InstanceConfig$Builder.putLabels(InstanceConfig.java:4239)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.buildsInstanceConfigWithReplicasLabelsAndEnumFields(Proto_google_cloud_spanner_admin_instance_v1Test.java:151)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.IllegalStateException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:2140)
-	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:55)
-	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1964)
-	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1884)
-	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:71)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
-	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:2137)
-	... 21 more
-]]></error>
+<testcase name="buildsInstanceConfigWithReplicasLabelsAndEnumFields()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.008">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsInstanceConfigWithReplicasLabelsAndEnumFields()]
 display-name: buildsInstanceConfigWithReplicasLabelsAndEnumFields()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.005">
+<testcase name="createsInstancePartitionMessagesAndMoveInstanceMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstancePartitionMessagesAndMoveInstanceMetadata()]
 display-name: createsInstancePartitionMessagesAndMoveInstanceMetadata()
 ]]></system-out>
 </testcase>
-<testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
-<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
-	at com.google.spanner.admin.instance.v1.CommonProto.<clinit>(CommonProto.java:84)
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.descriptorsExposeCommonMessagesAndInstanceAdminService(Proto_google_cloud_spanner_admin_instance_v1Test.java:110)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
+<testcase name="descriptorsExposeCommonMessagesAndInstanceAdminService()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:descriptorsExposeCommonMessagesAndInstanceAdminService()]
 display-name: descriptorsExposeCommonMessagesAndInstanceAdminService()
 ]]></system-out>
 </testcase>
-<testcase name="buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.001">
+<testcase name="buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()]
 display-name: buildsProcessingUnitInstancePartitionWithAutoscalingAndBackupReferences()
 ]]></system-out>
 </testcase>
-<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.007">
+<testcase name="createsInstanceAdminRequestsResponsesAndOperationMetadata()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsInstanceAdminRequestsResponsesAndOperationMetadata()]
 display-name: createsInstanceAdminRequestsResponsesAndOperationMetadata()
 ]]></system-out>
 </testcase>
 <testcase name="createsIamPolicyRequestsForInstanceAdminResources()" classname="com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test" time="0">
-<error message="Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.spanner.admin.instance.v1.SpannerInstanceAdminProto
-	at com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test.createsIamPolicyRequestsForInstanceAdminResources(Proto_google_cloud_spanner_admin_instance_v1Test.java:414)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_spanner_admin_instance_v1.Proto_google_cloud_spanner_admin_instance_v1Test]/[method:createsIamPolicyRequestsForInstanceAdminResources()]
 display-name: createsIamPolicyRequestsForInstanceAdminResources()

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:53:45">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:55:40">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:55:40">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:57:48">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:53:45">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4709-74082d54/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:57:48">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:01:15">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4709-74082d54/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.spanner.admin.instance.v1.**"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-spanner-admin-instance-v1/6.116.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.spanner.admin.instance.v1.**"
+      "includeClasses" : "com.google.spanner.admin.instance.v1.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4709

This PR introduces tests and metadata for com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:6.116.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 128289
- Cached input tokens: 1921024
- Output tokens: 21585
- Metadata entries: 19
- Iterations: 3
- Library coverage percentage: 21.2
- Generated lines of code: 534
- Tested library lines of code: 3665

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 13660/64569 (21.16%)
- Line: 3665/17290 (21.20%)
- Method: 911/3963 (22.99%)
