### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:3.14.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/reachability-metadata.json
@@ -1,0 +1,389 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.TableProto"
+      },
+      "type": "com.google.api.FieldBehavior"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ArrowSchema"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.AvroSchema"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.DataFormat"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ReadSession"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ReadSession$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ReadSession$TableModifiers"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ReadSession$TableReadOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1.ReadStream"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.Extension"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "com.google.protobuf.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ExtensionRegistryFactory"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.AnnotationsProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ReadSession"
+      },
+      "type": "com.google.protobuf.Timestamp"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ArrowSchema"
+      },
+      "type": "libcore.io.Memory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.ArrowSchema"
+      },
+      "type": "org.robolectric.Robolectric"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-javadoc.jar",
+    "description" : "This artifact provides the generated Java Protocol Buffer classes and .proto descriptors for the Google Cloud BigQuery Storage v1 API. It defines messages, enums, resource names, and service-related types used by Java clients and gRPC stubs to read from and write to BigQuery Storage.",
+    "tested-versions" : [
+      "3.14.1"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1"
+    ]
+  }
+]

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.14.1",
-    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-sources.jar",
-    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
-    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-tests.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-javadoc.jar",
-    "description" : "This artifact provides the generated Java Protocol Buffer classes and .proto descriptors for the Google Cloud BigQuery Storage v1 API. It defines messages, enums, resource names, and service-related types used by Java clients and gRPC stubs to read from and write to BigQuery Storage.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "3.14.1",
+    "source-code-url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-sources.jar",
+    "repository-url": "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-tests.jar",
+    "documentation-url": "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1/$version$/proto-google-cloud-bigquerystorage-v1-$version$-javadoc.jar",
+    "description": "This artifact provides the generated Java Protocol Buffer classes and .proto descriptors for the Google Cloud BigQuery Storage v1 API. It defines messages, enums, resource names, and service-related types used by Java clients and gRPC stubs to read from and write to BigQuery Storage.",
+    "tested-versions": [
       "3.14.1"
     ],
-    "allowed-packages" : [
-      "com.google.cloud.bigquery.storage.v1"
+    "allowed-packages": [
+      "com.google.cloud.bigquery.storage.v1",
+      "com.google.protobuf"
     ]
   }
 ]

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T07:35:31.405618Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:3.14.1",
+    "starting_commit": "c24af94fcaf8a59ce8f19cd43d09875f9759d04c",
+    "ending_commit": "421a6ac58a8f93a5454c6943659790e65ac31175",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.14.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 18755,
+          "missed": 30723,
+          "ratio": 0.379057,
+          "total": 49478
+        },
+        "line": {
+          "covered": 5130,
+          "missed": 8183,
+          "ratio": 0.385338,
+          "total": 13313
+        },
+        "method": {
+          "covered": 1168,
+          "missed": 2367,
+          "ratio": 0.33041,
+          "total": 3535
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 167780,
+      "cached_input_tokens_used": 2563584,
+      "output_tokens_used": 21726,
+      "iterations": 3,
+      "cost_usd": 1.9336,
+      "generated_loc": 487,
+      "tested_library_loc": 5130,
+      "metadata_entries": 95,
+      "code_coverage_percent": 38.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.14.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 18755,
+        "missed" : 30723,
+        "ratio" : 0.379057,
+        "total" : 49478
+      },
+      "line" : {
+        "covered" : 5130,
+        "missed" : 8183,
+        "ratio" : 0.385338,
+        "total" : 13313
+      },
+      "method" : {
+        "covered" : 1168,
+        "missed" : 2367,
+        "ratio" : 0.33041,
+        "total" : 3535
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:3.14.1
+library.version = 3.14.1
+metadata.dir = com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-cloud-bigquerystorage-v1_tests'

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
@@ -6,11 +6,430 @@
  */
 package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.cloud.bigquery.storage.v1.AppendRowsRequest;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
+import com.google.cloud.bigquery.storage.v1.ArrowSchema;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
+import com.google.cloud.bigquery.storage.v1.AvroRows;
+import com.google.cloud.bigquery.storage.v1.AvroSchema;
+import com.google.cloud.bigquery.storage.v1.AvroSerializationOptions;
+import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsRequest;
+import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsResponse;
+import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1.CreateWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1.FinalizeWriteStreamResponse;
+import com.google.cloud.bigquery.storage.v1.FlushRowsRequest;
+import com.google.cloud.bigquery.storage.v1.FlushRowsResponse;
+import com.google.cloud.bigquery.storage.v1.GetWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1.ProjectName;
+import com.google.cloud.bigquery.storage.v1.ProtoRows;
+import com.google.cloud.bigquery.storage.v1.ProtoSchema;
+import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadStream;
+import com.google.cloud.bigquery.storage.v1.ReadStreamName;
+import com.google.cloud.bigquery.storage.v1.RowError;
+import com.google.cloud.bigquery.storage.v1.SplitReadStreamRequest;
+import com.google.cloud.bigquery.storage.v1.SplitReadStreamResponse;
+import com.google.cloud.bigquery.storage.v1.StorageError;
+import com.google.cloud.bigquery.storage.v1.StreamStats;
+import com.google.cloud.bigquery.storage.v1.TableFieldSchema;
+import com.google.cloud.bigquery.storage.v1.TableName;
+import com.google.cloud.bigquery.storage.v1.TableSchema;
+import com.google.cloud.bigquery.storage.v1.ThrottleState;
+import com.google.cloud.bigquery.storage.v1.WriteStream;
+import com.google.cloud.bigquery.storage.v1.WriteStreamName;
+import com.google.cloud.bigquery.storage.v1.WriteStreamView;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_bigquerystorage_v1Test {
+public class Proto_google_cloud_bigquerystorage_v1Test {
+    private static final String PROJECT = "sample-project";
+    private static final String DATASET = "analytics";
+    private static final String TABLE = "events";
+    private static final String LOCATION = "us";
+    private static final String SESSION = "session-1";
+    private static final String READ_STREAM = "stream-1";
+    private static final String WRITE_STREAM = "committed";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void resourceNamesFormatParseAndExposeFieldValues() {
+        ProjectName projectName = ProjectName.of(PROJECT);
+        assertEquals("projects/sample-project", projectName.toString());
+        assertEquals(PROJECT, ProjectName.parse(projectName.toString()).getProject());
+        assertEquals(Map.of("project", PROJECT), projectName.getFieldValuesMap());
+        assertEquals(PROJECT, projectName.getFieldValue("project"));
+        assertTrue(ProjectName.isParsableFrom(projectName.toString()));
+        assertFalse(ProjectName.isParsableFrom("organizations/sample-project"));
+
+        TableName tableName = TableName.of(PROJECT, DATASET, TABLE);
+        assertEquals("projects/sample-project/datasets/analytics/tables/events", tableName.toString());
+        TableName parsedTableName = TableName.parse(TableName.format(PROJECT, DATASET, TABLE));
+        assertEquals(PROJECT, parsedTableName.getProject());
+        assertEquals(DATASET, parsedTableName.getDataset());
+        assertEquals(TABLE, parsedTableName.getTable());
+        assertEquals("events", parsedTableName.getFieldValue("table"));
+        assertEquals(parsedTableName, parsedTableName.toBuilder().build());
+        assertNotEquals(parsedTableName, TableName.of(PROJECT, DATASET, "sessions"));
+
+        ReadStreamName readStreamName = ReadStreamName.of(PROJECT, LOCATION, SESSION, READ_STREAM);
+        assertEquals("projects/sample-project/locations/us/sessions/session-1/streams/stream-1",
+                readStreamName.toString());
+        assertEquals(readStreamName, ReadStreamName.parse(readStreamName.toString()));
+        assertEquals(READ_STREAM, readStreamName.getFieldValuesMap().get("stream"));
+
+        WriteStreamName writeStreamName = WriteStreamName.of(PROJECT, DATASET, TABLE, WRITE_STREAM);
+        assertEquals("projects/sample-project/datasets/analytics/tables/events/streams/committed",
+                writeStreamName.toString());
+        assertEquals(writeStreamName, WriteStreamName.parse(writeStreamName.toString()));
+        assertEquals(WRITE_STREAM, writeStreamName.getFieldValue("stream"));
+
+        List<TableName> names = List.of(tableName, TableName.of(PROJECT, DATASET, "users"));
+        List<String> formattedNames = TableName.toStringList(names);
+        assertIterableEquals(List.of(tableName.toString(), "projects/sample-project/datasets/analytics/tables/users"),
+                formattedNames);
+        assertIterableEquals(names, TableName.parseList(formattedNames));
+    }
+
+    @Test
+    void tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip() throws Exception {
+        TableFieldSchema rangeField = TableFieldSchema.newBuilder()
+                .setName("active_date")
+                .setType(TableFieldSchema.Type.RANGE)
+                .setMode(TableFieldSchema.Mode.NULLABLE)
+                .setDescription("inclusive activity range")
+                .setRangeElementType(TableFieldSchema.FieldElementType.newBuilder()
+                        .setType(TableFieldSchema.Type.DATE))
+                .build();
+        TableFieldSchema structField = TableFieldSchema.newBuilder()
+                .setName("payload")
+                .setType(TableFieldSchema.Type.STRUCT)
+                .setMode(TableFieldSchema.Mode.REPEATED)
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("id")
+                        .setType(TableFieldSchema.Type.INT64)
+                        .setMode(TableFieldSchema.Mode.REQUIRED)
+                        .setPrecision(19))
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("comment")
+                        .setType(TableFieldSchema.Type.STRING)
+                        .setMaxLength(256)
+                        .setDefaultValueExpression("'n/a'"))
+                .build();
+        TableSchema schema = TableSchema.newBuilder()
+                .addFields(rangeField)
+                .addFields(structField)
+                .build();
+
+        TableSchema parsed = TableSchema.parseFrom(schema.toByteArray());
+        assertEquals(schema, parsed);
+        assertEquals(2, parsed.getFieldsCount());
+        assertTrue(parsed.getFields(0).hasRangeElementType());
+        assertEquals(TableFieldSchema.Type.DATE, parsed.getFields(0).getRangeElementType().getType());
+        assertEquals(TableFieldSchema.Mode.REPEATED, parsed.getFields(1).getMode());
+        assertEquals("comment", parsed.getFields(1).getFields(1).getName());
+        assertEquals("'n/a'", parsed.getFields(1).getFields(1).getDefaultValueExpression());
+        assertEquals("TableSchema", TableSchema.getDescriptor().getName());
+    }
+
+    @Test
+    void readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata() throws Exception {
+        Timestamp snapshotTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).setNanos(123_000_000).build();
+        ArrowSerializationOptions arrowOptions = ArrowSerializationOptions.newBuilder()
+                .setBufferCompression(ArrowSerializationOptions.CompressionCodec.LZ4_FRAME)
+                .build();
+        ReadSession.TableReadOptions readOptions = ReadSession.TableReadOptions.newBuilder()
+                .addSelectedFields("user_id")
+                .addSelectedFields("event_time")
+                .setRowRestriction("event_date >= '2024-01-01'")
+                .setArrowSerializationOptions(arrowOptions)
+                .setSamplePercentage(12.5D)
+                .setResponseCompressionCodec(
+                        ReadSession.TableReadOptions.ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_LZ4)
+                .build();
+        ReadSession readSession = ReadSession.newBuilder()
+                .setName("projects/sample-project/locations/us/sessions/session-1")
+                .setExpireTime(Timestamp.newBuilder().setSeconds(1_700_003_600L))
+                .setDataFormat(DataFormat.ARROW)
+                .setArrowSchema(ArrowSchema.newBuilder().setSerializedSchema(ByteString.copyFromUtf8("arrow-schema")))
+                .setTable(TableName.format(PROJECT, DATASET, TABLE))
+                .setTableModifiers(ReadSession.TableModifiers.newBuilder().setSnapshotTime(snapshotTime))
+                .setReadOptions(readOptions)
+                .addStreams(ReadStream.newBuilder()
+                        .setName(ReadStreamName.format(PROJECT, LOCATION, SESSION, READ_STREAM)))
+                .setEstimatedTotalBytesScanned(4096L)
+                .setEstimatedTotalPhysicalFileSize(2048L)
+                .setEstimatedRowCount(64L)
+                .setTraceId("trace-read-session")
+                .build();
+        CreateReadSessionRequest request = CreateReadSessionRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setReadSession(readSession)
+                .setMaxStreamCount(3)
+                .setPreferredMinStreamCount(1)
+                .build();
+
+        CreateReadSessionRequest parsed = CreateReadSessionRequest.parseFrom(
+                new ByteArrayInputStream(request.toByteArray()));
+        assertEquals(ProjectName.format(PROJECT), parsed.getParent());
+        assertEquals(DataFormat.ARROW, parsed.getReadSession().getDataFormat());
+        assertEquals(ReadSession.SchemaCase.ARROW_SCHEMA, parsed.getReadSession().getSchemaCase());
+        assertEquals("event_time", parsed.getReadSession().getReadOptions().getSelectedFields(1));
+        assertEquals(ReadSession.TableReadOptions.OutputFormatSerializationOptionsCase.ARROW_SERIALIZATION_OPTIONS,
+                parsed.getReadSession().getReadOptions().getOutputFormatSerializationOptionsCase());
+        assertEquals(ArrowSerializationOptions.CompressionCodec.LZ4_FRAME,
+                parsed.getReadSession().getReadOptions().getArrowSerializationOptions().getBufferCompression());
+        assertTrue(parsed.getReadSession().getReadOptions().hasSamplePercentage());
+        assertEquals(12.5D, parsed.getReadSession().getReadOptions().getSamplePercentage(), 0.0001D);
+        assertEquals(snapshotTime, parsed.getReadSession().getTableModifiers().getSnapshotTime());
+        assertEquals(64L, parsed.getReadSession().getEstimatedRowCount());
+    }
+
+    @Test
+    void appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching() throws Exception {
+        DescriptorProtos.DescriptorProto rowDescriptor = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("EventRow")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("user_id")
+                        .setNumber(1)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("event_name")
+                        .setNumber(2)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+        ProtoRows rows = ProtoRows.newBuilder()
+                .addSerializedRows(ByteString.copyFrom(new byte[] {8, 7, 18, 5, 108, 111, 103, 105, 110}))
+                .build();
+        AppendRowsRequest request = AppendRowsRequest.newBuilder()
+                .setWriteStream(WriteStreamName.format(PROJECT, DATASET, TABLE, WRITE_STREAM))
+                .setOffset(Int64Value.of(42L))
+                .setProtoRows(AppendRowsRequest.ProtoData.newBuilder()
+                        .setWriterSchema(ProtoSchema.newBuilder().setProtoDescriptor(rowDescriptor))
+                        .setRows(rows))
+                .setTraceId("trace-append")
+                .putMissingValueInterpretations("event_name",
+                        AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE)
+                .setDefaultMissingValueInterpretation(AppendRowsRequest.MissingValueInterpretation.NULL_VALUE)
+                .build();
+
+        AppendRowsRequest parsed = AppendRowsRequest.parseFrom(request.toByteString());
+        assertEquals(AppendRowsRequest.RowsCase.PROTO_ROWS, parsed.getRowsCase());
+        assertEquals(42L, parsed.getOffset().getValue());
+        assertEquals("EventRow", parsed.getProtoRows().getWriterSchema().getProtoDescriptor().getName());
+        assertEquals(1, parsed.getProtoRows().getRows().getSerializedRowsCount());
+        assertTrue(parsed.containsMissingValueInterpretations("event_name"));
+        assertEquals(AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE,
+                parsed.getMissingValueInterpretationsMap().get("event_name"));
+        assertEquals(AppendRowsRequest.MissingValueInterpretation.NULL_VALUE,
+                parsed.getDefaultMissingValueInterpretation());
+
+        AppendRowsRequest arrowRequest = parsed.toBuilder()
+                .setArrowRows(AppendRowsRequest.ArrowData.newBuilder()
+                        .setWriterSchema(ArrowSchema.newBuilder()
+                                .setSerializedSchema(ByteString.copyFromUtf8("schema")))
+                        .setRows(ArrowRecordBatch.newBuilder()
+                                .setSerializedRecordBatch(ByteString.copyFromUtf8("batch"))
+                                .setRowCount(2L)))
+                .build();
+        assertEquals(AppendRowsRequest.RowsCase.ARROW_ROWS, arrowRequest.getRowsCase());
+        assertFalse(arrowRequest.hasProtoRows());
+        assertEquals(2L, arrowRequest.getArrowRows().getRows().getRowCount());
+    }
+
+    @Test
+    void appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas() throws Exception {
+        TableSchema updatedSchema = TableSchema.newBuilder()
+                .addFields(TableFieldSchema.newBuilder().setName("user_id").setType(TableFieldSchema.Type.INT64))
+                .build();
+        RowError rowError = RowError.newBuilder()
+                .setIndex(3L)
+                .setCode(RowError.RowErrorCode.FIELDS_ERROR)
+                .setMessage("missing user_id")
+                .build();
+        AppendRowsResponse success = AppendRowsResponse.newBuilder()
+                .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(42L)))
+                .setUpdatedSchema(updatedSchema)
+                .addRowErrors(rowError)
+                .setWriteStream(WriteStreamName.format(PROJECT, DATASET, TABLE, WRITE_STREAM))
+                .build();
+
+        AppendRowsResponse parsedSuccess = AppendRowsResponse.parseFrom(success.toByteArray());
+        assertEquals(AppendRowsResponse.ResponseCase.APPEND_RESULT, parsedSuccess.getResponseCase());
+        assertEquals(42L, parsedSuccess.getAppendResult().getOffset().getValue());
+        assertTrue(parsedSuccess.hasUpdatedSchema());
+        assertEquals(RowError.RowErrorCode.FIELDS_ERROR, parsedSuccess.getRowErrors(0).getCode());
+        assertEquals("missing user_id", parsedSuccess.getRowErrors(0).getMessage());
+
+        AppendRowsResponse error = parsedSuccess.toBuilder()
+                .setError(Status.newBuilder().setCode(3).setMessage("invalid argument"))
+                .build();
+        assertEquals(AppendRowsResponse.ResponseCase.ERROR, error.getResponseCase());
+        assertFalse(error.hasAppendResult());
+        assertEquals("invalid argument", error.getError().getMessage());
+    }
+
+    @Test
+    void readRowsRequestResponseAndSplitOperationsUseStreamPayloads() throws Exception {
+        ReadRowsRequest request = ReadRowsRequest.newBuilder()
+                .setReadStream(ReadStreamName.format(PROJECT, LOCATION, SESSION, READ_STREAM))
+                .setOffset(10L)
+                .build();
+        assertEquals(request, ReadRowsRequest.parseFrom(request.toByteArray()));
+
+        StreamStats stats = StreamStats.newBuilder()
+                .setProgress(StreamStats.Progress.newBuilder().setAtResponseStart(0.25D).setAtResponseEnd(0.5D))
+                .build();
+        ReadRowsResponse avroResponse = ReadRowsResponse.newBuilder()
+                .setAvroRows(AvroRows.newBuilder()
+                        .setSerializedBinaryRows(ByteString.copyFromUtf8("avro"))
+                        .setRowCount(2L))
+                .setRowCount(2L)
+                .setStats(stats)
+                .setThrottleState(ThrottleState.newBuilder().setThrottlePercent(15))
+                .setAvroSchema(AvroSchema.newBuilder().setSchema("{\"type\":\"record\",\"name\":\"Row\"}"))
+                .setUncompressedByteSize(128L)
+                .build();
+
+        ReadRowsResponse parsedAvro = ReadRowsResponse.parseFrom(avroResponse.toByteString());
+        assertEquals(ReadRowsResponse.RowsCase.AVRO_ROWS, parsedAvro.getRowsCase());
+        assertEquals(ReadRowsResponse.SchemaCase.AVRO_SCHEMA, parsedAvro.getSchemaCase());
+        assertEquals(2L, parsedAvro.getAvroRows().getRowCount());
+        assertEquals(0.5D, parsedAvro.getStats().getProgress().getAtResponseEnd(), 0.0001D);
+        assertEquals(15, parsedAvro.getThrottleState().getThrottlePercent());
+        assertTrue(parsedAvro.hasUncompressedByteSize());
+
+        ReadRowsResponse arrowResponse = parsedAvro.toBuilder()
+                .setArrowRecordBatch(ArrowRecordBatch.newBuilder()
+                        .setSerializedRecordBatch(ByteString.copyFromUtf8("arrow"))
+                        .setRowCount(4L))
+                .setArrowSchema(ArrowSchema.newBuilder().setSerializedSchema(ByteString.copyFromUtf8("arrow-schema")))
+                .build();
+        assertEquals(ReadRowsResponse.RowsCase.ARROW_RECORD_BATCH, arrowResponse.getRowsCase());
+        assertEquals(ReadRowsResponse.SchemaCase.ARROW_SCHEMA, arrowResponse.getSchemaCase());
+        assertEquals(4L, arrowResponse.getArrowRecordBatch().getRowCount());
+
+        SplitReadStreamRequest splitRequest = SplitReadStreamRequest.newBuilder()
+                .setName(request.getReadStream())
+                .setFraction(0.33D)
+                .build();
+        SplitReadStreamResponse splitResponse = SplitReadStreamResponse.newBuilder()
+                .setPrimaryStream(ReadStream.newBuilder().setName(request.getReadStream()))
+                .setRemainderStream(ReadStream.newBuilder()
+                        .setName(ReadStreamName.format(PROJECT, LOCATION, SESSION, "stream-2")))
+                .build();
+        assertEquals(0.33D, SplitReadStreamRequest.parseFrom(splitRequest.toByteArray()).getFraction(), 0.0001D);
+        assertEquals("stream-2", ReadStreamName.parse(splitResponse.getRemainderStream().getName()).getStream());
+    }
+
+    @Test
+    void writeStreamLifecycleMessagesRoundTrip() throws Exception {
+        TableSchema tableSchema = TableSchema.newBuilder()
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("event_name")
+                        .setType(TableFieldSchema.Type.STRING)
+                        .setMode(TableFieldSchema.Mode.NULLABLE))
+                .build();
+        Timestamp createTime = Timestamp.newBuilder().setSeconds(1_700_000_001L).build();
+        Timestamp commitTime = Timestamp.newBuilder().setSeconds(1_700_000_120L).build();
+        WriteStream writeStream = WriteStream.newBuilder()
+                .setName(WriteStreamName.format(PROJECT, DATASET, TABLE, WRITE_STREAM))
+                .setType(WriteStream.Type.COMMITTED)
+                .setCreateTime(createTime)
+                .setCommitTime(commitTime)
+                .setTableSchema(tableSchema)
+                .setWriteMode(WriteStream.WriteMode.INSERT)
+                .setLocation(LOCATION)
+                .build();
+
+        CreateWriteStreamRequest createRequest = CreateWriteStreamRequest.newBuilder()
+                .setParent(TableName.format(PROJECT, DATASET, TABLE))
+                .setWriteStream(writeStream)
+                .build();
+        GetWriteStreamRequest getRequest = GetWriteStreamRequest.newBuilder()
+                .setName(writeStream.getName())
+                .setView(WriteStreamView.FULL)
+                .build();
+        FinalizeWriteStreamRequest finalizeRequest = FinalizeWriteStreamRequest.newBuilder()
+                .setName(writeStream.getName())
+                .build();
+        FinalizeWriteStreamResponse finalizeResponse = FinalizeWriteStreamResponse.newBuilder()
+                .setRowCount(5L)
+                .build();
+        FlushRowsRequest flushRequest = FlushRowsRequest.newBuilder()
+                .setWriteStream(writeStream.getName())
+                .setOffset(Int64Value.of(5L))
+                .build();
+        FlushRowsResponse flushResponse = FlushRowsResponse.newBuilder()
+                .setOffset(5L)
+                .build();
+        BatchCommitWriteStreamsRequest commitRequest = BatchCommitWriteStreamsRequest.newBuilder()
+                .setParent(TableName.format(PROJECT, DATASET, TABLE))
+                .addWriteStreams(writeStream.getName())
+                .build();
+        BatchCommitWriteStreamsResponse commitResponse = BatchCommitWriteStreamsResponse.newBuilder()
+                .setCommitTime(commitTime)
+                .addStreamErrors(StorageError.newBuilder()
+                        .setCode(StorageError.StorageErrorCode.STREAM_ALREADY_COMMITTED)
+                        .setEntity(writeStream.getName())
+                        .setErrorMessage("already committed"))
+                .build();
+
+        assertEquals(writeStream, WriteStream.parseFrom(writeStream.toByteArray()));
+        assertEquals(WriteStream.Type.COMMITTED, createRequest.getWriteStream().getType());
+        assertEquals(WriteStream.WriteMode.INSERT, createRequest.getWriteStream().getWriteMode());
+        assertEquals(WriteStreamView.FULL, GetWriteStreamRequest.parseFrom(getRequest.toByteArray()).getView());
+        assertEquals(writeStream.getName(),
+                FinalizeWriteStreamRequest.parseFrom(finalizeRequest.toByteArray()).getName());
+        assertEquals(5L, FinalizeWriteStreamResponse.parseFrom(finalizeResponse.toByteArray()).getRowCount());
+        assertEquals(5L, FlushRowsRequest.parseFrom(flushRequest.toByteArray()).getOffset().getValue());
+        assertEquals(5L, FlushRowsResponse.parseFrom(flushResponse.toByteArray()).getOffset());
+        assertEquals(writeStream.getName(),
+                BatchCommitWriteStreamsRequest.parseFrom(commitRequest.toByteArray()).getWriteStreams(0));
+        assertEquals(StorageError.StorageErrorCode.STREAM_ALREADY_COMMITTED,
+                BatchCommitWriteStreamsResponse.parseFrom(commitResponse.toByteArray()).getStreamErrors(0).getCode());
+        assertEquals(commitTime, commitResponse.getCommitTime());
+    }
+
+    @Test
+    void serializationOptionsEnumsAndParsersExposeExpectedValues() throws Exception {
+        AvroSerializationOptions avroOptions = AvroSerializationOptions.newBuilder()
+                .setEnableDisplayNameAttribute(true)
+                .build();
+        assertTrue(AvroSerializationOptions.parseFrom(avroOptions.toByteArray()).getEnableDisplayNameAttribute());
+        assertSame(DataFormat.ARROW, DataFormat.forNumber(DataFormat.ARROW_VALUE));
+        assertSame(TableFieldSchema.Type.JSON,
+                TableFieldSchema.Type.valueOf(TableFieldSchema.Type.JSON.getValueDescriptor()));
+        assertSame(AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE,
+                AppendRowsRequest.MissingValueInterpretation.forNumber(
+                        AppendRowsRequest.MissingValueInterpretation.DEFAULT_VALUE_VALUE));
+        assertSame(StorageError.StorageErrorCode.KMS_PERMISSION_DENIED,
+                StorageError.StorageErrorCode.internalGetValueMap().findValueByNumber(
+                        StorageError.StorageErrorCode.KMS_PERMISSION_DENIED_VALUE));
+
+        assertThrows(InvalidProtocolBufferException.class,
+                () -> ReadSession.parser().parseFrom(ByteString.copyFrom(new byte[] {-1, 0, 1})));
+        assertEquals(ReadSession.getDefaultInstance(), ReadSession.parseFrom(ByteString.EMPTY));
+        assertEquals("ReadSession", ReadSession.getDefaultInstance().getDescriptorForType().getName());
     }
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_bigquerystorage_v1Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.cloud.bigquery.storage.v1.AnnotationsProto;
 import com.google.cloud.bigquery.storage.v1.AppendRowsRequest;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
@@ -54,6 +55,7 @@ import com.google.cloud.bigquery.storage.v1.WriteStreamName;
 import com.google.cloud.bigquery.storage.v1.WriteStreamView;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
@@ -203,6 +205,31 @@ public class Proto_google_cloud_bigquerystorage_v1Test {
         assertEquals(12.5D, parsed.getReadSession().getReadOptions().getSamplePercentage(), 0.0001D);
         assertEquals(snapshotTime, parsed.getReadSession().getTableModifiers().getSnapshotTime());
         assertEquals(64L, parsed.getReadSession().getEstimatedRowCount());
+    }
+
+    @Test
+    void protoSchemaSupportsBigQueryColumnNameAnnotations() throws Exception {
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        AnnotationsProto.registerAllExtensions(registry);
+        DescriptorProtos.FieldDescriptorProto field = DescriptorProtos.FieldDescriptorProto.newBuilder()
+                .setName("customer_display_name")
+                .setNumber(1)
+                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                .setOptions(DescriptorProtos.FieldOptions.newBuilder()
+                        .setExtension(AnnotationsProto.columnName, "Customer Display Name"))
+                .build();
+        ProtoSchema schema = ProtoSchema.newBuilder()
+                .setProtoDescriptor(DescriptorProtos.DescriptorProto.newBuilder()
+                        .setName("CustomerRow")
+                        .addField(field))
+                .build();
+
+        ProtoSchema parsed = ProtoSchema.parseFrom(schema.toByteString(), registry);
+        DescriptorProtos.FieldOptions parsedOptions = parsed.getProtoDescriptor().getField(0).getOptions();
+        assertEquals("CustomerRow", parsed.getProtoDescriptor().getName());
+        assertEquals("customer_display_name", parsed.getProtoDescriptor().getField(0).getName());
+        assertTrue(parsedOptions.hasExtension(AnnotationsProto.columnName));
+        assertEquals("Customer Display Name", parsedOptions.getExtension(AnnotationsProto.columnName));
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1/Proto_google_cloud_bigquerystorage_v1Test.java
@@ -10,10 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.api.ClientProto;
+import com.google.api.HttpRule;
 import com.google.cloud.bigquery.storage.v1.AnnotationsProto;
 import com.google.cloud.bigquery.storage.v1.AppendRowsRequest;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
@@ -45,6 +48,7 @@ import com.google.cloud.bigquery.storage.v1.RowError;
 import com.google.cloud.bigquery.storage.v1.SplitReadStreamRequest;
 import com.google.cloud.bigquery.storage.v1.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1.StorageError;
+import com.google.cloud.bigquery.storage.v1.StorageProto;
 import com.google.cloud.bigquery.storage.v1.StreamStats;
 import com.google.cloud.bigquery.storage.v1.TableFieldSchema;
 import com.google.cloud.bigquery.storage.v1.TableName;
@@ -55,6 +59,9 @@ import com.google.cloud.bigquery.storage.v1.WriteStreamName;
 import com.google.cloud.bigquery.storage.v1.WriteStreamView;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -205,6 +212,58 @@ public class Proto_google_cloud_bigquerystorage_v1Test {
         assertEquals(12.5D, parsed.getReadSession().getReadOptions().getSamplePercentage(), 0.0001D);
         assertEquals(snapshotTime, parsed.getReadSession().getTableModifiers().getSnapshotTime());
         assertEquals(64L, parsed.getReadSession().getEstimatedRowCount());
+    }
+
+    @Test
+    void storageProtoDescriptorExposesServicesStreamingAndHttpBindings() {
+        FileDescriptor descriptor = StorageProto.getDescriptor();
+        ServiceDescriptor readService = descriptor.findServiceByName("BigQueryRead");
+        ServiceDescriptor writeService = descriptor.findServiceByName("BigQueryWrite");
+        assertNotNull(readService);
+        assertNotNull(writeService);
+        assertEquals("bigquerystorage.googleapis.com", readService.getOptions().getExtension(ClientProto.defaultHost));
+        assertEquals("https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/cloud-platform",
+                readService.getOptions().getExtension(ClientProto.oauthScopes));
+        assertEquals("bigquerystorage.googleapis.com", writeService.getOptions().getExtension(ClientProto.defaultHost));
+        assertEquals("https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/bigquery.insertdata,"
+                + "https://www.googleapis.com/auth/cloud-platform",
+                writeService.getOptions().getExtension(ClientProto.oauthScopes));
+
+        MethodDescriptor createReadSession = readService.findMethodByName("CreateReadSession");
+        assertNotNull(createReadSession);
+        assertEquals(CreateReadSessionRequest.getDescriptor(), createReadSession.getInputType());
+        assertEquals(ReadSession.getDescriptor(), createReadSession.getOutputType());
+        assertFalse(createReadSession.isClientStreaming());
+        assertFalse(createReadSession.isServerStreaming());
+        assertTrue(createReadSession.getOptions().hasExtension(com.google.api.AnnotationsProto.http));
+        HttpRule createReadSessionHttp = createReadSession.getOptions()
+                .getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.POST, createReadSessionHttp.getPatternCase());
+        assertEquals("/v1/{read_session.table=projects/*/datasets/*/tables/*}", createReadSessionHttp.getPost());
+        assertEquals("*", createReadSessionHttp.getBody());
+
+        MethodDescriptor readRows = readService.findMethodByName("ReadRows");
+        assertNotNull(readRows);
+        assertEquals(ReadRowsRequest.getDescriptor(), readRows.getInputType());
+        assertEquals(ReadRowsResponse.getDescriptor(), readRows.getOutputType());
+        assertFalse(readRows.isClientStreaming());
+        assertTrue(readRows.isServerStreaming());
+        assertTrue(readRows.getOptions().hasExtension(com.google.api.AnnotationsProto.http));
+        HttpRule readRowsHttp = readRows.getOptions().getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.GET, readRowsHttp.getPatternCase());
+        assertEquals("/v1/{read_stream=projects/*/locations/*/sessions/*/streams/*}", readRowsHttp.getGet());
+
+        MethodDescriptor appendRows = writeService.findMethodByName("AppendRows");
+        assertNotNull(appendRows);
+        assertEquals(AppendRowsRequest.getDescriptor(), appendRows.getInputType());
+        assertEquals(AppendRowsResponse.getDescriptor(), appendRows.getOutputType());
+        assertTrue(appendRows.isClientStreaming());
+        assertTrue(appendRows.isServerStreaming());
+        assertTrue(appendRows.getOptions().hasExtension(com.google.api.AnnotationsProto.http));
+        HttpRule appendRowsHttp = appendRows.getOptions().getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.POST, appendRowsHttp.getPatternCase());
+        assertEquals("/v1/{write_stream=projects/*/datasets/*/tables/*/streams/*}", appendRowsHttp.getPost());
+        assertEquals("*", appendRowsHttp.getBody());
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="3" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T09:22:50">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="4" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:23:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -58,7 +58,7 @@
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$MissingValueInterpretationsDefaultEntryHolder.<clinit>(AppendRowsRequest.java:3021)
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.internalGetMutableMissingValueInterpretations(AppendRowsRequest.java:5148)
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.putMissingValueInterpretations(AppendRowsRequest.java:5545)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:231)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:258)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -83,7 +83,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: readRowsRequestResponseAndSplitOperationsUseStreamPayloads()
 ]]></system-out>
 </testcase>
-<testcase name="readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0.005">
+<testcase name="readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()]
 display-name: readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()
@@ -101,7 +101,7 @@ display-name: appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema.getDescriptor(TableFieldSchema.java:58)
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getDescriptor(TableFieldSchema.java:521)
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getValueDescriptor(TableFieldSchema.java:513)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:422)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:449)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -138,6 +138,35 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: writeStreamLifecycleMessagesRoundTrip()
 ]]></system-out>
 </testcase>
+<testcase name="protoSchemaSupportsBigQueryColumnNameAnnotations()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<error message="Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@562a700f" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@562a700f
+	at com.google.protobuf.ExtensionRegistryLite.add(ExtensionRegistryLite.java:156)
+	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:26)
+	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:30)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.protoSchemaSupportsBigQueryColumnNameAnnotations(Proto_google_cloud_bigquerystorage_v1Test.java:213)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.NoSuchMethodException: com.google.protobuf.ExtensionRegistry.add(com.google.protobuf.Extension)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
+	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
+	at com.google.protobuf.ExtensionRegistryLite.add(ExtensionRegistryLite.java:153)
+	... 15 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:protoSchemaSupportsBigQueryColumnNameAnnotations()]
+display-name: protoSchemaSupportsBigQueryColumnNameAnnotations()
+]]></system-out>
+</testcase>
 <testcase name="resourceNamesFormatParseAndExposeFieldValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:resourceNamesFormatParseAndExposeFieldValues()]
@@ -147,7 +176,7 @@ display-name: resourceNamesFormatParseAndExposeFieldValues()
 <testcase name="tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
 <error message="Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto
 	at com.google.cloud.bigquery.storage.v1.TableSchema.getDescriptor(TableSchema.java:55)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:152)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:154)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="3" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T09:22:50">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4711-825f48f5/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
+	at com.google.cloud.bigquery.storage.v1.StorageProto.<clinit>(StorageProto.java:334)
+	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$MissingValueInterpretationsDefaultEntryHolder.<clinit>(AppendRowsRequest.java:3021)
+	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.internalGetMutableMissingValueInterpretations(AppendRowsRequest.java:5148)
+	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.putMissingValueInterpretations(AppendRowsRequest.java:5545)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:231)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()]
+display-name: appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()
+]]></system-out>
+</testcase>
+<testcase name="readRowsRequestResponseAndSplitOperationsUseStreamPayloads()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:readRowsRequestResponseAndSplitOperationsUseStreamPayloads()]
+display-name: readRowsRequestResponseAndSplitOperationsUseStreamPayloads()
+]]></system-out>
+</testcase>
+<testcase name="readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0.005">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()]
+display-name: readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()
+]]></system-out>
+</testcase>
+<testcase name="appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()]
+display-name: appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()
+]]></system-out>
+</testcase>
+<testcase name="serializationOptionsEnumsAndParsersExposeExpectedValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
+	at com.google.cloud.bigquery.storage.v1.TableProto.<clinit>(TableProto.java:112)
+	at com.google.cloud.bigquery.storage.v1.TableFieldSchema.getDescriptor(TableFieldSchema.java:58)
+	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getDescriptor(TableFieldSchema.java:521)
+	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getValueDescriptor(TableFieldSchema.java:513)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:422)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.RuntimeException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1865)
+	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:36)
+	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1688)
+	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1541)
+	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:59)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
+	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
+	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1862)
+	... 21 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:serializationOptionsEnumsAndParsersExposeExpectedValues()]
+display-name: serializationOptionsEnumsAndParsersExposeExpectedValues()
+]]></system-out>
+</testcase>
+<testcase name="writeStreamLifecycleMessagesRoundTrip()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:writeStreamLifecycleMessagesRoundTrip()]
+display-name: writeStreamLifecycleMessagesRoundTrip()
+]]></system-out>
+</testcase>
+<testcase name="resourceNamesFormatParseAndExposeFieldValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:resourceNamesFormatParseAndExposeFieldValues()]
+display-name: resourceNamesFormatParseAndExposeFieldValues()
+]]></system-out>
+</testcase>
+<testcase name="tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<error message="Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto
+	at com.google.cloud.bigquery.storage.v1.TableSchema.getDescriptor(TableSchema.java:55)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:152)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()]
+display-name: tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="4" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T09:23:57">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="5" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-03T09:26:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -53,12 +53,11 @@
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <testcase name="appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
-	at com.google.cloud.bigquery.storage.v1.StorageProto.<clinit>(StorageProto.java:334)
+<error message="Could not initialize class com.google.cloud.bigquery.storage.v1.StorageProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.StorageProto
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$MissingValueInterpretationsDefaultEntryHolder.<clinit>(AppendRowsRequest.java:3021)
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.internalGetMutableMissingValueInterpretations(AppendRowsRequest.java:5148)
 	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.putMissingValueInterpretations(AppendRowsRequest.java:5545)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:258)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:317)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -83,6 +82,28 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: readRowsRequestResponseAndSplitOperationsUseStreamPayloads()
 ]]></system-out>
 </testcase>
+<testcase name="storageProtoDescriptorExposesServicesStreamingAndHttpBindings()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
+	at com.google.cloud.bigquery.storage.v1.StorageProto.<clinit>(StorageProto.java:334)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.storageProtoDescriptorExposesServicesStreamingAndHttpBindings(Proto_google_cloud_bigquerystorage_v1Test.java:219)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:storageProtoDescriptorExposesServicesStreamingAndHttpBindings()]
+display-name: storageProtoDescriptorExposesServicesStreamingAndHttpBindings()
+]]></system-out>
+</testcase>
 <testcase name="readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:readSessionRequestsCarrySchemaReadOptionsAndStreamMetadata()]
@@ -95,13 +116,13 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()
 ]]></system-out>
 </testcase>
-<testcase name="serializationOptionsEnumsAndParsersExposeExpectedValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
+<testcase name="serializationOptionsEnumsAndParsersExposeExpectedValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0.002">
 <error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
 	at com.google.cloud.bigquery.storage.v1.TableProto.<clinit>(TableProto.java:112)
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema.getDescriptor(TableFieldSchema.java:58)
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getDescriptor(TableFieldSchema.java:521)
 	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getValueDescriptor(TableFieldSchema.java:513)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:449)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:508)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -139,11 +160,11 @@ display-name: writeStreamLifecycleMessagesRoundTrip()
 ]]></system-out>
 </testcase>
 <testcase name="protoSchemaSupportsBigQueryColumnNameAnnotations()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@562a700f" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@562a700f
+<error message="Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@237dd2e3" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@237dd2e3
 	at com.google.protobuf.ExtensionRegistryLite.add(ExtensionRegistryLite.java:156)
 	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:26)
 	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:30)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.protoSchemaSupportsBigQueryColumnNameAnnotations(Proto_google_cloud_bigquerystorage_v1Test.java:213)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.protoSchemaSupportsBigQueryColumnNameAnnotations(Proto_google_cloud_bigquerystorage_v1Test.java:272)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -176,7 +197,7 @@ display-name: resourceNamesFormatParseAndExposeFieldValues()
 <testcase name="tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
 <error message="Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto
 	at com.google.cloud.bigquery.storage.v1.TableSchema.getDescriptor(TableSchema.java:55)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:154)
+	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:161)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="5" time="0.005" hostname="kung-fu-workstation" timestamp="2026-05-03T09:26:01">
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.003" hostname="kung-fu-workstation" timestamp="2026-05-03T09:34:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4711-825f48f5/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1"/>
@@ -53,24 +52,6 @@
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
 <testcase name="appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not initialize class com.google.cloud.bigquery.storage.v1.StorageProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.StorageProto
-	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$MissingValueInterpretationsDefaultEntryHolder.<clinit>(AppendRowsRequest.java:3021)
-	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.internalGetMutableMissingValueInterpretations(AppendRowsRequest.java:5148)
-	at com.google.cloud.bigquery.storage.v1.AppendRowsRequest$Builder.putMissingValueInterpretations(AppendRowsRequest.java:5545)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching(Proto_google_cloud_bigquerystorage_v1Test.java:317)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()]
 display-name: appendRowsRequestSupportsProtoRowsMapInterpretationsAndOneofSwitching()
@@ -83,22 +64,6 @@ display-name: readRowsRequestResponseAndSplitOperationsUseStreamPayloads()
 ]]></system-out>
 </testcase>
 <testcase name="storageProtoDescriptorExposesServicesStreamingAndHttpBindings()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not initialize class com.google.api.FieldBehaviorProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.api.FieldBehaviorProto
-	at com.google.cloud.bigquery.storage.v1.StorageProto.<clinit>(StorageProto.java:334)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.storageProtoDescriptorExposesServicesStreamingAndHttpBindings(Proto_google_cloud_bigquerystorage_v1Test.java:219)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:storageProtoDescriptorExposesServicesStreamingAndHttpBindings()]
 display-name: storageProtoDescriptorExposesServicesStreamingAndHttpBindings()
@@ -116,38 +81,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_
 display-name: appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas()
 ]]></system-out>
 </testcase>
-<testcase name="serializationOptionsEnumsAndParsersExposeExpectedValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0.002">
-<error type="java.lang.ExceptionInInitializerError"><![CDATA[java.lang.ExceptionInInitializerError
-	at com.google.cloud.bigquery.storage.v1.TableProto.<clinit>(TableProto.java:112)
-	at com.google.cloud.bigquery.storage.v1.TableFieldSchema.getDescriptor(TableFieldSchema.java:58)
-	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getDescriptor(TableFieldSchema.java:521)
-	at com.google.cloud.bigquery.storage.v1.TableFieldSchema$Type.getValueDescriptor(TableFieldSchema.java:513)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.serializationOptionsEnumsAndParsersExposeExpectedValues(Proto_google_cloud_bigquerystorage_v1Test.java:508)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.RuntimeException: Generated message class "com.google.api.FieldBehavior" missing method "valueOf".
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1865)
-	at com.google.protobuf.GeneratedMessage.access$1100(GeneratedMessage.java:36)
-	at com.google.protobuf.GeneratedMessage$GeneratedExtension.<init>(GeneratedMessage.java:1688)
-	at com.google.protobuf.GeneratedMessage.newFileScopedGeneratedExtension(GeneratedMessage.java:1541)
-	at com.google.api.FieldBehaviorProto.<clinit>(FieldBehaviorProto.java:59)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: com.google.api.FieldBehavior.valueOf(com.google.protobuf.Descriptors$EnumValueDescriptor)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
-	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
-	at com.google.protobuf.GeneratedMessage.getMethodOrDie(GeneratedMessage.java:1862)
-	... 21 more
-]]></error>
+<testcase name="serializationOptionsEnumsAndParsersExposeExpectedValues()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:serializationOptionsEnumsAndParsersExposeExpectedValues()]
 display-name: serializationOptionsEnumsAndParsersExposeExpectedValues()
@@ -160,29 +94,6 @@ display-name: writeStreamLifecycleMessagesRoundTrip()
 ]]></system-out>
 </testcase>
 <testcase name="protoSchemaSupportsBigQueryColumnNameAnnotations()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@237dd2e3" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Could not invoke ExtensionRegistry#add for com.google.protobuf.GeneratedMessage$GeneratedExtension@237dd2e3
-	at com.google.protobuf.ExtensionRegistryLite.add(ExtensionRegistryLite.java:156)
-	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:26)
-	at com.google.cloud.bigquery.storage.v1.AnnotationsProto.registerAllExtensions(AnnotationsProto.java:30)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.protoSchemaSupportsBigQueryColumnNameAnnotations(Proto_google_cloud_bigquerystorage_v1Test.java:272)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.NoSuchMethodException: com.google.protobuf.ExtensionRegistry.add(com.google.protobuf.Extension)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
-	at java.base@25.0.2/java.lang.Class.getMethod(DynamicHub.java:1650)
-	at com.google.protobuf.ExtensionRegistryLite.add(ExtensionRegistryLite.java:153)
-	... 15 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:protoSchemaSupportsBigQueryColumnNameAnnotations()]
 display-name: protoSchemaSupportsBigQueryColumnNameAnnotations()
@@ -195,22 +106,6 @@ display-name: resourceNamesFormatParseAndExposeFieldValues()
 ]]></system-out>
 </testcase>
 <testcase name="tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()" classname="com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test" time="0">
-<error message="Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.google.cloud.bigquery.storage.v1.TableProto
-	at com.google.cloud.bigquery.storage.v1.TableSchema.getDescriptor(TableSchema.java:55)
-	at com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test.tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip(Proto_google_cloud_bigquerystorage_v1Test.java:161)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_api_grpc.proto_google_cloud_bigquerystorage_v1.Proto_google_cloud_bigquerystorage_v1Test]/[method:tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()]
 display-name: tableSchemaPreservesNestedFieldsAndRangeTypesThroughBinaryRoundTrip()

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:23:57">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:26:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:22:50">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:23:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:22:50">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4711-825f48f5/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:26:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T09:34:20">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4711-825f48f5/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1"/>

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.bigquery.storage.v1.**"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1/3.14.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.bigquery.storage.v1.**"
+      "includeClasses" : "com.google.cloud.bigquery.storage.v1.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4711

This PR introduces tests and metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:3.14.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 167780
- Cached input tokens: 2563584
- Output tokens: 21726
- Metadata entries: 95
- Iterations: 3
- Library coverage percentage: 38.53
- Generated lines of code: 487
- Tested library lines of code: 5130

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d8de39a5bf2125615813e4d1fe0a500644a94193`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 18755/49478 (37.91%)
- Line: 5130/13313 (38.53%)
- Method: 1168/3535 (33.04%)
