### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-xml:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-xml/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-xml/4.1.79.Final/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator",
+      "methods": [
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.ByteBuf"
+          ]
+        },
+        {
+          "name": "toLeakAwareBuffer",
+          "parameterTypes": [
+            "io.netty.buffer.CompositeByteBuf"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-xml/index.json
+++ b/metadata/io.netty/netty-codec-xml/index.json
@@ -1,16 +1,32 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-test-sources.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-javadoc.jar",
-    "description" : "Netty Codec XML provides XML codec handlers for Netty pipelines, built on Netty's asynchronous event-driven networking framework. It helps applications decode and process XML-based protocols as part of high-performance client and server networking stacks.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.1.79.Final",
+    "test-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-javadoc.jar",
+    "description": "Netty Codec XML provides XML codec handlers for Netty pipelines, built on Netty's asynchronous event-driven networking framework. It helps applications decode and process XML-based protocols as part of high-performance client and server networking stacks.",
+    "tested-versions": [
+      "4.1.79.Final"
+    ],
+    "allowed-packages": [
+      "io.netty.handler.codec.xml",
+      "io.netty.buffer"
+    ]
+  },
+  {
+    "metadata-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-test-sources.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-codec-xml/$version$/netty-codec-xml-$version$-javadoc.jar",
+    "description": "Netty Codec XML provides XML codec handlers for Netty pipelines, built on Netty's asynchronous event-driven networking framework. It helps applications decode and process XML-based protocols as part of high-performance client and server networking stacks.",
+    "tested-versions": [
       "4.1.74.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.netty.handler.codec.xml"
     ]
   }

--- a/stats/io.netty/netty-codec-xml/4.1.79.Final/stats.json
+++ b/stats/io.netty/netty-codec-xml/4.1.79.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.79.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1022,
+        "missed" : 393,
+        "ratio" : 0.722261,
+        "total" : 1415
+      },
+      "line" : {
+        "covered" : 205,
+        "missed" : 62,
+        "ratio" : 0.76779,
+        "total" : 267
+      },
+      "method" : {
+        "covered" : 59,
+        "missed" : 9,
+        "ratio" : 0.867647,
+        "total" : 68
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4834

This PR provides new metadata needed for the io.netty:netty-codec-xml:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-xml:4.1.74.Final`): 0
- Metadata entries (new `io.netty:netty-codec-xml:4.1.79.Final`): 3
- Library coverage (previous): 76.78%
- Library coverage (new): 76.78%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-xml:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-xml:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-xml:4.1.74.Final: 1022/1415 (72.23%)
- io.netty:netty-codec-xml:4.1.79.Final: 1022/1415 (72.23%)

**Line:**
- io.netty:netty-codec-xml:4.1.74.Final: 205/267 (76.78%)
- io.netty:netty-codec-xml:4.1.79.Final: 205/267 (76.78%)

**Method:**
- io.netty:netty-codec-xml:4.1.74.Final: 59/68 (86.76%)
- io.netty:netty-codec-xml:4.1.79.Final: 59/68 (86.76%)
