### PR TITLE
[Automation] Generated metadata for org.flywaydb:flyway-database-postgresql:10.19.0

### DIFF
--- a/metadata/org.flywaydb/flyway-database-postgresql/10.19.0/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-database-postgresql/10.19.0/reachability-metadata.json
@@ -1,509 +1,497 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
-      "methods": [
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
-      "methods": [
+      "type" : "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
-      "methods": [
+      "type" : "com.sun.crypto.provider.PBKDF2Core$HmacSHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "java.lang.Comparable"
+      "type" : "java.lang.Comparable"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
       },
-      "type": "org.apache.commons.logging.Log"
+      "type" : "org.apache.commons.logging.Log"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineAppliedMigration"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getBaselineMigrationPrefix",
-          "parameterTypes": []
+          "name" : "getBaselineMigrationPrefix",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setBaselineMigrationPrefix",
-          "parameterTypes": [
+          "name" : "setBaselineMigrationPrefix",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineMigrationTypeResolver"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineMigrationTypeResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
+      "type" : "org.flywaydb.core.api.migration.baseline.BaselineResourceTypeProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.experimental.migration.CoreMigrationTypeResolver"
+      "type" : "org.flywaydb.core.experimental.migration.CoreMigrationTypeResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "type" : "org.flywaydb.core.extensibility.ConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.extensibility.Plugin"
+      "type" : "org.flywaydb.core.extensibility.Plugin"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getClean",
-          "parameterTypes": []
+          "name" : "getClean",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setClean",
-          "parameterTypes": [
+          "name" : "setClean",
+          "parameterTypes" : [
             "org.flywaydb.core.internal.command.clean.CleanModel"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModeConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.CleanModel"
+      "type" : "org.flywaydb.core.internal.command.clean.CleanModel"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.command.clean.SchemaModel"
+      "type" : "org.flywaydb.core.internal.command.clean.SchemaModel"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getDeployScript",
-          "parameterTypes": []
+          "name" : "getDeployScript",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setDeployScript",
-          "parameterTypes": [
+          "name" : "setDeployScript",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.configuration.extensions.DeployScriptConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentProvisionerNone"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
+      "type" : "org.flywaydb.core.internal.configuration.resolvers.EnvironmentVariableResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
+      "type" : "org.flywaydb.core.internal.database.base.TestContainersDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.h2.H2DatabaseType"
+      "type" : "org.flywaydb.core.internal.database.h2.H2DatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
+      "type" : "org.flywaydb.core.internal.database.sqlite.SQLiteDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.AuthCommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.CommandExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.LicensingConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
+      "type" : "org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.api.configuration.ClassicConfiguration"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.api.configuration.ClassicConfiguration"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "isPublishResult",
-          "parameterTypes": []
+          "name" : "isPublishResult",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setPublishResult",
-          "parameterTypes": [
+          "name" : "setPublishResult",
+          "parameterTypes" : [
             "boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
+      "type" : "org.flywaydb.core.internal.publishing.PublishingConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
+      "type" : "org.flywaydb.core.internal.resource.CoreResourceTypeProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
+      "type" : "org.flywaydb.core.internal.schemahistory.BaseAppliedMigration"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.cockroachdb.CockroachDBDatabaseType"
+      "type" : "org.flywaydb.database.cockroachdb.CockroachDBDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension",
-      "methods": [
+      "type" : "org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getTransactional",
-          "parameterTypes": []
+          "name" : "getTransactional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "isTransactionalLock",
-          "parameterTypes": []
+          "name" : "isTransactionalLock",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setTransactional",
-          "parameterTypes": [
+          "name" : "setTransactional",
+          "parameterTypes" : [
             "org.flywaydb.database.postgresql.TransactionalModel"
           ]
         },
         {
-          "name": "setTransactionalLock",
-          "parameterTypes": [
+          "name" : "setTransactionalLock",
+          "parameterTypes" : [
             "boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension"
+      "type" : "org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "type": "org.flywaydb.database.postgresql.PostgreSQLDatabaseType"
+      "type" : "org.flywaydb.database.postgresql.PostgreSQLDatabaseType"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.extensibility.ConfigurationExtension"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.extensibility.ConfigurationExtension"
       },
-      "type": "org.flywaydb.database.postgresql.TransactionalModel",
-      "methods": [
+      "type" : "org.flywaydb.database.postgresql.TransactionalModel",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getLock",
-          "parameterTypes": []
+          "name" : "getLock",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "setLock",
-          "parameterTypes": [
+          "name" : "setLock",
+          "parameterTypes" : [
             "java.lang.Boolean"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "org.postgresql.Driver"
+      "type" : "org.postgresql.Driver"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.database.base.BaseDatabaseType"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.database.base.BaseDatabaseType"
       },
-      "type": "org.postgresql.jdbc.PgStatement"
+      "type" : "org.postgresql.jdbc.PgStatement"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.FeatureDetector"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.FeatureDetector"
       },
-      "type": "org.slf4j.Logger"
+      "type" : "org.slf4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.util.ClassUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.util.ClassUtils"
       },
-      "type": "org.slf4j.spi.SLF4JServiceProvider"
+      "type" : "org.slf4j.spi.SLF4JServiceProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.NativePRNG",
-      "methods": [
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.security.SecureRandomParameters"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.jdbc.JdbcUtils"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.jdbc.JdbcUtils"
       },
-      "type": "sun.security.provider.SHA2$SHA256",
-      "methods": [
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
       },
-      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.plugin.PluginRegister"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.plugin.PluginRegister"
       },
-      "glob": "META-INF/services/org.flywaydb.core.extensibility.Plugin"
+      "glob" : "META-INF/services/org.flywaydb.core.extensibility.Plugin"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.ClasspathClassScanner"
       },
-      "glob": "db/callback"
+      "glob" : "db/callback"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.scanner.Scanner"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.scanner.Scanner"
       },
-      "glob": "db/migration"
+      "glob" : "db/migration"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.license.VersionPrinter"
       },
-      "glob": "db/migration/V1__create_table.sql"
+      "glob" : "org/flywaydb/core/internal/version.txt"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.resource.classpath.ClassPathResource"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
       },
-      "glob": "db/migration/V2__alter_table.sql"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.license.VersionPrinter"
+      "condition" : {
+        "typeReached" : "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
       },
-      "glob": "org/flywaydb/core/internal/version.txt"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
-    },
-    {
-      "condition": {
-        "typeReached": "org.flywaydb.core.internal.logging.javautil.JavaUtilLog"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en_US.properties"
-    },
-    {
-      "bundle": "sun.util.logging.resources.logging"
+      "bundle" : "sun.util.logging.resources.logging"
     }
   ]
 }

--- a/metadata/org.flywaydb/flyway-database-postgresql/index.json
+++ b/metadata/org.flywaydb/flyway-database-postgresql/index.json
@@ -1,17 +1,29 @@
 [
   {
-    "latest": true,
-    "allowed-packages": [
-      "org.flywaydb"
+    "latest" : true,
+    "metadata-version" : "10.19.0",
+    "test-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/blob/flyway-$version$/documentation/Flyway%20CLI%20and%20API/Supported%20Databases/PostgreSQL%20Database.md",
+    "description" : "This Flyway module adds PostgreSQL and CockroachDB database support by providing database type detection, SQL parsing, and JDBC integration for PostgreSQL-compatible systems. It enables Flyway migrations to run with PostgreSQL-specific connection handling, schema support, table operations, and advisory locking behavior.",
+    "tested-versions" : [
+      "10.19.0"
     ],
-    "metadata-version": "10.13.0",
-    "source-code-url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",
-    "repository-url": "https://github.com/flyway/flyway",
-    "test-code-url": "https://github.com/flyway/flyway/tree/flyway-$version$/flyway-database/flyway-database-postgresql",
-    "documentation-url": "https://github.com/flyway/flyway/tree/flyway-$version$/documentation",
-    "description": "This Flyway module adds PostgreSQL and CockroachDB database support by providing database type detection, SQL parsing, and JDBC integration for PostgreSQL-compatible systems. It enables Flyway migrations to run with PostgreSQL-specific connection handling, schema support, table operations, and advisory locking behavior.",
-    "test-version": "10.10.0",
-    "tested-versions": [
+    "allowed-packages" : [
+      "org.flywaydb"
+    ]
+  },
+  {
+    "metadata-version" : "10.13.0",
+    "test-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "https://github.com/flyway/flyway/tree/flyway-$version$/flyway-database/flyway-database-postgresql",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-$version$/documentation",
+    "description" : "This Flyway module adds PostgreSQL and CockroachDB database support by providing database type detection, SQL parsing, and JDBC integration for PostgreSQL-compatible systems. It enables Flyway migrations to run with PostgreSQL-specific connection handling, schema support, table operations, and advisory locking behavior.",
+    "tested-versions" : [
       "10.13.0",
       "10.14.0",
       "10.15.0",
@@ -24,22 +36,25 @@
       "10.18.0",
       "10.18.1",
       "10.18.2"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
     ]
   },
   {
-    "allowed-packages": [
-      "org.flywaydb"
-    ],
-    "metadata-version": "10.10.0",
-    "source-code-url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",
-    "repository-url": "https://github.com/flyway/flyway",
-    "test-code-url": "https://github.com/flyway/flyway/tree/flyway-$version$/flyway-database/flyway-database-postgresql",
-    "documentation-url": "https://github.com/flyway/flyway/tree/flyway-$version$/documentation",
-    "tested-versions": [
+    "metadata-version" : "10.10.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "https://github.com/flyway/flyway/tree/flyway-$version$/flyway-database/flyway-database-postgresql",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-$version$/documentation",
+    "tested-versions" : [
       "10.10.0",
       "10.11.0",
       "10.11.1",
       "10.12.0"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
     ]
   }
 ]


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#1618

This PR provides new metadata needed for the org.flywaydb:flyway-database-postgresql:10.19.0, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.flywaydb:flyway-database-postgresql:10.10.0`): 6
- Test-only metadata entries (previous `org.flywaydb:flyway-database-postgresql:10.10.0`): 2
- Metadata entries (new `org.flywaydb:flyway-database-postgresql:10.19.0`): 86
- Test-only metadata entries (new `org.flywaydb:flyway-database-postgresql:10.19.0`): 2
- Library coverage (previous): 24.52%
- Library coverage (new): 24.66%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5e0b2ac606599cfa86204b225fd8b7f110f5900c`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.flywaydb:flyway-database-postgresql:10.10.0: 0/6 covered calls (0.00%)
- org.flywaydb:flyway-database-postgresql:10.19.0: 0/6 covered calls (0.00%)

**Reflection:**
- org.flywaydb:flyway-database-postgresql:10.10.0: 0/6 covered calls (0.00%)
- org.flywaydb:flyway-database-postgresql:10.19.0: 0/6 covered calls (0.00%)

#### Library coverage

**Instruction:**
- org.flywaydb:flyway-database-postgresql:10.10.0: 735/3344 (21.98%)
- org.flywaydb:flyway-database-postgresql:10.19.0: 750/3392 (22.11%)

**Line:**
- org.flywaydb:flyway-database-postgresql:10.10.0: 142/579 (24.52%)
- org.flywaydb:flyway-database-postgresql:10.19.0: 145/588 (24.66%)

**Method:**
- org.flywaydb:flyway-database-postgresql:10.10.0: 61/179 (34.08%)
- org.flywaydb:flyway-database-postgresql:10.19.0: 63/183 (34.43%)
