### PR TITLE
Add reachability metadata for JUnit Platform Launcher 1.9.2

### DIFF
--- a/metadata/org.junit.platform/junit-platform-launcher/1.9.2/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-launcher/1.9.2/reachability-metadata.json
@@ -1,10 +1,68 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.listeners.OutputDir"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.listeners.OutputDir"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
   "resources" : [
     {
       "condition" : {
         "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
       },
+      "glob" : "META-INF/services/org.junit.platform.engine.TestEngine"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
+      },
+      "glob" : "META-INF/services/org.junit.platform.launcher.LauncherDiscoveryListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
+      },
+      "glob" : "META-INF/services/org.junit.platform.launcher.LauncherSessionListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
+      },
       "glob" : "META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
+      },
+      "glob" : "META-INF/services/org.junit.platform.launcher.TestExecutionListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherConfigurationParameters"
+      },
+      "glob" : "junit-platform.properties"
     }
   ]
 }

--- a/metadata/org.junit.platform/junit-platform-launcher/1.9.2/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-launcher/1.9.2/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.LauncherFactory"
+      },
+      "glob" : "META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter"
+    }
+  ]
+}

--- a/metadata/org.junit.platform/junit-platform-launcher/index.json
+++ b/metadata/org.junit.platform/junit-platform-launcher/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/$version$/junit-platform-launcher-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit-framework",
+    "test-code-url" : "https://github.com/junit-team/junit-framework/tree/r5.9.2/platform-tests/src/test/java/org/junit/platform/launcher",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/$version$/junit-platform-launcher-$version$-javadoc.jar",
+    "description" : "JUnit Platform Launcher provides the public API and default implementation for discovering and executing tests through JUnit Platform test engines. It builds test plans, coordinates engine discovery and execution, and reports progress and results through registered listeners.",
+    "tested-versions" : [
+      "1.9.2"
+    ],
+    "allowed-packages" : [
+      "org.junit.platform.launcher"
+    ]
+  }
+]

--- a/stats/org.junit.platform/junit-platform-launcher/1.9.2/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-launcher/1.9.2/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T08:48:16.137991Z",
+    "library": "org.junit.platform:junit-platform-launcher:1.9.2",
+    "starting_commit": "d8de39a5bf2125615813e4d1fe0a500644a94193",
+    "ending_commit": "94888609e63e4b43febea12c4520e4bc1cfeae67",
+    "strategy_name": "dynamic_access_main_sources_codex_gpt-5.5",
+    "agent": "codex",
+    "model": "gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.9.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2527,
+          "missed": 5684,
+          "ratio": 0.307758,
+          "total": 8211
+        },
+        "line": {
+          "covered": 636,
+          "missed": 1097,
+          "ratio": 0.366994,
+          "total": 1733
+        },
+        "method": {
+          "covered": 233,
+          "missed": 463,
+          "ratio": 0.33477,
+          "total": 696
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 0,
+      "output_tokens_used": 0,
+      "iterations": 0,
+      "cost_usd": 0.0,
+      "generated_loc": 18,
+      "tested_library_loc": 636,
+      "metadata_entries": 10,
+      "test_only_metadata_entries": 3,
+      "code_coverage_percent": 36.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.junit.platform/junit-platform-launcher/1.9.2/src/test/java/org_junit_platform/junit_platform_launcher/Junit_platform_launcherTest.java",
+      "metadata_file": "metadata/org.junit.platform/junit-platform-launcher/1.9.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.junit.platform/junit-platform-launcher/1.9.2/stats.json
+++ b/stats/org.junit.platform/junit-platform-launcher/1.9.2/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.9.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2527,
+        "missed" : 5684,
+        "ratio" : 0.307758,
+        "total" : 8211
+      },
+      "line" : {
+        "covered" : 636,
+        "missed" : 1097,
+        "ratio" : 0.366994,
+        "total" : 1733
+      },
+      "method" : {
+        "covered" : 233,
+        "missed" : 463,
+        "ratio" : 0.33477,
+        "total" : 696
+      }
+    }
+  } ]
+}

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/.gitignore
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.platform:junit-platform-launcher:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/gradle.properties
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.platform:junit-platform-launcher:1.9.2
+library.version = 1.9.2
+metadata.dir = org.junit.platform/junit-platform-launcher/1.9.2/

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/settings.gradle
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.platform.junit-platform-launcher_tests'

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/src/test/java/org_junit_platform/junit_platform_launcher/Junit_platform_launcherTest.java
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/src/test/java/org_junit_platform/junit_platform_launcher/Junit_platform_launcherTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+class Junit_platform_launcherTest {
+    @Test
+    void createsDefaultLauncher() {
+        Launcher launcher = LauncherFactory.create();
+
+        assertThat(launcher).isNotNull();
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineDiscoveryOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_launcher.Junit_platform_launcherTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineExecutionOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_launcher.Junit_platform_launcherTest",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.junit.platform.launcher.**"
+      "includeClasses" : "org.junit.platform.launcher.**"
     }
   ]
 }

--- a/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-launcher/1.9.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.junit.platform.launcher.**"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
Fixes: #2476
Refs: #4641

- Add reachability metadata and tests for `org.junit.platform:junit-platform-launcher:1.9.2`.
- Run full metadata discovery with `generateMetadata --agentAllowedPackages=fromJar`, expanding the launcher metadata from the original missing `PostDiscoveryFilter` service resource to all generated service resources plus the discovered reflection entries.
- Add generated test-only metadata split under the test module so launcher test infrastructure stays out of library metadata.
- Add generated `stats.json` and `execution-metrics.json` for the coordinate.

### Stats
From `stats/org.junit.platform/junit-platform-launcher/1.9.2/stats.json`:

Dynamic access coverage:
- Total: 2/2 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)
- Resources: 1/1 covered calls (100.00%)

Library coverage:
- Instruction: 2527/8211 covered (30.78%)
- Line: 636/1733 covered (36.70%)
- Method: 233/696 covered (33.48%)

Execution metrics:
- Metadata entries: 10
- Test-only metadata entries: 3
- Generated lines of code: 18
- Tested library lines of code: 636

### Testing
All commands were run with `JAVA_HOME` and `GRAALVM_HOME` pinned to the local GraalVM 25 build used for native-image verification.

- `./gradlew generateMetadata -Pcoordinates=org.junit.platform:junit-platform-launcher:1.9.2 --agentAllowedPackages=fromJar --stacktrace`
- `./gradlew generateLibraryStats -Pcoordinates=org.junit.platform:junit-platform-launcher:1.9.2 --stacktrace`
- `./gradlew checkMetadataFiles -Pcoordinates=org.junit.platform:junit-platform-launcher:1.9.2 --stacktrace`
- `./gradlew test -Pcoordinates=org.junit.platform:junit-platform-launcher:1.9.2 --stacktrace`
- `python3 utility_scripts/schema_validator.py run_metrics_output ../stats/org.junit.platform/junit-platform-launcher/1.9.2/execution-metrics.json`

### Open question
- This PR intentionally scopes the recurring exact-metadata failure to first-class support for `org.junit.platform:junit-platform-launcher:1.9.2`, where the missing service resource originates. Follow-up PRs can add adjacent JUnit Platform artifacts if the exact-metadata workflow surfaces more reusable gaps.
