### PR TITLE
[GenAI] Add support for org.apache.kerby:kerby-pkix:1.0.1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.kerby/kerby-pkix/1.0.1/reachability-metadata.json
+++ b/metadata/org.apache.kerby/kerby-pkix/1.0.1/reachability-metadata.json
@@ -1,0 +1,328 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1Any",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DirectoryString"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1BmpString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.Time"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1GeneralizedTime",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1IA5String",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1ObjectIdentifier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1OctetString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DirectoryString"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1PrintableString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DirectoryString"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1T61String",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DirectoryString"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1UniversalString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.Time"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1UtcTime",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DirectoryString"
+      },
+      "type": "org.apache.kerby.asn1.type.Asn1Utf8String",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.CertificateChoices"
+      },
+      "type": "org.apache.kerby.cms.type.AttributeCertificateV1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.CertificateChoices"
+      },
+      "type": "org.apache.kerby.cms.type.AttributeCertificateV2",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.CertificateChoices"
+      },
+      "type": "org.apache.kerby.cms.type.ExtendedCertificate",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.SignerIdentifier"
+      },
+      "type": "org.apache.kerby.cms.type.IssuerAndSerialNumber",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.CertificateChoices"
+      },
+      "type": "org.apache.kerby.cms.type.OtherCertificateFormat",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.x500.type.Name",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x500.type.Name"
+      },
+      "type": "org.apache.kerby.x500.type.RDNSequence",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DistributionPointName"
+      },
+      "type": "org.apache.kerby.x500.type.RelativeDistinguishedName",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.CertificateChoices"
+      },
+      "type": "org.apache.kerby.x509.type.Certificate",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.EDIPartyName"
+      },
+      "type": "org.apache.kerby.x509.type.DirectoryString",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.x509.type.EDIPartyName",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.AttCertIssuer"
+      },
+      "type": "org.apache.kerby.x509.type.GeneralNames",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.DistributionPointName"
+      },
+      "type": "org.apache.kerby.x509.type.GeneralNames",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.GeneralName"
+      },
+      "type": "org.apache.kerby.x509.type.OtherName",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.cms.type.SignerIdentifier"
+      },
+      "type": "org.apache.kerby.x509.type.SubjectKeyIdentifier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.kerby.x509.type.AttCertIssuer"
+      },
+      "type": "org.apache.kerby.x509.type.V2Form",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.kerby/kerby-pkix/index.json
+++ b/metadata/org.apache.kerby/kerby-pkix/index.json
@@ -1,0 +1,20 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/kerby/kerby-pkix/$version$/kerby-pkix-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/directory-kerby",
+    "test-code-url" : "https://github.com/apache/directory-kerby/tree/kerby-all-$version$/kerby-pkix/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/kerby/kerby-pkix/$version$/kerby-pkix-$version$-javadoc.jar",
+    "description" : "Kerby PKIX provides Java ASN.1 model classes and helpers for PKI structures such as X.509 certificates, attribute certificates, CRLs, X.500 names, and CMS content. It is part of Apache Kerby and supplies certificate and message type definitions plus basic PKI utility hooks built on Kerby's ASN.1 and utility modules.",
+    "tested-versions" : [
+      "1.0.1"
+    ],
+    "allowed-packages" : [
+      "org.apache.kerby.cms.type",
+      "org.apache.kerby.pkix",
+      "org.apache.kerby.x500.type",
+      "org.apache.kerby.x509.type"
+    ]
+  }
+]

--- a/stats/org.apache.kerby/kerby-pkix/1.0.1/execution-metrics.json
+++ b/stats/org.apache.kerby/kerby-pkix/1.0.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T08:48:08.521853Z",
+    "library": "org.apache.kerby:kerby-pkix:1.0.1",
+    "starting_commit": "537a54b9fc9d139206549f47b1cd3f79aa95017b",
+    "ending_commit": "fe39c6fc40ec02ddf4c886ef3e8245be12a2248b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3799,
+          "missed": 6023,
+          "ratio": 0.386785,
+          "total": 9822
+        },
+        "line": {
+          "covered": 586,
+          "missed": 1094,
+          "ratio": 0.34881,
+          "total": 1680
+        },
+        "method": {
+          "covered": 328,
+          "missed": 692,
+          "ratio": 0.321569,
+          "total": 1020
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 261754,
+      "cached_input_tokens_used": 2135040,
+      "output_tokens_used": 28975,
+      "iterations": 6,
+      "cost_usd": 1.9368,
+      "generated_loc": 428,
+      "tested_library_loc": 586,
+      "metadata_entries": 54,
+      "code_coverage_percent": 34.88
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java",
+      "metadata_file": "metadata/org.apache.kerby/kerby-pkix/1.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.kerby/kerby-pkix/1.0.1/stats.json
+++ b/stats/org.apache.kerby/kerby-pkix/1.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3799,
+        "missed" : 6023,
+        "ratio" : 0.386785,
+        "total" : 9822
+      },
+      "line" : {
+        "covered" : 586,
+        "missed" : 1094,
+        "ratio" : 0.34881,
+        "total" : 1680
+      },
+      "method" : {
+        "covered" : 328,
+        "missed" : 692,
+        "ratio" : 0.321569,
+        "total" : 1020
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/.gitignore
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/build.gradle
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.kerby:kerby-pkix:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/gradle.properties
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.kerby:kerby-pkix:1.0.1
+library.version = 1.0.1
+metadata.dir = org.apache.kerby/kerby-pkix/1.0.1/

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/settings.gradle
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.kerby.kerby-pkix_tests'

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
@@ -35,7 +35,13 @@ import org.apache.kerby.x500.type.Name;
 import org.apache.kerby.x500.type.RDNSequence;
 import org.apache.kerby.x500.type.RelativeDistinguishedName;
 import org.apache.kerby.x509.type.AlgorithmIdentifier;
+import org.apache.kerby.x509.type.AttCertIssuer;
 import org.apache.kerby.x509.type.AttCertValidityPeriod;
+import org.apache.kerby.x509.type.Attribute;
+import org.apache.kerby.x509.type.AttributeCertificate;
+import org.apache.kerby.x509.type.AttributeCertificateInfo;
+import org.apache.kerby.x509.type.AttributeValues;
+import org.apache.kerby.x509.type.Attributes;
 import org.apache.kerby.x509.type.BasicConstraints;
 import org.apache.kerby.x509.type.Certificate;
 import org.apache.kerby.x509.type.CertificateList;
@@ -46,15 +52,19 @@ import org.apache.kerby.x509.type.Extension;
 import org.apache.kerby.x509.type.Extensions;
 import org.apache.kerby.x509.type.GeneralName;
 import org.apache.kerby.x509.type.GeneralNames;
+import org.apache.kerby.x509.type.Holder;
+import org.apache.kerby.x509.type.IssuerSerial;
 import org.apache.kerby.x509.type.KeyUsage;
 import org.apache.kerby.x509.type.ReasonFlags;
 import org.apache.kerby.x509.type.RevokedCertificate;
 import org.apache.kerby.x509.type.RevokedCertificates;
+import org.apache.kerby.x509.type.RoleSyntax;
 import org.apache.kerby.x509.type.SubjectKeyIdentifier;
 import org.apache.kerby.x509.type.SubjectPublicKeyInfo;
 import org.apache.kerby.x509.type.TBSCertList;
 import org.apache.kerby.x509.type.TBSCertificate;
 import org.apache.kerby.x509.type.Time;
+import org.apache.kerby.x509.type.V2Form;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -328,6 +338,71 @@ public class Kerby_pkixTest {
     }
 
     @Test
+    void assemblesAttributeCertificateWithRoleAttribute() {
+        IssuerSerial holderCertificate = issuerSerial("Kerby Holder Issuer", 101L);
+        Holder holder = new Holder();
+        holder.setBaseCertificateId(holderCertificate);
+        holder.setEntityName(generalNamesWithDirectoryName("Kerby Attribute Holder"));
+
+        V2Form issuerForm = new V2Form();
+        issuerForm.setIssuerName(generalNamesWithDirectoryName("Kerby Attribute Authority"));
+        issuerForm.setBaseCertificateId(issuerSerial("Kerby Authority Issuer", 202L));
+        AttCertIssuer issuer = new AttCertIssuer();
+        issuer.setV2Form(issuerForm);
+
+        GeneralName roleName = new GeneralName();
+        roleName.setUniformResourceIdentifier(new Asn1IA5String("urn:kerby:role:administrator"));
+        RoleSyntax roleSyntax = new RoleSyntax();
+        roleSyntax.setRoleAuthority(generalNamesWithDirectoryName("Kerby Role Authority"));
+        roleSyntax.setRoleName(roleName);
+
+        AttributeValues roleValues = new AttributeValues();
+        roleValues.addElement(new Asn1Any(roleSyntax));
+        Attribute roleAttribute = new Attribute();
+        roleAttribute.setAttrType(new Asn1ObjectIdentifier("2.5.24.72"));
+        roleAttribute.setAttrValues(roleValues);
+        Attributes attributes = new Attributes();
+        attributes.addElement(roleAttribute);
+
+        AttributeCertificateInfo certificateInfo = new AttributeCertificateInfo();
+        certificateInfo.setVersion(1);
+        certificateInfo.setHolder(holder);
+        certificateInfo.setIssuer(issuer);
+        certificateInfo.setSignature(algorithm(SHA256_WITH_RSA_OID));
+        certificateInfo.setSerialNumber(serialNumber(303L));
+        certificateInfo.setAttrCertValidityPeriod(validityPeriod(1_700_000_000_000L, 1_700_086_400_000L));
+        certificateInfo.setAttributes(attributes);
+        certificateInfo.setIssuerUniqueId(new byte[] {4, 3, 2, 1});
+        certificateInfo.setExtensions(new Extensions());
+
+        AttributeCertificate certificate = new AttributeCertificate();
+        certificate.setAciInfo(certificateInfo);
+        certificate.setSignatureAlgorithm(algorithm(SHA256_WITH_RSA_OID));
+        certificate.setSignatureValue(new Asn1BitString(new byte[] {8, 6, 7, 5, 3, 0, 9}, 0));
+
+        Attribute storedAttribute = certificate.getAcinfo().getAttributes().getElements().get(0);
+        RoleSyntax storedRole = (RoleSyntax) storedAttribute.getAttrValues().getElements().get(0).getValue();
+
+        assertThat(certificate.getAcinfo().getVersion()).isEqualTo(1);
+        assertThat(certificate.getAcinfo().getHolder().getBaseCertificateID().getSerial().getValue())
+                .isEqualTo(BigInteger.valueOf(101L));
+        assertThat(certificate.getAcinfo().getHolder().getEntityName().getElements().get(0)
+                .getDirectoryName().getName().getElements()).hasSize(1);
+        assertThat(certificate.getAcinfo().getIssuer().getV2Form().getBaseCertificateID().getSerial().getValue())
+                .isEqualTo(BigInteger.valueOf(202L));
+        assertThat(certificate.getAcinfo().getSerialNumber().getValue()).isEqualTo(BigInteger.valueOf(303L));
+        assertThat(certificate.getAcinfo().getAttrCertValidityPeriod().getNotBeforeTime().getValue())
+                .isEqualTo(new Date(1_700_000_000_000L));
+        assertThat(storedAttribute.getAttrType().getValue()).isEqualTo("2.5.24.72");
+        assertThat(storedRole.getRoleAuthority().getElements().get(0).getDirectoryName()).isNotNull();
+        assertThat(storedRole.getRoleName().getUniformResourceIdentifier().getValue())
+                .isEqualTo("urn:kerby:role:administrator");
+        assertThat(certificate.getAcinfo().getIssuerUniqueID()).containsExactly(4, 3, 2, 1);
+        assertThat(certificate.getSignatureAlgorithm().getAlgorithm()).isEqualTo(SHA256_WITH_RSA_OID);
+        assertThat(certificate.getSignatureValue().getValue()).isEqualTo(new byte[] {8, 6, 7, 5, 3, 0, 9});
+    }
+
+    @Test
     void supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers() {
         GeneralName directoryName = new GeneralName();
         directoryName.setDirectoryName(name("Directory Choice"));
@@ -357,6 +432,35 @@ public class Kerby_pkixTest {
         Time time = new Time();
         time.setGeneralTime(new Asn1GeneralizedTime(new Date(timeInMillis)));
         return time;
+    }
+
+    private static AttCertValidityPeriod validityPeriod(long notBeforeMillis, long notAfterMillis) {
+        AttCertValidityPeriod validityPeriod = new AttCertValidityPeriod();
+        validityPeriod.setNotBeforeTime(new Asn1GeneralizedTime(new Date(notBeforeMillis)));
+        validityPeriod.setNotAfterTime(new Asn1GeneralizedTime(new Date(notAfterMillis)));
+        return validityPeriod;
+    }
+
+    private static IssuerSerial issuerSerial(String issuerName, long serialValue) {
+        IssuerSerial issuerSerial = new IssuerSerial();
+        issuerSerial.setIssuer(generalNamesWithDirectoryName(issuerName));
+        issuerSerial.setSerial(serialNumber(serialValue));
+        issuerSerial.setIssuerUID(new Asn1BitString(new byte[] {1, 0, 1}, 0));
+        return issuerSerial;
+    }
+
+    private static CertificateSerialNumber serialNumber(long serialValue) {
+        CertificateSerialNumber serialNumber = new CertificateSerialNumber();
+        serialNumber.setValue(BigInteger.valueOf(serialValue));
+        return serialNumber;
+    }
+
+    private static GeneralNames generalNamesWithDirectoryName(String commonNameValue) {
+        GeneralName directoryName = new GeneralName();
+        directoryName.setDirectoryName(name(commonNameValue));
+        GeneralNames generalNames = new GeneralNames();
+        generalNames.addElement(directoryName);
+        return generalNames;
     }
 
     private static Certificate minimalCertificate() {

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
@@ -6,11 +6,303 @@
  */
 package org_apache_kerby.kerby_pkix;
 
+import org.apache.kerby.asn1.type.Asn1Any;
+import org.apache.kerby.asn1.type.Asn1BitString;
+import org.apache.kerby.asn1.type.Asn1Boolean;
+import org.apache.kerby.asn1.type.Asn1GeneralizedTime;
+import org.apache.kerby.asn1.type.Asn1IA5String;
+import org.apache.kerby.asn1.type.Asn1Integer;
+import org.apache.kerby.asn1.type.Asn1ObjectIdentifier;
+import org.apache.kerby.asn1.type.Asn1OctetString;
+import org.apache.kerby.asn1.type.Asn1PrintableString;
+import org.apache.kerby.cms.type.CertificateChoices;
+import org.apache.kerby.cms.type.CertificateSet;
+import org.apache.kerby.cms.type.ContentInfo;
+import org.apache.kerby.cms.type.DigestAlgorithmIdentifier;
+import org.apache.kerby.cms.type.DigestAlgorithmIdentifiers;
+import org.apache.kerby.cms.type.EncapsulatedContentInfo;
+import org.apache.kerby.cms.type.IssuerAndSerialNumber;
+import org.apache.kerby.cms.type.SignatureAlgorithmIdentifier;
+import org.apache.kerby.cms.type.SignatureValue;
+import org.apache.kerby.cms.type.SignedAttributes;
+import org.apache.kerby.cms.type.SignedData;
+import org.apache.kerby.cms.type.SignerIdentifier;
+import org.apache.kerby.cms.type.SignerInfo;
+import org.apache.kerby.cms.type.SignerInfos;
+import org.apache.kerby.pkix.PkiUtil;
+import org.apache.kerby.x500.type.AttributeTypeAndValue;
+import org.apache.kerby.x500.type.Name;
+import org.apache.kerby.x500.type.RDNSequence;
+import org.apache.kerby.x500.type.RelativeDistinguishedName;
+import org.apache.kerby.x509.type.AlgorithmIdentifier;
+import org.apache.kerby.x509.type.AttCertValidityPeriod;
+import org.apache.kerby.x509.type.BasicConstraints;
+import org.apache.kerby.x509.type.Certificate;
+import org.apache.kerby.x509.type.CertificateSerialNumber;
+import org.apache.kerby.x509.type.Extension;
+import org.apache.kerby.x509.type.Extensions;
+import org.apache.kerby.x509.type.GeneralName;
+import org.apache.kerby.x509.type.GeneralNames;
+import org.apache.kerby.x509.type.KeyUsage;
+import org.apache.kerby.x509.type.SubjectKeyIdentifier;
+import org.apache.kerby.x509.type.SubjectPublicKeyInfo;
+import org.apache.kerby.x509.type.TBSCertificate;
 import org.junit.jupiter.api.Test;
 
-class Kerby_pkixTest {
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Kerby_pkixTest {
+    private static final String COMMON_NAME_OID = "2.5.4.3";
+    private static final String RSA_ENCRYPTION_OID = "1.2.840.113549.1.1.1";
+    private static final String SHA256_WITH_RSA_OID = "1.2.840.113549.1.1.11";
+    private static final String DATA_CONTENT_TYPE_OID = "1.2.840.113549.1.7.1";
+    private static final byte[] CONTENT = "Kerby PKIX CMS content".getBytes(StandardCharsets.UTF_8);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void buildsX500NameFromRelativeDistinguishedNames() {
+        AttributeTypeAndValue commonName = new AttributeTypeAndValue();
+        commonName.setType(new Asn1ObjectIdentifier(COMMON_NAME_OID));
+        commonName.setAttributeValue(new Asn1PrintableString("Kerby Test CA"));
+
+        RelativeDistinguishedName relativeDistinguishedName = new RelativeDistinguishedName();
+        relativeDistinguishedName.addElement(commonName);
+
+        RDNSequence sequence = new RDNSequence();
+        sequence.addElement(relativeDistinguishedName);
+
+        Name name = new Name();
+        name.setName(sequence);
+
+        AttributeTypeAndValue actualAttribute = name.getName().getElements().get(0).getElements().get(0);
+        assertThat(actualAttribute.getType().getValue()).isEqualTo(COMMON_NAME_OID);
+        assertThat(name.getName().getElements()).hasSize(1);
+        assertThat(relativeDistinguishedName.getElements()).containsExactly(commonName);
+    }
+
+    @Test
+    void modelsGeneralNamesAndCommonCertificateExtensions() {
+        GeneralName dnsName = new GeneralName();
+        dnsName.setDNSName(new Asn1IA5String("service.example.test"));
+
+        GeneralName uriName = new GeneralName();
+        uriName.setUniformResourceIdentifier(new Asn1IA5String("https://example.test/certs/ca.crt"));
+
+        GeneralName ipAddress = new GeneralName();
+        ipAddress.setIpAddress(new byte[] {127, 0, 0, 1});
+
+        GeneralName registeredId = new GeneralName();
+        registeredId.setRegisteredID(new Asn1ObjectIdentifier("1.3.6.1.5.5.7.48.1"));
+
+        GeneralNames names = new GeneralNames();
+        names.addElement(dnsName);
+        names.addElement(uriName);
+        names.addElement(ipAddress);
+        names.addElement(registeredId);
+
+        BasicConstraints constraints = new BasicConstraints();
+        constraints.setCA(new Asn1Boolean(Boolean.TRUE));
+        constraints.setPathLenConstraint(new Asn1Integer(BigInteger.valueOf(3L)));
+
+        KeyUsage keyUsage = new KeyUsage();
+        keyUsage.setFlag(1);
+        keyUsage.setFlag(32);
+
+        assertThat(names.getElements()).hasSize(4);
+        assertThat(names.getElements().get(0).getDNSName().getValue()).isEqualTo("service.example.test");
+        assertThat(names.getElements().get(1).getUniformResourceIdentifier().getValue())
+                .isEqualTo("https://example.test/certs/ca.crt");
+        assertThat(names.getElements().get(2).getIPAddress()).containsExactly(127, 0, 0, 1);
+        assertThat(names.getElements().get(3).getRegisteredID().getValue()).isEqualTo("1.3.6.1.5.5.7.48.1");
+        assertThat(constraints.getCA()).isTrue();
+        assertThat(constraints.getPathLenConstraint()).isEqualTo(BigInteger.valueOf(3L));
+        assertThat(keyUsage.isFlagSet(1)).isTrue();
+        assertThat(keyUsage.isFlagSet(32)).isTrue();
+        assertThat(keyUsage.isFlagSet(2)).isFalse();
+    }
+
+    @Test
+    void assemblesX509CertificateStructure() {
+        AlgorithmIdentifier signatureAlgorithm = algorithm(SHA256_WITH_RSA_OID);
+        SubjectPublicKeyInfo publicKeyInfo = new SubjectPublicKeyInfo();
+        publicKeyInfo.setAlgorithm(algorithm(RSA_ENCRYPTION_OID));
+        publicKeyInfo.setSubjectPubKey(new byte[] {1, 2, 3, 4, 5});
+
+        CertificateSerialNumber serialNumber = new CertificateSerialNumber();
+        serialNumber.setValue(BigInteger.valueOf(42L));
+
+        AttCertValidityPeriod validity = new AttCertValidityPeriod();
+        validity.setNotBeforeTime(new Asn1GeneralizedTime(new Date(1_700_000_000_000L)));
+        validity.setNotAfterTime(new Asn1GeneralizedTime(new Date(1_703_600_000_000L)));
+
+        Extension subjectAlternativeName = new Extension();
+        subjectAlternativeName.setExtnId(new Asn1ObjectIdentifier("2.5.29.17"));
+        subjectAlternativeName.setCritical(false);
+        subjectAlternativeName.setExtnValue(new byte[] {48, 3, -126, 1, 97});
+
+        Extensions extensions = new Extensions();
+        extensions.addElement(subjectAlternativeName);
+
+        TBSCertificate tbsCertificate = new TBSCertificate();
+        tbsCertificate.setVersion(2);
+        tbsCertificate.setSerialNumber(serialNumber);
+        tbsCertificate.setSignature(signatureAlgorithm);
+        tbsCertificate.setIssuer(name("Kerby Test Issuer"));
+        tbsCertificate.setValidity(validity);
+        tbsCertificate.setSubject(name("Kerby Test Subject"));
+        tbsCertificate.setSubjectPublicKeyInfo(publicKeyInfo);
+        tbsCertificate.setIssuerUniqueId(new byte[] {9, 8, 7});
+        tbsCertificate.setSubjectUniqueId(new byte[] {6, 5, 4});
+        tbsCertificate.setExtensions(extensions);
+
+        Certificate certificate = new Certificate();
+        certificate.setTbsCertificate(tbsCertificate);
+        certificate.setSignatureAlgorithm(signatureAlgorithm);
+        certificate.setSignature(new Asn1BitString(new byte[] {10, 11, 12}, 0));
+
+        assertThat(certificate.getTBSCertificate().getVersion()).isEqualTo(2);
+        assertThat(certificate.getTBSCertificate().getSerialNumber().getValue()).isEqualTo(BigInteger.valueOf(42L));
+        assertThat(certificate.getTBSCertificate().getIssuer().getName().getElements()).hasSize(1);
+        assertThat(certificate.getTBSCertificate().getSubjectPublicKeyInfo().getAlgorithm().getAlgorithm())
+                .isEqualTo(RSA_ENCRYPTION_OID);
+        assertThat(certificate.getTBSCertificate().getSubjectPublicKeyInfo().getSubjectPubKey().getValue())
+                .isEqualTo(new byte[] {1, 2, 3, 4, 5});
+        assertThat(certificate.getTBSCertificate().getIssuerUniqueID()).containsExactly(9, 8, 7);
+        assertThat(certificate.getTBSCertificate().getSubject()).isNotNull();
+        assertThat(certificate.getTBSCertificate().getExtensions().getElements().get(0).getExtnId().getValue())
+                .isEqualTo("2.5.29.17");
+        assertThat(certificate.getSignatureAlgorithm().getAlgorithm()).isEqualTo(SHA256_WITH_RSA_OID);
+        assertThat(certificate.getSignature().getValue()).isEqualTo(new byte[] {10, 11, 12});
+    }
+
+    @Test
+    void assemblesCmsSignedDataEnvelope() throws Exception {
+        DigestAlgorithmIdentifier digestAlgorithm = new DigestAlgorithmIdentifier();
+        digestAlgorithm.setAlgorithm("2.16.840.1.101.3.4.2.1");
+        DigestAlgorithmIdentifiers digestAlgorithms = new DigestAlgorithmIdentifiers();
+        digestAlgorithms.addElement(digestAlgorithm);
+
+        EncapsulatedContentInfo encapsulatedContentInfo = new EncapsulatedContentInfo();
+        encapsulatedContentInfo.setContentType(DATA_CONTENT_TYPE_OID);
+        encapsulatedContentInfo.setContent(CONTENT);
+
+        CertificateChoices certificateChoice = new CertificateChoices();
+        certificateChoice.setCertificate(minimalCertificate());
+        CertificateSet certificateSet = new CertificateSet();
+        certificateSet.addElement(certificateChoice);
+
+        IssuerAndSerialNumber issuerAndSerialNumber = new IssuerAndSerialNumber();
+        issuerAndSerialNumber.setIssuer(name("Kerby CMS Issuer"));
+        issuerAndSerialNumber.setSerialNumber(7);
+
+        SignerIdentifier signerIdentifier = new SignerIdentifier();
+        signerIdentifier.setIssuerAndSerialNumber(issuerAndSerialNumber);
+
+        SignatureAlgorithmIdentifier signatureAlgorithm = new SignatureAlgorithmIdentifier();
+        signatureAlgorithm.setAlgorithm(SHA256_WITH_RSA_OID);
+
+        SignatureValue signatureValue = new SignatureValue();
+        signatureValue.setValue(new byte[] {3, 1, 4, 1, 5});
+
+        SignerInfo signerInfo = new SignerInfo();
+        signerInfo.setCmsVersion(1);
+        signerInfo.setSignerIdentifier(signerIdentifier);
+        signerInfo.setDigestAlgorithmIdentifier(digestAlgorithm);
+        signerInfo.setSignedAttributes(new SignedAttributes());
+        signerInfo.setSignatureAlgorithmIdentifier(signatureAlgorithm);
+        signerInfo.setSignatureValue(signatureValue);
+
+        SignerInfos signerInfos = new SignerInfos();
+        signerInfos.addElement(signerInfo);
+
+        SignedData signedData = new SignedData();
+        signedData.setVersion(1);
+        signedData.setDigestAlgorithms(digestAlgorithms);
+        signedData.setEncapContentInfo(encapsulatedContentInfo);
+        signedData.setCertificates(certificateSet);
+        signedData.setSignerInfos(signerInfos);
+
+        ContentInfo contentInfo = new ContentInfo();
+        contentInfo.setContentType("1.2.840.113549.1.7.2");
+        contentInfo.setContent(signedData);
+
+        assertThat(signedData.getVersion()).isEqualTo(1);
+        assertThat(signedData.getDigestAlgorithms().getElements().get(0).getAlgorithm())
+                .isEqualTo("2.16.840.1.101.3.4.2.1");
+        assertThat(signedData.getEncapContentInfo().getContent()).isEqualTo(CONTENT);
+        assertThat(signedData.getCertificates().getElements().get(0).getCertificate()).isNotNull();
+        assertThat(signedData.getSignerInfos().getElements().get(0).getSignerIdentifier()
+                .getIssuerAndSerialNumber().getSerialNumber().getValue()).isEqualTo(BigInteger.valueOf(7L));
+        assertThat(signedData.isSigned()).isTrue();
+        assertThat(contentInfo.getContentType()).isEqualTo("1.2.840.113549.1.7.2");
+        assertThat(signedData.getSignerInfos().getElements()).hasSize(1);
+        assertThat(PkiUtil.validateSignedData(signedData)).isFalse();
+        assertThat(PkiUtil.getSignedData(null, null, CONTENT, SHA256_WITH_RSA_OID)).isNull();
+    }
+
+    @Test
+    void supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers() {
+        GeneralName directoryName = new GeneralName();
+        directoryName.setDirectoryName(name("Directory Choice"));
+
+        SubjectKeyIdentifier subjectKeyIdentifier = new SubjectKeyIdentifier();
+        subjectKeyIdentifier.setValue(new byte[] {11, 12, 13, 14});
+
+        SignerIdentifier signerIdentifier = new SignerIdentifier();
+        signerIdentifier.setSubjectKeyIdentifier(subjectKeyIdentifier);
+
+        Asn1Any anyPrintableString = new Asn1Any(new Asn1PrintableString("typed-any-value"));
+
+        assertThat(directoryName.getDirectoryName().getName().getElements().get(0).getElements().get(0)
+                .getType().getValue()).isEqualTo(COMMON_NAME_OID);
+        assertThat(signerIdentifier.getSubjectKeyIdentifier().getValue()).isEqualTo(new byte[] {11, 12, 13, 14});
+        assertThat(anyPrintableString.getValue()).isInstanceOf(Asn1PrintableString.class);
+    }
+
+    private static AlgorithmIdentifier algorithm(String oid) {
+        AlgorithmIdentifier identifier = new AlgorithmIdentifier();
+        identifier.setAlgorithm(oid);
+        identifier.setParameters(new Asn1OctetString(new byte[] {5, 0}));
+        return identifier;
+    }
+
+    private static Certificate minimalCertificate() {
+        TBSCertificate tbsCertificate = new TBSCertificate();
+        tbsCertificate.setVersion(2);
+        tbsCertificate.setSerialNumber(new CertificateSerialNumber());
+        tbsCertificate.getSerialNumber().setValue(BigInteger.ONE);
+        tbsCertificate.setSignature(algorithm(SHA256_WITH_RSA_OID));
+        tbsCertificate.setIssuer(name("Certificate Set Issuer"));
+        tbsCertificate.setSubject(name("Certificate Set Subject"));
+
+        SubjectPublicKeyInfo publicKeyInfo = new SubjectPublicKeyInfo();
+        publicKeyInfo.setAlgorithm(algorithm(RSA_ENCRYPTION_OID));
+        publicKeyInfo.setSubjectPubKey(new byte[] {1, 1, 2, 3, 5, 8});
+        tbsCertificate.setSubjectPublicKeyInfo(publicKeyInfo);
+
+        Certificate certificate = new Certificate();
+        certificate.setTbsCertificate(tbsCertificate);
+        certificate.setSignatureAlgorithm(algorithm(SHA256_WITH_RSA_OID));
+        certificate.setSignature(new Asn1BitString(new byte[] {1, 2, 3}, 0));
+        return certificate;
+    }
+
+    private static Name name(String commonNameValue) {
+        AttributeTypeAndValue commonName = new AttributeTypeAndValue();
+        commonName.setType(new Asn1ObjectIdentifier(COMMON_NAME_OID));
+        commonName.setAttributeValue(new Asn1PrintableString(commonNameValue));
+
+        RelativeDistinguishedName relativeDistinguishedName = new RelativeDistinguishedName();
+        relativeDistinguishedName.addElement(commonName);
+
+        RDNSequence sequence = new RDNSequence();
+        sequence.addElement(relativeDistinguishedName);
+
+        Name name = new Name();
+        name.setName(sequence);
+        return name;
     }
 }

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
@@ -38,15 +38,23 @@ import org.apache.kerby.x509.type.AlgorithmIdentifier;
 import org.apache.kerby.x509.type.AttCertValidityPeriod;
 import org.apache.kerby.x509.type.BasicConstraints;
 import org.apache.kerby.x509.type.Certificate;
+import org.apache.kerby.x509.type.CertificateList;
 import org.apache.kerby.x509.type.CertificateSerialNumber;
+import org.apache.kerby.x509.type.DistributionPoint;
+import org.apache.kerby.x509.type.DistributionPointName;
 import org.apache.kerby.x509.type.Extension;
 import org.apache.kerby.x509.type.Extensions;
 import org.apache.kerby.x509.type.GeneralName;
 import org.apache.kerby.x509.type.GeneralNames;
 import org.apache.kerby.x509.type.KeyUsage;
+import org.apache.kerby.x509.type.ReasonFlags;
+import org.apache.kerby.x509.type.RevokedCertificate;
+import org.apache.kerby.x509.type.RevokedCertificates;
 import org.apache.kerby.x509.type.SubjectKeyIdentifier;
 import org.apache.kerby.x509.type.SubjectPublicKeyInfo;
+import org.apache.kerby.x509.type.TBSCertList;
 import org.apache.kerby.x509.type.TBSCertificate;
+import org.apache.kerby.x509.type.Time;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -244,6 +252,82 @@ public class Kerby_pkixTest {
     }
 
     @Test
+    void modelsCertificateRevocationListsAndDistributionPoints() {
+        GeneralName crlLocation = new GeneralName();
+        crlLocation.setUniformResourceIdentifier(new Asn1IA5String("https://example.test/crl/root.crl"));
+        GeneralNames fullName = new GeneralNames();
+        fullName.addElement(crlLocation);
+
+        DistributionPointName distributionPointName = new DistributionPointName();
+        distributionPointName.setFullName(fullName);
+
+        ReasonFlags reasons = new ReasonFlags();
+        reasons.setFlag(1);
+        reasons.setFlag(5);
+
+        GeneralName crlIssuer = new GeneralName();
+        crlIssuer.setDirectoryName(name("Kerby CRL Issuer"));
+        GeneralNames crlIssuers = new GeneralNames();
+        crlIssuers.addElement(crlIssuer);
+
+        DistributionPoint distributionPoint = new DistributionPoint();
+        distributionPoint.setDistributionPoint(distributionPointName);
+        distributionPoint.setReasons(reasons);
+        distributionPoint.setCRLIssuer(crlIssuers);
+
+        CertificateSerialNumber revokedSerialNumber = new CertificateSerialNumber();
+        revokedSerialNumber.setValue(BigInteger.valueOf(99L));
+        Time revocationDate = generalizedTime(1_701_000_000_000L);
+
+        Extension reasonExtension = new Extension();
+        reasonExtension.setExtnId(new Asn1ObjectIdentifier("2.5.29.21"));
+        reasonExtension.setCritical(false);
+        reasonExtension.setExtnValue(new byte[] {10, 1, 1});
+        Extensions entryExtensions = new Extensions();
+        entryExtensions.addElement(reasonExtension);
+
+        RevokedCertificate revokedCertificate = new RevokedCertificate();
+        revokedCertificate.setUserCertificate(revokedSerialNumber);
+        revokedCertificate.setRevocationData(revocationDate);
+        revokedCertificate.setCrlEntryExtensions(entryExtensions);
+        RevokedCertificates revokedCertificates = new RevokedCertificates();
+        revokedCertificates.addElement(revokedCertificate);
+
+        TBSCertList tbsCertList = new TBSCertList();
+        tbsCertList.setVersion(new Asn1Integer(BigInteger.ONE));
+        tbsCertList.setSignature(algorithm(SHA256_WITH_RSA_OID));
+        tbsCertList.setIssuer(name("Kerby CRL Issuer"));
+        tbsCertList.setThisUpdata(generalizedTime(1_700_900_000_000L));
+        tbsCertList.setNextUpdate(generalizedTime(1_701_500_000_000L));
+        tbsCertList.setRevokedCertificates(revokedCertificates);
+        tbsCertList.setCrlExtensions(new Extensions());
+
+        CertificateList certificateList = new CertificateList();
+        certificateList.setTBSCertList(tbsCertList);
+        certificateList.setSignatureAlgorithms(algorithm(SHA256_WITH_RSA_OID));
+        certificateList.setSignatureValue(new Asn1BitString(new byte[] {2, 7, 1, 8}, 0));
+
+        assertThat(distributionPoint.getDistributionPoint().getFullName().getElements().get(0)
+                .getUniformResourceIdentifier().getValue()).isEqualTo("https://example.test/crl/root.crl");
+        assertThat(distributionPoint.getReasons().isFlagSet(1)).isTrue();
+        assertThat(distributionPoint.getReasons().isFlagSet(5)).isTrue();
+        assertThat(distributionPoint.getReasons().isFlagSet(8)).isFalse();
+        assertThat(distributionPoint.getCRLIssuer().getElements().get(0).getDirectoryName().getName().getElements())
+                .hasSize(1);
+        assertThat(certificateList.getTBSCertList().getVersion().getValue()).isEqualTo(BigInteger.ONE);
+        assertThat(certificateList.getTBSCertList().getRevokedCertificates().getElements().get(0)
+                .getUserCertificate().getValue()).isEqualTo(BigInteger.valueOf(99L));
+        assertThat(certificateList.getTBSCertList().getRevokedCertificates().getElements().get(0)
+                .getRevocationDate().generalizedTime()).isEqualTo(new Date(1_701_000_000_000L));
+        assertThat(certificateList.getTBSCertList().getRevokedCertificates().getElements().get(0)
+                .getCrlEntryExtensions().getElements().get(0).getExtnId().getValue()).isEqualTo("2.5.29.21");
+        assertThat(certificateList.getTBSCertList().getNextUpdate().generalizedTime())
+                .isEqualTo(new Date(1_701_500_000_000L));
+        assertThat(certificateList.getSignatureAlgorithm().getAlgorithm()).isEqualTo(SHA256_WITH_RSA_OID);
+        assertThat(certificateList.getSignature().getValue()).isEqualTo(new byte[] {2, 7, 1, 8});
+    }
+
+    @Test
     void supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers() {
         GeneralName directoryName = new GeneralName();
         directoryName.setDirectoryName(name("Directory Choice"));
@@ -267,6 +351,12 @@ public class Kerby_pkixTest {
         identifier.setAlgorithm(oid);
         identifier.setParameters(new Asn1OctetString(new byte[] {5, 0}));
         return identifier;
+    }
+
+    private static Time generalizedTime(long timeInMillis) {
+        Time time = new Time();
+        time.setGeneralTime(new Asn1GeneralizedTime(new Date(timeInMillis)));
+        return time;
     }
 
     private static Certificate minimalCertificate() {

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/src/test/java/org_apache_kerby/kerby_pkix/Kerby_pkixTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kerby.kerby_pkix;
+
+import org.junit.jupiter.api.Test;
+
+class Kerby_pkixTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.013" hostname="kung-fu-workstation" timestamp="2026-05-03T10:43:18">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.016" hostname="kung-fu-workstation" timestamp="2026-05-03T10:45:45">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3046-71beefa9/tests/src/org.apache.kerby/kerby-pkix/1.0.1"/>
@@ -52,249 +51,43 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="assemblesAttributeCertificateWithRoleAttribute()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.003">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.generalNamesWithDirectoryName(Kerby_pkixTest.java:459)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.issuerSerial(Kerby_pkixTest.java:446)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesAttributeCertificateWithRoleAttribute(Kerby_pkixTest.java:342)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 19 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 20 more
-]]></error>
+<testcase name="assemblesAttributeCertificateWithRoleAttribute()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesAttributeCertificateWithRoleAttribute()]
 display-name: assemblesAttributeCertificateWithRoleAttribute()
 ]]></system-out>
 </testcase>
-<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:106)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 18 more
-]]></error>
+<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:modelsGeneralNamesAndCommonCertificateExtensions()]
 display-name: modelsGeneralNamesAndCommonCertificateExtensions()
 ]]></system-out>
 </testcase>
-<testcase name="supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.001">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:407)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 18 more
-]]></error>
+<testcase name="supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()]
 display-name: supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()
 ]]></system-out>
 </testcase>
-<testcase name="assemblesCmsSignedDataEnvelope()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.cms.type.CertificateChoices.<init>(CertificateChoices.java:64)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:210)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.Certificate
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.Certificate.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 18 more
-]]></error>
+<testcase name="assemblesCmsSignedDataEnvelope()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesCmsSignedDataEnvelope()]
 display-name: assemblesCmsSignedDataEnvelope()
 ]]></system-out>
 </testcase>
 <testcase name="buildsX500NameFromRelativeDistinguishedNames()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:95)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x500.type.RDNSequence
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x500.type.RDNSequence.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 18 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:buildsX500NameFromRelativeDistinguishedNames()]
 display-name: buildsX500NameFromRelativeDistinguishedNames()
 ]]></system-out>
 </testcase>
-<testcase name="assemblesX509CertificateStructure()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.003">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:498)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:171)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x500.type.RDNSequence
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 18 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x500.type.RDNSequence.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 19 more
-]]></error>
+<testcase name="assemblesX509CertificateStructure()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesX509CertificateStructure()]
 display-name: assemblesX509CertificateStructure()
 ]]></system-out>
 </testcase>
 <testcase name="modelsCertificateRevocationListsAndDistributionPoints()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.002">
-<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
-	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
-	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
-	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
-	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsCertificateRevocationListsAndDistributionPoints(Kerby_pkixTest.java:266)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
-	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
-	... 17 more
-Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
-	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
-	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
-	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
-	... 18 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:modelsCertificateRevocationListsAndDistributionPoints()]
 display-name: modelsCertificateRevocationListsAndDistributionPoints()

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="5" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:36:58">
+<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T10:39:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,14 +52,14 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.002">
 <error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
 	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
 	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:88)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:96)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -94,7 +94,7 @@ display-name: modelsGeneralNamesAndCommonCertificateExtensions()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:248)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:332)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -129,7 +129,7 @@ display-name: supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.cms.type.CertificateChoices.<init>(CertificateChoices.java:64)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:192)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:200)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -164,7 +164,7 @@ display-name: assemblesCmsSignedDataEnvelope()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:77)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:85)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -199,8 +199,8 @@ display-name: buildsX500NameFromRelativeDistinguishedNames()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:304)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:153)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:394)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:161)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -226,6 +226,41 @@ Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x500.type.RDNSequen
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesX509CertificateStructure()]
 display-name: assemblesX509CertificateStructure()
+]]></system-out>
+</testcase>
+<testcase name="modelsCertificateRevocationListsAndDistributionPoints()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsCertificateRevocationListsAndDistributionPoints(Kerby_pkixTest.java:256)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 18 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:modelsCertificateRevocationListsAndDistributionPoints()]
+display-name: modelsCertificateRevocationListsAndDistributionPoints()
 ]]></system-out>
 </testcase>
 <system-out><![CDATA[

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="6" skipped="0" failures="0" errors="6" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T10:39:57">
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="7" time="0.013" hostname="kung-fu-workstation" timestamp="2026-05-03T10:43:18">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,14 +52,51 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.002">
+<testcase name="assemblesAttributeCertificateWithRoleAttribute()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.003">
 <error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
 	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
 	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:96)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.generalNamesWithDirectoryName(Kerby_pkixTest.java:459)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.issuerSerial(Kerby_pkixTest.java:446)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesAttributeCertificateWithRoleAttribute(Kerby_pkixTest.java:342)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 19 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 20 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesAttributeCertificateWithRoleAttribute()]
+display-name: assemblesAttributeCertificateWithRoleAttribute()
+]]></system-out>
+</testcase>
+<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:106)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -87,14 +124,14 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixT
 display-name: modelsGeneralNamesAndCommonCertificateExtensions()
 ]]></system-out>
 </testcase>
-<testcase name="supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<testcase name="supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.001">
 <error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
 	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
 	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:332)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:407)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -129,7 +166,7 @@ display-name: supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.cms.type.CertificateChoices.<init>(CertificateChoices.java:64)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:200)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:210)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -164,7 +201,7 @@ display-name: assemblesCmsSignedDataEnvelope()
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:85)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:95)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -192,15 +229,15 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixT
 display-name: buildsX500NameFromRelativeDistinguishedNames()
 ]]></system-out>
 </testcase>
-<testcase name="assemblesX509CertificateStructure()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<testcase name="assemblesX509CertificateStructure()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.003">
 <error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
 	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
 	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:394)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:161)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:498)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:171)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
@@ -228,14 +265,14 @@ unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixT
 display-name: assemblesX509CertificateStructure()
 ]]></system-out>
 </testcase>
-<testcase name="modelsCertificateRevocationListsAndDistributionPoints()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<testcase name="modelsCertificateRevocationListsAndDistributionPoints()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0.002">
 <error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
 	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
 	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
 	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
 	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
 	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
-	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsCertificateRevocationListsAndDistributionPoints(Kerby_pkixTest.java:256)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsCertificateRevocationListsAndDistributionPoints(Kerby_pkixTest.java:266)
 	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="5" skipped="0" failures="0" errors="5" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:36:58">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3046-71beefa9/tests/src/org.apache.kerby/kerby-pkix/1.0.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="modelsGeneralNamesAndCommonCertificateExtensions()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.modelsGeneralNamesAndCommonCertificateExtensions(Kerby_pkixTest.java:88)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 18 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:modelsGeneralNamesAndCommonCertificateExtensions()]
+display-name: modelsGeneralNamesAndCommonCertificateExtensions()
+]]></system-out>
+</testcase>
+<testcase name="supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x509.type.GeneralName.<init>(GeneralName.java:86)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers(Kerby_pkixTest.java:248)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.OtherName
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.OtherName.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 18 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()]
+display-name: supportsChoiceAccessorsForDirectoryAndSubjectKeyIdentifiers()
+]]></system-out>
+</testcase>
+<testcase name="assemblesCmsSignedDataEnvelope()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.cms.type.CertificateChoices.<init>(CertificateChoices.java:64)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesCmsSignedDataEnvelope(Kerby_pkixTest.java:192)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x509.type.Certificate
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x509.type.Certificate.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 18 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesCmsSignedDataEnvelope()]
+display-name: assemblesCmsSignedDataEnvelope()
+]]></system-out>
+</testcase>
+<testcase name="buildsX500NameFromRelativeDistinguishedNames()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.buildsX500NameFromRelativeDistinguishedNames(Kerby_pkixTest.java:77)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x500.type.RDNSequence
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 17 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x500.type.RDNSequence.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 18 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:buildsX500NameFromRelativeDistinguishedNames()]
+display-name: buildsX500NameFromRelativeDistinguishedNames()
+]]></system-out>
+</testcase>
+<testcase name="assemblesX509CertificateStructure()" classname="org_apache_kerby.kerby_pkix.Kerby_pkixTest" time="0">
+<error message="Bad field type provided, no default constructor?" type="java.lang.IllegalArgumentException"><![CDATA[java.lang.IllegalArgumentException: Bad field type provided, no default constructor?
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:99)
+	at org.apache.kerby.asn1.Asn1FieldInfo.getFieldTag(Asn1FieldInfo.java:106)
+	at org.apache.kerby.asn1.type.Asn1Choice.initTags(Asn1Choice.java:63)
+	at org.apache.kerby.asn1.type.Asn1Choice.<init>(Asn1Choice.java:48)
+	at org.apache.kerby.x500.type.Name.<init>(Name.java:52)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.name(Kerby_pkixTest.java:304)
+	at org_apache_kerby.kerby_pkix.Kerby_pkixTest.assemblesX509CertificateStructure(Kerby_pkixTest.java:153)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.lang.InstantiationException: org.apache.kerby.x500.type.RDNSequence
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:709)
+	at org.apache.kerby.asn1.Asn1FieldInfo.createFieldValue(Asn1FieldInfo.java:97)
+	... 18 more
+Caused by: java.lang.NoSuchMethodException: org.apache.kerby.x500.type.RDNSequence.<init>()
+	at java.base@25.0.2/java.lang.Class.checkConstructor(DynamicHub.java:1683)
+	at java.base@25.0.2/java.lang.Class.getConstructor0(DynamicHub.java:1875)
+	at java.base@25.0.2/java.lang.Class.newInstance(DynamicHub.java:702)
+	... 19 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_apache_kerby.kerby_pkix.Kerby_pkixTest]/[method:assemblesX509CertificateStructure()]
+display-name: assemblesX509CertificateStructure()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:39:57">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:43:18">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:43:18">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:45:45">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3046-71beefa9/tests/src/org.apache.kerby/kerby-pkix/1.0.1"/>

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:36:58">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:39:57">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T10:36:58">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/3046-71beefa9/tests/src/org.apache.kerby/kerby-pkix/1.0.1"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/user-code-filter.json
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/user-code-filter.json
@@ -1,19 +1,19 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.kerby.cms.type.**"
+      "includeClasses" : "org.apache.kerby.cms.type.**"
     },
     {
-      "includeClasses": "org.apache.kerby.pkix.**"
+      "includeClasses" : "org.apache.kerby.pkix.**"
     },
     {
-      "includeClasses": "org.apache.kerby.x500.type.**"
+      "includeClasses" : "org.apache.kerby.x500.type.**"
     },
     {
-      "includeClasses": "org.apache.kerby.x509.type.**"
+      "includeClasses" : "org.apache.kerby.x509.type.**"
     }
   ]
 }

--- a/tests/src/org.apache.kerby/kerby-pkix/1.0.1/user-code-filter.json
+++ b/tests/src/org.apache.kerby/kerby-pkix/1.0.1/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.kerby.cms.type.**"
+    },
+    {
+      "includeClasses": "org.apache.kerby.pkix.**"
+    },
+    {
+      "includeClasses": "org.apache.kerby.x500.type.**"
+    },
+    {
+      "includeClasses": "org.apache.kerby.x509.type.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3046

This PR introduces tests and metadata for org.apache.kerby:kerby-pkix:1.0.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 261754
- Cached input tokens: 2135040
- Output tokens: 28975
- Metadata entries: 54
- Iterations: 6
- Library coverage percentage: 34.88
- Generated lines of code: 428
- Tested library lines of code: 586

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fa6ea3d20a45e1be60da3360057f18975945765a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3799/9822 (38.68%)
- Line: 586/1680 (34.88%)
- Method: 328/1020 (32.16%)
