### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-smtp:4.2.1.Final

### DIFF
--- a/metadata/io.netty/netty-codec-smtp/4.2.1.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-smtp/4.2.1.Final/reachability-metadata.json
@@ -1,0 +1,197 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+      "fields": [
+        {
+          "name": "refCnt"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpRequestEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.lang.Thread",
+      "methods": [
+        {
+          "name": "isVirtual",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.Bits"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.Buffer",
+      "fields": [
+        {
+          "name": "address"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.ByteBuffer",
+      "methods": [
+        {
+          "name": "alignedSlice",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "jdk.internal.misc.Unsafe",
+      "methods": [
+        {
+          "name": "getUnsafe",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.smtp.SmtpCommand"
+      },
+      "type": "sun.misc.VM"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-codec-smtp/index.json
+++ b/metadata/io.netty/netty-codec-smtp/index.json
@@ -1,6 +1,21 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.2.1.Final",
+    "test-version" : "4.1.74.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/$version$/netty-codec-smtp-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/$version$/netty-codec-smtp-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/$version$/netty-codec-smtp-$version$-javadoc.jar",
+    "description" : "Netty Codec SMTP provides SMTP protocol support for Netty by modeling SMTP commands, requests, responses, and message content. It includes an SMTP request encoder and response decoder for implementing asynchronous SMTP clients on Netty's channel pipeline.",
+    "tested-versions" : [
+      "4.2.1.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.handler.codec.smtp"
+    ]
+  },
+  {
     "metadata-version" : "4.1.74.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-smtp/$version$/netty-codec-smtp-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/stats/io.netty/netty-codec-smtp/4.2.1.Final/stats.json
+++ b/stats/io.netty/netty-codec-smtp/4.2.1.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.2.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 979,
+        "missed" : 181,
+        "ratio" : 0.843966,
+        "total" : 1160
+      },
+      "line" : {
+        "covered" : 210,
+        "missed" : 42,
+        "ratio" : 0.833333,
+        "total" : 252
+      },
+      "method" : {
+        "covered" : 62,
+        "missed" : 21,
+        "ratio" : 0.746988,
+        "total" : 83
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/build.gradle
+++ b/tests/src/io.netty/netty-codec-smtp/4.1.74.Final/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.named("nativeTest") {
+    if (libraryVersion == '4.2.1.Final') {
+        // Netty 4.2.x requires explicit unsafe access on Java 25 native runs.
+        runtimeArgs.addAll([
+                '-Dsun.misc.unsafe.memory.access=allow',
+                '-Dio.netty.tryReflectionSetAccessible=true'
+        ])
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4308

This PR provides new metadata needed for the io.netty:netty-codec-smtp:4.2.1.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-smtp:4.1.74.Final`): 34
- Metadata entries (new `io.netty:netty-codec-smtp:4.2.1.Final`): 37
- Library coverage (previous): 83.27%
- Library coverage (new): 83.33%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5e0b2ac606599cfa86204b225fd8b7f110f5900c`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-smtp:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-smtp:4.2.1.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-smtp:4.1.74.Final: 980/1161 (84.41%)
- io.netty:netty-codec-smtp:4.2.1.Final: 979/1160 (84.40%)

**Line:**
- io.netty:netty-codec-smtp:4.1.74.Final: 209/251 (83.27%)
- io.netty:netty-codec-smtp:4.2.1.Final: 210/252 (83.33%)

**Method:**
- io.netty:netty-codec-smtp:4.1.74.Final: 62/83 (74.70%)
- io.netty:netty-codec-smtp:4.2.1.Final: 62/83 (74.70%)
