### PR TITLE
[Automation] Generated metadata for org.jline:jline-reader:3.22.0

### DIFF
--- a/metadata/org.jline/jline-reader/3.22.0/reachability-metadata.json
+++ b/metadata/org.jline/jline-reader/3.22.0/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.spi.TerminalProvider"
+      },
+      "type": "org.jline.terminal.impl.exec.ExecTerminalProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.spi.TerminalProvider"
+      },
+      "glob": "META-INF/services/org/jline/terminal/provider/exec"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.spi.TerminalProvider"
+      },
+      "glob": "META-INF/services/org/jline/terminal/provider/jansi"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.spi.TerminalProvider"
+      },
+      "glob": "META-INF/services/org/jline/terminal/provider/jna"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.utils.InfoCmp"
+      },
+      "glob": "org/jline/utils/capabilities.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.utils.InfoCmp"
+      },
+      "glob": "org/jline/utils/xterm-256color.caps"
+    }
+  ]
+}

--- a/metadata/org.jline/jline-reader/index.json
+++ b/metadata/org.jline/jline-reader/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.22.0",
+    "test-version" : "3.19.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-reader/$version$/jline-reader-$version$-sources.jar",
+    "repository-url" : "https://github.com/jline/jline3",
+    "test-code-url" : "https://github.com/jline/jline3/tree/jline-parent-$version$/reader/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-reader/$version$/jline-reader-$version$-javadoc.jar",
+    "description" : "JLine Reader provides the line-editing, history, completion, key binding, and prompt-reading APIs used to build interactive command-line interfaces on the JVM. It sits on top of JLine terminal abstractions so Java applications can implement shell-like input behavior across supported consoles and terminal backends.",
+    "tested-versions" : [
+      "3.22.0"
+    ],
+    "allowed-packages" : [
+      "org.jline"
+    ]
+  },
+  {
     "metadata-version" : "3.19.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-reader/$version$/jline-reader-$version$-sources.jar",
     "repository-url" : "https://github.com/jline/jline3",

--- a/stats/org.jline/jline-reader/3.22.0/stats.json
+++ b/stats/org.jline/jline-reader/3.22.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.22.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9638,
+        "missed" : 17677,
+        "ratio" : 0.352846,
+        "total" : 27315
+      },
+      "line" : {
+        "covered" : 1814,
+        "missed" : 3659,
+        "ratio" : 0.331445,
+        "total" : 5473
+      },
+      "method" : {
+        "covered" : 307,
+        "missed" : 533,
+        "ratio" : 0.365476,
+        "total" : 840
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4843

This PR provides new metadata needed for the org.jline:jline-reader:3.22.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.jline:jline-reader:3.19.0`): 4
- Metadata entries (new `org.jline:jline-reader:3.22.0`): 7
- Library coverage (previous): 32.98%
- Library coverage (new): 33.14%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jline:jline-reader:3.19.0: 0/0 covered calls (100.00%)
- org.jline:jline-reader:3.22.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jline:jline-reader:3.19.0: 9743/27234 (35.78%)
- org.jline:jline-reader:3.22.0: 9638/27315 (35.28%)

**Line:**
- org.jline:jline-reader:3.19.0: 1781/5401 (32.98%)
- org.jline:jline-reader:3.22.0: 1814/5473 (33.14%)

**Method:**
- org.jline:jline-reader:3.19.0: 302/819 (36.87%)
- org.jline:jline-reader:3.22.0: 307/840 (36.55%)
