### PR TITLE
[GenAI] Test fix for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0 using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/reachability-metadata.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/reachability-metadata.json
@@ -1,0 +1,135 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "io.opentelemetry.internal.shaded.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil"
+      },
+      "type": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk",
+      "methods": [
+        {
+          "name": "getConfig",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "type": "io.opentelemetry.sdk.autoconfigure.internal.EnvironmentResourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.MeterProviderConfiguration"
+      },
+      "type": "io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder",
+      "methods": [
+        {
+          "name": "setExemplarFilter",
+          "parameterTypes": [
+            "io.opentelemetry.sdk.metrics.internal.exemplar.ExemplarFilter"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.PropagatorConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.ResourceConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.TracerProviderConfiguration"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "bundle": "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.28.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/$version$/opentelemetry-sdk-extension-autoconfigure-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java/tree/v$version$/sdk-extensions/autoconfigure/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/$version$/opentelemetry-sdk-extension-autoconfigure-$version$-javadoc.jar",
+    "description" : "The OpenTelemetry SDK autoconfigure module builds and configures an OpenTelemetry SDK instance from environment variables and Java system properties. It wires exporters, propagators, resources, processors, samplers, limits, and SPI-based customizers so applications can enable telemetry without hand-building the SDK.",
     "tested-versions" : [
       "1.28.0"
     ],

--- a/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.28.0",
+    "tested-versions" : [
+      "1.28.0"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.sdk.autoconfigure"
+    ]
+  },
+  {
     "metadata-version" : "1.25.0-alpha",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-sdk-extension-autoconfigure/$version$/opentelemetry-sdk-extension-autoconfigure-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "fix_javac_fail:2026-05-03": {
+    "timestamp": "2026-05-03T07:02:34.738497Z",
+    "library": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0",
+    "starting_commit": "fa07d391327264a11e10d1117ae7a45151c2103c",
+    "ending_commit": "882bc417a1aca615030a26070c095ff736e8c7bd",
+    "previous_library": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.28.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1274,
+          "missed": 887,
+          "ratio": 0.589542,
+          "total": 2161
+        },
+        "line": {
+          "covered": 338,
+          "missed": 212,
+          "ratio": 0.614545,
+          "total": 550
+        },
+        "method": {
+          "covered": 69,
+          "missed": 26,
+          "ratio": 0.726316,
+          "total": 95
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.25.0-alpha",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1213,
+          "missed": 902,
+          "ratio": 0.573522,
+          "total": 2115
+        },
+        "line": {
+          "covered": 324,
+          "missed": 215,
+          "ratio": 0.601113,
+          "total": 539
+        },
+        "method": {
+          "covered": 67,
+          "missed": 24,
+          "ratio": 0.736264,
+          "total": 91
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 64669,
+      "cached_input_tokens_used": 723968,
+      "output_tokens_used": 9719,
+      "iterations": 2,
+      "cost_usd": 0.6536,
+      "tested_library_loc": 338,
+      "metadata_entries": 24,
+      "previous_library_metadata_entries": 22,
+      "code_coverage_percent": 61.45,
+      "previous_library_coverage_percent": 60.11
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java",
+      "metadata_file": "metadata/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/stats.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.28.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1274,
+        "missed" : 887,
+        "ratio" : 0.589542,
+        "total" : 2161
+      },
+      "line" : {
+        "covered" : 338,
+        "missed" : 212,
+        "ratio" : 0.614545,
+        "total" : 550
+      },
+      "method" : {
+        "covered" : 69,
+        "missed" : 26,
+        "ratio" : 0.726316,
+        "total" : 95
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/.gitignore
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/build.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/gradle.properties
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0
+library.version = 1.28.0
+metadata.dir = io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/settings.gradle
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.opentelemetry-sdk-extension-autoconfigure_tests'

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/AutoConfigureUtilTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/AutoConfigureUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class AutoConfigureUtilTest {
+    @Test
+    void readsAutoConfiguredSdkConfigThroughUtility() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .disableShutdownHook()
+                    .addPropertiesCustomizer(config -> configuredProperties())
+                    .build();
+
+            ConfigProperties config = AutoConfigureUtil.getConfig(configured);
+
+            assertThat(config.getString("test.config.key")).isEqualTo("configured-value");
+            assertThat(config.getList("test.config.list")).containsExactly("first", "second");
+            assertThat(config.getString("otel.service.name")).isEqualTo("auto-configure-util-test");
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    private static Map<String, String> configuredProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.propagators", "none");
+        properties.put("otel.traces.sampler", "always_off");
+        properties.put("otel.service.name", "auto-configure-util-test");
+        properties.put("test.config.key", "configured-value");
+        properties.put("test.config.list", "first,second");
+        return properties;
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class Opentelemetry_sdk_extension_autoconfigureTest {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> SERVICE_NAMESPACE = AttributeKey.stringKey("service.namespace");
+    private static final AttributeKey<String> SERVICE_INSTANCE_ID = AttributeKey.stringKey("service.instance.id");
+    private static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
+            AttributeKey.stringKey("deployment.environment");
+    private static final AttributeKey<String> CUSTOM_RESOURCE = AttributeKey.stringKey("test.custom.resource");
+    private static final TextMapSetter<Map<String, String>> MAP_SETTER =
+            (carrier, key, value) -> carrier.put(key, value);
+    private static final TextMapGetter<Map<String, String>> MAP_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+        }
+    };
+
+    @Test
+    void buildsSdkFromPropertiesAndAppliesAllCoreCustomizers() {
+        RecordingSpanExporter spanExporter = new RecordingSpanExporter();
+        AtomicReference<String> valueSeenByPropertiesCustomizer = new AtomicReference<>();
+        AtomicInteger resourceCustomizations = new AtomicInteger();
+        AtomicInteger samplerCustomizations = new AtomicInteger();
+        AtomicInteger propagatorCustomizations = new AtomicInteger();
+        AtomicInteger tracerProviderCustomizations = new AtomicInteger();
+        AtomicInteger meterProviderCustomizations = new AtomicInteger();
+        AtomicInteger loggerProviderCustomizations = new AtomicInteger();
+        AtomicInteger spanExporterCustomizations = new AtomicInteger();
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .setServiceClassLoader(Opentelemetry_sdk_extension_autoconfigureTest.class.getClassLoader())
+                    .addPropertiesSupplier(() -> Map.of("test.customizer.input", "from-supplier"))
+                    .addPropertiesCustomizer(config -> {
+                        valueSeenByPropertiesCustomizer.set(config.getString("test.customizer.input"));
+                        return workingProperties();
+                    })
+                    .addResourceCustomizer((resource, config) -> {
+                        resourceCustomizations.incrementAndGet();
+                        Resource customResource = Resource.create(Attributes.of(
+                                CUSTOM_RESOURCE, config.getString("test.custom.resource")));
+                        return resource.merge(customResource);
+                    })
+                    .addSamplerCustomizer((sampler, config) -> {
+                        samplerCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.traces.sampler")).isEqualTo("always_off");
+                        return Sampler.alwaysOn();
+                    })
+                    .addPropagatorCustomizer((propagator, config) -> {
+                        propagatorCustomizations.incrementAndGet();
+                        assertThat(config.getList("otel.propagators")).containsExactly("tracecontext", "baggage");
+                        return propagator;
+                    })
+                    .addSpanExporterCustomizer((exporter, config) -> {
+                        spanExporterCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.traces.exporter")).isEqualTo("none");
+                        return spanExporter;
+                    })
+                    .addTracerProviderCustomizer((builder, config) -> {
+                        tracerProviderCustomizations.incrementAndGet();
+                        assertThat(config.getInt("otel.span.attribute.count.limit")).isEqualTo(16);
+                        return builder;
+                    })
+                    .addMeterProviderCustomizer((builder, config) -> {
+                        meterProviderCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.metrics.exporter")).isEqualTo("none");
+                        return builder;
+                    })
+                    .addLoggerProviderCustomizer((builder, config) -> {
+                        loggerProviderCustomizations.incrementAndGet();
+                        assertThat(config.getString("otel.logs.exporter")).isEqualTo("none");
+                        return builder;
+                    })
+                    .build();
+
+            ConfigProperties config = configured.getConfig();
+            assertThat(valueSeenByPropertiesCustomizer).hasValue("from-supplier");
+            assertThat(config.getString("otel.service.name")).isEqualTo("payments");
+            assertThat(config.getBoolean("otel.sdk.disabled", true)).isFalse();
+            assertThat(config.getDuration("test.duration")).isEqualTo(Duration.ofSeconds(2));
+            assertThat(config.getList("test.list")).containsExactly("alpha", "beta", "gamma");
+            assertThat(config.getMap("test.map"))
+                    .containsEntry("left", "right")
+                    .containsEntry("region", "eu");
+
+            Resource resource = configured.getResource();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isEqualTo("checkout");
+            assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isEqualTo("integration-test");
+            assertThat(resource.getAttribute(CUSTOM_RESOURCE)).isEqualTo("resource-customized");
+
+            Map<String, String> carrier = new HashMap<>();
+            Context contextWithBaggage = Baggage.builder()
+                    .put("tenant", "acme")
+                    .build()
+                    .storeInContext(Context.root());
+            configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .inject(contextWithBaggage, carrier, MAP_SETTER);
+            Context extractedContext = configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator()
+                    .extract(Context.root(), carrier, MAP_GETTER);
+
+            assertThat(carrier).containsEntry("baggage", "tenant=acme");
+            assertThat(Baggage.fromContext(extractedContext).getEntryValue("tenant")).isEqualTo("acme");
+
+            Span span = configured.getOpenTelemetrySdk()
+                    .getTracer("autoconfigure-test")
+                    .spanBuilder("configured-span")
+                    .startSpan();
+            try {
+                assertThat(span.getSpanContext().isSampled()).isTrue();
+            } finally {
+                span.end();
+            }
+            assertThat(configured.getOpenTelemetrySdk().getSdkTracerProvider().forceFlush().join(5, TimeUnit.SECONDS)
+                    .isSuccess()).isTrue();
+            assertThat(spanExporter.exportedSpanNames()).containsExactly("configured-span");
+
+            LongCounter counter = configured.getOpenTelemetrySdk()
+                    .getMeter("autoconfigure-test")
+                    .counterBuilder("processed.items")
+                    .build();
+            counter.add(1, Attributes.of(AttributeKey.stringKey("queue"), "orders"));
+
+            assertThat(resourceCustomizations).hasValue(1);
+            assertThat(samplerCustomizations).hasValue(1);
+            assertThat(propagatorCustomizations.get()).isGreaterThanOrEqualTo(1);
+            assertThat(tracerProviderCustomizations).hasValue(1);
+            assertThat(meterProviderCustomizations).hasValue(1);
+            assertThat(loggerProviderCustomizations).hasValue(1);
+            assertThat(spanExporterCustomizations).hasValue(1);
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void resourceDisabledKeysFilterDecodedConfiguredAttributes() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.service.name", "filtered-service");
+                        properties.put("otel.resource.attributes",
+                                "service.namespace=filtered-namespace,service.instance.id=node%201,"
+                                        + "deployment.environment=filtered-environment");
+                        properties.put("otel.experimental.resource.disabled.keys",
+                                "service.name,service.namespace,deployment.environment");
+                        return properties;
+                    })
+                    .build();
+
+            Resource resource = configured.getResource();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isNull();
+            assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isNull();
+            assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isNull();
+            assertThat(resource.getAttribute(SERVICE_INSTANCE_ID)).isEqualTo("node 1");
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource() {
+        AtomicBoolean tracerProviderCustomizerCalled = new AtomicBoolean();
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.sdk.disabled", "true");
+                        return properties;
+                    })
+                    .addTracerProviderCustomizer((builder, config) -> {
+                        tracerProviderCustomizerCalled.set(true);
+                        return builder;
+                    })
+                    .build();
+
+            Span span = configured.getOpenTelemetrySdk()
+                    .getTracer("disabled-sdk-test")
+                    .spanBuilder("not-recorded")
+                    .startSpan();
+            span.end();
+
+            assertThat(configured.getConfig().getBoolean("otel.sdk.disabled", false)).isTrue();
+            assertThat(configured.getResource().getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            assertThat(configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator().fields()).isEmpty();
+            assertThat(tracerProviderCustomizerCalled).isFalse();
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .setResultAsGlobal(false)
+                    .registerShutdownHook(false)
+                    .addPropertiesCustomizer(config -> {
+                        Map<String, String> properties = workingProperties();
+                        properties.put("otel.traces.sampler", "parentbased_traceidratio");
+                        properties.put("otel.traces.sampler.arg", "0");
+                        return properties;
+                    })
+                    .build();
+
+            Span rootSpan = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("root-span")
+                    .startSpan();
+            try {
+                assertThat(rootSpan.getSpanContext().isSampled()).isFalse();
+            } finally {
+                rootSpan.end();
+            }
+
+            Context sampledRemoteParent = remoteParentContext(TraceFlags.getSampled());
+            Span childOfSampledRemoteParent = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("child-of-sampled-remote-parent")
+                    .setParent(sampledRemoteParent)
+                    .startSpan();
+            try {
+                assertThat(childOfSampledRemoteParent.getSpanContext().isSampled()).isTrue();
+            } finally {
+                childOfSampledRemoteParent.end();
+            }
+
+            Context unsampledRemoteParent = remoteParentContext(TraceFlags.getDefault());
+            Span childOfUnsampledRemoteParent = configured.getOpenTelemetrySdk()
+                    .getTracer("parentbased-sampler-test")
+                    .spanBuilder("child-of-unsampled-remote-parent")
+                    .setParent(unsampledRemoteParent)
+                    .startSpan();
+            try {
+                assertThat(childOfUnsampledRemoteParent.getSpanContext().isSampled()).isFalse();
+            } finally {
+                childOfUnsampledRemoteParent.end();
+            }
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    @Test
+    void invalidConfigurationFailsFastWithConfigurationException() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
+                .setResultAsGlobal(false)
+                .registerShutdownHook(false)
+                .addPropertiesCustomizer(config -> {
+                    Map<String, String> properties = workingProperties();
+                    properties.put("otel.traces.sampler", "not-a-sampler");
+                    return properties;
+                });
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Unrecognized value for otel.traces.sampler");
+    }
+
+    @Test
+    void exporterConfigurationRejectsNoneMixedWithOtherExporters() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
+                .setResultAsGlobal(false)
+                .registerShutdownHook(false)
+                .addPropertiesCustomizer(config -> {
+                    Map<String, String> properties = workingProperties();
+                    properties.put("otel.traces.exporter", "none,custom");
+                    return properties;
+                });
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("otel.traces.exporter contains none along with other exporters");
+    }
+
+    @Test
+    void builderMethodsAreChainableAndValidateRequiredArguments() {
+        AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder();
+
+        assertThat(builder.registerShutdownHook(false)).isSameAs(builder);
+        assertThat(builder.setResultAsGlobal(false)).isSameAs(builder);
+        assertThat(builder.setServiceClassLoader(getClass().getClassLoader())).isSameAs(builder);
+        assertThat(builder.addPropertiesSupplier(Map::of)).isSameAs(builder);
+        assertThat(builder.addPropertiesCustomizer(config -> Map.of())).isSameAs(builder);
+        assertThat(builder.addResourceCustomizer((resource, config) -> resource)).isSameAs(builder);
+        assertThat(builder.addSamplerCustomizer((sampler, config) -> sampler)).isSameAs(builder);
+        assertThat(builder.addPropagatorCustomizer((propagator, config) -> propagator)).isSameAs(builder);
+        assertThat(builder.addSpanExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+        assertThat(builder.addTracerProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addMeterProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addMetricExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+        assertThat(builder.addLoggerProviderCustomizer((providerBuilder, config) -> providerBuilder)).isSameAs(builder);
+        assertThat(builder.addLogRecordExporterCustomizer((exporter, config) -> exporter)).isSameAs(builder);
+
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .setServiceClassLoader(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesSupplier(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropertiesCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addResourceCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addSamplerCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addPropagatorCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addSpanExporterCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addTracerProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addMeterProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addMetricExporterCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addLoggerProviderCustomizer(null));
+        assertThatNullPointerException().isThrownBy(() -> AutoConfiguredOpenTelemetrySdk.builder()
+                .addLogRecordExporterCustomizer(null));
+    }
+
+    private static Context remoteParentContext(TraceFlags traceFlags) {
+        SpanContext spanContext = SpanContext.createFromRemoteParent(
+                "4bf92f3577b34da6a3ce929d0e0e4736",
+                "00f067aa0ba902b7",
+                traceFlags,
+                TraceState.getDefault());
+        return Span.wrap(spanContext).storeInContext(Context.root());
+    }
+
+    private static Map<String, String> workingProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.propagators", "tracecontext,baggage");
+        properties.put("otel.traces.sampler", "always_off");
+        properties.put("otel.span.attribute.count.limit", "16");
+        properties.put("otel.bsp.schedule.delay", "1d");
+        properties.put("otel.bsp.export.timeout", "5s");
+        properties.put("otel.service.name", "payments");
+        properties.put("otel.resource.attributes",
+                "service.namespace=checkout,deployment.environment=integration-test");
+        properties.put("test.custom.resource", "resource-customized");
+        properties.put("test.duration", "2s");
+        properties.put("test.list", "alpha,beta,,gamma");
+        properties.put("test.map", "left=right,region=eu");
+        return properties;
+    }
+
+    private static final class RecordingSpanExporter implements SpanExporter {
+        private final List<String> exportedSpanNames = new ArrayList<>();
+        private boolean shutdown;
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            for (SpanData span : spans) {
+                exportedSpanNames.add(span.getName());
+            }
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            shutdown = true;
+            return CompletableResultCode.ofSuccess();
+        }
+
+        private List<String> exportedSpanNames() {
+            assertThat(shutdown).isFalse();
+            return exportedSpanNames;
+        }
+    }
+}

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -74,12 +74,13 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
         AtomicInteger meterProviderCustomizations = new AtomicInteger();
         AtomicInteger loggerProviderCustomizations = new AtomicInteger();
         AtomicInteger spanExporterCustomizations = new AtomicInteger();
+        AtomicReference<ConfigProperties> configuredConfig = new AtomicReference<>();
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .setServiceClassLoader(Opentelemetry_sdk_extension_autoconfigureTest.class.getClassLoader())
                     .addPropertiesSupplier(() -> Map.of("test.customizer.input", "from-supplier"))
                     .addPropertiesCustomizer(config -> {
@@ -88,9 +89,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     })
                     .addResourceCustomizer((resource, config) -> {
                         resourceCustomizations.incrementAndGet();
+                        configuredConfig.set(config);
                         Resource customResource = Resource.create(Attributes.of(
                                 CUSTOM_RESOURCE, config.getString("test.custom.resource")));
-                        return resource.merge(customResource);
+                        Resource customizedResource = resource.merge(customResource);
+                        configuredResource.set(customizedResource);
+                        return customizedResource;
                     })
                     .addSamplerCustomizer((sampler, config) -> {
                         samplerCustomizations.incrementAndGet();
@@ -124,7 +128,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     })
                     .build();
 
-            ConfigProperties config = configured.getConfig();
+            ConfigProperties config = configuredConfig.get();
+            assertThat(config).isNotNull();
             assertThat(valueSeenByPropertiesCustomizer).hasValue("from-supplier");
             assertThat(config.getString("otel.service.name")).isEqualTo("payments");
             assertThat(config.getBoolean("otel.sdk.disabled", true)).isFalse();
@@ -134,7 +139,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     .containsEntry("left", "right")
                     .containsEntry("region", "eu");
 
-            Resource resource = configured.getResource();
+            Resource resource = configuredResource.get();
+            assertThat(resource).isNotNull();
             assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
             assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isEqualTo("checkout");
             assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isEqualTo("integration-test");
@@ -188,12 +194,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
 
     @Test
     void resourceDisabledKeysFilterDecodedConfiguredAttributes() {
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.service.name", "filtered-service");
@@ -204,9 +210,14 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                                 "service.name,service.namespace,deployment.environment");
                         return properties;
                     })
+                    .addResourceCustomizer((resource, config) -> {
+                        configuredResource.set(resource);
+                        return resource;
+                    })
                     .build();
 
-            Resource resource = configured.getResource();
+            Resource resource = configuredResource.get();
+            assertThat(resource).isNotNull();
             assertThat(resource.getAttribute(SERVICE_NAME)).isNull();
             assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isNull();
             assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isNull();
@@ -221,16 +232,22 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource() {
         AtomicBoolean tracerProviderCustomizerCalled = new AtomicBoolean();
+        AtomicReference<ConfigProperties> configuredConfig = new AtomicReference<>();
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.sdk.disabled", "true");
                         return properties;
+                    })
+                    .addResourceCustomizer((resource, config) -> {
+                        configuredConfig.set(config);
+                        configuredResource.set(resource);
+                        return resource;
                     })
                     .addTracerProviderCustomizer((builder, config) -> {
                         tracerProviderCustomizerCalled.set(true);
@@ -244,8 +261,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     .startSpan();
             span.end();
 
-            assertThat(configured.getConfig().getBoolean("otel.sdk.disabled", false)).isTrue();
-            assertThat(configured.getResource().getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            ConfigProperties config = configuredConfig.get();
+            Resource resource = configuredResource.get();
+            assertThat(config).isNotNull();
+            assertThat(resource).isNotNull();
+            assertThat(config.getBoolean("otel.sdk.disabled", false)).isTrue();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
             assertThat(configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator().fields()).isEmpty();
             assertThat(tracerProviderCustomizerCalled).isFalse();
         } finally {
@@ -261,8 +282,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.traces.sampler", "parentbased_traceidratio");
@@ -314,8 +334,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void invalidConfigurationFailsFastWithConfigurationException() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
-                .setResultAsGlobal(false)
-                .registerShutdownHook(false)
+                .disableShutdownHook()
                 .addPropertiesCustomizer(config -> {
                     Map<String, String> properties = workingProperties();
                     properties.put("otel.traces.sampler", "not-a-sampler");
@@ -330,8 +349,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void exporterConfigurationRejectsNoneMixedWithOtherExporters() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
-                .setResultAsGlobal(false)
-                .registerShutdownHook(false)
+                .disableShutdownHook()
                 .addPropertiesCustomizer(config -> {
                     Map<String, String> properties = workingProperties();
                     properties.put("otel.traces.exporter", "none,custom");
@@ -347,8 +365,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     void builderMethodsAreChainableAndValidateRequiredArguments() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder();
 
-        assertThat(builder.registerShutdownHook(false)).isSameAs(builder);
-        assertThat(builder.setResultAsGlobal(false)).isSameAs(builder);
+        assertThat(builder.disableShutdownHook()).isSameAs(builder);
+        assertThat(builder.setResultAsGlobal()).isSameAs(builder);
         assertThat(builder.setServiceClassLoader(getClass().getClassLoader())).isSameAs(builder);
         assertThat(builder.addPropertiesSupplier(Map::of)).isSameAs(builder);
         assertThat(builder.addPropertiesCustomizer(config -> Map.of())).isSameAs(builder);

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.011" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<testcase name="parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()]
+display-name: parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()
+]]></system-out>
+</testcase>
+<testcase name="resourceDisabledKeysFilterDecodedConfiguredAttributes()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:resourceDisabledKeysFilterDecodedConfiguredAttributes()]
+display-name: resourceDisabledKeysFilterDecodedConfiguredAttributes()
+]]></system-out>
+</testcase>
+<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()]
+display-name: disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()
+]]></system-out>
+</testcase>
+<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:exporterConfigurationRejectsNoneMixedWithOtherExporters()]
+display-name: exporterConfigurationRejectsNoneMixedWithOtherExporters()
+]]></system-out>
+</testcase>
+<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:invalidConfigurationFailsFastWithConfigurationException()]
+display-name: invalidConfigurationFailsFastWithConfigurationException()
+]]></system-out>
+</testcase>
+<testcase name="buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()]
+display-name: buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()
+]]></system-out>
+</testcase>
+<testcase name="builderMethodsAreChainableAndValidateRequiredArguments()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:builderMethodsAreChainableAndValidateRequiredArguments()]
+display-name: builderMethodsAreChainableAndValidateRequiredArguments()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-03T08:56:30">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.009" hostname="kung-fu-workstation" timestamp="2026-05-03T09:01:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4835-cc5d3892/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0"/>
@@ -76,13 +75,13 @@ unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_exte
 display-name: exporterConfigurationRejectsNoneMixedWithOtherExporters()
 ]]></system-out>
 </testcase>
-<testcase name="readsAutoConfiguredSdkConfigThroughUtility()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.AutoConfigureUtilTest" time="0">
+<testcase name="readsAutoConfiguredSdkConfigThroughUtility()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.AutoConfigureUtilTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.AutoConfigureUtilTest]/[method:readsAutoConfiguredSdkConfigThroughUtility()]
 display-name: readsAutoConfiguredSdkConfigThroughUtility()
 ]]></system-out>
 </testcase>
-<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
+<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:invalidConfigurationFailsFastWithConfigurationException()]
 display-name: invalidConfigurationFailsFastWithConfigurationException()

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.011" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-03T08:56:30">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -27,12 +25,14 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,45 +43,52 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
-<property name="user.home" value="/home/mihailo"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4835-cc5d3892/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0"/>
+<property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
-<property name="user.name" value="mihailo"/>
-<property name="user.timezone" value="Europe/Belgrade"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<testcase name="parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()]
 display-name: parentBasedSamplerConfigurationHonorsRemoteParentSamplingDecision()
 ]]></system-out>
 </testcase>
-<testcase name="resourceDisabledKeysFilterDecodedConfiguredAttributes()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<testcase name="resourceDisabledKeysFilterDecodedConfiguredAttributes()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:resourceDisabledKeysFilterDecodedConfiguredAttributes()]
 display-name: resourceDisabledKeysFilterDecodedConfiguredAttributes()
 ]]></system-out>
 </testcase>
-<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<testcase name="disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()]
 display-name: disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource()
 ]]></system-out>
 </testcase>
-<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
+<testcase name="exporterConfigurationRejectsNoneMixedWithOtherExporters()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:exporterConfigurationRejectsNoneMixedWithOtherExporters()]
 display-name: exporterConfigurationRejectsNoneMixedWithOtherExporters()
 ]]></system-out>
 </testcase>
-<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
+<testcase name="readsAutoConfiguredSdkConfigThroughUtility()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.AutoConfigureUtilTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.AutoConfigureUtilTest]/[method:readsAutoConfiguredSdkConfigThroughUtility()]
+display-name: readsAutoConfiguredSdkConfigThroughUtility()
+]]></system-out>
+</testcase>
+<testcase name="invalidConfigurationFailsFastWithConfigurationException()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:invalidConfigurationFailsFastWithConfigurationException()]
 display-name: invalidConfigurationFailsFastWithConfigurationException()
 ]]></system-out>
 </testcase>
-<testcase name="buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.002">
+<testcase name="buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()" classname="io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_opentelemetry.opentelemetry_sdk_extension_autoconfigure.Opentelemetry_sdk_extension_autoconfigureTest]/[method:buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()]
 display-name: buildsSdkFromPropertiesAndAppliesAllCoreCustomizers()

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
+<property name="user.home" value="/home/mihailo"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="mihailo"/>
+<property name="user.timezone" value="Europe/Belgrade"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="mihailo-Precision-5690" timestamp="2026-05-02T22:29:07">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:56:30">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.2+10.1"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
 <property name="java.version" value="25.0.2"/>
 <property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
@@ -27,12 +25,14 @@
 <property name="java.vm.vendor" value="Oracle Corporation"/>
 <property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,13 +43,14 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/mihailo/git/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3885-acee83f0/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha"/>
-<property name="user.home" value="/home/mihailo"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4835-cc5d3892/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0"/>
+<property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
-<property name="user.name" value="mihailo"/>
-<property name="user.timezone" value="Europe/Belgrade"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <system-out><![CDATA[
 unique-id: [engine:junit-vintage]

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T08:56:30">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:01:39">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4835-cc5d3892/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0"/>

--- a/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/user-code-filter.json
+++ b/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.opentelemetry.sdk.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #4835

This PR provides test fixes and new metadata for io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 64669
- Cached input tokens: 723968
- Output tokens: 9719
- Metadata entries: 24
- Iterations: 2
- Library coverage percentage: 61.45
- Previous library version metadata entries: 22
- Previous library version coverage percentage: 60.11

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha: 0/0 covered calls (100.00%)
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0: 1/1 covered calls (100.00%)

**Reflection:**
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha: N/A
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha: 1213/2115 (57.35%)
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0: 1274/2161 (58.95%)

**Line:**
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha: 324/539 (60.11%)
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0: 338/550 (61.45%)

**Method:**
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.25.0-alpha: 67/91 (73.63%)
- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.28.0: 69/95 (72.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/AutoConfigureUtilTest.java 2/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/AutoConfigureUtilTest.java
new file mode 100644
index 0000000000..e2ca9e4ad9
--- /dev/null
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/AutoConfigureUtilTest.java
@@ -0,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry.opentelemetry_sdk_extension_autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.internal.AutoConfigureUtil;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class AutoConfigureUtilTest {
+    @Test
+    void readsAutoConfiguredSdkConfigThroughUtility() {
+        AutoConfiguredOpenTelemetrySdk configured = null;
+
+        try {
+            configured = AutoConfiguredOpenTelemetrySdk.builder()
+                    .disableShutdownHook()
+                    .addPropertiesCustomizer(config -> configuredProperties())
+                    .build();
+
+            ConfigProperties config = AutoConfigureUtil.getConfig(configured);
+
+            assertThat(config.getString("test.config.key")).isEqualTo("configured-value");
+            assertThat(config.getList("test.config.list")).containsExactly("first", "second");
+            assertThat(config.getString("otel.service.name")).isEqualTo("auto-configure-util-test");
+        } finally {
+            if (configured != null) {
+                configured.getOpenTelemetrySdk().close();
+            }
+        }
+    }
+
+    private static Map<String, String> configuredProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otel.sdk.disabled", "false");
+        properties.put("otel.traces.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.propagators", "none");
+        properties.put("otel.traces.sampler", "always_off");
+        properties.put("otel.service.name", "auto-configure-util-test");
+        properties.put("test.config.key", "configured-value");
+        properties.put("test.config.list", "first,second");
+        return properties;
+    }
+}
diff --git 1/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java 2/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
index b487b55244..e4d6da2feb 100644
--- 1/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.25.0-alpha/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
+++ 2/tests/src/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure/1.28.0/src/test/java/io_opentelemetry/opentelemetry_sdk_extension_autoconfigure/Opentelemetry_sdk_extension_autoconfigureTest.java
@@ -74,12 +74,13 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
         AtomicInteger meterProviderCustomizations = new AtomicInteger();
         AtomicInteger loggerProviderCustomizations = new AtomicInteger();
         AtomicInteger spanExporterCustomizations = new AtomicInteger();
+        AtomicReference<ConfigProperties> configuredConfig = new AtomicReference<>();
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .setServiceClassLoader(Opentelemetry_sdk_extension_autoconfigureTest.class.getClassLoader())
                     .addPropertiesSupplier(() -> Map.of("test.customizer.input", "from-supplier"))
                     .addPropertiesCustomizer(config -> {
@@ -88,9 +89,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     })
                     .addResourceCustomizer((resource, config) -> {
                         resourceCustomizations.incrementAndGet();
+                        configuredConfig.set(config);
                         Resource customResource = Resource.create(Attributes.of(
                                 CUSTOM_RESOURCE, config.getString("test.custom.resource")));
-                        return resource.merge(customResource);
+                        Resource customizedResource = resource.merge(customResource);
+                        configuredResource.set(customizedResource);
+                        return customizedResource;
                     })
                     .addSamplerCustomizer((sampler, config) -> {
                         samplerCustomizations.incrementAndGet();
@@ -124,7 +128,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     })
                     .build();
 
-            ConfigProperties config = configured.getConfig();
+            ConfigProperties config = configuredConfig.get();
+            assertThat(config).isNotNull();
             assertThat(valueSeenByPropertiesCustomizer).hasValue("from-supplier");
             assertThat(config.getString("otel.service.name")).isEqualTo("payments");
             assertThat(config.getBoolean("otel.sdk.disabled", true)).isFalse();
@@ -134,7 +139,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     .containsEntry("left", "right")
                     .containsEntry("region", "eu");
 
-            Resource resource = configured.getResource();
+            Resource resource = configuredResource.get();
+            assertThat(resource).isNotNull();
             assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
             assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isEqualTo("checkout");
             assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isEqualTo("integration-test");
@@ -188,12 +194,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
 
     @Test
     void resourceDisabledKeysFilterDecodedConfiguredAttributes() {
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.service.name", "filtered-service");
@@ -204,9 +210,14 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                                 "service.name,service.namespace,deployment.environment");
                         return properties;
                     })
+                    .addResourceCustomizer((resource, config) -> {
+                        configuredResource.set(resource);
+                        return resource;
+                    })
                     .build();
 
-            Resource resource = configured.getResource();
+            Resource resource = configuredResource.get();
+            assertThat(resource).isNotNull();
             assertThat(resource.getAttribute(SERVICE_NAME)).isNull();
             assertThat(resource.getAttribute(SERVICE_NAMESPACE)).isNull();
             assertThat(resource.getAttribute(DEPLOYMENT_ENVIRONMENT)).isNull();
@@ -221,17 +232,23 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void disabledSdkDoesNotConfigureSignalProvidersButExposesConfigAndResource() {
         AtomicBoolean tracerProviderCustomizerCalled = new AtomicBoolean();
+        AtomicReference<ConfigProperties> configuredConfig = new AtomicReference<>();
+        AtomicReference<Resource> configuredResource = new AtomicReference<>();
         AutoConfiguredOpenTelemetrySdk configured = null;
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.sdk.disabled", "true");
                         return properties;
                     })
+                    .addResourceCustomizer((resource, config) -> {
+                        configuredConfig.set(config);
+                        configuredResource.set(resource);
+                        return resource;
+                    })
                     .addTracerProviderCustomizer((builder, config) -> {
                         tracerProviderCustomizerCalled.set(true);
                         return builder;
@@ -244,8 +261,12 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
                     .startSpan();
             span.end();
 
-            assertThat(configured.getConfig().getBoolean("otel.sdk.disabled", false)).isTrue();
-            assertThat(configured.getResource().getAttribute(SERVICE_NAME)).isEqualTo("payments");
+            ConfigProperties config = configuredConfig.get();
+            Resource resource = configuredResource.get();
+            assertThat(config).isNotNull();
+            assertThat(resource).isNotNull();
+            assertThat(config.getBoolean("otel.sdk.disabled", false)).isTrue();
+            assertThat(resource.getAttribute(SERVICE_NAME)).isEqualTo("payments");
             assertThat(configured.getOpenTelemetrySdk().getPropagators().getTextMapPropagator().fields()).isEmpty();
             assertThat(tracerProviderCustomizerCalled).isFalse();
         } finally {
@@ -261,8 +282,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
 
         try {
             configured = AutoConfiguredOpenTelemetrySdk.builder()
-                    .setResultAsGlobal(false)
-                    .registerShutdownHook(false)
+                    .disableShutdownHook()
                     .addPropertiesCustomizer(config -> {
                         Map<String, String> properties = workingProperties();
                         properties.put("otel.traces.sampler", "parentbased_traceidratio");
@@ -314,8 +334,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void invalidConfigurationFailsFastWithConfigurationException() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
-                .setResultAsGlobal(false)
-                .registerShutdownHook(false)
+                .disableShutdownHook()
                 .addPropertiesCustomizer(config -> {
                     Map<String, String> properties = workingProperties();
                     properties.put("otel.traces.sampler", "not-a-sampler");
@@ -330,8 +349,7 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     @Test
     void exporterConfigurationRejectsNoneMixedWithOtherExporters() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder()
-                .setResultAsGlobal(false)
-                .registerShutdownHook(false)
+                .disableShutdownHook()
                 .addPropertiesCustomizer(config -> {
                     Map<String, String> properties = workingProperties();
                     properties.put("otel.traces.exporter", "none,custom");
@@ -347,8 +365,8 @@ public class Opentelemetry_sdk_extension_autoconfigureTest {
     void builderMethodsAreChainableAndValidateRequiredArguments() {
         AutoConfiguredOpenTelemetrySdkBuilder builder = AutoConfiguredOpenTelemetrySdk.builder();
 
-        assertThat(builder.registerShutdownHook(false)).isSameAs(builder);
-        assertThat(builder.setResultAsGlobal(false)).isSameAs(builder);
+        assertThat(builder.disableShutdownHook()).isSameAs(builder);
+        assertThat(builder.setResultAsGlobal()).isSameAs(builder);
         assertThat(builder.setServiceClassLoader(getClass().getClassLoader())).isSameAs(builder);
         assertThat(builder.addPropertiesSupplier(Map::of)).isSameAs(builder);
         assertThat(builder.addPropertiesCustomizer(config -> Map.of())).isSameAs(builder);

```
