### PR TITLE
[GenAI] Add support for io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/reachability-metadata.json
+++ b/metadata/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/reachability-metadata.json
@@ -1,0 +1,51 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.IOUringDatagramChannel"
+      },
+      "type": "io.netty.channel.unix.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.Native"
+      },
+      "type": "io.netty.channel.unix.PeerCredentials"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.Native"
+      },
+      "type": "io.netty.util.internal.NativeLibraryUtil",
+      "methods": [
+        {
+          "name": "loadLibrary",
+          "parameterTypes": [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.Native"
+      },
+      "type": "java.io.FileDescriptor"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.Native"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_io_uring.so"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.incubator.channel.uring.Native"
+      },
+      "glob": "META-INF/native/libnetty_transport_native_io_uring_x86_64.so"
+    }
+  ]
+}

--- a/metadata/io.netty.incubator/netty-incubator-transport-classes-io_uring/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-transport-classes-io_uring/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.0.26.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/netty/incubator/netty-incubator-transport-classes-io_uring/$version$/netty-incubator-transport-classes-io_uring-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty-incubator-transport-io_uring",
+    "test-code-url" : "https://github.com/netty/netty-incubator-transport-io_uring/tree/netty-incubator-transport-parent-io_uring-$version$/transport-native-io_uring/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/netty/incubator/netty-incubator-transport-classes-io_uring/$version$/netty-incubator-transport-classes-io_uring-$version$-javadoc.jar",
+    "description" : "Netty incubator transport classes for io_uring provide the Java-side channel, event loop, buffer, and socket integration used by Netty's Linux io_uring native transport. The artifact lets Netty applications use the io_uring transport API with the matching native classifier artifact for high-performance asynchronous network I/O on supported Linux kernels.",
+    "tested-versions" : [
+      "0.0.26.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.incubator.channel.uring"
+    ]
+  }
+]

--- a/stats/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/execution-metrics.json
+++ b/stats/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T08:11:34.985275Z",
+    "library": "io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final",
+    "starting_commit": "8985a0b49837a76700a5547ecb18bf4eed5940ba",
+    "ending_commit": "b0f8104d289226a1892de916e2e00e241eed3421",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0.26.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 412,
+          "missed": 9377,
+          "ratio": 0.042088,
+          "total": 9789
+        },
+        "line": {
+          "covered": 104,
+          "missed": 2180,
+          "ratio": 0.045534,
+          "total": 2284
+        },
+        "method": {
+          "covered": 49,
+          "missed": 486,
+          "ratio": 0.091589,
+          "total": 535
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 153128,
+      "cached_input_tokens_used": 1181696,
+      "output_tokens_used": 24670,
+      "iterations": 4,
+      "cost_usd": 1.3309,
+      "generated_loc": 451,
+      "tested_library_loc": 104,
+      "metadata_entries": 7,
+      "code_coverage_percent": 4.55
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java",
+      "metadata_file": "metadata/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/stats.json
+++ b/stats/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.0.26.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 412,
+        "missed" : 9377,
+        "ratio" : 0.042088,
+        "total" : 9789
+      },
+      "line" : {
+        "covered" : 104,
+        "missed" : 2180,
+        "ratio" : 0.045534,
+        "total" : 2284
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 486,
+        "ratio" : 0.091589,
+        "total" : 535
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/.gitignore
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/build.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty.incubator:netty-incubator-transport-classes-io_uring:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/gradle.properties
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final
+library.version = 0.0.26.Final
+metadata.dir = io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/settings.gradle
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.incubator.netty-incubator-transport-classes-io_uring_tests'

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
@@ -6,11 +6,305 @@
  */
 package io_netty_incubator.netty_incubator_transport_classes_io_uring;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.incubator.channel.uring.IOUring;
+import io.netty.incubator.channel.uring.IOUringChannelOption;
+import io.netty.incubator.channel.uring.IOUringDatagramChannel;
+import io.netty.incubator.channel.uring.IOUringDatagramChannelConfig;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
+import io.netty.incubator.channel.uring.IOUringServerSocketChannelConfig;
+import io.netty.incubator.channel.uring.IOUringSocketChannel;
+import io.netty.incubator.channel.uring.IOUringSocketChannelConfig;
+import io.netty.incubator.channel.uring.IOUringTcpInfo;
 import org.junit.jupiter.api.Test;
 
-class Netty_incubator_transport_classes_io_uringTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_incubator_transport_classes_io_uringTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void ioUringAvailabilityContractIsSelfConsistent() {
+        boolean available = IOUring.isAvailable();
+        Throwable cause = IOUring.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(IOUring::ensureAvailability).doesNotThrowAnyException();
+            assertThatCode(IOUring::isTcpFastOpenClientSideAvailable).doesNotThrowAnyException();
+            assertThatCode(IOUring::isTcpFastOpenServerSideAvailable).doesNotThrowAnyException();
+            assertThat(IOUringDatagramChannel.isSegmentedDatagramPacketSupported()).isTrue();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(IOUring.isTcpFastOpenClientSideAvailable()).isFalse();
+        assertThat(IOUring.isTcpFastOpenServerSideAvailable()).isFalse();
+        assertThat(IOUringDatagramChannel.isSegmentedDatagramPacketSupported()).isFalse();
+
+        Throwable thrown = catchThrowable(IOUring::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+        assertThat(rootCauseMessage(thrown)).isNotBlank();
+    }
+
+    @Test
+    void publicChannelConstructorsRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(IOUringSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(IOUringServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(IOUringDatagramChannel::new);
+    }
+
+    @Test
+    void datagramProtocolFamilyConstructorsRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(() -> new IOUringDatagramChannel(InternetProtocolFamily.IPv4));
+    }
+
+    @Test
+    void eventLoopGroupConstructorRespectsTransportAvailability() {
+        AtomicInteger threadCounter = new AtomicInteger();
+        ThreadFactory factory = runnable -> {
+            Thread thread = new Thread(runnable, "iouring-test-" + threadCounter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        assertEventLoopGroupConstructorMatchesAvailability(() -> new IOUringEventLoopGroup(1, factory, 8, 2));
+    }
+
+    @Test
+    void ioUringChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                IOUringChannelOption.TCP_CORK,
+                IOUringChannelOption.TCP_NOTSENT_LOWAT,
+                IOUringChannelOption.TCP_KEEPIDLE,
+                IOUringChannelOption.TCP_KEEPINTVL,
+                IOUringChannelOption.TCP_KEEPCNT,
+                IOUringChannelOption.TCP_USER_TIMEOUT,
+                IOUringChannelOption.IP_FREEBIND,
+                IOUringChannelOption.IP_TRANSPARENT,
+                IOUringChannelOption.IP_RECVORIGDSTADDR,
+                IOUringChannelOption.TCP_DEFER_ACCEPT,
+                IOUringChannelOption.TCP_QUICKACK,
+                IOUringChannelOption.TCP_MD5SIG,
+                IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances() {
+        assertThat(IOUringChannelOption.TCP_FASTOPEN).isSameAs(ChannelOption.TCP_FASTOPEN);
+        assertThat(IOUringChannelOption.TCP_FASTOPEN.name())
+                .isEqualTo(ChannelOption.TCP_FASTOPEN.name())
+                .contains("TCP_FASTOPEN");
+
+        assertThat(IOUringChannelOption.TCP_FASTOPEN_CONNECT).isSameAs(ChannelOption.TCP_FASTOPEN_CONNECT);
+        assertThat(IOUringChannelOption.TCP_FASTOPEN_CONNECT.name())
+                .isEqualTo(ChannelOption.TCP_FASTOPEN_CONNECT.name())
+                .contains("TCP_FASTOPEN_CONNECT");
+
+        assertThat(ChannelOption.valueOf(IOUringChannelOption.TCP_FASTOPEN.name()))
+                .isSameAs(IOUringChannelOption.TCP_FASTOPEN);
+        assertThat(ChannelOption.valueOf(IOUringChannelOption.TCP_FASTOPEN_CONNECT.name()))
+                .isSameAs(IOUringChannelOption.TCP_FASTOPEN_CONNECT);
+    }
+
+    @Test
+    void tcpInfoStartsWithZeroedKernelCounters() {
+        IOUringTcpInfo tcpInfo = new IOUringTcpInfo();
+
+        assertThat(new long[] {
+                tcpInfo.state(),
+                tcpInfo.caState(),
+                tcpInfo.retransmits(),
+                tcpInfo.probes(),
+                tcpInfo.backoff(),
+                tcpInfo.options(),
+                tcpInfo.sndWscale(),
+                tcpInfo.rcvWscale(),
+                tcpInfo.rto(),
+                tcpInfo.ato(),
+                tcpInfo.sndMss(),
+                tcpInfo.rcvMss(),
+                tcpInfo.unacked(),
+                tcpInfo.sacked(),
+                tcpInfo.lost(),
+                tcpInfo.retrans(),
+                tcpInfo.fackets(),
+                tcpInfo.lastDataSent(),
+                tcpInfo.lastAckSent(),
+                tcpInfo.lastDataRecv(),
+                tcpInfo.lastAckRecv(),
+                tcpInfo.pmtu(),
+                tcpInfo.rcvSsthresh(),
+                tcpInfo.rtt(),
+                tcpInfo.rttvar(),
+                tcpInfo.sndSsthresh(),
+                tcpInfo.sndCwnd(),
+                tcpInfo.advmss(),
+                tcpInfo.reordering(),
+                tcpInfo.rcvRtt(),
+                tcpInfo.rcvSpace(),
+                tcpInfo.totalRetrans()
+        }).containsOnly(0L);
+    }
+
+    @Test
+    void socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable() {
+        if (!IOUring.isAvailable()) {
+            assertThatThrownBy(IOUringSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+            return;
+        }
+
+        IOUringSocketChannel channel = new IOUringSocketChannel();
+        try {
+            IOUringSocketChannelConfig config = channel.config();
+
+            assertThat(config.getOptions()).containsKeys(
+                    IOUringChannelOption.TCP_CORK,
+                    IOUringChannelOption.TCP_NOTSENT_LOWAT,
+                    IOUringChannelOption.TCP_KEEPIDLE,
+                    IOUringChannelOption.TCP_KEEPINTVL,
+                    IOUringChannelOption.TCP_KEEPCNT,
+                    IOUringChannelOption.TCP_USER_TIMEOUT,
+                    IOUringChannelOption.TCP_QUICKACK,
+                    IOUringChannelOption.TCP_FASTOPEN_CONNECT
+            );
+
+            assertThat(config.setAllowHalfClosure(true)).isSameAs(config);
+            assertThat(config.isAllowHalfClosure()).isTrue();
+            assertThat(config.setOption(IOUringChannelOption.TCP_CORK, true)).isTrue();
+            assertThat(config.getOption(IOUringChannelOption.TCP_CORK)).isTrue();
+            assertThat(config.setOption(IOUringChannelOption.TCP_CORK, false)).isTrue();
+            assertThat(config.isTcpCork()).isFalse();
+            assertThat(config.setOption(IOUringChannelOption.TCP_FASTOPEN_CONNECT, false)).isTrue();
+            assertThat(config.isTcpFastOpenConnect()).isFalse();
+            assertThat(config.setOption(IOUringChannelOption.TCP_KEEPIDLE, 30)).isTrue();
+            assertThat(config.getTcpKeepIdle()).isEqualTo(30);
+            assertThat(config.setOption(IOUringChannelOption.TCP_KEEPINTVL, 10)).isTrue();
+            assertThat(config.getTcpKeepIntvl()).isEqualTo(10);
+            assertThat(config.setOption(IOUringChannelOption.TCP_KEEPCNT, 5)).isTrue();
+            assertThat(config.getTcpKeepCnt()).isEqualTo(5);
+            assertThat(config.setOption(IOUringChannelOption.TCP_USER_TIMEOUT, 1_000)).isTrue();
+            assertThat(config.getTcpUserTimeout()).isEqualTo(1_000);
+        } finally {
+            channel.close().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable() {
+        if (!IOUring.isAvailable()) {
+            assertThatThrownBy(IOUringServerSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+            return;
+        }
+
+        IOUringServerSocketChannel channel = new IOUringServerSocketChannel();
+        try {
+            IOUringServerSocketChannelConfig config = channel.config();
+
+            assertThat(config.getOptions()).containsKeys(
+                    IOUringChannelOption.TCP_DEFER_ACCEPT,
+                    IOUringChannelOption.TCP_FASTOPEN,
+                    IOUringChannelOption.IP_FREEBIND,
+                    IOUringChannelOption.IP_TRANSPARENT
+            );
+
+            assertThat(config.setBacklog(16)).isSameAs(config);
+            assertThat(config.getBacklog()).isEqualTo(16);
+            assertThat(config.setOption(IOUringChannelOption.TCP_DEFER_ACCEPT, 2)).isTrue();
+            assertThat(config.getTcpDeferAccept()).isEqualTo(2);
+            assertThat(config.setOption(IOUringChannelOption.TCP_FASTOPEN, 4)).isTrue();
+            assertThat(config.getTcpFastopen()).isEqualTo(4);
+        } finally {
+            channel.close().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable() {
+        if (!IOUring.isAvailable()) {
+            assertThatThrownBy(IOUringDatagramChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+            return;
+        }
+
+        IOUringDatagramChannel channel = new IOUringDatagramChannel();
+        try {
+            IOUringDatagramChannelConfig config = channel.config();
+
+            assertThat(config.getOptions()).containsKeys(
+                    IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE,
+                    IOUringChannelOption.IP_FREEBIND,
+                    IOUringChannelOption.IP_TRANSPARENT
+            );
+
+            assertThat(config.setOption(IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, 1_200)).isTrue();
+            assertThat(config.getMaxDatagramPayloadSize()).isEqualTo(1_200);
+            assertThat(config.setMaxDatagramPayloadSize(512)).isSameAs(config);
+            assertThat(config.getOption(IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE)).isEqualTo(512);
+        } finally {
+            channel.close().syncUninterruptibly();
+        }
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (IOUring.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+                assertThat(channel.isActive()).isFalse();
+                assertThat(channel.config()).isNotNull();
+                assertThat(channel.metadata()).isNotNull();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(
+            Supplier<? extends EventLoopGroup> constructor) {
+        if (IOUring.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+                assertThat(group.next()).isNotNull();
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage() == null ? current.getClass().getName() : current.getMessage();
     }
 }

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty_incubator.netty_incubator_transport_classes_io_uring;
+
+import org.junit.jupiter.api.Test;
+
+class Netty_incubator_transport_classes_io_uringTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
@@ -6,15 +6,30 @@
  */
 package io_netty_incubator.netty_incubator_transport_classes_io_uring;
 
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.incubator.channel.uring.IOUring;
 import io.netty.incubator.channel.uring.IOUringChannelOption;
@@ -34,6 +49,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class Netty_incubator_transport_classes_io_uringTest {
+    private static final long FUTURE_TIMEOUT_SECONDS = 5;
+
     @Test
     void ioUringAvailabilityContractIsSelfConsistent() {
         boolean available = IOUring.isAvailable();
@@ -267,6 +284,92 @@ public class Netty_incubator_transport_classes_io_uringTest {
         }
     }
 
+    @Test
+    void socketChannelsExchangeDataThroughBootstrapWhenAvailable() throws InterruptedException {
+        if (!IOUring.isAvailable()) {
+            assertThat(IOUring.unavailabilityCause()).isNotNull();
+            return;
+        }
+
+        EventLoopGroup bossGroup = new IOUringEventLoopGroup(1);
+        EventLoopGroup workerGroup = new IOUringEventLoopGroup(1);
+        EventLoopGroup clientGroup = new IOUringEventLoopGroup(1);
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        CountDownLatch responseReceived = new CountDownLatch(1);
+        AtomicReference<String> clientResponse = new AtomicReference<>();
+        AtomicReference<Throwable> serverError = new AtomicReference<>();
+        AtomicReference<Throwable> clientError = new AtomicReference<>();
+
+        try {
+            ServerBootstrap serverBootstrap = new ServerBootstrap()
+                    .group(bossGroup, workerGroup)
+                    .channelFactory((ChannelFactory<IOUringServerSocketChannel>) IOUringServerSocketChannel::new)
+                    .childHandler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelRead(ChannelHandlerContext context, Object message) {
+                                    context.writeAndFlush(message);
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+                                    serverError.set(cause);
+                                    context.close();
+                                }
+                            });
+                        }
+                    });
+            ChannelFuture bindFuture = serverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0));
+            assertFutureCompletesSuccessfully(bindFuture);
+            serverChannel = bindFuture.channel();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clientGroup)
+                    .channelFactory((ChannelFactory<IOUringSocketChannel>) IOUringSocketChannel::new)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel channel) {
+                            channel.pipeline().addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                                @Override
+                                protected void channelRead0(ChannelHandlerContext context, ByteBuf message) {
+                                    clientResponse.set(message.toString(StandardCharsets.UTF_8));
+                                    responseReceived.countDown();
+                                }
+
+                                @Override
+                                public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+                                    clientError.set(cause);
+                                    responseReceived.countDown();
+                                    context.close();
+                                }
+                            });
+                        }
+                    });
+            ChannelFuture connectFuture = clientBootstrap.connect(serverChannel.localAddress());
+            assertFutureCompletesSuccessfully(connectFuture);
+            clientChannel = connectFuture.channel();
+
+            String payloadText = "io_uring bootstrap round trip";
+            ChannelFuture writeFuture = clientChannel.writeAndFlush(
+                    Unpooled.copiedBuffer(payloadText, StandardCharsets.UTF_8));
+            assertFutureCompletesSuccessfully(writeFuture);
+
+            assertThat(responseReceived.await(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            assertThat(serverError.get()).isNull();
+            assertThat(clientError.get()).isNull();
+            assertThat(clientResponse.get()).isEqualTo(payloadText);
+        } finally {
+            closeChannel(clientChannel);
+            closeChannel(serverChannel);
+            shutdownGroup(clientGroup);
+            shutdownGroup(workerGroup);
+            shutdownGroup(bossGroup);
+        }
+    }
+
     private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
         if (IOUring.isAvailable()) {
             Channel channel = constructor.get();
@@ -298,6 +401,23 @@ public class Netty_incubator_transport_classes_io_uringTest {
         }
 
         assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertFutureCompletesSuccessfully(ChannelFuture future) throws InterruptedException {
+        assertThat(future.await(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        assertThat(future.cause()).isNull();
+        assertThat(future.isSuccess()).isTrue();
+    }
+
+    private static void closeChannel(Channel channel) {
+        if (channel != null) {
+            channel.close().awaitUninterruptibly(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void shutdownGroup(EventLoopGroup group) {
+        group.shutdownGracefully(0, 1, TimeUnit.SECONDS)
+                .awaitUninterruptibly(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     private static String rootCauseMessage(Throwable throwable) {

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/src/test/java/io_netty_incubator/netty_incubator_transport_classes_io_uring/Netty_incubator_transport_classes_io_uringTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.incubator.channel.uring.IOUring;
 import io.netty.incubator.channel.uring.IOUringChannelOption;
@@ -367,6 +368,81 @@ public class Netty_incubator_transport_classes_io_uringTest {
             shutdownGroup(clientGroup);
             shutdownGroup(workerGroup);
             shutdownGroup(bossGroup);
+        }
+    }
+
+    @Test
+    void datagramChannelsExchangePacketsThroughBootstrapWhenAvailable() throws InterruptedException {
+        if (!IOUring.isAvailable()) {
+            assertThat(IOUring.unavailabilityCause()).isNotNull();
+            return;
+        }
+
+        EventLoopGroup receiverGroup = new IOUringEventLoopGroup(1);
+        EventLoopGroup senderGroup = new IOUringEventLoopGroup(1);
+        Channel receiverChannel = null;
+        Channel senderChannel = null;
+        CountDownLatch packetReceived = new CountDownLatch(1);
+        AtomicReference<String> receivedPayload = new AtomicReference<>();
+        AtomicReference<InetSocketAddress> packetSender = new AtomicReference<>();
+        AtomicReference<Throwable> receiverError = new AtomicReference<>();
+        AtomicReference<Throwable> senderError = new AtomicReference<>();
+
+        try {
+            Bootstrap receiverBootstrap = new Bootstrap()
+                    .group(receiverGroup)
+                    .channelFactory((ChannelFactory<IOUringDatagramChannel>) IOUringDatagramChannel::new)
+                    .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+                        @Override
+                        protected void channelRead0(ChannelHandlerContext context, DatagramPacket packet) {
+                            receivedPayload.set(packet.content().toString(StandardCharsets.UTF_8));
+                            packetSender.set(packet.sender());
+                            packetReceived.countDown();
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+                            receiverError.set(cause);
+                            packetReceived.countDown();
+                            context.close();
+                        }
+                    });
+            ChannelFuture receiverBindFuture = receiverBootstrap.bind(new InetSocketAddress("127.0.0.1", 0));
+            assertFutureCompletesSuccessfully(receiverBindFuture);
+            receiverChannel = receiverBindFuture.channel();
+
+            Bootstrap senderBootstrap = new Bootstrap()
+                    .group(senderGroup)
+                    .channelFactory((ChannelFactory<IOUringDatagramChannel>) IOUringDatagramChannel::new)
+                    .handler(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+                            senderError.set(cause);
+                            context.close();
+                        }
+                    });
+            ChannelFuture senderBindFuture = senderBootstrap.bind(new InetSocketAddress("127.0.0.1", 0));
+            assertFutureCompletesSuccessfully(senderBindFuture);
+            senderChannel = senderBindFuture.channel();
+
+            String payloadText = "io_uring datagram payload";
+            ChannelFuture writeFuture = senderChannel.writeAndFlush(new DatagramPacket(
+                    Unpooled.copiedBuffer(payloadText, StandardCharsets.UTF_8),
+                    (InetSocketAddress) receiverChannel.localAddress()));
+            assertFutureCompletesSuccessfully(writeFuture);
+
+            assertThat(packetReceived.await(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            assertThat(receiverError.get()).isNull();
+            assertThat(senderError.get()).isNull();
+            assertThat(receivedPayload.get()).isEqualTo(payloadText);
+            assertThat(packetSender.get()).isNotNull();
+            assertThat(packetSender.get().getPort())
+                    .isEqualTo(((InetSocketAddress) senderChannel.localAddress()).getPort());
+        } finally {
+            closeChannel(senderChannel);
+            closeChannel(receiverChannel);
+            shutdownGroup(senderGroup);
+            shutdownGroup(receiverGroup);
         }
     }
 

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T10:04:32">
+<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T10:07:35">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -82,6 +82,12 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_tran
 display-name: eventLoopGroupConstructorRespectsTransportAvailability()
 ]]></system-out>
 </testcase>
+<testcase name="socketChannelsExchangeDataThroughBootstrapWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:socketChannelsExchangeDataThroughBootstrapWhenAvailable()]
+display-name: socketChannelsExchangeDataThroughBootstrapWhenAvailable()
+]]></system-out>
+</testcase>
 <testcase name="datagramProtocolFamilyConstructorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:datagramProtocolFamilyConstructorsRespectTransportAvailability()]
@@ -94,13 +100,13 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_tran
 display-name: datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
 ]]></system-out>
 </testcase>
-<testcase name="ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.002">
+<testcase name="ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()]
 display-name: ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()
 ]]></system-out>
 </testcase>
-<testcase name="serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.001">
+<testcase name="serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
 display-name: serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="10" skipped="0" failures="0" errors="0" time="0.006" hostname="kung-fu-workstation" timestamp="2026-05-03T10:04:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4826-14146f0e/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="publicChannelConstructorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:publicChannelConstructorsRespectTransportAvailability()]
+display-name: publicChannelConstructorsRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
+display-name: socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
+]]></system-out>
+</testcase>
+<testcase name="ioUringChannelOptionsAreRegisteredInTheConstantPool()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringChannelOptionsAreRegisteredInTheConstantPool()]
+display-name: ioUringChannelOptionsAreRegisteredInTheConstantPool()
+]]></system-out>
+</testcase>
+<testcase name="ioUringAvailabilityContractIsSelfConsistent()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringAvailabilityContractIsSelfConsistent()]
+display-name: ioUringAvailabilityContractIsSelfConsistent()
+]]></system-out>
+</testcase>
+<testcase name="eventLoopGroupConstructorRespectsTransportAvailability()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:eventLoopGroupConstructorRespectsTransportAvailability()]
+display-name: eventLoopGroupConstructorRespectsTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="datagramProtocolFamilyConstructorsRespectTransportAvailability()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:datagramProtocolFamilyConstructorsRespectTransportAvailability()]
+display-name: datagramProtocolFamilyConstructorsRespectTransportAvailability()
+]]></system-out>
+</testcase>
+<testcase name="datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
+display-name: datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
+]]></system-out>
+</testcase>
+<testcase name="ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()]
+display-name: ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()
+]]></system-out>
+</testcase>
+<testcase name="serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
+display-name: serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
+]]></system-out>
+</testcase>
+<testcase name="tcpInfoStartsWithZeroedKernelCounters()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:tcpInfoStartsWithZeroedKernelCounters()]
+display-name: tcpInfoStartsWithZeroedKernelCounters()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T10:07:35">
+<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T10:08:51">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -116,6 +116,12 @@ display-name: serverSocketChannelConfigRoundTripsPublicTransportOptionsWhenAvail
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:tcpInfoStartsWithZeroedKernelCounters()]
 display-name: tcpInfoStartsWithZeroedKernelCounters()
+]]></system-out>
+</testcase>
+<testcase name="datagramChannelsExchangePacketsThroughBootstrapWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:datagramChannelsExchangePacketsThroughBootstrapWhenAvailable()]
+display-name: datagramChannelsExchangePacketsThroughBootstrapWhenAvailable()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="0.002" hostname="kung-fu-workstation" timestamp="2026-05-03T10:08:51">
+<testsuite name="JUnit Jupiter" tests="12" skipped="0" failures="0" errors="0" time="0.008" hostname="kung-fu-workstation" timestamp="2026-05-03T10:10:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4826-14146f0e/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final"/>
@@ -58,13 +57,13 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_tran
 display-name: publicChannelConstructorsRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<testcase name="socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
 display-name: socketChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
 ]]></system-out>
 </testcase>
-<testcase name="ioUringChannelOptionsAreRegisteredInTheConstantPool()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<testcase name="ioUringChannelOptionsAreRegisteredInTheConstantPool()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringChannelOptionsAreRegisteredInTheConstantPool()]
 display-name: ioUringChannelOptionsAreRegisteredInTheConstantPool()
@@ -94,13 +93,13 @@ unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_tran
 display-name: datagramProtocolFamilyConstructorsRespectTransportAvailability()
 ]]></system-out>
 </testcase>
-<testcase name="datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<testcase name="datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()]
 display-name: datagramChannelConfigRoundTripsPublicTransportOptionsWhenAvailable()
 ]]></system-out>
 </testcase>
-<testcase name="ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0">
+<testcase name="ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()" classname="io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:io_netty_incubator.netty_incubator_transport_classes_io_uring.Netty_incubator_transport_classes_io_uringTest]/[method:ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()]
 display-name: ioUringFastOpenOptionsReuseTheSharedChannelOptionInstances()

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:04:32">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4826-14146f0e/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:08:51">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:10:38">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4826-14146f0e/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final"/>

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:04:32">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:07:35">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:07:35">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:08:51">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/user-code-filter.json
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.netty.incubator.channel.uring.**"
+      "includeClasses" : "io.netty.incubator.channel.uring.**"
     }
   ]
 }

--- a/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/user-code-filter.json
+++ b/tests/src/io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.26.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.netty.incubator.channel.uring.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4826

This PR introduces tests and metadata for io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 153128
- Cached input tokens: 1181696
- Output tokens: 24670
- Metadata entries: 7
- Iterations: 4
- Library coverage percentage: 4.55
- Generated lines of code: 451
- Tested library lines of code: 104

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fd8a1c88df15027ad869e87401662616eeb7b781`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 412/9789 (4.21%)
- Line: 104/2284 (4.55%)
- Method: 49/535 (9.16%)
