### PR TITLE
Add Forge local CI verification gate

### DIFF
--- a/.github/workflows/scripts/restore-docker.sh
+++ b/.github/workflows/scripts/restore-docker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+set -euo pipefail
+
+# Undo the Docker proxy drop-in installed by disable-docker.sh so a local Forge
+# process can verify multiple PRs without carrying CI's no-network setting into
+# the next verification run.
+sudo rm -f /etc/systemd/system/docker.service.d/http-proxy.conf
+if [[ -d /etc/systemd/system/docker.service.d ]]; then
+    sudo rmdir --ignore-fail-on-non-empty /etc/systemd/system/docker.service.d || true
+fi
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+echo "Docker outbound network restored."

--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -36,7 +36,7 @@ from utility_scripts import metrics_writer
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics, validate_benchmark_run_metrics
 from utility_scripts.source_context import (
     discover_artifact_metadata,
@@ -110,7 +110,6 @@ def build_parser():
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "--docs-path",
         default=None,
@@ -204,7 +203,6 @@ def parse_flags(argv_list):
         flags.metrics_repo_path,
         flags.benchmark_mode,
         flags.keep_tests_without_dynamic_access,
-        flags.in_metadata_repo,
         flags.large_library_series,
         flags.chunk_class_limit,
         flags.chunk_call_limit,
@@ -217,14 +215,12 @@ def resolve_repo_paths(
         explicit_repo_path: str | None,
         explicit_metrics_repo_path: str | None,
         benchmark_mode: bool,
-        in_metadata_repo: bool = True,
 ):
     """Resolve paths for reachability-metadata and metrics-metadata-forge repositories."""
 
     res_reachability_repo, res_metrics_repo = resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
 
     subdir_name = "benchmark_run_metrics" if benchmark_mode else "script_run_metrics"
@@ -399,7 +395,6 @@ def main(argv=None):
         explicit_metrics_repo_path,
         is_benchmark_mode,
         keep_tests_without_dynamic_access,
-        in_metadata_repo,
         large_library_series,
         chunk_class_limit,
         chunk_call_limit,
@@ -414,7 +409,6 @@ def main(argv=None):
         explicit_repo_path,
         explicit_metrics_repo_path,
         is_benchmark_mode,
-        in_metadata_repo=in_metadata_repo,
     )
     resolve_graalvm_java_home()
 

--- a/forge/ai_workflows/fix_java_fails.py
+++ b/forge/ai_workflows/fix_java_fails.py
@@ -23,8 +23,6 @@ Usage:
 import argparse
 import sys
 
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument
-
 DEFAULT_JAVAC_STRATEGY = "javac_iterative_with_coverage_sources_pi_gpt-5.5"
 DEFAULT_JAVA_RUN_STRATEGY = "java_run_iterative_with_coverage_sources_pi_gpt-5.5"
 
@@ -72,7 +70,6 @@ def build_parser():
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "--strategy-name",
         metavar="NAME",
@@ -99,8 +96,6 @@ def _workflow_argv(flags):
         workflow_argv.extend(["--reachability-metadata-path", flags.reachability_metadata_path])
     if flags.metrics_repo_path:
         workflow_argv.extend(["--metrics-repo-path", flags.metrics_repo_path])
-    if flags.in_metadata_repo:
-        workflow_argv.append("--in-metadata-repo")
     if flags.strategy_name:
         workflow_argv.extend(["--strategy-name", flags.strategy_name])
     if flags.docs_path:

--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -10,7 +10,7 @@ import sys
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts.library_finalization import run_library_finalization
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.source_context import populate_artifact_urls
 
 
@@ -44,7 +44,6 @@ def build_parser():
             "If omitted, the parent checkout of this Forge directory is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     return parser
 
 
@@ -95,7 +94,6 @@ def main(argv=None) -> int:
     reachability_metadata_path, _ = resolve_repo_roots(
         args.reachability_metadata_path,
         None,
-        in_metadata_repo=args.in_metadata_repo,
     )
 
     current_coordinates = args.coordinates

--- a/forge/ai_workflows/improve_library_coverage.py
+++ b/forge/ai_workflows/improve_library_coverage.py
@@ -38,7 +38,7 @@ from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if
 from utility_scripts import metrics_writer
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
 from utility_scripts.metrics_writer import count_metadata_entries, count_test_only_metadata_entries, create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
 from utility_scripts.source_context import (
     normalize_source_context_types,
@@ -92,7 +92,6 @@ def build_parser() -> argparse.ArgumentParser:
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "--strategy-name",
         dest="strategy_name",
@@ -155,7 +154,6 @@ def parse_flags(argv_list: list[str]):
         flags.verbose,
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
-        flags.in_metadata_repo,
         flags.large_library_series,
         flags.chunk_class_limit,
         flags.chunk_call_limit,
@@ -167,13 +165,11 @@ def parse_flags(argv_list: list[str]):
 def resolve_repo_paths(
         explicit_repo_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool = True,
 ) -> tuple[str, str, str]:
     """Resolve repository paths for code and metrics outputs."""
     resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
     resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
     os.makedirs(resolved_metrics_dir, exist_ok=True)
@@ -213,7 +209,6 @@ def main(argv=None) -> int:
         is_verbose,
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo,
         large_library_series,
         chunk_class_limit,
         chunk_call_limit,
@@ -226,7 +221,6 @@ def main(argv=None) -> int:
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -22,7 +22,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
 from utility_scripts.source_context import (
     normalize_source_context_types,
@@ -119,7 +119,6 @@ def build_parser(config: JavaFailWorkflowConfig):
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "--strategy-name",
         dest="strategy_name",
@@ -162,16 +161,14 @@ def parse_flags(config: JavaFailWorkflowConfig, argv_list):
         flags.verbose,
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
-        flags.in_metadata_repo,
     )
 
 
-def resolve_repo_paths(explicit_repo_path, explicit_metrics_repo_path, in_metadata_repo: bool = True):
+def resolve_repo_paths(explicit_repo_path, explicit_metrics_repo_path):
     """Resolve repository paths for code and metrics outputs."""
     resolved_reachability_repo, resolved_metrics_repo = resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
 
     resolved_metrics_dir = os.path.join(resolved_metrics_repo, "script_run_metrics")
@@ -349,14 +346,12 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         is_verbose,
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo,
     ) = parse_flags(config, argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -249,20 +249,6 @@ class WorkflowStrategy(ABC):
         if future_defaults_status == SUCCESS_WITH_INTERVENTION_STATUS:
             final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
-        graalvm_25_home = os.environ["GRAALVM_HOME_25_0"]
-        graalvm_25_env = dict(os.environ)
-        graalvm_25_env["GRAALVM_HOME"] = graalvm_25_home
-        graalvm_25_env["JAVA_HOME"] = graalvm_25_home
-        graalvm_25_status = run_lane(
-            "current-defaults GRAALVM_25_0 test",
-            lambda: self._run_command_with_env(test_cmd, graalvm_25_env),
-            f"GRAALVM_HOME=$GRAALVM_HOME_25_0 JAVA_HOME=$GRAALVM_HOME_25_0 {test_cmd}",
-        )
-        if graalvm_25_status == RUN_STATUS_FAILURE:
-            return RUN_STATUS_FAILURE
-        if graalvm_25_status == SUCCESS_WITH_INTERVENTION_STATUS:
-            final_status = SUCCESS_WITH_INTERVENTION_STATUS
-
         return final_status
 
     def _run_gradle_command_with_output(self, command: list[str]) -> subprocess.CompletedProcess[str]:

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -249,6 +249,8 @@ class WorkflowStrategy(ABC):
         if future_defaults_status == SUCCESS_WITH_INTERVENTION_STATUS:
             final_status = SUCCESS_WITH_INTERVENTION_STATUS
 
+        # Full CI-matrix GraalVM coverage, including GRAALVM_HOME_25_0, runs in
+        # local CI verification after generation.
         return final_status
 
     def _run_gradle_command_with_output(self, command: list[str]) -> subprocess.CompletedProcess[str]:

--- a/forge/benchmarks/benchmark_runner.py
+++ b/forge/benchmarks/benchmark_runner.py
@@ -28,7 +28,7 @@ BENCHMARK_SUITE_PATH = Path(os.path.join(REPO_ROOT, "benchmarks", "benchmark_sui
 STRATEGIES_PATH = Path(os.path.join(REPO_ROOT, "strategies", "predefined_strategies.json"))
 BENCHMARK_WORKTREE_DIRNAME = "forge_benchmark_worktrees"
 
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 from utility_scripts.metrics_writer import count_metadata_entries
 from git_scripts.common_git import build_ai_branch_name
 
@@ -58,7 +58,6 @@ def parse_args(argv):
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "-v", "--verbose",
         action="store_true",
@@ -128,19 +127,18 @@ def resolve_benchmark_execution_paths(
         benchmark_name: str,
         explicit_reachability_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool,
 ) -> tuple[Path, Path, Path | None, Path]:
     """Resolve the reachability worktree and durable metrics root for a benchmark run."""
     base_reachability_path = Path(reachability_root).resolve()
     metrics_repo_dir = Path(metrics_root).resolve()
     created_worktree_path = None
 
-    if in_metadata_repo and explicit_metrics_repo_path is None:
+    if explicit_metrics_repo_path is None:
         metrics_repo_dir = Path(REPO_ROOT).resolve()
         os.makedirs(os.path.join(metrics_repo_dir, "benchmark_run_metrics"), exist_ok=True)
 
     reachability_metadata_path = base_reachability_path
-    if in_metadata_repo and explicit_reachability_path is None:
+    if explicit_reachability_path is None:
         created_worktree_path = create_benchmark_worktree(base_reachability_path, benchmark_name)
         reachability_metadata_path = created_worktree_path.resolve()
 
@@ -202,7 +200,7 @@ def compute_original_metadata_entries(repo_path: Path, coords: str):
 
 def run_workflow_for_coords(coords: str, reachability_metadata_path: str, metrics_repo_path: str,
                             strategy_name: str, verbose: bool, keep_tests_without_dynamic_access: bool,
-                            in_metadata_repo: bool):
+                            ):
     """
     Execute ai_workflows/add_new_library_support.py for the given coordinates.
     On completion, validate that output/results.json exists and is valid JSON (array).
@@ -212,8 +210,6 @@ def run_workflow_for_coords(coords: str, reachability_metadata_path: str, metric
     cmd.extend(["--reachability-metadata-path", reachability_metadata_path])
     cmd.extend(["--metrics-repo-path", metrics_repo_path])
     cmd.extend(["--strategy-name", strategy_name])
-    if in_metadata_repo:
-        cmd.append("--in-metadata-repo")
 
     # Ensure benchmark runs are recorded under benchmark_run_metrics in the metrics repo
     cmd.append("--benchmark-mode")
@@ -308,7 +304,7 @@ def cleanup_and_commit_for_libraries(reachability_metadata_path: Path, libraries
 
 def run_workflow_for_libraries(libraries: List[str], reachability_metadata_path: Path,
                                metrics_repo_dir: Path, strategy_name: str, verbose: bool,
-                               keep_tests_without_dynamic_access: bool, in_metadata_repo: bool) -> None:
+                               keep_tests_without_dynamic_access: bool) -> None:
     for coords in libraries:
         print(f"[Executing AI workflow for {coords}...]")
         run_workflow_for_coords(
@@ -318,7 +314,6 @@ def run_workflow_for_libraries(libraries: List[str], reachability_metadata_path:
             strategy_name,
             verbose,
             keep_tests_without_dynamic_access,
-            in_metadata_repo,
         )
 
 
@@ -332,7 +327,6 @@ def main(argv: Optional[List[str]] = None):
     reachability_root, metrics_root = resolve_repo_roots(
         reachability_metadata_path_arg,
         metrics_repo_path_arg,
-        in_metadata_repo=args.in_metadata_repo,
     )
 
     reachability_metadata_path, metrics_repo_dir, created_worktree_path, base_reachability_path = (
@@ -342,7 +336,6 @@ def main(argv: Optional[List[str]] = None):
             benchmark_name=benchmark_name,
             explicit_reachability_path=reachability_metadata_path_arg,
             explicit_metrics_repo_path=metrics_repo_path_arg,
-            in_metadata_repo=args.in_metadata_repo,
         )
     )
     if not reachability_metadata_path.exists():
@@ -388,7 +381,6 @@ def main(argv: Optional[List[str]] = None):
             strategy_name,
             verbose,
             keep_tests_without_dynamic_access,
-            args.in_metadata_repo,
         )
     finally:
         print(f"[Restoring repository to original state...]")

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -130,15 +130,47 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - **Pull request** (only when invoked through `complete_pipelines/` or
   `git_scripts/make_pr_*.py`).
 
-## 6. Failure Semantics
+## 6. Local CI-Equivalent Verification
+
+Every Forge task must be fully tested locally in the same way it will be
+tested by CI before it is allowed to produce a PR-eligible result. This is a
+hard requirement, not an optimization or best-effort check.
+
+For the task's affected coordinate set, Forge must run the same validation
+surface that the corresponding CI workflow will run, including metadata
+validation, style checks, compilation, JVM tests, native-image build/run
+tests, Docker image pre-pull requirements, vulnerability checks when Docker
+images change, stats validation, and any workflow-specific gates. The local
+commands, coordinates filter, native-image mode, JDK/GraalVM selection, and
+Docker/image setup must be derived from the same repo configuration that CI
+uses, including `ci.json` and the Gradle task contracts.
+
+Forge must record the exact local verification commands and their outcomes in
+the run metrics and PR description. A task must not open a PR, mark a project
+item `Done`, return `RUN_STATUS_SUCCESS`, return
+`SUCCESS_WITH_INTERVENTION_STATUS`, or return `RUN_STATUS_CHUNK_READY` until
+that local CI-equivalent verification has passed. If Forge cannot reproduce
+the CI-equivalent validation locally, the workflow must return
+`RUN_STATUS_FAILURE` and preserve enough diagnostics for human follow-up.
+
+If local CI-equivalent verification fails, Forge may run a bounded fixup step
+before retrying the full verification. The fixup may repair generated
+library-scoped files or shared repository files when the failure is caused by
+the repository itself. After verification passes, Forge must algorithmically
+compare the final PR diff with the expected library-scoped paths. If any
+shared repository file changed, the PR must be labeled `human-intervention`
+and the verification metrics and PR description must list the repository-level
+paths that require maintainer review.
+
+## 7. Failure Semantics
 
 Every workflow records one of these statuses:
 
 | Status | Meaning |
 | --- | --- |
-| `RUN_STATUS_SUCCESS` | All gates passed; metadata and tests committed. |
-| `SUCCESS_WITH_INTERVENTION_STATUS` | Tests succeeded after the configured `PostGenerationIntervention` modified the working tree (e.g. `codex_then_pi` removing failing tests via Pi). The intervention's record is included in the run-metrics and PR description. PR-eligible. |
-| `RUN_STATUS_CHUNK_READY` | A large-library series reached a reviewable chunk boundary. The current part is PR-eligible and the issue remains labeled for continuation. |
+| `RUN_STATUS_SUCCESS` | All generation gates and the local CI-equivalent verification passed; metadata and tests committed. |
+| `SUCCESS_WITH_INTERVENTION_STATUS` | Tests succeeded after the configured `PostGenerationIntervention` modified the working tree (e.g. `codex_then_pi` removing failing tests via Pi), and the local CI-equivalent verification passed. The intervention's record is included in the run-metrics and PR description. PR-eligible. |
+| `RUN_STATUS_CHUNK_READY` | A large-library series reached a reviewable chunk boundary and the local CI-equivalent verification passed for the current part. The current part is PR-eligible and the issue remains labeled for continuation. |
 | `RUN_STATUS_FAILURE` | The workflow could not converge or a quality gate failed; the feature branch is reset to the scaffold checkpoint and no PR is opened. |
 
 The exit code is `0` for PR-eligible statuses and `1` for failure.
@@ -150,7 +182,7 @@ workflow creates a durable progress state, returns `RUN_STATUS_CHUNK_READY`
 at the first chunk boundary, and Forge applies the large-library continuation
 labels after publishing the part PR.
 
-## 7. Workflow Specifications
+## 8. Workflow Specifications
 
 - [Workflow strategies](workflow-strategies.md) — registry of strategies
   and post-generation interventions, including the

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -197,6 +197,7 @@ CODEX_REVIEW_TIMEOUT_SECONDS = 1800
 DEFAULT_WORKTREE_BASE_REF = "master"
 DEV_GRAALVM_ENV_VAR = "GRAALVM_HOME"
 POST_GENERATION_GRAALVM_ENV_VAR = "GRAALVM_HOME_25_0"
+LATEST_EA_GRAALVM_ENV_VAR = "GRAALVM_HOME_LATEST_EA"
 INTERRUPT_EXIT_CODES = {130, -int(signal.SIGINT)}
 INTERRUPT_REASON_CTRL_C = "Ctrl+C interrupt"
 INTERRUPT_REASON_SHUTDOWN = "shutdown request"
@@ -366,6 +367,7 @@ def validate_issue_processing_environment() -> None:
     """Validate environment required before issue processing can start."""
     require_graalvm_home_env(DEV_GRAALVM_ENV_VAR)
     require_graalvm_home_env(POST_GENERATION_GRAALVM_ENV_VAR)
+    require_graalvm_home_env(LATEST_EA_GRAALVM_ENV_VAR)
 
 
 def gh(

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -87,7 +87,6 @@ from utility_scripts.metadata_index import (
 )
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import (
-    add_in_metadata_repo_argument,
     get_forge_subdir_name,
     get_repo_root,
     resolve_repo_roots,
@@ -214,7 +213,6 @@ class ClaimedIssue:
     base_reachability_metadata_path: str
     worktree_path: str
     scratch_metrics_repo_path: str
-    in_metadata_repo: bool
     issue_coordinates: str
     current_coordinates: str | None = None
     new_version: str | None = None
@@ -2738,8 +2736,6 @@ def invoke_pipeline(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
-        if claimed_issue.in_metadata_repo:
-            pipeline_argv.append("--in-metadata-repo")
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         if keep_tests_without_dynamic_access:
@@ -2768,8 +2764,6 @@ def invoke_pipeline(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
-        if claimed_issue.in_metadata_repo:
-            pipeline_argv.append("--in-metadata-repo")
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         rc = run_fix_javac_workflow(pipeline_argv)
@@ -2795,8 +2789,6 @@ def invoke_pipeline(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
-        if claimed_issue.in_metadata_repo:
-            pipeline_argv.append("--in-metadata-repo")
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         rc = run_fix_java_run_workflow(pipeline_argv)
@@ -2821,8 +2813,6 @@ def invoke_pipeline(
             "--new-version", claimed_issue.new_version,
             "--reachability-metadata-path", claimed_issue.worktree_path,
         ]
-        if claimed_issue.in_metadata_repo:
-            pipeline_argv.append("--in-metadata-repo")
         rc = run_fix_ni_run_workflow(pipeline_argv)
         if is_interrupt_exit_code(rc):
             mark_user_interrupt_requested()
@@ -2845,8 +2835,6 @@ def invoke_pipeline(
             "--reachability-metadata-path", claimed_issue.worktree_path,
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
-        if claimed_issue.in_metadata_repo:
-            pipeline_argv.append("--in-metadata-repo")
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         append_large_library_workflow_args(pipeline_argv, claimed_issue)
@@ -3220,10 +3208,8 @@ def create_issue_workspace(
         base_reachability_metadata_path: str,
         canonical_metrics_repo_path: str,
         issue_number: int,
-        in_metadata_repo: bool = True,
 ) -> tuple[str, str]:
     """Create isolated worktrees for reachability-metadata and metrics storage."""
-    _ = in_metadata_repo
     repo_root = get_repo_root()
     worktrees_root = os.path.join(repo_root, "local_repositories", SCRATCH_WORKTREE_DIRNAME)
     os.makedirs(worktrees_root, exist_ok=True)
@@ -3260,8 +3246,6 @@ def cleanup_issue_workspace(claimed_issue: ClaimedIssue, canonical_metrics_repo_
         )
     else:
         remove_worktree(claimed_issue.base_reachability_metadata_path, claimed_issue.worktree_path)
-    if not claimed_issue.in_metadata_repo:
-        remove_worktree(canonical_metrics_repo_path, claimed_issue.scratch_metrics_repo_path)
 
 
 def build_claim_metadata(
@@ -3416,11 +3400,9 @@ def claim_issue_for_processing(
         base_reachability_metadata_path: str,
         canonical_metrics_repo_path: str,
         authenticated_user: str,
-        in_metadata_repo: bool = True,
         large_library_resume_artifact_override: str | None = None,
 ) -> Optional[ClaimedIssue]:
     """Claim an issue and prepare its isolated execution workspace."""
-    in_metadata_repo = True
     print(format_issue_processing_message(issue))
 
     if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
@@ -3453,7 +3435,6 @@ def claim_issue_for_processing(
             base_reachability_metadata_path,
             canonical_metrics_repo_path,
             issue["number"],
-            in_metadata_repo=in_metadata_repo,
         )
         if large_library_resume_artifact:
             large_library_state = LargeLibraryProgressState.load(large_library_resume_artifact)
@@ -3478,7 +3459,6 @@ def claim_issue_for_processing(
         base_reachability_metadata_path=base_reachability_metadata_path,
         worktree_path=worktree_path,
         scratch_metrics_repo_path=scratch_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
         issue_coordinates=issue_coordinates,
         current_coordinates=current_coordinates,
         new_version=new_version,
@@ -3619,7 +3599,6 @@ def finalize_successful_issue(
                 [
                     "--coordinates", claimed_issue.issue_coordinates,
                     "--reachability-metadata-path", claimed_issue.worktree_path,
-                    *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
                 ]
             )
             return
@@ -3629,7 +3608,6 @@ def finalize_successful_issue(
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 *large_library_pr_args,
-                *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
             ]
         )
         return
@@ -3641,7 +3619,6 @@ def finalize_successful_issue(
                 "--new-version", claimed_issue.new_version,
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
-                *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
             ]
         )
         return
@@ -3653,7 +3630,6 @@ def finalize_successful_issue(
                 "--new-version", claimed_issue.new_version,
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
-                *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
             ]
         )
         return
@@ -3664,7 +3640,7 @@ def finalize_successful_issue(
                 "--coordinates", claimed_issue.current_coordinates,
                 "--new-version", claimed_issue.new_version,
                 "--reachability-metadata-path", claimed_issue.worktree_path,
-                *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
+                "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
         )
         return
@@ -3676,7 +3652,6 @@ def finalize_successful_issue(
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 *large_library_pr_args,
-                *(["--in-metadata-repo"] if claimed_issue.in_metadata_repo else []),
             ]
         )
         return
@@ -4473,7 +4448,6 @@ def process_issues_with_label(
         keep_tests_without_dynamic_access: bool,
         authenticated_user: str | None,
         parallelism: int,
-        in_metadata_repo: bool = True,
         environment_already_validated: bool = False,
 ) -> int:
     """
@@ -4482,7 +4456,6 @@ def process_issues_with_label(
     The scan advances through the issue list using `offset`, but the returned count
     reflects only issues that were successfully claimed for processing.
     """
-    in_metadata_repo = True
     if is_shutdown_requested():
         log_stage(
             "shutdown",
@@ -4575,7 +4548,6 @@ def process_issues_with_label(
                         base_reachability_metadata_path,
                         canonical_metrics_repo_path,
                         authenticated_user,
-                        in_metadata_repo=in_metadata_repo,
                     )
                     if not claimed_issue:
                         continue
@@ -4641,11 +4613,9 @@ def process_work_queues(
         work_strategy_name_override: str | None = None,
         keep_tests_without_dynamic_access_override: bool = False,
         parallelism_default: int = DEFAULT_PARALLELISM,
-        in_metadata_repo: bool = True,
         random_offset_override: bool | None = None,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
-    in_metadata_repo = True
     queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
     review_queue_configs = get_review_queue_configs_from_environment()
     validate_work_queue_strategies(queue_configs)
@@ -4703,7 +4673,6 @@ def process_work_queues(
             keep_tests_without_dynamic_access,
             authenticated_user,
             parallelism,
-            in_metadata_repo=in_metadata_repo,
             environment_already_validated=True,
         )
 
@@ -4777,7 +4746,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "If omitted, the parent checkout of this Forge directory is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     parser.add_argument(
         "--strategy-name",
         help="Workflow strategy name to pass to the pipeline. If omitted, the pipeline default is used.",
@@ -4848,10 +4816,8 @@ def process_single_issue(
         strategy_name: str | None,
         keep_tests_without_dynamic_access: bool,
         authenticated_user: str,
-        in_metadata_repo: bool = True,
 ) -> bool:
     """Fetch, claim, and process a single issue by number."""
-    in_metadata_repo = True
     validate_issue_processing_environment()
 
     issue, label = get_issue_by_number(issue_number)
@@ -4864,7 +4830,6 @@ def process_single_issue(
         base_reachability_metadata_path,
         canonical_metrics_repo_path,
         authenticated_user,
-        in_metadata_repo=in_metadata_repo,
     )
     if not claimed_issue:
         print(f"ERROR: Could not claim issue #{issue_number}.", file=sys.stderr)
@@ -4885,7 +4850,6 @@ def process_large_library_continuation(
         strategy_name: str | None,
         keep_tests_without_dynamic_access: bool,
         authenticated_user: str,
-        in_metadata_repo: bool = True,
 ) -> bool:
     """Resume a large-library issue from a durable progress artifact."""
     state = LargeLibraryProgressState.load(resume_artifact)
@@ -4899,7 +4863,6 @@ def process_large_library_continuation(
         base_reachability_metadata_path,
         canonical_metrics_repo_path,
         authenticated_user,
-        in_metadata_repo=in_metadata_repo,
         large_library_resume_artifact_override=resume_artifact,
     )
     if not claimed_issue:
@@ -4927,7 +4890,6 @@ def main() -> None:
         reachability_metadata_path, metrics_repo_path = resolve_repo_roots(
             args.reachability_metadata_path,
             None,
-            in_metadata_repo=args.in_metadata_repo,
         )
 
         if not PROJECT_NUMBER:
@@ -4942,7 +4904,6 @@ def main() -> None:
                 args.strategy_name,
                 args.keep_tests_without_dynamic_access,
                 args.parallelism,
-                in_metadata_repo=args.in_metadata_repo,
                 random_offset_override=args.random_offset,
             )
         elif args.review_pr is not None:
@@ -4964,7 +4925,6 @@ def main() -> None:
                 args.strategy_name,
                 args.keep_tests_without_dynamic_access,
                 authenticated_user,
-                in_metadata_repo=args.in_metadata_repo,
             )
         elif args.continue_large_library_artifact is not None:
             authenticated_user = resolve_authenticated_user()
@@ -4975,7 +4935,6 @@ def main() -> None:
                 args.strategy_name,
                 args.keep_tests_without_dynamic_access,
                 authenticated_user,
-                in_metadata_repo=args.in_metadata_repo,
             )
         else:
             authenticated_user = resolve_authenticated_user()
@@ -4994,7 +4953,6 @@ def main() -> None:
                 args.keep_tests_without_dynamic_access,
                 authenticated_user,
                 args.parallelism,
-                in_metadata_repo=args.in_metadata_repo,
             )
     except KeyboardInterrupt:
         if is_shutdown_requested():

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -3603,6 +3603,7 @@ def finalize_successful_issue(
                 [
                     "--coordinates", claimed_issue.issue_coordinates,
                     "--reachability-metadata-path", claimed_issue.worktree_path,
+                    "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 ]
             )
             return

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -195,6 +195,7 @@ DEFAULT_REVIEW_MODEL = "gpt-5.4"
 DEFAULT_WORK_QUEUE_STRATEGY_NAME = "dynamic_access_main_sources_pi_gpt-5.5"
 CODEX_REVIEW_TIMEOUT_SECONDS = 1800
 DEFAULT_WORKTREE_BASE_REF = "master"
+DEV_GRAALVM_ENV_VAR = "GRAALVM_HOME"
 POST_GENERATION_GRAALVM_ENV_VAR = "GRAALVM_HOME_25_0"
 INTERRUPT_EXIT_CODES = {130, -int(signal.SIGINT)}
 INTERRUPT_REASON_CTRL_C = "Ctrl+C interrupt"
@@ -363,6 +364,7 @@ def _handle_sigint(_signum, _frame) -> None:
 
 def validate_issue_processing_environment() -> None:
     """Validate environment required before issue processing can start."""
+    require_graalvm_home_env(DEV_GRAALVM_ENV_VAR)
     require_graalvm_home_env(POST_GENERATION_GRAALVM_ENV_VAR)
 
 

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -29,21 +29,23 @@ from git_scripts.common_git import (
 )
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metrics_writer import (
-    commit_run_metrics_with_retry,
     count_metadata_entries,
     count_test_only_metadata_entries,
     read_pending_metrics,
 )
 from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART, LargeLibraryProgressState
-from utility_scripts.repo_path_resolver import (
-    add_in_metadata_repo_argument,
-    resolve_repo_roots,
+from utility_scripts.repo_path_resolver import resolve_repo_roots
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LOCAL_CI_VERIFICATION_KEY,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
 )
 
 REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = "master"
 REVIEWERS = get_configured_reviewers()
-SCRIPT_RUN_METRICS_DIR = "script_run_metrics"
 BASELINE_STATS_FILENAME = ".baseline-stats.json"
 
 
@@ -65,6 +67,7 @@ def build_pull_request_body(
         is_final_large_library_part: bool = True,
         large_library_part: int | None = None,
         series_id: str | None = None,
+        local_ci_verification: dict | None = None,
 ) -> str:
     """Build the PR body with metrics and optional stats."""
     input_tokens_used = metrics.get("input_tokens_used", 0)
@@ -123,6 +126,7 @@ Summary:
         body += f"- Stage: `{post_generation_intervention.get('stage', 'unknown')}`\n\n"
         body += f"- Intervention file: `{post_generation_intervention.get('intervention_file', 'unknown')}`\n\n"
         body += str(post_generation_intervention.get("analysis_markdown", "")).strip() + "\n"
+    body += format_local_ci_verification_pr_section(local_ci_verification)
     return body
 
 
@@ -237,6 +241,7 @@ def create_pull_request(
         baseline_test_only_entries=baseline_test_only_entries,
         current_test_only_entries=current_test_only_entries,
         post_generation_intervention=matched.get("post_generation_intervention"),
+        local_ci_verification=matched.get(LOCAL_CI_VERIFICATION_KEY),
         is_large_library_part=large_library_part is not None,
         is_final_large_library_part=is_final_large_library_part,
         large_library_part=large_library_part,
@@ -253,6 +258,8 @@ def create_pull_request(
         "--label", "GenAI",
         "--label", "library-update-request",
     ]
+    if local_ci_requires_human_intervention(matched.get(LOCAL_CI_VERIFICATION_KEY)):
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     if large_library_part is not None:
         cmd.extend(["--label", LABEL_LARGE_LIBRARY_PART])
     if REVIEWERS:
@@ -300,7 +307,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--series-id", help="Large-library series identifier for the PR body.")
     parser.add_argument("--large-library-state-path", help="Progress state JSON path to update after publishing.")
-    add_in_metadata_repo_argument(parser)
     return parser
 
 
@@ -310,13 +316,11 @@ def parse_flags(argv_list: list[str]):
     repo_path, metrics_repo_path = resolve_repo_roots(
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
-        in_metadata_repo=flags.in_metadata_repo,
     )
     return (
         flags.coordinates,
         repo_path,
         metrics_repo_path,
-        flags.in_metadata_repo,
         flags.issue_number,
         flags.large_library_part,
         flags.large_library_final,
@@ -325,7 +329,12 @@ def parse_flags(argv_list: list[str]):
     )
 
 
-def push_current_branch_to_origin(coordinates: str, repo_path: str, large_library_part: int | None = None) -> str:
+def push_current_branch_to_origin(
+        coordinates: str,
+        repo_path: str,
+        metrics_repo_path: str | None = None,
+        large_library_part: int | None = None,
+) -> str:
     """Create and push a feature branch, returning the branch name."""
     group, artifact, library_version = parse_coordinate_parts(coordinates)
 
@@ -340,6 +349,12 @@ def push_current_branch_to_origin(coordinates: str, repo_path: str, large_librar
 
     base_ref = _fetch_pr_base(repo_path)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
     subprocess.run(["git", "push", "origin", new_branch], check=True, cwd=repo_path)
 
     return new_branch
@@ -369,39 +384,11 @@ def update_large_library_state_after_publish(
     state.save(state_path)
 
 
-def metrics_commit_and_push(
-        metrics_repo_root: str,
-        coordinates: str,
-        extra_paths_to_stage: list[str] | None = None,
-) -> None:
-    """Read pending metrics and push with retry logic."""
-    run_metrics = read_pending_metrics(metrics_repo_root)
-    metrics_json_path = os.path.join(SCRIPT_RUN_METRICS_DIR, "improve_library_coverage.json")
-    commit_run_metrics_with_retry(
-        metrics_repo_root=metrics_repo_root,
-        metrics_json_relative_path=metrics_json_path,
-        run_metrics=run_metrics,
-        commit_message=f"Run metrics: improve_library_coverage.py for {coordinates}",
-        extra_paths_to_stage=extra_paths_to_stage,
-    )
-
-
-def _large_library_extra_paths(
-        state_path: str | None,
-        metrics_repo_root: str,
-) -> list[str] | None:
-    """Return the series progress dir relative to the metrics root, when state is present."""
-    if not state_path:
-        return None
-    return [os.path.relpath(os.path.dirname(state_path), metrics_repo_root)]
-
-
 def main(argv=None) -> None:
     (
         coordinates,
         repo_path,
         metrics_repo_path,
-        in_metadata_repo,
         issue_number,
         large_library_part,
         large_library_final,
@@ -416,6 +403,7 @@ def main(argv=None) -> None:
     branch = push_current_branch_to_origin(
         coordinates=coordinates,
         repo_path=repo_path,
+        metrics_repo_path=metrics_repo_path,
         large_library_part=large_library_part,
     )
     pr_number = create_pull_request(
@@ -439,12 +427,6 @@ def main(argv=None) -> None:
         pr_number,
         large_library_final or large_library_part is None,
     )
-    if not in_metadata_repo:
-        metrics_commit_and_push(
-            metrics_repo_path,
-            coordinates,
-            extra_paths_to_stage=_large_library_extra_paths(large_library_state_path, metrics_repo_path),
-        )
 
 
 if __name__ == "__main__":

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -24,30 +24,29 @@ from git_scripts.common_git import (
 )
 from git_scripts.make_pr_javac_fix import generate_diff_text
 from utility_scripts.library_stats import stats_artifact_dir
-from utility_scripts.metrics_writer import commit_run_metrics_with_retry, read_pending_metrics
-from utility_scripts.repo_path_resolver import (
-    add_in_metadata_repo_argument,
-    resolve_repo_roots,
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LOCAL_CI_VERIFICATION_KEY,
+    fetch_pr_base_ref,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
 )
+from utility_scripts.metrics_writer import read_pending_metrics
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 import shutil
 
 REPO = 'oracle/graalvm-reachability-metadata'
 BASE_BRANCH = 'master'
 REVIEWERS = ["vjovanov", "jormundur00", "kimeta"]
-SCRIPT_RUN_METRICS_DIR = "script_run_metrics"
-FIX_JAVA_RUN_METRICS_FILE = "fix_java_run_fail.json"
-
-
 def resolve_repo_paths(
         explicit_repo_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool = True,
 ):
     """Resolve repo and metrics paths using provided values or local defaults."""
     return resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
 
 
@@ -166,6 +165,7 @@ Summary:
             f"- Intervention file: `{post_generation_intervention.get('intervention_file', 'unknown')}`\n\n"
             f"{str(post_generation_intervention.get('analysis_markdown', '')).strip()}\n"
         )
+    body += format_local_ci_verification_pr_section(metrics_entry.get(LOCAL_CI_VERIFICATION_KEY))
     cmd = [
         "gh",
         "pr",
@@ -185,6 +185,8 @@ Summary:
         "--label",
         "GenAI",
     ]
+    if local_ci_requires_human_intervention(metrics_entry.get(LOCAL_CI_VERIFICATION_KEY)):
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     if REVIEWERS:
         for reviewer in REVIEWERS:
             cmd.extend(["--reviewer", reviewer])
@@ -219,7 +221,6 @@ def build_parser():
         dest="metrics_repo_path",
         help="Path to the metrics repository root.",
     )
-    add_in_metadata_repo_argument(parser)
     return parser
 
 
@@ -230,9 +231,8 @@ def parse_flags(argv_list):
     repo_path, metrics_repo_path = resolve_repo_paths(
         explicit_repo_path=flags.reachability_metadata_path,
         explicit_metrics_repo_path=flags.metrics_repo_path,
-        in_metadata_repo=flags.in_metadata_repo,
     )
-    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.in_metadata_repo
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
 
 
 def push_current_branch_to_origin(
@@ -265,6 +265,14 @@ def push_current_branch_to_origin(
         metrics_repo_path=metrics_repo_path,
         include_in_repo_metrics=include_in_repo_metrics,
     )
+    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
+    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=new_coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
 
     subprocess.run(
         ["git", "push", "origin", branch],
@@ -275,23 +283,10 @@ def push_current_branch_to_origin(
     return branch, group, artifact, old_version, new_coordinates
 
 
-def metrics_commit_and_push(metrics_repo_root: str, old_coordinates: str, new_coordinates: str):
-    """Read pending metrics and push with retry logic."""
-    run_metrics = read_pending_metrics(metrics_repo_root)
-    metrics_json_relative_path = os.path.join(SCRIPT_RUN_METRICS_DIR, FIX_JAVA_RUN_METRICS_FILE)
-
-    commit_run_metrics_with_retry(
-        metrics_repo_root=metrics_repo_root,
-        metrics_json_relative_path=metrics_json_relative_path,
-        run_metrics=run_metrics,
-        commit_message=f"Run metrics: fix_java_run_fail.py for {new_coordinates}",
-    )
-
-
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path, metrics_repo_path, in_metadata_repo = parse_flags(
+    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(
         argv if argv is not None else sys.argv[1:]
     )
 
@@ -300,7 +295,6 @@ def main(argv=None):
         new_version=new_version,
         repo_path=repo_path,
         metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=in_metadata_repo,
     )
     create_pull_request(
         branch=branch,
@@ -313,9 +307,6 @@ def main(argv=None):
         metrics_repo_root=metrics_repo_path,
         repo_path=repo_path,
     )
-    if not in_metadata_repo:
-        metrics_commit_and_push(metrics_repo_path, old_coordinates, new_coordinates)
-
 
 if __name__ == "__main__":
     if any(a in ("-h", "--help") for a in sys.argv[1:]):

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -28,29 +28,28 @@ from git_scripts.common_git import (
     get_configured_reviewers,
 )
 from utility_scripts.library_stats import stats_artifact_dir
-from utility_scripts.metrics_writer import commit_run_metrics_with_retry, read_pending_metrics
-from utility_scripts.repo_path_resolver import (
-    add_in_metadata_repo_argument,
-    resolve_repo_roots,
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LOCAL_CI_VERIFICATION_KEY,
+    fetch_pr_base_ref,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
 )
+from utility_scripts.metrics_writer import read_pending_metrics
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 
 REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = 'master'
 REVIEWERS = get_configured_reviewers()
-SCRIPT_RUN_METRICS_DIR = "script_run_metrics"
-FIX_JAVAC_METRICS_FILE = "fix_javac_fail.json"
-
-
 def resolve_repo_paths(
         explicit_repo_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool = True,
 ):
     """Resolve repo and metrics paths using provided values or local defaults."""
     return resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
 
 
@@ -237,6 +236,7 @@ Summary:
             f"- Intervention file: `{post_generation_intervention.get('intervention_file', 'unknown')}`\n\n"
             f"{str(post_generation_intervention.get('analysis_markdown', '')).strip()}\n"
         )
+    body += format_local_ci_verification_pr_section(metrics_entry.get(LOCAL_CI_VERIFICATION_KEY))
     cmd = [
         "gh",
         "pr",
@@ -256,6 +256,8 @@ Summary:
         "--label",
         "GenAI",
     ]
+    if local_ci_requires_human_intervention(metrics_entry.get(LOCAL_CI_VERIFICATION_KEY)):
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     if REVIEWERS:
         for reviewer in REVIEWERS:
             cmd.extend(["--reviewer", reviewer])
@@ -307,7 +309,6 @@ def build_parser():
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
     return parser
 
 
@@ -318,9 +319,8 @@ def parse_flags(argv_list):
     repo_path, metrics_repo_path = resolve_repo_paths(
         explicit_repo_path=flags.reachability_metadata_path,
         explicit_metrics_repo_path=flags.metrics_repo_path,
-        in_metadata_repo=flags.in_metadata_repo,
     )
-    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.in_metadata_repo
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
 
 
 def push_current_branch_to_origin(
@@ -353,6 +353,14 @@ def push_current_branch_to_origin(
         metrics_repo_path=metrics_repo_path,
         include_in_repo_metrics=include_in_repo_metrics,
     )
+    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
+    subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=new_coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
 
     subprocess.run(
         ["git", "push", "origin", branch],
@@ -363,23 +371,10 @@ def push_current_branch_to_origin(
     return branch, group, artifact, old_version, new_coordinates
 
 
-def metrics_commit_and_push(metrics_repo_root: str, old_coordinates: str, new_coordinates: str):
-    """Read pending metrics and push with retry logic."""
-    run_metrics = read_pending_metrics(metrics_repo_root)
-    metrics_json_relative_path = os.path.join(SCRIPT_RUN_METRICS_DIR, FIX_JAVAC_METRICS_FILE)
-
-    commit_run_metrics_with_retry(
-        metrics_repo_root=metrics_repo_root,
-        metrics_json_relative_path=metrics_json_relative_path,
-        run_metrics=run_metrics,
-        commit_message=f"Run metrics: fix_javac_fail.py for {new_coordinates}",
-    )
-
-
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path, metrics_repo_path, in_metadata_repo = parse_flags(
+    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(
         argv if argv is not None else sys.argv[1:]
     )
 
@@ -388,7 +383,6 @@ def main(argv=None):
         new_version=new_version,
         repo_path=repo_path,
         metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=in_metadata_repo,
     )
     create_pull_request(
         branch=branch,
@@ -401,9 +395,6 @@ def main(argv=None):
         metrics_repo_root=metrics_repo_path,
         repo_path=repo_path,
     )
-    if not in_metadata_repo:
-        metrics_commit_and_push(metrics_repo_path, old_coordinates, new_coordinates)
-
 
 if __name__ == "__main__":
     if any(a in ("-h", "--help") for a in sys.argv[1:]):

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -28,20 +28,22 @@ from git_scripts.common_git import (
 )
 from utility_scripts.metrics_writer import (
     collect_new_library_support_quality_issues,
-    commit_run_metrics_with_retry,
     read_pending_metrics,
 )
 from utility_scripts.large_library_progress import LABEL_LARGE_LIBRARY_PART, LargeLibraryProgressState
 from utility_scripts.library_stats import stats_artifact_dir
-from utility_scripts.repo_path_resolver import (
-    add_in_metadata_repo_argument,
-    resolve_repo_roots,
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LOCAL_CI_VERIFICATION_KEY,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
 )
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 
 REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = 'master'
 REVIEWERS = get_configured_reviewers()
-SCRIPT_RUN_METRICS_DIR = "script_run_metrics"
 
 
 def build_pull_request_body(
@@ -58,6 +60,7 @@ def build_pull_request_body(
         is_final_large_library_part=True,
         large_library_part=None,
         series_id=None,
+        local_ci_verification=None,
 ):
     """Build the PR body with metrics, strategy name, and optional stats."""
     input_tokens_used = metrics.get("input_tokens_used", 0)
@@ -110,6 +113,7 @@ Summary:
         body += f"- Stage: `{post_generation_intervention.get('stage', 'unknown')}`\n\n"
         body += f"- Intervention file: `{post_generation_intervention.get('intervention_file', 'unknown')}`\n\n"
         body += str(post_generation_intervention.get("analysis_markdown", "")).strip() + "\n"
+    body += format_local_ci_verification_pr_section(local_ci_verification)
 
     return body
 
@@ -203,6 +207,7 @@ def create_pull_request(
         metrics=metrics,
         library_stats=library_stats,
         post_generation_intervention=matched.get("post_generation_intervention"),
+        local_ci_verification=matched.get(LOCAL_CI_VERIFICATION_KEY),
         is_large_library_part=large_library_part is not None,
         is_final_large_library_part=is_final_large_library_part,
         large_library_part=large_library_part,
@@ -219,6 +224,8 @@ def create_pull_request(
         "--label", "GenAI",
         "--label", "library-new-request",
     ]
+    if local_ci_requires_human_intervention(matched.get(LOCAL_CI_VERIFICATION_KEY)):
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     if large_library_part is not None:
         cmd.extend(["--label", LABEL_LARGE_LIBRARY_PART])
     if REVIEWERS:
@@ -276,15 +283,12 @@ def build_parser():
     )
     parser.add_argument("--series-id", help="Large-library series identifier for the PR body.")
     parser.add_argument("--large-library-state-path", help="Progress state JSON path to update after publishing.")
-    add_in_metadata_repo_argument(parser)
-
     return parser
 
 
 def resolve_repo_paths(
         explicit_repo_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool = True,
 ):
     """Resolve repo and metrics paths similar to add_new_library_support.
 
@@ -295,7 +299,6 @@ def resolve_repo_paths(
     return resolve_repo_roots(
         explicit_repo_path,
         explicit_metrics_repo_path,
-        in_metadata_repo=in_metadata_repo,
     )
 
 
@@ -308,14 +311,12 @@ def parse_flags(argv_list):
     resolved_repo_path, resolved_metrics_repo_path = resolve_repo_paths(
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
-        in_metadata_repo=flags.in_metadata_repo,
     )
 
     return (
         coordinates,
         resolved_repo_path,
         resolved_metrics_repo_path,
-        flags.in_metadata_repo,
         flags.issue_number,
         flags.large_library_part,
         flags.large_library_final,
@@ -353,6 +354,12 @@ def push_current_branch_to_origin(
 
     base_ref = _fetch_pr_base(repo_path)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
     subprocess.run(
         ["git", "push", "origin", new_branch],
         check=True,
@@ -386,34 +393,6 @@ def update_large_library_state_after_publish(
     state.save(state_path)
 
 
-def _large_library_extra_paths(
-        state_path: str | None,
-        metrics_repo_root: str,
-) -> list[str] | None:
-    """Return the series progress dir relative to the metrics root, when state is present."""
-    if not state_path:
-        return None
-    return [os.path.relpath(os.path.dirname(state_path), metrics_repo_root)]
-
-
-def metrics_commit_and_push(
-        metrics_repo_root: str,
-        coordinates: str,
-        extra_paths_to_stage: list[str] | None = None,
-):
-    """Read pending metrics and push with retry logic."""
-    run_metrics = read_pending_metrics(metrics_repo_root)
-    metrics_json_path = os.path.join(SCRIPT_RUN_METRICS_DIR, "add_new_library_support.json")
-
-    commit_run_metrics_with_retry(
-        metrics_repo_root=metrics_repo_root,
-        metrics_json_relative_path=metrics_json_path,
-        run_metrics=run_metrics,
-        commit_message=f"Run metrics: add_new_library_support.py for {coordinates}",
-        extra_paths_to_stage=extra_paths_to_stage,
-    )
-
-
 def validate_run_quality(coordinates: str, metrics_repo_path: str) -> None:
     """Raise ValueError if the run metrics are not good enough for a PR."""
     matched = read_pending_metrics(metrics_repo_path)
@@ -428,7 +407,6 @@ def main(argv=None):
         coordinates,
         repo_path,
         metrics_repo_path,
-        in_metadata_repo,
         issue_number,
         large_library_part,
         large_library_final,
@@ -443,7 +421,6 @@ def main(argv=None):
         coordinates=coordinates,
         repo_path=repo_path,
         metrics_repo_path=metrics_repo_path,
-        include_in_repo_metrics=in_metadata_repo,
         large_library_part=large_library_part,
     )
     pr_number = create_pull_request(
@@ -463,12 +440,6 @@ def main(argv=None):
         pr_number,
         large_library_final or large_library_part is None,
     )
-    if not in_metadata_repo:
-        metrics_commit_and_push(
-            metrics_repo_path,
-            coordinates,
-            extra_paths_to_stage=_large_library_extra_paths(large_library_state_path, metrics_repo_path),
-        )
 
 
 if __name__ == "__main__":

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -27,21 +27,18 @@ from utility_scripts.metrics_writer import (
     collect_version_coverage_metrics,
 )
 from utility_scripts.library_stats import stats_artifact_dir
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LocalCIVerificationResult,
+    fetch_pr_base_ref,
+    format_local_ci_verification_pr_section,
+    run_local_ci_verification,
+)
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 
 REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = 'master'
 REVIEWERS = get_configured_reviewers()
-
-
-def resolve_repo_path(explicit_repo_path: str | None, in_metadata_repo: bool = True) -> str:
-    """Resolve repo path using provided value or local default."""
-    repo_path, _ = resolve_repo_roots(
-        explicit_repo_path,
-        None,
-        in_metadata_repo=in_metadata_repo,
-    )
-    return repo_path
 
 
 def stage_and_commit(
@@ -80,6 +77,7 @@ def create_pull_request(
         group: str,
         artifact: str,
         repo_path: str,
+        local_ci_verification: LocalCIVerificationResult | None = None,
 ):
     """Create a GitHub pull request for the current branch."""
     origin_owner = get_origin_owner(cwd=repo_path)
@@ -132,6 +130,8 @@ def create_pull_request(
         f"\n\n{format_forge_revision_section()}"
         f"{stats_section}"
     )
+    if local_ci_verification is not None:
+        body += format_local_ci_verification_pr_section(local_ci_verification.to_metrics())
 
     cmd = [
         "gh", "pr", "create",
@@ -142,6 +142,8 @@ def create_pull_request(
         "--head", f"{origin_owner}:{branch}",
         "--label", "fixes-native-image-run-fail",
     ]
+    if local_ci_verification is not None and local_ci_verification.human_intervention_required:
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     for r in REVIEWERS:
         cmd.extend(["--reviewer", r])
     gh(*cmd[1:])
@@ -183,7 +185,11 @@ def build_parser():
             "If omitted, the parent checkout of this Forge directory is used."
         ),
     )
-    add_in_metadata_repo_argument(parser)
+    parser.add_argument(
+        "--metrics-repo-path",
+        dest="metrics_repo_path",
+        help="Path to the metrics repository root.",
+    )
     return parser
 
 
@@ -191,14 +197,18 @@ def parse_flags(argv_list):
     """Parse CLI flags and resolve repository path."""
     parser = build_parser()
     flags = parser.parse_args(argv_list)
-    repo_path = resolve_repo_path(flags.reachability_metadata_path, in_metadata_repo=flags.in_metadata_repo)
-    return flags.coordinates, flags.new_version, repo_path
+    repo_path, metrics_repo_path = resolve_repo_roots(
+        flags.reachability_metadata_path,
+        flags.metrics_repo_path,
+    )
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
 
 
 def push_current_branch_to_origin(
         old_coordinates: str,
         new_version: str,
         repo_path: str,
+        metrics_repo_path: str | None = None,
 ):
     """
     Switch to the feature branch, stage and commit changes,
@@ -225,6 +235,14 @@ def push_current_branch_to_origin(
         coordinates=new_coordinates,
         repo_path=repo_path,
     )
+    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
+    subprocess.run(["git", "rebase", base_ref], cwd=repo_path, check=True)
+    local_ci_verification = run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=new_coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
 
     subprocess.run(
         ["git", "push", "origin", branch],
@@ -232,18 +250,19 @@ def push_current_branch_to_origin(
         check=True,
     )
 
-    return branch, group, artifact, new_coordinates
+    return branch, group, artifact, new_coordinates, local_ci_verification
 
 
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path = parse_flags(argv if argv is not None else sys.argv[1:])
+    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(argv if argv is not None else sys.argv[1:])
 
-    branch, group, artifact, new_coordinates = push_current_branch_to_origin(
+    branch, group, artifact, new_coordinates, local_ci_verification = push_current_branch_to_origin(
         old_coordinates=old_coordinates,
         new_version=new_version,
         repo_path=repo_path,
+        metrics_repo_path=metrics_repo_path,
     )
     create_pull_request(
         branch=branch,
@@ -252,6 +271,7 @@ def main(argv=None):
         group=group,
         artifact=artifact,
         repo_path=repo_path,
+        local_ci_verification=local_ci_verification,
     )
 
 

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -23,7 +23,7 @@ from git_scripts.common_git import (
     stage_and_commit,
 )
 from utility_scripts.metadata_index import get_not_for_native_image_marker
-from utility_scripts.repo_path_resolver import add_in_metadata_repo_argument, resolve_repo_roots
+from utility_scripts.repo_path_resolver import resolve_repo_roots
 
 
 REPO = "oracle/graalvm-reachability-metadata"
@@ -39,7 +39,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--coordinates", required=True, help="Coordinates in group:artifact:version form")
     parser.add_argument("--reachability-metadata-path", help="Path to the reachability-metadata checkout")
-    add_in_metadata_repo_argument(parser)
     return parser
 
 
@@ -135,7 +134,6 @@ def main(argv=None) -> None:
     repo_path, _metrics_path = resolve_repo_roots(
         args.reachability_metadata_path,
         None,
-        in_metadata_repo=args.in_metadata_repo,
     )
     ensure_gh_authenticated()
     branch = push_marker_branch(args.coordinates, repo_path)

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -23,6 +23,14 @@ from git_scripts.common_git import (
     stage_and_commit,
 )
 from utility_scripts.metadata_index import get_not_for_native_image_marker
+from utility_scripts.local_ci_verification import (
+    HUMAN_INTERVENTION_LABEL,
+    LocalCIVerificationResult,
+    fetch_pr_base_ref,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
+)
 from utility_scripts.repo_path_resolver import resolve_repo_roots
 
 
@@ -39,29 +47,24 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--coordinates", required=True, help="Coordinates in group:artifact:version form")
     parser.add_argument("--reachability-metadata-path", help="Path to the reachability-metadata checkout")
+    parser.add_argument(
+        "--metrics-repo-path",
+        default=None,
+        help="Path to the metrics repository. If omitted, the forge directory in the selected worktree is used.",
+    )
     return parser
 
 
 def fetch_pr_base(repo_path: str) -> str:
     """Fetch the upstream PR base and return the ref to rebase onto."""
-    upstream_url = f"https://github.com/{REPO}.git"
-    upstream_remote_url = subprocess.run(
-        ["git", "remote", "get-url", "upstream"],
-        cwd=repo_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    if upstream_remote_url.returncode == 0 and REPO in upstream_remote_url.stdout.strip():
-        subprocess.run(["git", "fetch", "upstream", BASE_BRANCH], check=True, cwd=repo_path)
-        return f"upstream/{BASE_BRANCH}"
-
-    subprocess.run(["git", "fetch", upstream_url, BASE_BRANCH], check=True, cwd=repo_path)
-    return "FETCH_HEAD"
+    return fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
 
 
-def push_marker_branch(coordinates: str, repo_path: str) -> str:
+def push_marker_branch(
+        coordinates: str,
+        repo_path: str,
+        metrics_repo_path: str | None = None,
+) -> tuple[str, LocalCIVerificationResult]:
     """Create, commit, rebase, and push the marker branch."""
     group, artifact, _version = parse_coordinate_parts(coordinates)
     branch = build_ai_branch_name(f"not-for-native-image-{group}-{artifact}", cwd=repo_path)
@@ -74,11 +77,22 @@ def push_marker_branch(coordinates: str, repo_path: str) -> str:
     )
     base_ref = fetch_pr_base(repo_path)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    local_ci_verification = run_local_ci_verification(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        base_commit=base_ref,
+        metrics_repo_path=metrics_repo_path,
+    )
     subprocess.run(["git", "push", "origin", branch], check=True, cwd=repo_path)
-    return branch
+    return branch, local_ci_verification
 
 
-def create_pull_request(branch: str, coordinates: str, repo_path: str) -> None:
+def create_pull_request(
+        branch: str,
+        coordinates: str,
+        repo_path: str,
+        local_ci_verification: LocalCIVerificationResult | None = None,
+) -> None:
     """Create the marker PR."""
     if shutil.which("gh") is None:
         print("gh CLI not found. Skipping PR creation.")
@@ -111,6 +125,8 @@ Reason:
     if replacement:
         body += f"\nReplacement guidance:\n- {replacement}\n"
     body += "\n" + format_forge_revision_section()
+    local_ci_metrics = None if local_ci_verification is None else local_ci_verification.to_metrics()
+    body += format_local_ci_verification_pr_section(local_ci_metrics)
 
     cmd = [
         "gh", "pr", "create",
@@ -123,6 +139,8 @@ Reason:
         "--label", "library-new-request",
         "--label", "not-for-native-image",
     ]
+    if local_ci_requires_human_intervention(local_ci_metrics):
+        cmd.extend(["--label", HUMAN_INTERVENTION_LABEL])
     for reviewer in REVIEWERS:
         cmd.extend(["--reviewer", reviewer])
     gh(*cmd[1:])
@@ -131,13 +149,13 @@ Reason:
 def main(argv=None) -> None:
     """Run the marker PR flow."""
     args = build_parser().parse_args(argv)
-    repo_path, _metrics_path = resolve_repo_roots(
+    repo_path, metrics_repo_path = resolve_repo_roots(
         args.reachability_metadata_path,
-        None,
+        args.metrics_repo_path,
     )
     ensure_gh_authenticated()
-    branch = push_marker_branch(args.coordinates, repo_path)
-    create_pull_request(branch, args.coordinates, repo_path)
+    branch, local_ci_verification = push_marker_branch(args.coordinates, repo_path, metrics_repo_path)
+    create_pull_request(branch, args.coordinates, repo_path, local_ci_verification)
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1472,6 +1472,7 @@ class EnvironmentValidationTests(unittest.TestCase):
         require_graalvm_home.assert_has_calls([
             call(forge_metadata.DEV_GRAALVM_ENV_VAR),
             call(forge_metadata.POST_GENERATION_GRAALVM_ENV_VAR),
+            call(forge_metadata.LATEST_EA_GRAALVM_ENV_VAR),
         ])
 
 

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -111,6 +111,24 @@ def _claimed_issue(
     )
 
 
+class FinalizeSuccessfulIssueTests(unittest.TestCase):
+    def test_not_for_native_image_pr_receives_metrics_repo_path_for_local_ci(self) -> None:
+        claimed_issue = _claimed_issue()
+
+        with patch.object(forge_metadata, "find_progress_state_path", return_value=None), \
+                patch.object(forge_metadata, "_load_pending_run_metrics", return_value={"status": "success"}), \
+                patch.object(forge_metadata, "metadata_coordinate_parts", return_value=("org.example", "lib", "1.0.0")), \
+                patch.object(forge_metadata, "is_not_for_native_image", return_value=True), \
+                patch.object(forge_metadata, "run_make_pr_not_for_native_image") as make_pr:
+            forge_metadata.finalize_successful_issue(claimed_issue)
+
+        make_pr.assert_called_once_with([
+            "--coordinates", "org.example:lib:1.0.0",
+            "--reachability-metadata-path", "/tmp/reachability-worktree",
+            "--metrics-repo-path", "/tmp/metrics-worktree",
+        ])
+
+
 class IssueClaimPreflightTests(unittest.TestCase):
     def test_forge_gh_logs_github_query_to_console(self) -> None:
         completed_process = subprocess.CompletedProcess(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1464,6 +1464,17 @@ class IssueClaimLockTests(unittest.TestCase):
         clear_issue_assignees.assert_called_once_with(1412)
 
 
+class EnvironmentValidationTests(unittest.TestCase):
+    def test_issue_processing_requires_dev_and_ci_graalvm_homes(self) -> None:
+        with patch.object(forge_metadata, "require_graalvm_home_env") as require_graalvm_home:
+            forge_metadata.validate_issue_processing_environment()
+
+        require_graalvm_home.assert_has_calls([
+            call(forge_metadata.DEV_GRAALVM_ENV_VAR),
+            call(forge_metadata.POST_GENERATION_GRAALVM_ENV_VAR),
+        ])
+
+
 class InterruptHandlingTests(unittest.TestCase):
     def setUp(self) -> None:
         forge_metadata.clear_user_interrupt_requested()

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -105,7 +105,6 @@ def _claimed_issue(
         base_reachability_metadata_path="/tmp/reachability",
         worktree_path="/tmp/reachability-worktree",
         scratch_metrics_repo_path="/tmp/metrics-worktree",
-        in_metadata_repo=False,
         issue_coordinates="org.example:lib:1.0.0",
         large_library_resume_artifact=large_library_resume_artifact,
         large_library_part=large_library_part,
@@ -600,7 +599,6 @@ class IssueClaimPreflightTests(unittest.TestCase):
             "/tmp/reachability",
             "/tmp/metrics",
             "automation-user",
-            in_metadata_repo=True,
         )
         get_open_blocking_issue_numbers.assert_not_called()
         get_issue_assignees.assert_not_called()
@@ -718,7 +716,6 @@ class SingleIssueProcessingTests(unittest.TestCase):
             "/tmp/reachability",
             "/tmp/metrics",
             "automation-user",
-            in_metadata_repo=True,
         )
 
     def test_process_large_library_continuation_passes_explicit_artifact_to_claim(self) -> None:
@@ -769,7 +766,6 @@ class SingleIssueProcessingTests(unittest.TestCase):
             "/tmp/reachability",
             "/tmp/metrics",
             "automation-user",
-            in_metadata_repo=True,
             large_library_resume_artifact_override=resume_artifact,
         )
         claimed_issue = process_claimed_issue_lifecycle.call_args.args[0]
@@ -913,7 +909,6 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             False,
             "automation-user",
             forge_metadata.DEFAULT_PARALLELISM,
-            in_metadata_repo=True,
             environment_already_validated=True,
         )
         process_reviews.assert_not_called()
@@ -955,7 +950,6 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             False,
             "automation-user",
             forge_metadata.DEFAULT_PARALLELISM,
-            in_metadata_repo=True,
             environment_already_validated=True,
         )
         process_reviews.assert_not_called()
@@ -1274,7 +1268,6 @@ class IssueClaimCacheTests(unittest.TestCase):
                     "/tmp/reachability",
                     "/tmp/metrics",
                     "automation-user",
-                    in_metadata_repo=True,
                 )
                 for issue in issues
             ],

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -15,13 +15,17 @@ from utility_scripts.local_ci_verification import (
     LOCAL_CI_VERIFICATION_KEY,
     LocalCIVerificationResult,
     classify_repo_fix_paths,
+    fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
     run_local_ci_verification,
     _github_repo_slug_from_url,
     _graalvm_home_for_java_version,
+    _run_infrastructure_matrix_entries,
     _run_recorded_command,
+    _run_spring_aot_matrix_entries,
     _run_test_matrix_entries,
+    _run_verification_once,
 )
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
 
@@ -45,6 +49,67 @@ def _commit_all(repo_path: str, message: str) -> str:
 
 
 class LocalCIVerificationTests(unittest.TestCase):
+    def test_fetch_pr_base_ref_falls_back_to_target_repo_when_origin_is_a_fork(self) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(
+                command: list[str],
+                cwd: str | None = None,
+                stdout=None,
+                stderr=None,
+                text: bool | None = None,
+                check: bool | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del cwd, stdout, stderr, text, check
+            commands.append(command)
+            if command == ["git", "remote", "get-url", "upstream"]:
+                return subprocess.CompletedProcess(command, 1, stdout="")
+            if command == ["git", "remote", "get-url", "origin"]:
+                return subprocess.CompletedProcess(command, 0, stdout="git@github.com:contributor/fork.git\n")
+            if command[:2] == ["git", "fetch"]:
+                return subprocess.CompletedProcess(command, 0, stdout="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        with patch("utility_scripts.local_ci_verification.subprocess.run", side_effect=fake_run):
+            base_ref = fetch_pr_base_ref("/repo", "oracle/graalvm-reachability-metadata")
+
+        self.assertEqual(base_ref, "FETCH_HEAD")
+        self.assertIn(
+            ["git", "fetch", "https://github.com/oracle/graalvm-reachability-metadata.git", "master"],
+            commands,
+        )
+
+    def test_fetch_pr_base_ref_uses_origin_only_when_origin_matches_target_repo(self) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(
+                command: list[str],
+                cwd: str | None = None,
+                stdout=None,
+                stderr=None,
+                text: bool | None = None,
+                check: bool | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del cwd, stdout, stderr, text, check
+            commands.append(command)
+            if command == ["git", "remote", "get-url", "upstream"]:
+                return subprocess.CompletedProcess(command, 1, stdout="")
+            if command == ["git", "remote", "get-url", "origin"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout="git@github.com:oracle/graalvm-reachability-metadata.git\n",
+                )
+            if command[:2] == ["git", "fetch"]:
+                return subprocess.CompletedProcess(command, 0, stdout="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        with patch("utility_scripts.local_ci_verification.subprocess.run", side_effect=fake_run):
+            base_ref = fetch_pr_base_ref("/repo", "oracle/graalvm-reachability-metadata")
+
+        self.assertEqual(base_ref, "origin/master")
+        self.assertIn(["git", "fetch", "origin", "master"], commands)
+
     def test_classify_repo_fix_paths_flags_only_files_outside_target_library_scope(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             _git(repo_path, "init")
@@ -169,6 +234,122 @@ class LocalCIVerificationTests(unittest.TestCase):
 
         self.assertIs(failed, failed_record)
         self.assertEqual(gates[-1], "restore-docker-networking")
+
+    def test_infrastructure_matrix_runs_test_infra_for_each_entry(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        calls: list[tuple[str, list[str], dict[str, str] | None]] = []
+
+        def fake_run_recorded_command(
+                repo_path: str,
+                gate: str,
+                command: list[str],
+                local_result: LocalCIVerificationResult,
+                env: dict[str, str] | None = None,
+                failure_output_pattern: str | None = None,
+        ) -> CommandRecord | None:
+            del repo_path, local_result, failure_output_pattern
+            calls.append((gate, command, env))
+            return None
+
+        with patch.dict(os.environ, {"GRAALVM_HOME_25_0": "/graalvm25"}, clear=True), \
+                patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+            failed = _run_infrastructure_matrix_entries(
+                "/repo",
+                [{"coordinates": "org.example:demo:1.0.0", "version": "25", "nativeImageMode": "future-defaults-all"}],
+                result,
+            )
+
+        self.assertIsNone(failed)
+        self.assertEqual(
+            [call[0] for call in calls],
+            [
+                "infrastructure-pull-allowed-docker-images",
+                "infrastructure-check-metadata-files",
+                "test-infra",
+            ],
+        )
+        self.assertEqual(
+            calls[-1][1],
+            ["./gradlew", "testInfra", "-Pcoordinates=org.example:demo:1.0.0", "-Pparallelism=1", "--stacktrace"],
+        )
+        self.assertEqual(calls[-1][2]["GRAALVM_HOME"], "/graalvm25")
+        self.assertEqual(calls[-1][2]["GVM_TCK_NATIVE_IMAGE_MODE"], "future-defaults-all")
+
+    def test_spring_aot_matrix_runs_triaged_smoke_test(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        calls: list[tuple[str, list[str], dict[str, str] | None]] = []
+
+        def fake_run_recorded_command(
+                repo_path: str,
+                gate: str,
+                command: list[str],
+                local_result: LocalCIVerificationResult,
+                env: dict[str, str] | None = None,
+                failure_output_pattern: str | None = None,
+        ) -> CommandRecord | None:
+            del repo_path, local_result, failure_output_pattern
+            calls.append((gate, command, env))
+            return None
+
+        with patch.dict(os.environ, {"GRAALVM_HOME_25_0": "/graalvm25"}, clear=True), \
+                patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+            failed = _run_spring_aot_matrix_entries(
+                "/repo",
+                "/tmp/spring-aot-smoke-tests",
+                [{"project": ":data:data-mongodb", "java": "25"}],
+                result,
+            )
+
+        self.assertIsNone(failed)
+        self.assertEqual(calls[0][0], "spring-aot-smoke-test")
+        self.assertEqual(
+            calls[0][1],
+            [
+                "bash",
+                ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
+                "/tmp/spring-aot-smoke-tests",
+                ":data:data-mongodb",
+                "4.1.x",
+            ],
+        )
+        self.assertEqual(calls[0][2]["JAVA_HOME"], "/graalvm25")
+
+    def test_verification_once_runs_infrastructure_and_spring_lanes_when_triggered(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        gradle_tasks: list[str] = []
+
+        def fake_gradle_json_output(
+                repo_path: str,
+                task_name: str,
+                base_commit: str,
+                local_result: LocalCIVerificationResult,
+                gate: str,
+                extra_args: list[str] | None = None,
+        ) -> dict:
+            del repo_path, base_commit, local_result, gate, extra_args
+            gradle_tasks.append(task_name)
+            if task_name == "generateInfrastructureChangedCoordinatesMatrix":
+                return {"include": [{"coordinates": "org.example:demo:1.0.0"}]}
+            return {"include": []}
+
+        changed_files = [
+            "build.gradle",
+            "metadata/org.example/demo/1.0.0/reachability-metadata.json",
+        ]
+        with patch("utility_scripts.local_ci_verification.changed_files_for_ci", return_value=changed_files), \
+                patch("utility_scripts.local_ci_verification._gradle_json_output", side_effect=fake_gradle_json_output), \
+                patch("utility_scripts.local_ci_verification._run_test_matrix_entries", return_value=None), \
+                patch("utility_scripts.local_ci_verification._run_infrastructure_matrix_entries", return_value=None) as infra, \
+                patch("utility_scripts.local_ci_verification._run_spring_aot_verification", return_value=None) as spring, \
+                patch("utility_scripts.local_ci_verification._run_index_validation", return_value=None), \
+                patch("utility_scripts.local_ci_verification._run_style_validation", return_value=None), \
+                patch("utility_scripts.local_ci_verification._run_recorded_command", return_value=None):
+            failed = _run_verification_once("/repo", "base", result)
+
+        self.assertIsNone(failed)
+        self.assertIn("generateInfrastructureChangedCoordinatesMatrix", gradle_tasks)
+        infra.assert_called_once()
+        spring.assert_called_once_with("/repo", "base", changed_files, result)
 
     def test_latest_ea_requires_latest_ea_graalvm_home(self) -> None:
         with patch.dict(os.environ, {"GRAALVM_HOME": "/stable"}, clear=True):

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -11,11 +11,17 @@ import unittest
 from unittest.mock import patch
 
 from utility_scripts.local_ci_verification import (
+    CommandRecord,
     LOCAL_CI_VERIFICATION_KEY,
+    LocalCIVerificationResult,
     classify_repo_fix_paths,
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
     run_local_ci_verification,
+    _github_repo_slug_from_url,
+    _graalvm_home_for_java_version,
+    _run_recorded_command,
+    _run_test_matrix_entries,
 )
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
 
@@ -114,6 +120,80 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertTrue(local_ci_requires_human_intervention(metrics))
         self.assertIn("Local CI Verification", section)
         self.assertIn("build.gradle", section)
+
+    def test_run_recorded_command_fails_on_ci_failure_output_pattern(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            command = ["python3", "-c", "print('FAILED[javaTest][1.0.0][./gradlew test]')"]
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "command.log"),
+            ):
+                failed = _run_recorded_command(
+                    repo_path,
+                    "run-consecutive-tests",
+                    command,
+                    result,
+                    failure_output_pattern=r"^FAILED",
+                )
+
+            self.assertIsNotNone(failed)
+            self.assertEqual(result.commands[0].returncode, 1)
+            self.assertIn("FAILED[javaTest]", result.commands[0].output_excerpt)
+
+    def test_test_matrix_restores_docker_after_test_failure(self) -> None:
+        result = LocalCIVerificationResult(status="running", base_commit="base")
+        failed_record = CommandRecord(gate="run-consecutive-tests", command=["bash"], returncode=1)
+        gates: list[str] = []
+
+        def fake_run_recorded_command(
+                repo_path: str,
+                gate: str,
+                command: list[str],
+                local_result: LocalCIVerificationResult,
+                env: dict[str, str] | None = None,
+                failure_output_pattern: str | None = None,
+        ) -> CommandRecord | None:
+            gates.append(gate)
+            if gate == "run-consecutive-tests":
+                self.assertEqual(failure_output_pattern, r"^FAILED")
+                return failed_record
+            return None
+
+        with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+            failed = _run_test_matrix_entries(
+                "/repo",
+                [{"coordinates": "org.example:demo:1.0.0", "versions": ["1.0.0"]}],
+                result,
+            )
+
+        self.assertIs(failed, failed_record)
+        self.assertEqual(gates[-1], "restore-docker-networking")
+
+    def test_latest_ea_requires_latest_ea_graalvm_home(self) -> None:
+        with patch.dict(os.environ, {"GRAALVM_HOME": "/stable"}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "GRAALVM_HOME_LATEST_EA"):
+                _graalvm_home_for_java_version("latest-ea")
+
+        with patch.dict(os.environ, {"GRAALVM_HOME_LATEST_EA": "/ea"}, clear=True):
+            self.assertEqual(_graalvm_home_for_java_version("latest-ea"), "/ea")
+
+    def test_github_repo_slug_from_url_accepts_https_and_ssh_forms(self) -> None:
+        expected = "oracle/graalvm-reachability-metadata"
+
+        self.assertEqual(
+            _github_repo_slug_from_url("https://github.com/oracle/graalvm-reachability-metadata.git"),
+            expected,
+        )
+        self.assertEqual(
+            _github_repo_slug_from_url("git@github.com:oracle/graalvm-reachability-metadata.git"),
+            expected,
+        )
+        self.assertEqual(
+            _github_repo_slug_from_url("ssh://git@github.com/oracle/graalvm-reachability-metadata.git"),
+            expected,
+        )
+        self.assertIsNone(_github_repo_slug_from_url("https://example.com/oracle/graalvm-reachability-metadata.git"))
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -1,0 +1,120 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts.local_ci_verification import (
+    LOCAL_CI_VERIFICATION_KEY,
+    classify_repo_fix_paths,
+    format_local_ci_verification_pr_section,
+    local_ci_requires_human_intervention,
+    run_local_ci_verification,
+)
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
+
+
+def _git(repo_path: str, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_all(repo_path: str, message: str) -> str:
+    _git(repo_path, "add", "-A")
+    _git(repo_path, "-c", "user.name=Forge Test", "-c", "user.email=forge@example.com", "commit", "-m", message)
+    return _git(repo_path, "rev-parse", "HEAD")
+
+
+class LocalCIVerificationTests(unittest.TestCase):
+    def test_classify_repo_fix_paths_flags_only_files_outside_target_library_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            os.makedirs(os.path.join(repo_path, "metadata", "org.example", "demo", "1.0.0"))
+            os.makedirs(os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0"))
+            os.makedirs(os.path.join(repo_path, "stats", "org.example", "demo", "1.0.0"))
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(repo_path, "base")
+
+            with open(
+                    os.path.join(repo_path, "metadata", "org.example", "demo", "1.0.0", "reachability-metadata.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as file:
+                file.write("{}\n")
+            with open(os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0", "build.gradle"), "w", encoding="utf-8") as file:
+                file.write("plugins {}\n")
+            with open(os.path.join(repo_path, "stats", "org.example", "demo", "1.0.0", "stats.json"), "w", encoding="utf-8") as file:
+                file.write("{}\n")
+            with open(os.path.join(repo_path, "build.gradle"), "w", encoding="utf-8") as file:
+                file.write("tasks.register('repoFix')\n")
+            _commit_all(repo_path, "generated support with repo fix")
+
+            self.assertEqual(
+                classify_repo_fix_paths(repo_path, base, "org.example:demo:1.0.0"),
+                ["build.gradle"],
+            )
+
+    def test_successful_verification_records_metrics_and_human_intervention_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as metrics_path:
+            _git(repo_path, "init")
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(repo_path, "base")
+            with open(os.path.join(repo_path, "build.gradle"), "w", encoding="utf-8") as file:
+                file.write("tasks.register('repoFix')\n")
+            _commit_all(repo_path, "repo fix")
+            pending_metrics = {
+                "library": "org.example:demo:1.0.0",
+                "status": "success",
+                "metrics": {},
+            }
+            with open(os.path.join(metrics_path, PENDING_METRICS_FILENAME), "w", encoding="utf-8") as file:
+                json.dump(pending_metrics, file)
+
+            with patch("utility_scripts.local_ci_verification._run_verification_once", return_value=None):
+                result = run_local_ci_verification(
+                    repo_path=repo_path,
+                    coordinates="org.example:demo:1.0.0",
+                    base_commit=base,
+                    metrics_repo_path=metrics_path,
+                )
+
+            self.assertTrue(result.human_intervention_required)
+            self.assertEqual(result.repo_fix_paths, ["build.gradle"])
+            with open(os.path.join(metrics_path, PENDING_METRICS_FILENAME), "r", encoding="utf-8") as file:
+                updated_metrics = json.load(file)
+            self.assertTrue(updated_metrics[LOCAL_CI_VERIFICATION_KEY]["human_intervention_required"])
+            self.assertEqual(updated_metrics[LOCAL_CI_VERIFICATION_KEY]["repo_fix_paths"], ["build.gradle"])
+
+    def test_pr_section_mentions_repo_fix_paths(self) -> None:
+        metrics = {
+            "status": "success",
+            "commands": [{"gate": "doc-links"}],
+            "fixups": [{"gate": "doc-links"}],
+            "human_intervention_required": True,
+            "repo_fix_paths": ["build.gradle"],
+        }
+
+        section = format_local_ci_verification_pr_section(metrics)
+
+        self.assertTrue(local_ci_requires_human_intervention(metrics))
+        self.assertIn("Local CI Verification", section)
+        self.assertIn("build.gradle", section)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_make_pr_not_for_native_image.py
+++ b/forge/tests/test_make_pr_not_for_native_image.py
@@ -1,0 +1,93 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from git_scripts import make_pr_not_for_native_image
+from utility_scripts.local_ci_verification import LocalCIVerificationResult
+
+
+class MakePrNotForNativeImageTests(unittest.TestCase):
+    def test_push_marker_branch_runs_local_ci_before_push(self) -> None:
+        result = LocalCIVerificationResult(status="success", base_commit="FETCH_HEAD")
+        events: list[str] = []
+
+        def fake_subprocess_run(command: list[str], check: bool = False, cwd: str | None = None):
+            del check, cwd
+            if command[:2] == ["git", "rebase"]:
+                events.append("rebase")
+            if command[:2] == ["git", "push"]:
+                events.append("push")
+            return subprocess.CompletedProcess(command, 0)
+
+        def fake_run_local_ci_verification(**kwargs):
+            events.append("local-ci")
+            self.assertEqual(kwargs["metrics_repo_path"], "/metrics")
+            self.assertEqual(kwargs["base_commit"], "FETCH_HEAD")
+            return result
+
+        with patch.object(make_pr_not_for_native_image, "build_ai_branch_name", return_value="not-native-branch"), \
+                patch.object(make_pr_not_for_native_image, "delete_remote_branch_if_exists"), \
+                patch.object(make_pr_not_for_native_image, "stage_and_commit"), \
+                patch.object(make_pr_not_for_native_image, "fetch_pr_base", return_value="FETCH_HEAD"), \
+                patch.object(
+                    make_pr_not_for_native_image,
+                    "run_local_ci_verification",
+                    side_effect=fake_run_local_ci_verification,
+                ), \
+                patch.object(make_pr_not_for_native_image.subprocess, "run", side_effect=fake_subprocess_run):
+            branch, local_ci_verification = make_pr_not_for_native_image.push_marker_branch(
+                "org.example:demo:1.0.0",
+                "/repo",
+                "/metrics",
+            )
+
+        self.assertEqual(branch, "not-native-branch")
+        self.assertIs(local_ci_verification, result)
+        self.assertEqual(events, ["rebase", "local-ci", "push"])
+
+    def test_create_pull_request_includes_local_ci_section(self) -> None:
+        local_ci_verification = LocalCIVerificationResult(
+            status="success",
+            base_commit="FETCH_HEAD",
+            repo_fix_paths=["build.gradle"],
+            human_intervention_required=True,
+        )
+        gh_calls: list[tuple[str, ...]] = []
+
+        def fake_gh(*args: str, check: bool = True):
+            del check
+            gh_calls.append(args)
+            return subprocess.CompletedProcess(["gh", *args], 1 if args[:2] == ("pr", "view") else 0)
+
+        with patch.object(make_pr_not_for_native_image.shutil, "which", return_value="/usr/bin/gh"), \
+                patch.object(
+                    make_pr_not_for_native_image,
+                    "get_not_for_native_image_marker",
+                    return_value={"reason": "native-image does not apply"},
+                ), \
+                patch.object(make_pr_not_for_native_image, "get_origin_owner", return_value="me"), \
+                patch.object(make_pr_not_for_native_image, "find_issue_for_coordinates", return_value=1234), \
+                patch.object(make_pr_not_for_native_image, "format_forge_revision_section", return_value="Forge revision"), \
+                patch.object(make_pr_not_for_native_image, "gh", side_effect=fake_gh):
+            make_pr_not_for_native_image.create_pull_request(
+                "not-native-branch",
+                "org.example:demo:1.0.0",
+                "/repo",
+                local_ci_verification,
+            )
+
+        create_call = gh_calls[1]
+        body = create_call[create_call.index("--body") + 1]
+        self.assertIn("Local CI Verification", body)
+        self.assertIn("Repository-level fix paths", body)
+        self.assertIn("--label", create_call)
+        self.assertIn("human-intervention", create_call)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -16,7 +16,7 @@ class _TestWorkflowStrategy(WorkflowStrategy):
 
 
 class WorkflowStrategyTests(unittest.TestCase):
-    def test_post_generation_tests_use_current_graalvm_until_final_ci_verification(self) -> None:
+    def test_post_generation_tests_defer_ci_matrix_graalvm_versions_to_final_verification(self) -> None:
         strategy = _TestWorkflowStrategy(
             {"model": "test-model"},
             reachability_repo_path="/tmp/reachability",

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -1,0 +1,44 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from ai_workflows.workflow_strategies.workflow_strategy import RUN_STATUS_SUCCESS, WorkflowStrategy
+
+
+class _TestWorkflowStrategy(WorkflowStrategy):
+    def run(self) -> dict:
+        return {}
+
+
+class WorkflowStrategyTests(unittest.TestCase):
+    def test_post_generation_tests_use_current_graalvm_until_final_ci_verification(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        commands: list[tuple[str, dict[str, str] | None]] = []
+
+        def run_command(command: str, env: dict[str, str] | None = None) -> str:
+            commands.append((command, env))
+            return "BUILD SUCCESSFUL"
+
+        with patch.object(strategy, "_run_command_with_env", side_effect=run_command), \
+                patch.dict(os.environ, {"GRAALVM_HOME": "/dev/graalvm", "JAVA_HOME": "/dev/graalvm"}, clear=True):
+            status = strategy._run_test_with_retry("org.example:demo:1.0.0")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        self.assertEqual(len(commands), 2)
+        self.assertIsNone(commands[0][1])
+        self.assertEqual(commands[1][1]["GRAALVM_HOME"], "/dev/graalvm")
+        self.assertEqual(commands[1][1]["JAVA_HOME"], "/dev/graalvm")
+        self.assertEqual(commands[1][1]["GVM_TCK_NATIVE_IMAGE_MODE"], "future-defaults-all")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -25,6 +25,8 @@ MAX_FIXUP_ATTEMPTS = 2
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1800
 DEFAULT_BASE_BRANCH = "master"
+SPRING_AOT_BRANCH = "main"
+SPRING_AOT_REPO_URL = "https://github.com/spring-projects/spring-aot-smoke-tests.git"
 
 
 @dataclass
@@ -137,20 +139,23 @@ def run_local_ci_verification(
 
 def fetch_pr_base_ref(repo_path: str, repo: str, base_branch: str = DEFAULT_BASE_BRANCH) -> str:
     """Fetch the upstream PR base and return a local ref suitable for diffing and rebasing."""
-    remote_url = subprocess.run(
-        ["git", "remote", "get-url", "upstream"],
-        cwd=repo_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    upstream_matches_target = (
-        remote_url.returncode == 0 and _github_repo_slug_from_url(remote_url.stdout.strip()) == repo.lower()
-    )
-    remote_name = "upstream" if upstream_matches_target else "origin"
-    subprocess.run(["git", "fetch", remote_name, base_branch], cwd=repo_path, check=True)
-    return f"{remote_name}/{base_branch}"
+    target_repo = repo.lower()
+    for remote_name in ("upstream", "origin"):
+        remote_url = subprocess.run(
+            ["git", "remote", "get-url", remote_name],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+        remote_repo = _github_repo_slug_from_url(remote_url.stdout.strip()) if remote_url.returncode == 0 else None
+        if remote_repo == target_repo:
+            subprocess.run(["git", "fetch", remote_name, base_branch], cwd=repo_path, check=True)
+            return f"{remote_name}/{base_branch}"
+
+    subprocess.run(["git", "fetch", f"https://github.com/{target_repo}.git", base_branch], cwd=repo_path, check=True)
+    return "FETCH_HEAD"
 
 
 def _github_repo_slug_from_url(remote_url: str) -> str | None:
@@ -240,11 +245,28 @@ def _run_verification_once(
             result,
             "changed-tested-versions-matrix",
         )
+        changed_infrastructure_matrix = {}
+        if _should_run_infrastructure_tests(changed_files):
+            changed_infrastructure_matrix = _gradle_json_output(
+                repo_path,
+                "generateInfrastructureChangedCoordinatesMatrix",
+                base_commit,
+                result,
+                "changed-infrastructure-matrix",
+            )
     except _GradleOutputFailure as exc:
         return exc.record
 
     test_entries = _matrix_entries(changed_metadata_matrix) + _matrix_entries(changed_tested_versions_matrix)
     failed = _run_test_matrix_entries(repo_path, test_entries, result)
+    if failed is not None:
+        return failed
+
+    failed = _run_infrastructure_matrix_entries(repo_path, _matrix_entries(changed_infrastructure_matrix), result)
+    if failed is not None:
+        return failed
+
+    failed = _run_spring_aot_verification(repo_path, base_commit, changed_files, result)
     if failed is not None:
         return failed
 
@@ -350,6 +372,114 @@ def _run_test_matrix_entries(
     return first_failed or restore_failed
 
 
+def _run_infrastructure_matrix_entries(
+        repo_path: str,
+        entries: list[dict],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        if not coordinates:
+            continue
+        env = _matrix_env(entry)
+        failed = _run_recorded_command(
+            repo_path,
+            "infrastructure-pull-allowed-docker-images",
+            ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+        failed = _run_recorded_command(
+            repo_path,
+            "infrastructure-check-metadata-files",
+            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+        failed = _run_recorded_command(
+            repo_path,
+            "test-infra",
+            ["./gradlew", "testInfra", f"-Pcoordinates={coordinates}", "-Pparallelism=1", "--stacktrace"],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
+def _run_spring_aot_verification(
+        repo_path: str,
+        base_commit: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not _should_run_spring_aot_tests(changed_files):
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="forge-spring-aot-") as spring_parent:
+        os.symlink(os.path.join(repo_path, "metadata"), os.path.join(spring_parent, "metadata"))
+        spring_path = os.path.join(spring_parent, "spring-aot-smoke-tests")
+        failed = _run_recorded_command(
+            repo_path,
+            "checkout-spring-aot-smoke-tests",
+            ["git", "clone", "--depth", "1", "--branch", SPRING_AOT_BRANCH, SPRING_AOT_REPO_URL, spring_path],
+            result,
+        )
+        if failed is not None:
+            return failed
+
+        try:
+            spring_matrix = _gradle_json_output(
+                repo_path,
+                "generateAffectedSpringTestMatrix",
+                base_commit,
+                result,
+                "affected-spring-aot-matrix",
+                extra_args=[
+                    f"-PspringAotBranch={SPRING_AOT_BRANCH}",
+                    f"-PspringAotPath={spring_path}",
+                ],
+            )
+        except _GradleOutputFailure as exc:
+            return exc.record
+
+        return _run_spring_aot_matrix_entries(repo_path, spring_path, _matrix_entries(spring_matrix), result)
+
+
+def _run_spring_aot_matrix_entries(
+        repo_path: str,
+        spring_path: str,
+        entries: list[dict],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    for entry in entries:
+        project = str(entry.get("project") or "").strip()
+        if not project:
+            continue
+        env = _spring_aot_env(entry)
+        failed = _run_recorded_command(
+            repo_path,
+            "spring-aot-smoke-test",
+            [
+                "bash",
+                ".github/workflows/scripts/run-spring-aot-triaged-test.sh",
+                spring_path,
+                project,
+                "4.1.x",
+            ],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
 def _restore_docker_networking(repo_path: str, result: LocalCIVerificationResult) -> CommandRecord | None:
     """Restore Docker networking after the CI-equivalent no-network test phase."""
     return _run_recorded_command(
@@ -431,8 +561,9 @@ def _gradle_json_output(
         base_commit: str,
         result: LocalCIVerificationResult,
         gate: str,
+        extra_args: list[str] | None = None,
 ) -> dict:
-    output = _gradle_output(repo_path, task_name, base_commit, result, gate)
+    output = _gradle_output(repo_path, task_name, base_commit, result, gate, extra_args=extra_args)
     raw_matrix = output.get("matrix")
     if raw_matrix is None:
         return {}
@@ -449,6 +580,7 @@ def _gradle_output(
         base_commit: str,
         result: LocalCIVerificationResult,
         gate: str,
+        extra_args: list[str] | None = None,
 ) -> dict[str, str]:
     with tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False) as output_file:
         output_path = output_file.name
@@ -456,7 +588,7 @@ def _gradle_output(
         failed = _run_recorded_command(
             repo_path,
             gate,
-            ["./gradlew", task_name, f"-PbaseCommit={base_commit}", "-PnewCommit=HEAD"],
+            ["./gradlew", task_name, f"-PbaseCommit={base_commit}", "-PnewCommit=HEAD", *(extra_args or [])],
             result,
             env={"GITHUB_OUTPUT": output_path},
         )
@@ -495,6 +627,16 @@ def _matrix_env(entry: dict) -> dict[str, str]:
     if native_image_mode:
         env["GVM_TCK_NATIVE_IMAGE_MODE"] = native_image_mode
     java_version = str(entry.get("version") or "").strip()
+    graalvm_home = _graalvm_home_for_java_version(java_version)
+    if graalvm_home:
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+    return env
+
+
+def _spring_aot_env(entry: dict) -> dict[str, str]:
+    env: dict[str, str] = {}
+    java_version = str(entry.get("java") or "").strip()
     graalvm_home = _graalvm_home_for_java_version(java_version)
     if graalvm_home:
         env["GRAALVM_HOME"] = graalvm_home
@@ -745,6 +887,21 @@ def _should_run_library_stats_validation(changed_files: list[str]) -> bool:
         if re.match(r"^metadata/[^/]+/[^/]+/[^/]+/", path):
             return True
     return False
+
+
+def _should_run_infrastructure_tests(changed_files: list[str]) -> bool:
+    return any(
+        path == "build.gradle"
+        or path == "settings.gradle"
+        or path == "gradle.properties"
+        or path.startswith("gradle/")
+        or path.startswith("tests/tck-build-logic/")
+        for path in changed_files
+    )
+
+
+def _should_run_spring_aot_tests(changed_files: list[str]) -> bool:
+    return any(path.startswith("metadata/") for path in changed_files)
 
 
 def _should_run_docker_scan(changed_files: list[str]) -> bool:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -137,7 +137,6 @@ def run_local_ci_verification(
 
 def fetch_pr_base_ref(repo_path: str, repo: str, base_branch: str = DEFAULT_BASE_BRANCH) -> str:
     """Fetch the upstream PR base and return a local ref suitable for diffing and rebasing."""
-    upstream_url = f"https://github.com/{repo}.git"
     remote_url = subprocess.run(
         ["git", "remote", "get-url", "upstream"],
         cwd=repo_path,
@@ -146,9 +145,26 @@ def fetch_pr_base_ref(repo_path: str, repo: str, base_branch: str = DEFAULT_BASE
         text=True,
         check=False,
     )
-    remote_name = "upstream" if remote_url.returncode == 0 and remote_url.stdout.strip() == upstream_url else "origin"
+    upstream_matches_target = (
+        remote_url.returncode == 0 and _github_repo_slug_from_url(remote_url.stdout.strip()) == repo.lower()
+    )
+    remote_name = "upstream" if upstream_matches_target else "origin"
     subprocess.run(["git", "fetch", remote_name, base_branch], cwd=repo_path, check=True)
     return f"{remote_name}/{base_branch}"
+
+
+def _github_repo_slug_from_url(remote_url: str) -> str | None:
+    """Return the lowercase GitHub owner/repo slug from common remote URL forms."""
+    patterns = (
+        r"^https://github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?$",
+        r"^git@github\.com:(?P<slug>[^/]+/[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, remote_url)
+        if match:
+            return match.group("slug").lower()
+    return None
 
 
 def format_local_ci_verification_pr_section(local_ci_verification: dict | None) -> str:
@@ -294,36 +310,54 @@ def _run_test_matrix_entries(
     if failed is not None:
         return failed
 
-    for entry in entries:
-        coordinates = str(entry.get("coordinates") or "").strip()
-        versions = entry.get("versions")
-        if not coordinates or not isinstance(versions, list):
-            continue
-        env = _matrix_env(entry)
-        failed = _run_recorded_command(
-            repo_path,
-            "check-metadata-files",
-            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
-        failed = _run_recorded_command(
-            repo_path,
-            "run-consecutive-tests",
-            [
-                "bash",
-                "./.github/workflows/scripts/run-consecutive-tests.sh",
-                coordinates,
-                json.dumps([str(version) for version in versions]),
-            ],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
-    return None
+    first_failed: CommandRecord | None = None
+    restore_failed: CommandRecord | None = None
+    try:
+        for entry in entries:
+            coordinates = str(entry.get("coordinates") or "").strip()
+            versions = entry.get("versions")
+            if not coordinates or not isinstance(versions, list):
+                continue
+            env = _matrix_env(entry)
+            failed = _run_recorded_command(
+                repo_path,
+                "check-metadata-files",
+                ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
+                result,
+                env=env,
+            )
+            if failed is not None:
+                first_failed = failed
+                break
+            failed = _run_recorded_command(
+                repo_path,
+                "run-consecutive-tests",
+                [
+                    "bash",
+                    "./.github/workflows/scripts/run-consecutive-tests.sh",
+                    coordinates,
+                    json.dumps([str(version) for version in versions]),
+                ],
+                result,
+                env=env,
+                failure_output_pattern=r"^FAILED",
+            )
+            if failed is not None:
+                first_failed = failed
+                break
+    finally:
+        restore_failed = _restore_docker_networking(repo_path, result)
+    return first_failed or restore_failed
+
+
+def _restore_docker_networking(repo_path: str, result: LocalCIVerificationResult) -> CommandRecord | None:
+    """Restore Docker networking after the CI-equivalent no-network test phase."""
+    return _run_recorded_command(
+        repo_path,
+        "restore-docker-networking",
+        ["bash", "./.github/workflows/scripts/restore-docker.sh"],
+        result,
+    )
 
 
 def _run_index_validation(
@@ -474,7 +508,7 @@ def _graalvm_home_for_java_version(java_version: str) -> str | None:
     if java_version == "25":
         return _required_env("GRAALVM_HOME_25_0")
     if java_version == "latest-ea":
-        return os.environ.get("GRAALVM_HOME_LATEST_EA") or _required_env("GRAALVM_HOME")
+        return _required_env("GRAALVM_HOME_LATEST_EA")
     env_name = "GRAALVM_HOME_" + re.sub(r"[^A-Za-z0-9]", "_", java_version).upper()
     return _required_env(env_name)
 
@@ -492,6 +526,7 @@ def _run_recorded_command(
         command: list[str],
         result: LocalCIVerificationResult,
         env: dict[str, str] | None = None,
+        failure_output_pattern: str | None = None,
 ) -> CommandRecord | None:
     command_env = dict(os.environ)
     display_env = dict(env or {})
@@ -509,16 +544,19 @@ def _run_recorded_command(
     output = completed.stdout or ""
     with open(log_path, "w", encoding="utf-8") as log_file:
         log_file.write(output)
+    returncode = completed.returncode
+    if returncode == 0 and failure_output_pattern and re.search(failure_output_pattern, output, re.MULTILINE):
+        returncode = 1
     record = CommandRecord(
         gate=gate,
         command=command,
-        returncode=completed.returncode,
+        returncode=returncode,
         env=display_env,
         log_path=display_log_path(log_path),
         output_excerpt=_tail(output),
     )
     result.commands.append(record)
-    if completed.returncode != 0:
+    if returncode != 0:
         return record
     return None
 

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -1,0 +1,713 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Local reproduction of the CI gates that run on generated Forge PRs."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
+from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+
+LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
+HUMAN_INTERVENTION_LABEL = "human-intervention"
+MAX_OUTPUT_CHARS = 12000
+MAX_FIXUP_ATTEMPTS = 2
+CODEX_MODEL_NAME = "oca/gpt-5.4"
+CODEX_TIMEOUT_SECONDS = 1800
+DEFAULT_BASE_BRANCH = "master"
+
+
+@dataclass
+class CommandRecord:
+    """A single local CI command and its outcome."""
+
+    gate: str
+    command: list[str]
+    returncode: int
+    env: dict[str, str] = field(default_factory=dict)
+    log_path: str | None = None
+    output_excerpt: str = ""
+
+
+@dataclass
+class FixupRecord:
+    """A verifier fixup attempt."""
+
+    gate: str
+    command: list[str]
+    commit: str | None
+    changed_paths: list[str]
+    log_path: str | None = None
+
+
+@dataclass
+class LocalCIVerificationResult:
+    """Final verifier result stored in metrics and reflected in PR metadata."""
+
+    status: str
+    base_commit: str
+    final_commit: str | None = None
+    commands: list[CommandRecord] = field(default_factory=list)
+    fixups: list[FixupRecord] = field(default_factory=list)
+    repo_fix_paths: list[str] = field(default_factory=list)
+    human_intervention_required: bool = False
+    failure_gate: str | None = None
+    failure_command: list[str] | None = None
+
+    def to_metrics(self) -> dict:
+        """Return a JSON-serializable metrics block."""
+        return asdict(self)
+
+
+class LocalCIVerificationError(RuntimeError):
+    """Raised when local CI-equivalent verification cannot be satisfied."""
+
+    def __init__(self, result: LocalCIVerificationResult):
+        self.result = result
+        gate = result.failure_gate or "unknown"
+        super().__init__(f"Local CI verification failed at gate '{gate}'")
+
+
+class _GradleOutputFailure(RuntimeError):
+    """Internal control flow for Gradle output-producing tasks."""
+
+    def __init__(self, record: CommandRecord):
+        self.record = record
+        super().__init__(f"Gradle output task failed at gate '{record.gate}'")
+
+
+def parse_coordinate_parts(coordinates: str) -> tuple[str, str, str]:
+    """Return group, artifact, version from Maven coordinates."""
+    parts = coordinates.split(":")
+    if len(parts) != 3:
+        raise ValueError(f"Expected Maven coordinates group:artifact:version, got {coordinates!r}")
+    return parts[0], parts[1], parts[2]
+
+
+def run_local_ci_verification(
+        *,
+        repo_path: str,
+        coordinates: str,
+        base_commit: str,
+        metrics_repo_path: str | None = None,
+        max_fixup_attempts: int = MAX_FIXUP_ATTEMPTS,
+) -> LocalCIVerificationResult:
+    """Run CI-equivalent local verification, fixing and retrying when possible."""
+    result = LocalCIVerificationResult(status="running", base_commit=base_commit)
+    for attempt in range(max_fixup_attempts + 1):
+        failed_command = _run_verification_once(repo_path, base_commit, result)
+        if failed_command is None:
+            result.status = "success"
+            result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+            result.repo_fix_paths = classify_repo_fix_paths(repo_path, base_commit, coordinates)
+            result.human_intervention_required = bool(result.repo_fix_paths)
+            _write_verification_metrics(metrics_repo_path, result)
+            return result
+
+        result.failure_gate = failed_command.gate
+        result.failure_command = failed_command.command
+        if attempt >= max_fixup_attempts:
+            result.status = "failure"
+            result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+            _write_verification_metrics(metrics_repo_path, result)
+            raise LocalCIVerificationError(result)
+
+        fixup = _run_fixup(repo_path, coordinates, failed_command)
+        result.fixups.append(fixup)
+        if fixup.commit is None:
+            result.status = "failure"
+            result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+            _write_verification_metrics(metrics_repo_path, result)
+            raise LocalCIVerificationError(result)
+
+    result.status = "failure"
+    _write_verification_metrics(metrics_repo_path, result)
+    raise LocalCIVerificationError(result)
+
+
+def fetch_pr_base_ref(repo_path: str, repo: str, base_branch: str = DEFAULT_BASE_BRANCH) -> str:
+    """Fetch the upstream PR base and return a local ref suitable for diffing and rebasing."""
+    upstream_url = f"https://github.com/{repo}.git"
+    remote_url = subprocess.run(
+        ["git", "remote", "get-url", "upstream"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    remote_name = "upstream" if remote_url.returncode == 0 and remote_url.stdout.strip() == upstream_url else "origin"
+    subprocess.run(["git", "fetch", remote_name, base_branch], cwd=repo_path, check=True)
+    return f"{remote_name}/{base_branch}"
+
+
+def format_local_ci_verification_pr_section(local_ci_verification: dict | None) -> str:
+    """Format a concise PR body section for local CI verification."""
+    if not isinstance(local_ci_verification, dict):
+        return ""
+    status = local_ci_verification.get("status", "unknown")
+    commands = local_ci_verification.get("commands")
+    command_count = len(commands) if isinstance(commands, list) else 0
+    fixups = local_ci_verification.get("fixups")
+    fixup_count = len(fixups) if isinstance(fixups, list) else 0
+    repo_fix_paths = local_ci_verification.get("repo_fix_paths")
+    repo_fix_list = repo_fix_paths if isinstance(repo_fix_paths, list) else []
+    body = (
+        "\n### Local CI Verification\n\n"
+        f"- Status: `{status}`\n"
+        f"- Commands run: {command_count}\n"
+        f"- Fixup attempts: {fixup_count}\n"
+    )
+    if local_ci_verification.get("human_intervention_required"):
+        body += "- Human intervention: required because repository-level files changed during verification.\n"
+    if repo_fix_list:
+        body += "- Repository-level fix paths:\n"
+        body += "".join(f"  - `{path}`\n" for path in repo_fix_list[:20])
+    return body
+
+
+def local_ci_requires_human_intervention(local_ci_verification: dict | None) -> bool:
+    """Return True if verification metrics require the PR label."""
+    return bool(isinstance(local_ci_verification, dict) and local_ci_verification.get("human_intervention_required"))
+
+
+def classify_repo_fix_paths(repo_path: str, base_commit: str, coordinates: str) -> list[str]:
+    """Return changed tracked paths outside the expected target-library output."""
+    group, artifact, _ = parse_coordinate_parts(coordinates)
+    allowed_prefixes = (
+        f"metadata/{group}/{artifact}/",
+        f"tests/src/{group}/{artifact}/",
+        f"stats/{group}/{artifact}/",
+    )
+    repo_fix_paths: list[str] = []
+    for path in _changed_files(repo_path, base_commit, "HEAD", diff_filter="ACMRTD"):
+        if path.startswith(allowed_prefixes):
+            continue
+        repo_fix_paths.append(path)
+    return sorted(repo_fix_paths)
+
+
+def changed_files_for_ci(repo_path: str, base_commit: str, head_commit: str = "HEAD") -> list[str]:
+    """Return changed files using the pull-request CI diff filter."""
+    return _changed_files(repo_path, base_commit, head_commit, diff_filter="ACMRT")
+
+
+def _run_verification_once(
+        repo_path: str,
+        base_commit: str,
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    changed_files = changed_files_for_ci(repo_path, base_commit)
+
+    try:
+        changed_metadata_matrix = _gradle_json_output(
+            repo_path,
+            "generateChangedMetadataTestMatrix",
+            base_commit,
+            result,
+            "changed-metadata-matrix",
+        )
+        changed_tested_versions_matrix = _gradle_json_output(
+            repo_path,
+            "generateChangedTestedVersionsMatrix",
+            base_commit,
+            result,
+            "changed-tested-versions-matrix",
+        )
+    except _GradleOutputFailure as exc:
+        return exc.record
+
+    test_entries = _matrix_entries(changed_metadata_matrix) + _matrix_entries(changed_tested_versions_matrix)
+    failed = _run_test_matrix_entries(repo_path, test_entries, result)
+    if failed is not None:
+        return failed
+
+    failed = _run_index_validation(repo_path, base_commit, changed_files, result)
+    if failed is not None:
+        return failed
+
+    failed = _run_style_validation(repo_path, base_commit, changed_files, result)
+    if failed is not None:
+        return failed
+
+    if _should_run_library_stats_validation(changed_files):
+        failed = _run_recorded_command(repo_path, "library-stats-validation", ["./gradlew", "validateLibraryStats"], result)
+        if failed is not None:
+            return failed
+
+    failed = _run_recorded_command(repo_path, "doc-links", ["./gradlew", "checkDocLinks", "--console=plain"], result)
+    if failed is not None:
+        return failed
+
+    if _should_run_docker_scan(changed_files):
+        failed = _run_recorded_command(
+            repo_path,
+            "docker-image-scan",
+            ["./gradlew", "checkAllowedDockerImages", f"--baseCommit={base_commit}", "--newCommit=HEAD"],
+            result,
+        )
+        if failed is not None:
+            return failed
+
+    return None
+
+
+def _run_test_matrix_entries(
+        repo_path: str,
+        entries: list[dict],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not entries:
+        return None
+
+    pulled_coordinates: set[str] = set()
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        if not coordinates or coordinates in pulled_coordinates:
+            continue
+        failed = _run_recorded_command(
+            repo_path,
+            "pull-allowed-docker-images",
+            ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
+            result,
+        )
+        if failed is not None:
+            return failed
+        pulled_coordinates.add(coordinates)
+
+    failed = _run_recorded_command(
+        repo_path,
+        "disable-docker-networking",
+        ["bash", "./.github/workflows/scripts/disable-docker.sh"],
+        result,
+    )
+    if failed is not None:
+        return failed
+
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        versions = entry.get("versions")
+        if not coordinates or not isinstance(versions, list):
+            continue
+        env = _matrix_env(entry)
+        failed = _run_recorded_command(
+            repo_path,
+            "check-metadata-files",
+            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+        failed = _run_recorded_command(
+            repo_path,
+            "run-consecutive-tests",
+            [
+                "bash",
+                "./.github/workflows/scripts/run-consecutive-tests.sh",
+                coordinates,
+                json.dumps([str(version) for version in versions]),
+            ],
+            result,
+            env=env,
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
+def _run_index_validation(
+        repo_path: str,
+        base_commit: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not any(_is_metadata_index_file(path) for path in changed_files):
+        return None
+    try:
+        output = _gradle_output(
+            repo_path,
+            "generateChangedIndexFileCoordinatesList",
+            base_commit,
+            result,
+            "changed-index-coordinates",
+        )
+    except _GradleOutputFailure as exc:
+        return exc.record
+    changed_coordinates = str(output.get("changed-coordinates") or "").strip()
+    if not changed_coordinates:
+        return None
+    return _run_recorded_command(
+        repo_path,
+        "index-file-validation",
+        ["./gradlew", "validateIndexFiles", f"-Pcoordinates={changed_coordinates}"],
+        result,
+    )
+
+
+def _run_style_validation(
+        repo_path: str,
+        base_commit: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    if not _should_run_style_validation(changed_files):
+        return None
+    failed = _run_recorded_command(repo_path, "spotless", ["./gradlew", "spotlessCheck", "--console=plain"], result)
+    if failed is not None:
+        return failed
+    try:
+        matrix = _gradle_json_output(
+            repo_path,
+            "generateChangedCoordinatesOnlyMatrix",
+            base_commit,
+            result,
+            "changed-coordinates-only-matrix",
+        )
+    except _GradleOutputFailure as exc:
+        return exc.record
+    coordinates = matrix.get("coordinates")
+    if not isinstance(coordinates, list):
+        return None
+    for coordinate in coordinates:
+        failed = _run_recorded_command(
+            repo_path,
+            "checkstyle",
+            ["./gradlew", "checkstyle", f"-Pcoordinates={coordinate}", "--console=plain"],
+            result,
+        )
+        if failed is not None:
+            return failed
+    return None
+
+
+def _gradle_json_output(
+        repo_path: str,
+        task_name: str,
+        base_commit: str,
+        result: LocalCIVerificationResult,
+        gate: str,
+) -> dict:
+    output = _gradle_output(repo_path, task_name, base_commit, result, gate)
+    raw_matrix = output.get("matrix")
+    if raw_matrix is None:
+        return {}
+    try:
+        parsed = json.loads(raw_matrix)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse matrix output from {task_name}: {exc}") from exc
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _gradle_output(
+        repo_path: str,
+        task_name: str,
+        base_commit: str,
+        result: LocalCIVerificationResult,
+        gate: str,
+) -> dict[str, str]:
+    with tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False) as output_file:
+        output_path = output_file.name
+    try:
+        failed = _run_recorded_command(
+            repo_path,
+            gate,
+            ["./gradlew", task_name, f"-PbaseCommit={base_commit}", "-PnewCommit=HEAD"],
+            result,
+            env={"GITHUB_OUTPUT": output_path},
+        )
+        if failed is not None:
+            raise _GradleOutputFailure(failed)
+        return _parse_github_output_file(output_path)
+    finally:
+        try:
+            os.remove(output_path)
+        except OSError:
+            pass
+
+
+def _parse_github_output_file(path: str) -> dict[str, str]:
+    output: dict[str, str] = {}
+    with open(path, "r", encoding="utf-8") as file:
+        for line in file:
+            stripped = line.rstrip("\n")
+            if not stripped or "=" not in stripped:
+                continue
+            key, value = stripped.split("=", 1)
+            output[key] = value
+    return output
+
+
+def _matrix_entries(matrix: dict) -> list[dict]:
+    include = matrix.get("include")
+    if isinstance(include, list):
+        return [entry for entry in include if isinstance(entry, dict)]
+    return []
+
+
+def _matrix_env(entry: dict) -> dict[str, str]:
+    env: dict[str, str] = {}
+    native_image_mode = str(entry.get("nativeImageMode") or "").strip()
+    if native_image_mode:
+        env["GVM_TCK_NATIVE_IMAGE_MODE"] = native_image_mode
+    java_version = str(entry.get("version") or "").strip()
+    graalvm_home = _graalvm_home_for_java_version(java_version)
+    if graalvm_home:
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+    return env
+
+
+def _graalvm_home_for_java_version(java_version: str) -> str | None:
+    if not java_version:
+        return None
+    if java_version == "25":
+        return _required_env("GRAALVM_HOME_25_0")
+    if java_version == "latest-ea":
+        return os.environ.get("GRAALVM_HOME_LATEST_EA") or _required_env("GRAALVM_HOME")
+    env_name = "GRAALVM_HOME_" + re.sub(r"[^A-Za-z0-9]", "_", java_version).upper()
+    return _required_env(env_name)
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable {name} for local CI verification.")
+    return value
+
+
+def _run_recorded_command(
+        repo_path: str,
+        gate: str,
+        command: list[str],
+        result: LocalCIVerificationResult,
+        env: dict[str, str] | None = None,
+) -> CommandRecord | None:
+    command_env = dict(os.environ)
+    display_env = dict(env or {})
+    command_env.update(display_env)
+    log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
+    completed = subprocess.run(
+        command,
+        cwd=repo_path,
+        env=command_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    output = completed.stdout or ""
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(output)
+    record = CommandRecord(
+        gate=gate,
+        command=command,
+        returncode=completed.returncode,
+        env=display_env,
+        log_path=display_log_path(log_path),
+        output_excerpt=_tail(output),
+    )
+    result.commands.append(record)
+    if completed.returncode != 0:
+        return record
+    return None
+
+
+def _run_fixup(repo_path: str, coordinates: str, failed_command: CommandRecord) -> FixupRecord:
+    before_paths = _worktree_changed_paths(repo_path)
+    log_path = build_timestamped_task_log_path("local-ci-fixup", coordinates, failed_command.gate)
+    prompt = _build_fixup_prompt(coordinates, failed_command)
+    command = [
+        "codex",
+        "exec",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+        "-c",
+        'reasoning.effort="high"',
+        "-m",
+        CODEX_MODEL_NAME,
+        prompt,
+    ]
+    try:
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            completed = subprocess.run(
+                command,
+                cwd=repo_path,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                timeout=CODEX_TIMEOUT_SECONDS,
+                check=False,
+            )
+    except subprocess.TimeoutExpired:
+        return FixupRecord(
+            gate=failed_command.gate,
+            command=command,
+            commit=None,
+            changed_paths=[],
+            log_path=display_log_path(log_path),
+        )
+
+    if completed.returncode != 0:
+        return FixupRecord(
+            gate=failed_command.gate,
+            command=command,
+            commit=None,
+            changed_paths=[],
+            log_path=display_log_path(log_path),
+        )
+
+    after_paths = _worktree_changed_paths(repo_path)
+    changed_paths = sorted(after_paths - before_paths)
+    if not changed_paths:
+        return FixupRecord(
+            gate=failed_command.gate,
+            command=command,
+            commit=None,
+            changed_paths=[],
+            log_path=display_log_path(log_path),
+        )
+
+    subprocess.run(["git", "add", "-A", "--", *changed_paths], cwd=repo_path, check=True)
+    staged = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, check=False)
+    if staged.returncode == 0:
+        return FixupRecord(
+            gate=failed_command.gate,
+            command=command,
+            commit=None,
+            changed_paths=changed_paths,
+            log_path=display_log_path(log_path),
+        )
+    subprocess.run(["git", "commit", "-m", "Apply local CI verification fixes"], cwd=repo_path, check=True)
+    commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+    return FixupRecord(
+        gate=failed_command.gate,
+        command=command,
+        commit=commit,
+        changed_paths=changed_paths,
+        log_path=display_log_path(log_path),
+    )
+
+
+def _build_fixup_prompt(coordinates: str, failed_command: CommandRecord) -> str:
+    env_lines = [f"{key}={value}" for key, value in sorted(failed_command.env.items())]
+    reproduction = " ".join(failed_command.command)
+    if env_lines:
+        reproduction = " ".join(env_lines + [reproduction])
+    return "\n".join([
+        "Fix the repository so the local CI-equivalent verification gate passes.",
+        "The fix may update generated library files or shared repository files when the root cause is in the repository.",
+        "Keep the change minimal and targeted to the failing gate.",
+        "",
+        f"Library: {coordinates}",
+        f"Failing gate: {failed_command.gate}",
+        "Reproduce with:",
+        reproduction,
+        "",
+        "Failure output excerpt:",
+        "```text",
+        failed_command.output_excerpt,
+        "```",
+    ])
+
+
+def _write_verification_metrics(metrics_repo_path: str | None, result: LocalCIVerificationResult) -> None:
+    if metrics_repo_path is None:
+        return
+    pending_path = os.path.join(metrics_repo_path, PENDING_METRICS_FILENAME)
+    if not os.path.isfile(pending_path):
+        return
+    metrics = read_pending_metrics(metrics_repo_path)
+    metrics[LOCAL_CI_VERIFICATION_KEY] = result.to_metrics()
+    write_pending_metrics(metrics_repo_path, metrics)
+
+
+def _worktree_changed_paths(repo_path: str) -> set[str]:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    paths: set[str] = set()
+    for line in completed.stdout.splitlines():
+        if not line:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.add(path)
+    return paths
+
+
+def _changed_files(repo_path: str, base_commit: str, head_commit: str, diff_filter: str) -> list[str]:
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", f"--diff-filter={diff_filter}", base_commit, head_commit],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _git_stdout(repo_path: str, args: list[str]) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _tail(output: str) -> str:
+    if len(output) <= MAX_OUTPUT_CHARS:
+        return output
+    return output[-MAX_OUTPUT_CHARS:]
+
+
+def _is_metadata_index_file(path: str) -> bool:
+    parts = path.split("/")
+    return len(parts) == 4 and parts[0] == "metadata" and parts[3] == "index.json"
+
+
+def _should_run_style_validation(changed_files: list[str]) -> bool:
+    for path in changed_files:
+        if path.startswith("docs/"):
+            continue
+        if path.endswith(".md"):
+            continue
+        if os.path.basename(path).startswith("library-and-framework-list") and path.endswith(".json"):
+            continue
+        return True
+    return False
+
+
+def _should_run_library_stats_validation(changed_files: list[str]) -> bool:
+    for path in changed_files:
+        if re.match(r"^stats/[^/]+/[^/]+/[^/]+/stats\.json$", path):
+            return True
+        if path.startswith("stats/schemas/") and os.path.basename(path).startswith("library-stats-schema"):
+            return True
+        if re.match(r"^metadata/[^/]+/[^/]+/[^/]+/", path):
+            return True
+    return False
+
+
+def _should_run_docker_scan(changed_files: list[str]) -> bool:
+    return any(path.startswith("tests/tck-build-logic/src/main/resources/allowed-docker-images/") for path in changed_files)

--- a/forge/utility_scripts/repo_path_resolver.py
+++ b/forge/utility_scripts/repo_path_resolver.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 
 REACHABILITY_REPO_CLONE_URL = "git@github.com:oracle/graalvm-reachability-metadata.git"
-IN_METADATA_REPO_FLAG = "--in-metadata-repo"
 
 
 def get_repo_root():
@@ -18,19 +17,6 @@ def get_repo_root():
 def get_forge_subdir_name() -> str:
     """Return the Forge directory name inside the reachability metadata repo."""
     return os.path.basename(get_repo_root())
-
-
-def add_in_metadata_repo_argument(parser) -> None:
-    """Add a deprecated compatibility flag for older commands."""
-    parser.add_argument(
-        IN_METADATA_REPO_FLAG,
-        action="store_true",
-        default=True,
-        help=(
-            "Deprecated no-op. Forge now always runs from a graalvm-reachability-metadata "
-            "checkout and stores metrics under its in-repo forge directory."
-        ),
-    )
 
 
 def _run_git(cmd: list[str], cwd: str) -> None:
@@ -189,11 +175,8 @@ def metrics_json_repo_relative_path(
 def resolve_repo_roots(
         explicit_reachability_path: str | None,
         explicit_metrics_repo_path: str | None,
-        in_metadata_repo: bool = False,
 ):
     """Resolve root paths for the target reachability repository and metrics storage."""
-    _ = in_metadata_repo
-
     # graalvm-reachability-metadata repo root
     print("[Resolving graalvm-reachability-metadata root path...]")
     if explicit_reachability_path:


### PR DESCRIPTION
## Summary
- add a Forge local CI-equivalent verification gate before generated PRs are pushed
- run changed-matrix metadata/tested-version validation, style/index/stats/docs/docker gates, and bounded verifier fixups
- algorithmically add human-intervention when verifier fixups touch shared repository files
- remove the obsolete --in-metadata-repo CLI flag and always use the in-repo Forge layout

## Testing
- PYTHONPATH=forge python3 -m py_compile forge/utility_scripts/repo_path_resolver.py forge/forge_metadata.py forge/ai_workflows/add_new_library_support.py forge/ai_workflows/improve_library_coverage.py forge/ai_workflows/java_fail_workflow.py forge/ai_workflows/fix_java_fails.py forge/ai_workflows/fix_ni_run.py forge/benchmarks/benchmark_runner.py forge/git_scripts/make_pr_new_library_support.py forge/git_scripts/make_pr_improve_coverage.py forge/git_scripts/make_pr_javac_fix.py forge/git_scripts/make_pr_java_run_fix.py forge/git_scripts/make_pr_ni_run_fix.py forge/git_scripts/make_pr_not_for_native_image.py
- PYTHONPATH=forge python3 -m unittest forge.tests.test_local_ci_verification forge.tests.test_metrics_paths forge.tests.test_large_library_progress
- ./gradlew checkDocLinks --console=plain
- git diff --check

Note: forge.tests.test_forge_metadata still has pre-existing local failures in this checkout around missing GRAALVM_HOME_25_0 and work-queue limit expectations.