### PR TITLE
[GenAI] Add support for com.google.cloud:proto-google-cloud-firestore-bundle-v1:3.31.6 using gpt-5.5

### DIFF
--- a/metadata/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/reachability-metadata.json
+++ b/metadata/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/reachability-metadata.json
@@ -1,0 +1,56 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.firestore.bundle.BundleProto"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.cloud/proto-google-cloud-firestore-bundle-v1/index.json
+++ b/metadata/com.google.cloud/proto-google-cloud-firestore-bundle-v1/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.31.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/proto-google-cloud-firestore-bundle-v1/$version$/proto-google-cloud-firestore-bundle-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-firestore",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/proto-google-cloud-firestore-bundle-v1/$version$/proto-google-cloud-firestore-bundle-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/proto-google-cloud-firestore-bundle-v1/$version$/proto-google-cloud-firestore-bundle-v1-$version$-javadoc.jar",
+    "description" : "This artifact bundles the Java protobuf classes for Firestore bundle messages used to represent serialized Firestore data bundles. It provides generated message types and descriptors for reading and writing Firestore bundle metadata, named queries, bundled queries, and bundled document metadata.",
+    "tested-versions" : [
+      "3.31.6"
+    ],
+    "allowed-packages" : [
+      "com.google.firestore.bundle"
+    ]
+  }
+]

--- a/stats/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/execution-metrics.json
+++ b/stats/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T07:15:32.873287Z",
+    "library": "com.google.cloud:proto-google-cloud-firestore-bundle-v1:3.31.6",
+    "starting_commit": "8bbc80923d3a04fec0365acc7c396b75a6ba4a66",
+    "ending_commit": "30de6354eb5f03c54f8433eadb92a8ccd33f0009",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.31.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3801,
+          "missed": 3713,
+          "ratio": 0.505856,
+          "total": 7514
+        },
+        "line": {
+          "covered": 1024,
+          "missed": 966,
+          "ratio": 0.514573,
+          "total": 1990
+        },
+        "method": {
+          "covered": 215,
+          "missed": 275,
+          "ratio": 0.438776,
+          "total": 490
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 106632,
+      "cached_input_tokens_used": 1071104,
+      "output_tokens_used": 17635,
+      "iterations": 3,
+      "cost_usd": 1.0647,
+      "generated_loc": 318,
+      "tested_library_loc": 1024,
+      "metadata_entries": 9,
+      "code_coverage_percent": 51.46
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java",
+      "metadata_file": "metadata/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/stats.json
+++ b/stats/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.31.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3801,
+        "missed" : 3713,
+        "ratio" : 0.505856,
+        "total" : 7514
+      },
+      "line" : {
+        "covered" : 1024,
+        "missed" : 966,
+        "ratio" : 0.514573,
+        "total" : 1990
+      },
+      "method" : {
+        "covered" : 215,
+        "missed" : 275,
+        "ratio" : 0.438776,
+        "total" : 490
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/.gitignore
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/build.gradle
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.cloud:proto-google-cloud-firestore-bundle-v1:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/gradle.properties
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.cloud:proto-google-cloud-firestore-bundle-v1:3.31.6
+library.version = 3.31.6
+metadata.dir = com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/settings.gradle
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.cloud.proto-google-cloud-firestore-bundle-v1_tests'

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_cloud.proto_google_cloud_firestore_bundle_v1;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_firestore_bundle_v1Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
@@ -186,6 +186,30 @@ public class Proto_google_cloud_firestore_bundle_v1Test {
     }
 
     @Test
+    void bundledQueryPreservesUnrecognizedLimitTypeValues() throws Exception {
+        StructuredQuery structuredQuery = StructuredQuery.newBuilder()
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder().setCollectionId("cities"))
+                .build();
+        BundledQuery bundledQuery = BundledQuery.newBuilder()
+                .setParent(PARENT)
+                .setStructuredQuery(structuredQuery)
+                .setLimitTypeValue(99)
+                .build();
+
+        BundledQuery parsed = BundledQuery.parseFrom(bundledQuery.toByteArray());
+        BundledQuery normalized = parsed.toBuilder()
+                .setLimitType(BundledQuery.LimitType.FIRST)
+                .build();
+
+        assertThat(parsed.getLimitTypeValue()).isEqualTo(99);
+        assertThat(parsed.getLimitType()).isEqualTo(BundledQuery.LimitType.UNRECOGNIZED);
+        assertThat(parsed.getQueryTypeCase()).isEqualTo(BundledQuery.QueryTypeCase.STRUCTURED_QUERY);
+        assertThat(parsed.getStructuredQuery().getFrom(0).getCollectionId()).isEqualTo("cities");
+        assertThat(normalized.getLimitTypeValue()).isEqualTo(BundledQuery.LimitType.FIRST.getNumber());
+        assertThat(normalized.getLimitType()).isEqualTo(BundledQuery.LimitType.FIRST);
+    }
+
+    @Test
     void bundledDocumentMetadataKeepsRepeatedQueryMembership() throws Exception {
         BundledDocumentMetadata documentMetadata = BundledDocumentMetadata.newBuilder()
                 .setName(DOCUMENT_NAME)

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
@@ -15,6 +15,7 @@ import com.google.firestore.bundle.BundleProto;
 import com.google.firestore.bundle.BundledDocumentMetadata;
 import com.google.firestore.bundle.BundledQuery;
 import com.google.firestore.bundle.NamedQuery;
+import com.google.firestore.v1.Cursor;
 import com.google.firestore.v1.Document;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
@@ -117,6 +118,71 @@ public class Proto_google_cloud_firestore_bundle_v1Test {
                 .getField()
                 .getFieldPath()).isEqualTo("name");
         assertThat(parsed.getBundledQuery().getStructuredQuery().getLimit().getValue()).isEqualTo(10);
+    }
+
+    @Test
+    void bundledQueryPreservesStructuredQueryFiltersAndCursors() {
+        StructuredQuery.Filter stateFilter = StructuredQuery.Filter.newBuilder()
+                .setFieldFilter(StructuredQuery.FieldFilter.newBuilder()
+                        .setField(fieldReference("state"))
+                        .setOp(StructuredQuery.FieldFilter.Operator.EQUAL)
+                        .setValue(stringValue("CA")))
+                .build();
+        StructuredQuery.Filter populationFilter = StructuredQuery.Filter.newBuilder()
+                .setFieldFilter(StructuredQuery.FieldFilter.newBuilder()
+                        .setField(fieldReference("population"))
+                        .setOp(StructuredQuery.FieldFilter.Operator.GREATER_THAN_OR_EQUAL)
+                        .setValue(integerValue(500_000L)))
+                .build();
+        StructuredQuery structuredQuery = StructuredQuery.newBuilder()
+                .setSelect(StructuredQuery.Projection.newBuilder()
+                        .addFields(fieldReference("name"))
+                        .addFields(fieldReference("population")))
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder()
+                        .setCollectionId("cities")
+                        .setAllDescendants(true))
+                .setWhere(StructuredQuery.Filter.newBuilder()
+                        .setCompositeFilter(StructuredQuery.CompositeFilter.newBuilder()
+                                .setOp(StructuredQuery.CompositeFilter.Operator.AND)
+                                .addFilters(stateFilter)
+                                .addFilters(populationFilter)))
+                .setStartAt(Cursor.newBuilder()
+                        .addValues(integerValue(500_000L))
+                        .setBefore(false))
+                .setEndAt(Cursor.newBuilder()
+                        .addValues(integerValue(1_000_000L))
+                        .setBefore(true))
+                .setOffset(2)
+                .build();
+        BundledQuery bundledQuery = BundledQuery.newBuilder()
+                .setParent(PARENT)
+                .setStructuredQuery(structuredQuery)
+                .build();
+
+        StructuredQuery storedQuery = bundledQuery.getStructuredQuery();
+        StructuredQuery.CompositeFilter storedFilter = storedQuery.getWhere().getCompositeFilter();
+
+        assertThat(bundledQuery.getQueryTypeCase()).isEqualTo(BundledQuery.QueryTypeCase.STRUCTURED_QUERY);
+        assertThat(storedQuery.getSelect().getFieldsList())
+                .extracting(StructuredQuery.FieldReference::getFieldPath)
+                .containsExactly("name", "population");
+        assertThat(storedQuery.getFrom(0).getCollectionId()).isEqualTo("cities");
+        assertThat(storedQuery.getFrom(0).getAllDescendants()).isTrue();
+        assertThat(storedFilter.getOp()).isEqualTo(StructuredQuery.CompositeFilter.Operator.AND);
+        assertThat(storedFilter.getFiltersList())
+                .extracting(filter -> filter.getFieldFilter().getField().getFieldPath())
+                .containsExactly("state", "population");
+        assertThat(storedFilter.getFilters(0).getFieldFilter().getOp())
+                .isEqualTo(StructuredQuery.FieldFilter.Operator.EQUAL);
+        assertThat(storedFilter.getFilters(0).getFieldFilter().getValue().getStringValue()).isEqualTo("CA");
+        assertThat(storedFilter.getFilters(1).getFieldFilter().getOp())
+                .isEqualTo(StructuredQuery.FieldFilter.Operator.GREATER_THAN_OR_EQUAL);
+        assertThat(storedFilter.getFilters(1).getFieldFilter().getValue().getIntegerValue()).isEqualTo(500_000L);
+        assertThat(storedQuery.getStartAt().getValues(0).getIntegerValue()).isEqualTo(500_000L);
+        assertThat(storedQuery.getStartAt().getBefore()).isFalse();
+        assertThat(storedQuery.getEndAt().getValues(0).getIntegerValue()).isEqualTo(1_000_000L);
+        assertThat(storedQuery.getEndAt().getBefore()).isTrue();
+        assertThat(storedQuery.getOffset()).isEqualTo(2);
     }
 
     @Test
@@ -248,6 +314,18 @@ public class Proto_google_cloud_firestore_bundle_v1Test {
                 .setCreateTime(timestamp(1_600_000_000L, 0))
                 .setUpdateTime(timestamp(1_700_000_200L, 0))
                 .build();
+    }
+
+    private static StructuredQuery.FieldReference fieldReference(String fieldPath) {
+        return StructuredQuery.FieldReference.newBuilder().setFieldPath(fieldPath).build();
+    }
+
+    private static Value stringValue(String value) {
+        return Value.newBuilder().setStringValue(value).build();
+    }
+
+    private static Value integerValue(long value) {
+        return Value.newBuilder().setIntegerValue(value).build();
     }
 
     private static Timestamp timestamp(long seconds, int nanos) {

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/src/test/java/com_google_cloud/proto_google_cloud_firestore_bundle_v1/Proto_google_cloud_firestore_bundle_v1Test.java
@@ -6,11 +6,251 @@
  */
 package com_google_cloud.proto_google_cloud_firestore_bundle_v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.firestore.bundle.BundleElement;
+import com.google.firestore.bundle.BundleMetadata;
+import com.google.firestore.bundle.BundleProto;
+import com.google.firestore.bundle.BundledDocumentMetadata;
+import com.google.firestore.bundle.BundledQuery;
+import com.google.firestore.bundle.NamedQuery;
+import com.google.firestore.v1.Document;
+import com.google.firestore.v1.StructuredQuery;
+import com.google.firestore.v1.Value;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_firestore_bundle_v1Test {
+public class Proto_google_cloud_firestore_bundle_v1Test {
+    private static final String PARENT = "projects/test-project/databases/(default)/documents";
+    private static final String DOCUMENT_NAME = PARENT + "/cities/SF";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void fileDescriptorExposesFirestoreBundleSchema() {
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        BundleProto.registerAllExtensions(registry);
+
+        Descriptors.FileDescriptor descriptor = BundleProto.getDescriptor();
+
+        assertThat(descriptor.getPackage()).isEqualTo("google.firestore.bundle");
+        assertThat(descriptor.getMessageTypes()).extracting(Descriptors.Descriptor::getName)
+                .containsExactly(
+                        "BundledQuery", "NamedQuery", "BundledDocumentMetadata", "BundleMetadata", "BundleElement");
+        assertThat(BundleElement.getDescriptor().getOneofs()).extracting(Descriptors.OneofDescriptor::getName)
+                .containsExactly("element_type");
+        assertThat(BundledQuery.getDescriptor().getOneofs()).extracting(Descriptors.OneofDescriptor::getName)
+                .containsExactly("query_type");
+        assertThat(BundleMetadata.getDescriptor().findFieldByNumber(BundleMetadata.TOTAL_BYTES_FIELD_NUMBER).getName())
+                .isEqualTo("total_bytes");
+    }
+
+    @Test
+    void bundleMetadataRoundTripsThroughBinaryRepresentations() throws Exception {
+        BundleMetadata metadata = BundleMetadata.newBuilder()
+                .setId("bundle-cities")
+                .setCreateTime(timestamp(1_700_000_000L, 123_000_000))
+                .setVersion(1)
+                .setTotalDocuments(2)
+                .setTotalBytes(4096L)
+                .build();
+
+        BundleMetadata parsedFromBytes = BundleMetadata.parseFrom(metadata.toByteArray());
+        BundleMetadata parsedFromByteString = BundleMetadata.parseFrom(metadata.toByteString());
+        BundleMetadata parsedFromBuffer = BundleMetadata.parseFrom(ByteBuffer.wrap(metadata.toByteArray()));
+        BundleMetadata parsedFromParser = BundleMetadata.parser().parseFrom(metadata.toByteString());
+
+        assertThat(List.of(parsedFromBytes, parsedFromByteString, parsedFromBuffer, parsedFromParser))
+                .containsOnly(metadata);
+        assertThat(parsedFromBytes.hasCreateTime()).isTrue();
+        assertThat(parsedFromBytes.getIdBytes()).isEqualTo(ByteString.copyFromUtf8("bundle-cities"));
+        assertThat(parsedFromBytes.getTotalBytes()).isEqualTo(4096L);
+        assertThat(parsedFromBytes.isInitialized()).isTrue();
+        assertThat(BundleMetadata.newBuilder(parsedFromBytes)
+                .setTotalDocuments(3)
+                .build()
+                .getTotalDocuments()).isEqualTo(3);
+    }
+
+    @Test
+    void namedQueryRetainsStructuredQueryAndReadTime() throws Exception {
+        StructuredQuery structuredQuery = StructuredQuery.newBuilder()
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder()
+                        .setCollectionId("cities")
+                        .setAllDescendants(false))
+                .addOrderBy(StructuredQuery.Order.newBuilder()
+                        .setField(StructuredQuery.FieldReference.newBuilder().setFieldPath("name"))
+                        .setDirection(StructuredQuery.Direction.ASCENDING))
+                .setLimit(Int32Value.of(10))
+                .build();
+        BundledQuery bundledQuery = BundledQuery.newBuilder()
+                .setParent(PARENT)
+                .setStructuredQuery(structuredQuery)
+                .setLimitType(BundledQuery.LimitType.LAST)
+                .build();
+        NamedQuery namedQuery = NamedQuery.newBuilder()
+                .setName("top-cities")
+                .setBundledQuery(bundledQuery)
+                .setReadTime(timestamp(1_700_000_100L, 0))
+                .build();
+
+        NamedQuery parsed = NamedQuery.parseFrom(new ByteArrayInputStream(namedQuery.toByteArray()));
+
+        assertThat(parsed.getName()).isEqualTo("top-cities");
+        assertThat(parsed.hasBundledQuery()).isTrue();
+        assertThat(parsed.hasReadTime()).isTrue();
+        assertThat(parsed.getBundledQuery().getParent()).isEqualTo(PARENT);
+        assertThat(parsed.getBundledQuery().getQueryTypeCase()).isEqualTo(BundledQuery.QueryTypeCase.STRUCTURED_QUERY);
+        assertThat(parsed.getBundledQuery().getLimitType()).isEqualTo(BundledQuery.LimitType.LAST);
+        assertThat(parsed.getBundledQuery().getStructuredQuery().getFrom(0).getCollectionId()).isEqualTo("cities");
+        assertThat(parsed.getBundledQuery()
+                .getStructuredQuery()
+                .getOrderBy(0)
+                .getField()
+                .getFieldPath()).isEqualTo("name");
+        assertThat(parsed.getBundledQuery().getStructuredQuery().getLimit().getValue()).isEqualTo(10);
+    }
+
+    @Test
+    void bundledDocumentMetadataKeepsRepeatedQueryMembership() throws Exception {
+        BundledDocumentMetadata documentMetadata = BundledDocumentMetadata.newBuilder()
+                .setName(DOCUMENT_NAME)
+                .setReadTime(timestamp(1_700_000_200L, 987_000_000))
+                .setExists(true)
+                .addAllQueries(List.of("top-cities", "california-cities"))
+                .setQueries(1, "west-coast-cities")
+                .addQueriesBytes(ByteString.copyFromUtf8("large-cities"))
+                .build();
+
+        BundledDocumentMetadata parsed = BundledDocumentMetadata.parseFrom(documentMetadata.toByteString());
+        BundledDocumentMetadata withoutReadTime = parsed.toBuilder().clearReadTime().clearExists().build();
+
+        assertThat(parsed.getName()).isEqualTo(DOCUMENT_NAME);
+        assertThat(parsed.hasReadTime()).isTrue();
+        assertThat(parsed.getExists()).isTrue();
+        assertThat(parsed.getQueriesList()).containsExactly("top-cities", "west-coast-cities", "large-cities");
+        assertThat(parsed.getQueriesBytes(2)).isEqualTo(ByteString.copyFromUtf8("large-cities"));
+        assertThat(withoutReadTime.hasReadTime()).isFalse();
+        assertThat(withoutReadTime.getExists()).isFalse();
+    }
+
+    @Test
+    void bundleElementOneofSwitchesBetweenSupportedElementTypes() {
+        BundleMetadata metadata = sampleMetadata();
+        NamedQuery namedQuery = sampleNamedQuery();
+        BundledDocumentMetadata documentMetadata = sampleDocumentMetadata();
+        Document document = sampleDocument();
+
+        BundleElement.Builder builder = BundleElement.newBuilder().setMetadata(metadata);
+        assertThat(builder.build().getElementTypeCase()).isEqualTo(BundleElement.ElementTypeCase.METADATA);
+
+        BundleElement namedQueryElement = builder.setNamedQuery(namedQuery).build();
+        assertThat(namedQueryElement.hasMetadata()).isFalse();
+        assertThat(namedQueryElement.hasNamedQuery()).isTrue();
+        assertThat(namedQueryElement.getElementTypeCase()).isEqualTo(BundleElement.ElementTypeCase.NAMED_QUERY);
+
+        BundleElement documentMetadataElement = namedQueryElement.toBuilder()
+                .setDocumentMetadata(documentMetadata)
+                .build();
+        assertThat(documentMetadataElement.hasNamedQuery()).isFalse();
+        assertThat(documentMetadataElement.hasDocumentMetadata()).isTrue();
+        assertThat(documentMetadataElement.getElementTypeCase())
+                .isEqualTo(BundleElement.ElementTypeCase.DOCUMENT_METADATA);
+
+        BundleElement documentElement = documentMetadataElement.toBuilder().setDocument(document).build();
+        assertThat(documentElement.hasDocumentMetadata()).isFalse();
+        assertThat(documentElement.hasDocument()).isTrue();
+        assertThat(documentElement.getElementTypeCase()).isEqualTo(BundleElement.ElementTypeCase.DOCUMENT);
+        assertThat(documentElement.toBuilder().clearElementType().build().getElementTypeCase())
+                .isEqualTo(BundleElement.ElementTypeCase.ELEMENTTYPE_NOT_SET);
+    }
+
+    @Test
+    void delimitedBundleElementStreamReadsElementsInOrder() throws Exception {
+        BundleElement metadataElement = BundleElement.newBuilder().setMetadata(sampleMetadata()).build();
+        BundleElement queryElement = BundleElement.newBuilder().setNamedQuery(sampleNamedQuery()).build();
+        BundleElement documentMetadataElement = BundleElement.newBuilder()
+                .setDocumentMetadata(sampleDocumentMetadata())
+                .build();
+        BundleElement documentElement = BundleElement.newBuilder().setDocument(sampleDocument()).build();
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        metadataElement.writeDelimitedTo(output);
+        queryElement.writeDelimitedTo(output);
+        documentMetadataElement.writeDelimitedTo(output);
+        documentElement.writeDelimitedTo(output);
+
+        ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
+
+        assertThat(BundleElement.parseDelimitedFrom(input)).isEqualTo(metadataElement);
+        assertThat(BundleElement.parseDelimitedFrom(input)).isEqualTo(queryElement);
+        assertThat(BundleElement.parseDelimitedFrom(input)).isEqualTo(documentMetadataElement);
+        assertThat(BundleElement.parseDelimitedFrom(input)).isEqualTo(documentElement);
+        assertThat(BundleElement.parseDelimitedFrom(input)).isNull();
+    }
+
+    @Test
+    void invalidBundleElementPayloadRaisesProtocolBufferException() {
+        byte[] invalidPayload = {(byte) 0x80, (byte) 0x80, (byte) 0x80};
+
+        assertThatThrownBy(() -> BundleElement.parseFrom(invalidPayload))
+                .isInstanceOf(InvalidProtocolBufferException.class);
+    }
+
+    private static BundleMetadata sampleMetadata() {
+        return BundleMetadata.newBuilder()
+                .setId("bundle-cities")
+                .setCreateTime(timestamp(1_700_000_000L, 0))
+                .setVersion(1)
+                .setTotalDocuments(1)
+                .setTotalBytes(256L)
+                .build();
+    }
+
+    private static NamedQuery sampleNamedQuery() {
+        StructuredQuery structuredQuery = StructuredQuery.newBuilder()
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder().setCollectionId("cities"))
+                .build();
+        BundledQuery bundledQuery = BundledQuery.newBuilder()
+                .setParent(PARENT)
+                .setStructuredQuery(structuredQuery)
+                .setLimitType(BundledQuery.LimitType.FIRST)
+                .build();
+        return NamedQuery.newBuilder()
+                .setName("top-cities")
+                .setBundledQuery(bundledQuery)
+                .setReadTime(timestamp(1_700_000_100L, 0))
+                .build();
+    }
+
+    private static BundledDocumentMetadata sampleDocumentMetadata() {
+        return BundledDocumentMetadata.newBuilder()
+                .setName(DOCUMENT_NAME)
+                .setReadTime(timestamp(1_700_000_200L, 0))
+                .setExists(true)
+                .addQueries("top-cities")
+                .build();
+    }
+
+    private static Document sampleDocument() {
+        return Document.newBuilder()
+                .setName(DOCUMENT_NAME)
+                .putFields("name", Value.newBuilder().setStringValue("San Francisco").build())
+                .putFields("population", Value.newBuilder().setIntegerValue(808_437L).build())
+                .setCreateTime(timestamp(1_600_000_000L, 0))
+                .setUpdateTime(timestamp(1_700_000_200L, 0))
+                .build();
+    }
+
+    private static Timestamp timestamp(long seconds, int nanos) {
+        return Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
     }
 }

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="3" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-03T09:12:25">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-03T09:14:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4710-acd8bd7e/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6"/>
@@ -58,13 +57,13 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_fir
 display-name: bundleMetadataRoundTripsThroughBinaryRepresentations()
 ]]></system-out>
 </testcase>
-<testcase name="bundledDocumentMetadataKeepsRepeatedQueryMembership()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<testcase name="bundledDocumentMetadataKeepsRepeatedQueryMembership()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundledDocumentMetadataKeepsRepeatedQueryMembership()]
 display-name: bundledDocumentMetadataKeepsRepeatedQueryMembership()
 ]]></system-out>
 </testcase>
-<testcase name="invalidBundleElementPayloadRaisesProtocolBufferException()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.002">
+<testcase name="invalidBundleElementPayloadRaisesProtocolBufferException()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:invalidBundleElementPayloadRaisesProtocolBufferException()]
 display-name: invalidBundleElementPayloadRaisesProtocolBufferException()
@@ -76,93 +75,25 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_fir
 display-name: namedQueryRetainsStructuredQueryAndReadTime()
 ]]></system-out>
 </testcase>
-<testcase name="fileDescriptorExposesFirestoreBundleSchema()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.003">
-<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
-	at com.google.firestore.v1.DocumentProto.<clinit>(DocumentProto.java:108)
-	at com.google.firestore.bundle.BundleProto.<clinit>(BundleProto.java:96)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.fileDescriptorExposesFirestoreBundleSchema(Proto_google_cloud_firestore_bundle_v1Test.java:41)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.RuntimeException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1908)
-	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:39)
-	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1731)
-	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1584)
-	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:59)
-	... 15 more
-Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
-	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1905)
-	... 19 more
-]]></error>
+<testcase name="fileDescriptorExposesFirestoreBundleSchema()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:fileDescriptorExposesFirestoreBundleSchema()]
 display-name: fileDescriptorExposesFirestoreBundleSchema()
 ]]></system-out>
 </testcase>
-<testcase name="bundledQueryPreservesStructuredQueryFiltersAndCursors()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<testcase name="bundledQueryPreservesStructuredQueryFiltersAndCursors()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundledQueryPreservesStructuredQueryFiltersAndCursors()]
 display-name: bundledQueryPreservesStructuredQueryFiltersAndCursors()
 ]]></system-out>
 </testcase>
 <testcase name="delimitedBundleElementStreamReadsElementsInOrder()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
-<error message="Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder
-	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
-	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
-	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:340)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:273)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:delimitedBundleElementStreamReadsElementsInOrder()]
 display-name: delimitedBundleElementStreamReadsElementsInOrder()
 ]]></system-out>
 </testcase>
 <testcase name="bundleElementOneofSwitchesBetweenSupportedElementTypes()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
-<error message="Could not initialize class com.google.firestore.v1.DocumentProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.firestore.v1.DocumentProto
-	at com.google.firestore.v1.Document$FieldsDefaultEntryHolder.<clinit>(Document.java:140)
-	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
-	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
-	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:340)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:240)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundleElementOneofSwitchesBetweenSupportedElementTypes()]
 display-name: bundleElementOneofSwitchesBetweenSupportedElementTypes()

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:11:03">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="3" time="0.007" hostname="kung-fu-workstation" timestamp="2026-05-03T09:12:25">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -64,7 +64,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_fir
 display-name: bundledDocumentMetadataKeepsRepeatedQueryMembership()
 ]]></system-out>
 </testcase>
-<testcase name="invalidBundleElementPayloadRaisesProtocolBufferException()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<testcase name="invalidBundleElementPayloadRaisesProtocolBufferException()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:invalidBundleElementPayloadRaisesProtocolBufferException()]
 display-name: invalidBundleElementPayloadRaisesProtocolBufferException()
@@ -76,7 +76,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_fir
 display-name: namedQueryRetainsStructuredQueryAndReadTime()
 ]]></system-out>
 </testcase>
-<testcase name="fileDescriptorExposesFirestoreBundleSchema()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<testcase name="fileDescriptorExposesFirestoreBundleSchema()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0.003">
 <error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
 	at com.google.firestore.v1.DocumentProto.<clinit>(DocumentProto.java:108)
 	at com.google.firestore.bundle.BundleProto.<clinit>(BundleProto.java:96)
@@ -122,8 +122,8 @@ display-name: bundledQueryPreservesStructuredQueryFiltersAndCursors()
 	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
 	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
 	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:316)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:249)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:340)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:273)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -148,8 +148,8 @@ display-name: delimitedBundleElementStreamReadsElementsInOrder()
 	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
 	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
 	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:316)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:216)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:340)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:240)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -166,6 +166,12 @@ display-name: delimitedBundleElementStreamReadsElementsInOrder()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundleElementOneofSwitchesBetweenSupportedElementTypes()]
 display-name: bundleElementOneofSwitchesBetweenSupportedElementTypes()
+]]></system-out>
+</testcase>
+<testcase name="bundledQueryPreservesUnrecognizedLimitTypeValues()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundledQueryPreservesUnrecognizedLimitTypeValues()]
+display-name: bundledQueryPreservesUnrecognizedLimitTypeValues()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:08:32">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:11:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -80,7 +80,7 @@ display-name: namedQueryRetainsStructuredQueryAndReadTime()
 <error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
 	at com.google.firestore.v1.DocumentProto.<clinit>(DocumentProto.java:108)
 	at com.google.firestore.bundle.BundleProto.<clinit>(BundleProto.java:96)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.fileDescriptorExposesFirestoreBundleSchema(Proto_google_cloud_firestore_bundle_v1Test.java:40)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.fileDescriptorExposesFirestoreBundleSchema(Proto_google_cloud_firestore_bundle_v1Test.java:41)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -111,13 +111,19 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_fir
 display-name: fileDescriptorExposesFirestoreBundleSchema()
 ]]></system-out>
 </testcase>
+<testcase name="bundledQueryPreservesStructuredQueryFiltersAndCursors()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundledQueryPreservesStructuredQueryFiltersAndCursors()]
+display-name: bundledQueryPreservesStructuredQueryFiltersAndCursors()
+]]></system-out>
+</testcase>
 <testcase name="delimitedBundleElementStreamReadsElementsInOrder()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
 <error message="Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder
 	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
 	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
 	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:250)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:183)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:316)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:249)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -142,8 +148,8 @@ display-name: delimitedBundleElementStreamReadsElementsInOrder()
 	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
 	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
 	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:250)
-	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:150)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:316)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:216)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:08:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4710-acd8bd7e/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="bundleMetadataRoundTripsThroughBinaryRepresentations()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundleMetadataRoundTripsThroughBinaryRepresentations()]
+display-name: bundleMetadataRoundTripsThroughBinaryRepresentations()
+]]></system-out>
+</testcase>
+<testcase name="bundledDocumentMetadataKeepsRepeatedQueryMembership()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundledDocumentMetadataKeepsRepeatedQueryMembership()]
+display-name: bundledDocumentMetadataKeepsRepeatedQueryMembership()
+]]></system-out>
+</testcase>
+<testcase name="invalidBundleElementPayloadRaisesProtocolBufferException()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:invalidBundleElementPayloadRaisesProtocolBufferException()]
+display-name: invalidBundleElementPayloadRaisesProtocolBufferException()
+]]></system-out>
+</testcase>
+<testcase name="namedQueryRetainsStructuredQueryAndReadTime()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:namedQueryRetainsStructuredQueryAndReadTime()]
+display-name: namedQueryRetainsStructuredQueryAndReadTime()
+]]></system-out>
+</testcase>
+<testcase name="fileDescriptorExposesFirestoreBundleSchema()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
+	at com.google.firestore.v1.DocumentProto.<clinit>(DocumentProto.java:108)
+	at com.google.firestore.bundle.BundleProto.<clinit>(BundleProto.java:96)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.fileDescriptorExposesFirestoreBundleSchema(Proto_google_cloud_firestore_bundle_v1Test.java:40)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.RuntimeException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1908)
+	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:39)
+	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1731)
+	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1584)
+	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:59)
+	... 15 more
+Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
+	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1905)
+	... 19 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:fileDescriptorExposesFirestoreBundleSchema()]
+display-name: fileDescriptorExposesFirestoreBundleSchema()
+]]></system-out>
+</testcase>
+<testcase name="delimitedBundleElementStreamReadsElementsInOrder()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<error message="Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.firestore.v1.Document$FieldsDefaultEntryHolder
+	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
+	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
+	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:250)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.delimitedBundleElementStreamReadsElementsInOrder(Proto_google_cloud_firestore_bundle_v1Test.java:183)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:delimitedBundleElementStreamReadsElementsInOrder()]
+display-name: delimitedBundleElementStreamReadsElementsInOrder()
+]]></system-out>
+</testcase>
+<testcase name="bundleElementOneofSwitchesBetweenSupportedElementTypes()" classname="com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test" time="0">
+<error message="Could not initialize class com.google.firestore.v1.DocumentProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.firestore.v1.DocumentProto
+	at com.google.firestore.v1.Document$FieldsDefaultEntryHolder.<clinit>(Document.java:140)
+	at com.google.firestore.v1.Document$Builder.buildPartial0(Document.java:789)
+	at com.google.firestore.v1.Document$Builder.buildPartial(Document.java:777)
+	at com.google.firestore.v1.Document$Builder.build(Document.java:766)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.sampleDocument(Proto_google_cloud_firestore_bundle_v1Test.java:250)
+	at com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test.bundleElementOneofSwitchesBetweenSupportedElementTypes(Proto_google_cloud_firestore_bundle_v1Test.java:150)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.proto_google_cloud_firestore_bundle_v1.Proto_google_cloud_firestore_bundle_v1Test]/[method:bundleElementOneofSwitchesBetweenSupportedElementTypes()]
+display-name: bundleElementOneofSwitchesBetweenSupportedElementTypes()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:12:25">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:14:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4710-acd8bd7e/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6"/>

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:08:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4710-acd8bd7e/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:08:32">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:11:03">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:11:03">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:12:25">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/user-code-filter.json
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.firestore.bundle.**"
+    }
+  ]
+}

--- a/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/user-code-filter.json
+++ b/tests/src/com.google.cloud/proto-google-cloud-firestore-bundle-v1/3.31.6/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.firestore.bundle.**"
+      "includeClasses" : "com.google.firestore.bundle.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4710

This PR introduces tests and metadata for com.google.cloud:proto-google-cloud-firestore-bundle-v1:3.31.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 106632
- Cached input tokens: 1071104
- Output tokens: 17635
- Metadata entries: 9
- Iterations: 3
- Library coverage percentage: 51.46
- Generated lines of code: 318
- Tested library lines of code: 1024

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3801/7514 (50.59%)
- Line: 1024/1990 (51.46%)
- Method: 215/490 (43.88%)
