### PR TITLE
[GenAI] Test fix for org.openjfx:javafx-base:13-ea using gpt-5.5

### DIFF
--- a/metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json
+++ b/metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json
@@ -1,0 +1,20 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.sun.javafx.reflect.MethodUtil"
+      },
+      "type": "com.sun.javafx.reflect.Trampoline",
+      "methods": [
+        {
+          "name": "invoke",
+          "parameterTypes": [
+            "java.lang.reflect.Method",
+            "java.lang.Object",
+            "java.lang.Object[]"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.openjfx/javafx-base/index.json
+++ b/metadata/org.openjfx/javafx-base/index.json
@@ -2,11 +2,17 @@
   {
     "latest" : true,
     "metadata-version" : "13-ea",
+    "source-code-url" : "N/A",
+    "repository-url" : "https://github.com/openjdk/jfx",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "JavaFX Base defines the core APIs that underpin the JavaFX toolkit, including properties, bindings, collections, and events. It provides the foundational observable and event infrastructure that higher-level JavaFX modules build on.",
     "tested-versions" : [
       "13-ea"
     ],
     "allowed-packages" : [
-      "org.openjfx"
+      "javafx",
+      "com.sun.javafx"
     ]
   },
   {
@@ -50,7 +56,8 @@
       "13"
     ],
     "allowed-packages" : [
-      "org.openjfx"
+      "javafx",
+      "com.sun.javafx"
     ]
   }
 ]

--- a/metadata/org.openjfx/javafx-base/index.json
+++ b/metadata/org.openjfx/javafx-base/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "13-ea",
+    "tested-versions" : [
+      "13-ea"
+    ],
+    "allowed-packages" : [
+      "org.openjfx"
+    ]
+  },
+  {
     "metadata-version" : "11.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/openjfx/javafx-base/$version$/javafx-base-$version$-sources.jar",
     "repository-url" : "https://github.com/javafxports/openjdk-jfx",

--- a/stats/org.openjfx/javafx-base/13-ea/execution-metrics.json
+++ b/stats/org.openjfx/javafx-base/13-ea/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-03": {
+    "timestamp": "2026-05-03T09:20:51.956043Z",
+    "library": "org.openjfx:javafx-base:13-ea",
+    "starting_commit": "60f64dbdbc0f903f85bd695f79f384eb9a5ab8fb",
+    "ending_commit": "5a8634373575cdd9f6530e9a445bbba46f1e09ee",
+    "previous_library": "org.openjfx:javafx-base:11.0.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "13-ea",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.298246,
+            "coveredCalls": 17,
+            "totalCalls": 57
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.310345,
+        "coveredCalls": 18,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5818,
+          "missed": 57673,
+          "ratio": 0.091635,
+          "total": 63491
+        },
+        "line": {
+          "covered": 1554,
+          "missed": 12806,
+          "ratio": 0.108217,
+          "total": 14360
+        },
+        "method": {
+          "covered": 460,
+          "missed": 4119,
+          "ratio": 0.100459,
+          "total": 4579
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "11.0.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.018519,
+            "coveredCalls": 1,
+            "totalCalls": 54
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.018182,
+        "coveredCalls": 1,
+        "totalCalls": 55
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5025,
+          "missed": 58430,
+          "ratio": 0.07919,
+          "total": 63455
+        },
+        "line": {
+          "covered": 1345,
+          "missed": 12940,
+          "ratio": 0.094155,
+          "total": 14285
+        },
+        "method": {
+          "covered": 411,
+          "missed": 4146,
+          "ratio": 0.090191,
+          "total": 4557
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 70257,
+      "cached_input_tokens_used": 895488,
+      "output_tokens_used": 11037,
+      "iterations": 2,
+      "cost_usd": 0.7788,
+      "tested_library_loc": 1554,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 10.82,
+      "previous_library_coverage_percent": 9.42
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java",
+      "metadata_file": "metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.openjfx/javafx-base/13-ea/stats.json
+++ b/stats/org.openjfx/javafx-base/13-ea/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "13-ea",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.298246,
+          "coveredCalls" : 17,
+          "totalCalls" : 57
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.310345,
+      "coveredCalls" : 18,
+      "totalCalls" : 58
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5818,
+        "missed" : 57673,
+        "ratio" : 0.091635,
+        "total" : 63491
+      },
+      "line" : {
+        "covered" : 1554,
+        "missed" : 12806,
+        "ratio" : 0.108217,
+        "total" : 14360
+      },
+      "method" : {
+        "covered" : 460,
+        "missed" : 4119,
+        "ratio" : 0.100459,
+        "total" : 4579
+      }
+    }
+  } ]
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/.gitignore
+++ b/tests/src/org.openjfx/javafx-base/13-ea/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
+++ b/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+String osName = System.getProperty("os.name").toLowerCase()
+String javafxPlatform = osName.contains("win") ? "win" : osName.contains("mac") ? "mac" : "linux"
+
+dependencies {
+    testImplementation "org.openjfx:javafx-base:$libraryVersion:$javafxPlatform"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
+++ b/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
@@ -9,11 +9,12 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String dependencyVersion = libraryVersion == "13-ea" ? "13-ea+14b" : libraryVersion
 String osName = System.getProperty("os.name").toLowerCase()
 String javafxPlatform = osName.contains("win") ? "win" : osName.contains("mac") ? "mac" : "linux"
 
 dependencies {
-    testImplementation "org.openjfx:javafx-base:$libraryVersion:$javafxPlatform"
+    testImplementation "org.openjfx:javafx-base:$dependencyVersion:$javafxPlatform"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.openjfx/javafx-base/13-ea/gradle.properties
+++ b/tests/src/org.openjfx/javafx-base/13-ea/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.openjfx:javafx-base:13-ea
+library.version = 13-ea
+metadata.dir = org.openjfx/javafx-base/13-ea/

--- a/tests/src/org.openjfx/javafx-base/13-ea/settings.gradle
+++ b/tests/src/org.openjfx/javafx-base/13-ea/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.openjfx.javafx-base_tests'

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/Javafx_baseTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/Javafx_baseTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import javafx.beans.Observable;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringBinding;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.ArrayChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableIntegerArray;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+import javafx.event.Event;
+import javafx.event.EventDispatchChain;
+import javafx.event.EventDispatcher;
+import javafx.event.EventTarget;
+import javafx.event.EventType;
+import javafx.util.Duration;
+import org.junit.jupiter.api.Test;
+
+public class Javafx_baseTest {
+
+    private static final EventType<Event> PROFILE_UPDATED_EVENT = new EventType<>(Event.ANY, "PROFILE_UPDATED_EVENT");
+
+    @Test
+    void propertiesAndBindingsStayInSyncAcrossBindingModes() {
+        SimpleStringProperty primaryName = new SimpleStringProperty("Ada");
+        SimpleStringProperty nickname = new SimpleStringProperty("Countess");
+        SimpleStringProperty mirror = new SimpleStringProperty("Ada");
+        SimpleBooleanProperty includeNickname = new SimpleBooleanProperty(true);
+        StringBinding displayName = Bindings.createStringBinding(
+                () -> includeNickname.get() ? primaryName.get() + " (" + nickname.get() + ")" : primaryName.get(),
+                primaryName,
+                nickname,
+                includeNickname);
+
+        try {
+            List<String> displayChanges = new ArrayList<>();
+            displayName.addListener((observable, oldValue, newValue) -> displayChanges.add(oldValue + "->" + newValue));
+            Bindings.bindBidirectional(primaryName, mirror);
+
+            assertThat(displayName.get()).isEqualTo("Ada (Countess)");
+
+            mirror.set("Grace");
+            assertThat(primaryName.get()).isEqualTo("Grace");
+            assertThat(displayName.get()).isEqualTo("Grace (Countess)");
+
+            includeNickname.set(false);
+            assertThat(displayName.get()).isEqualTo("Grace");
+
+            primaryName.set("Barbara");
+            assertThat(mirror.get()).isEqualTo("Barbara");
+            assertThat(displayName.get()).isEqualTo("Barbara");
+
+            nickname.set("Compiler");
+            includeNickname.set(true);
+            assertThat(displayName.get()).isEqualTo("Barbara (Compiler)");
+
+            Bindings.unbindBidirectional(primaryName, mirror);
+            mirror.set("Detached");
+            assertThat(primaryName.get()).isEqualTo("Barbara");
+            assertThat(displayChanges).isNotEmpty();
+            assertThat(displayChanges.get(displayChanges.size() - 1)).isEqualTo("Barbara->Barbara (Compiler)");
+        } finally {
+            displayName.dispose();
+        }
+    }
+
+    @Test
+    void observableIntegerArrayTracksChangesAndCopiesValues() {
+        ObservableIntegerArray values = FXCollections.observableIntegerArray(1, 2, 3);
+        List<String> arrayChanges = new ArrayList<>();
+
+        values.addListener((ArrayChangeListener<ObservableIntegerArray>) (observableArray, sizeChanged, from, to) ->
+                arrayChanges.add(sizeChanged + ":" + from + "-" + to));
+
+        values.set(1, 5);
+        values.addAll(8, 13);
+        values.resize(4);
+
+        ObservableIntegerArray copy = FXCollections.observableIntegerArray(values);
+        values.set(0, 21);
+
+        assertThat(values.toArray(null)).containsExactly(21, 5, 3, 8);
+        assertThat(copy.toArray(null)).containsExactly(1, 5, 3, 8);
+        assertThat(arrayChanges).hasSize(4);
+        assertThat(arrayChanges.get(0)).startsWith("false:1-");
+        assertThat(arrayChanges.get(1)).startsWith("true:3-");
+    }
+
+    @Test
+    void filteredAndSortedListsReactToSourceAndElementChanges() {
+        ObservableList<TaskItem> tasks = FXCollections.observableArrayList(task -> new Observable[] {
+                task.nameProperty(),
+                task.priorityProperty()
+        });
+        TaskItem beta = new TaskItem("beta", 2);
+        TaskItem alpha = new TaskItem("alpha", 1);
+        TaskItem gamma = new TaskItem("gamma", 3);
+        tasks.addAll(beta, alpha, gamma);
+
+        FilteredList<TaskItem> prioritized = new FilteredList<>(tasks, task -> task.getPriority() >= 2);
+        SortedList<TaskItem> sorted = new SortedList<>(prioritized, Comparator.comparing(TaskItem::getName));
+        List<List<String>> snapshots = new ArrayList<>();
+        sorted.addListener((ListChangeListener<TaskItem>) change -> {
+            while (change.next()) {
+                // exhaust change details so the transformation is fully applied
+            }
+            snapshots.add(taskNames(sorted));
+        });
+
+        assertThat(taskNames(prioritized)).containsExactly("beta", "gamma");
+        assertThat(taskNames(sorted)).containsExactly("beta", "gamma");
+
+        alpha.setPriority(4);
+        assertThat(taskNames(prioritized)).containsExactly("beta", "alpha", "gamma");
+        assertThat(taskNames(sorted)).containsExactly("alpha", "beta", "gamma");
+
+        gamma.setName("aardvark");
+        assertThat(taskNames(sorted)).containsExactly("aardvark", "alpha", "beta");
+        assertThat(prioritized.getSourceIndex(1)).isEqualTo(1);
+        assertThat(snapshots).contains(List.of("alpha", "beta", "gamma"), List.of("aardvark", "alpha", "beta"));
+    }
+
+    @Test
+    void observableMapAndSetListenersReportMutations() {
+        ObservableMap<String, Integer> counts = FXCollections.observableHashMap();
+        ObservableSet<String> labels = FXCollections.observableSet("base");
+        List<String> mapEvents = new ArrayList<>();
+        List<String> setEvents = new ArrayList<>();
+
+        counts.addListener((MapChangeListener<String, Integer>) change -> {
+            if (change.wasAdded() && change.wasRemoved()) {
+                mapEvents.add("replaced " + change.getKey() + ":" + change.getValueRemoved() + "->" + change.getValueAdded());
+            } else if (change.wasAdded()) {
+                mapEvents.add("added " + change.getKey() + ":" + change.getValueAdded());
+            } else {
+                mapEvents.add("removed " + change.getKey() + ":" + change.getValueRemoved());
+            }
+        });
+        labels.addListener((SetChangeListener<String>) change -> {
+            if (change.wasAdded()) {
+                setEvents.add("added " + change.getElementAdded());
+            }
+            if (change.wasRemoved()) {
+                setEvents.add("removed " + change.getElementRemoved());
+            }
+        });
+
+        counts.put("listeners", 1);
+        counts.put("listeners", 2);
+        counts.remove("listeners");
+        labels.add("bindings");
+        labels.remove("base");
+
+        assertThat(mapEvents).containsExactly(
+                "added listeners:1",
+                "replaced listeners:1->2",
+                "removed listeners:2");
+        assertThat(setEvents).containsExactly("added bindings", "removed base");
+        assertThat(labels).containsExactly("bindings");
+    }
+
+    @Test
+    void eventDispatchChainUsesCustomDispatchersAndSupportsCopyFor() {
+        List<String> order = new ArrayList<>();
+        RecordingEventTarget target = new RecordingEventTarget(
+                new RecordingDispatcher("first", order, false),
+                new RecordingDispatcher("second", order, true),
+                new RecordingDispatcher("third", order, false));
+
+        Event original = new Event("source", target, PROFILE_UPDATED_EVENT);
+        original.consume();
+
+        Event copied = original.copyFor("copy", target);
+        assertThat(copied.getSource()).isEqualTo("copy");
+        assertThat(copied.getTarget()).isSameAs(target);
+        assertThat(copied.getEventType()).isSameAs(PROFILE_UPDATED_EVENT);
+        assertThat(copied.isConsumed()).isFalse();
+
+        Event.fireEvent(target, copied);
+
+        assertThat(order).containsExactly("first:PROFILE_UPDATED_EVENT", "second:PROFILE_UPDATED_EVENT");
+        assertThat(copied.isConsumed()).isTrue();
+    }
+
+    @Test
+    void listPropertyTracksContentSizeAndAssignedLists() {
+        SimpleListProperty<String> names = new SimpleListProperty<>(FXCollections.observableArrayList("Ada"));
+        List<String> sizeChanges = new ArrayList<>();
+        List<List<String>> snapshots = new ArrayList<>();
+        List<Boolean> emptyStates = new ArrayList<>();
+
+        names.sizeProperty().addListener((observable, oldValue, newValue) -> sizeChanges.add(oldValue + "->" + newValue));
+        names.addListener((ListChangeListener<String>) change -> {
+            while (change.next()) {
+                // exhaust change details so the property state is fully applied
+            }
+            snapshots.add(List.copyOf(names));
+        });
+        names.emptyProperty().addListener((observable, oldValue, newValue) -> emptyStates.add(newValue));
+
+        names.addAll("Grace", "Barbara");
+        names.set(FXCollections.observableArrayList("Diana", "Evelyn"));
+        names.remove("Diana");
+        names.clear();
+
+        assertThat(names).isEmpty();
+        assertThat(sizeChanges).containsExactly("1->3", "3->2", "2->1", "1->0");
+        assertThat(snapshots).containsExactly(
+                List.of("Ada", "Grace", "Barbara"),
+                List.of("Diana", "Evelyn"),
+                List.of("Evelyn"),
+                List.of());
+        assertThat(emptyStates).containsExactly(true);
+    }
+
+    @Test
+    void durationFactoriesParsingAndArithmeticRemainConsistent() {
+        Duration parsedMilliseconds = Duration.valueOf("1500ms");
+        Duration parsedSeconds = Duration.valueOf("2.5s");
+        Duration scaledMinute = Duration.minutes(1).divide(4);
+        Duration combined = parsedMilliseconds.add(parsedSeconds).subtract(Duration.seconds(1));
+
+        assertThat(parsedMilliseconds).isEqualTo(Duration.millis(1500));
+        assertThat(parsedSeconds).isEqualTo(Duration.millis(2500));
+        assertThat(scaledMinute).isEqualTo(Duration.seconds(15));
+        assertThat(combined).isEqualTo(Duration.seconds(3));
+        assertThat(combined.greaterThan(Duration.seconds(2))).isTrue();
+        assertThat(combined.lessThan(Duration.seconds(4))).isTrue();
+    }
+
+    @Test
+    void durationSentinelValuesPreserveSpecialStateAcrossOperations() {
+        Duration indefinite = Duration.INDEFINITE.add(Duration.seconds(5)).divide(3);
+        Duration unknown = Duration.UNKNOWN.multiply(2).negate();
+
+        assertThat(indefinite.isIndefinite()).isTrue();
+        assertThat(indefinite.greaterThan(Duration.hours(1))).isTrue();
+        assertThat(unknown.isUnknown()).isTrue();
+        assertThat(unknown.compareTo(Duration.ZERO)).isEqualTo(1);
+    }
+
+    private static List<String> taskNames(List<TaskItem> tasks) {
+        List<String> names = new ArrayList<>(tasks.size());
+        for (TaskItem task : tasks) {
+            names.add(task.getName());
+        }
+        return names;
+    }
+
+    public static final class TaskItem {
+        private final StringProperty name = new SimpleStringProperty(this, "name");
+        private final SimpleIntegerProperty priority = new SimpleIntegerProperty(this, "priority");
+
+        public TaskItem(String name, int priority) {
+            this.name.set(name);
+            this.priority.set(priority);
+        }
+
+        public String getName() {
+            return name.get();
+        }
+
+        public void setName(String name) {
+            this.name.set(name);
+        }
+
+        public StringProperty nameProperty() {
+            return name;
+        }
+
+        public int getPriority() {
+            return priority.get();
+        }
+
+        public void setPriority(int priority) {
+            this.priority.set(priority);
+        }
+
+        public SimpleIntegerProperty priorityProperty() {
+            return priority;
+        }
+    }
+
+    public static final class RecordingEventTarget implements EventTarget {
+        private final List<EventDispatcher> dispatchers;
+
+        public RecordingEventTarget(EventDispatcher... dispatchers) {
+            this.dispatchers = List.of(dispatchers);
+        }
+
+        @Override
+        public EventDispatchChain buildEventDispatchChain(EventDispatchChain tail) {
+            EventDispatchChain chain = tail;
+            for (EventDispatcher dispatcher : dispatchers) {
+                chain = chain.append(dispatcher);
+            }
+            return chain;
+        }
+    }
+
+    public static final class RecordingDispatcher implements EventDispatcher {
+        private final String name;
+        private final List<String> order;
+        private final boolean consume;
+
+        public RecordingDispatcher(String name, List<String> order, boolean consume) {
+            this.name = name;
+            this.order = order;
+            this.consume = consume;
+        }
+
+        @Override
+        public Event dispatchEvent(Event event, EventDispatchChain tail) {
+            order.add(name + ":" + event.getEventType().getName());
+            if (consume) {
+                event.consume();
+                return event;
+            }
+            return tail.dispatchEvent(event);
+        }
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.beans.VetoableChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.beans.property.adapter.JavaBeanStringProperty;
+import javafx.beans.property.adapter.JavaBeanStringPropertyBuilder;
+import org.junit.jupiter.api.Test;
+
+public class PropertyDescriptorTest {
+
+    @Test
+    void propertySpecificVetoableListenersAreRegisteredAndRemoved() throws NoSuchMethodException {
+        PropertySpecificVetoableBean bean = new PropertySpecificVetoableBean("initial");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).isEmpty();
+            assertThat(property.get()).isEqualTo("initial");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).isEmpty();
+    }
+
+    @Test
+    void namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved() throws NoSuchMethodException {
+        NamedVetoableBean bean = new NamedVetoableBean("named");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).containsExactly("title");
+            assertThat(property.get()).isEqualTo("named");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).containsExactly("title");
+    }
+
+    @Test
+    void globalVetoableListenersAreRegisteredAndRemoved() throws NoSuchMethodException {
+        GlobalVetoableBean bean = new GlobalVetoableBean("global");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).isEmpty();
+            assertThat(property.get()).isEqualTo("global");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).isEmpty();
+    }
+
+    public static final class PropertySpecificVetoableBean extends VetoableStringBean {
+        public PropertySpecificVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addTitleListener(VetoableChangeListener listener) {
+            recordAdded(null, listener);
+        }
+
+        public void removeTitleListener(VetoableChangeListener listener) {
+            recordRemoved(null, listener);
+        }
+    }
+
+    public static final class NamedVetoableBean extends VetoableStringBean {
+        public NamedVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+            recordAdded(propertyName, listener);
+        }
+
+        public void removeVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+            recordRemoved(propertyName, listener);
+        }
+    }
+
+    public static final class GlobalVetoableBean extends VetoableStringBean {
+        public GlobalVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addVetoableChangeListener(VetoableChangeListener listener) {
+            recordAdded(null, listener);
+        }
+
+        public void removeVetoableChangeListener(VetoableChangeListener listener) {
+            recordRemoved(null, listener);
+        }
+    }
+
+    public abstract static class VetoableStringBean {
+        final List<String> addedProperties = new ArrayList<>();
+        final List<String> removedProperties = new ArrayList<>();
+        final List<VetoableChangeListener> addedListeners = new ArrayList<>();
+        final List<VetoableChangeListener> removedListeners = new ArrayList<>();
+        private String title;
+
+        VetoableStringBean(String title) {
+            this.title = title;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        void recordAdded(String propertyName, VetoableChangeListener listener) {
+            if (propertyName != null) {
+                addedProperties.add(propertyName);
+            }
+            addedListeners.add(listener);
+        }
+
+        void recordRemoved(String propertyName, VetoableChangeListener listener) {
+            if (propertyName != null) {
+                removedProperties.add(propertyName);
+            }
+            removedListeners.add(listener);
+        }
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T11:14:52">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2049-9d64dafc/tests/src/org.openjfx/javafx-base/13-ea"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="durationFactoriesParsingAndArithmeticRemainConsistent()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:durationFactoriesParsingAndArithmeticRemainConsistent()]
+display-name: durationFactoriesParsingAndArithmeticRemainConsistent()
+]]></system-out>
+</testcase>
+<testcase name="durationSentinelValuesPreserveSpecialStateAcrossOperations()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:durationSentinelValuesPreserveSpecialStateAcrossOperations()]
+display-name: durationSentinelValuesPreserveSpecialStateAcrossOperations()
+]]></system-out>
+</testcase>
+<testcase name="globalVetoableListenersAreRegisteredAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
+<error message="bouncer cannot be found" type="java.lang.InternalError"><![CDATA[java.lang.InternalError: bouncer cannot be found
+	at com.sun.javafx.reflect.MethodUtil.getTrampoline(MethodUtil.java:309)
+	at com.sun.javafx.reflect.MethodUtil.<clinit>(MethodUtil.java:86)
+	at com.sun.javafx.property.MethodHelper.<clinit>(MethodHelper.java:43)
+	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
+	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
+	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
+	at org_openjfx.javafx_base.PropertyDescriptorTest.globalVetoableListenersAreRegisteredAndRemoved(PropertyDescriptorTest.java:71)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+Caused by: java.security.PrivilegedActionException: java.lang.NoSuchMethodException: com.sun.javafx.reflect.Trampoline.invoke(java.lang.reflect.Method, java.lang.Object, [Ljava.lang.Object;)
+	at java.base@25.0.2/java.security.AccessController.wrapException(AccessController.java:394)
+	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:256)
+	at com.sun.javafx.reflect.MethodUtil.getTrampoline(MethodUtil.java:296)
+	... 18 more
+Caused by: java.lang.NoSuchMethodException: com.sun.javafx.reflect.Trampoline.invoke(java.lang.reflect.Method, java.lang.Object, [Ljava.lang.Object;)
+	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
+	at java.base@25.0.2/java.lang.Class.getDeclaredMethod(DynamicHub.java:1796)
+	at com.sun.javafx.reflect.MethodUtil$1.run(MethodUtil.java:303)
+	at com.sun.javafx.reflect.MethodUtil$1.run(MethodUtil.java:297)
+	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:251)
+	... 19 more
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:globalVetoableListenersAreRegisteredAndRemoved()]
+display-name: globalVetoableListenersAreRegisteredAndRemoved()
+]]></system-out>
+</testcase>
+<testcase name="propertySpecificVetoableListenersAreRegisteredAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
+<error message="Could not initialize class com.sun.javafx.property.MethodHelper" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.javafx.property.MethodHelper
+	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
+	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
+	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
+	at org_openjfx.javafx_base.PropertyDescriptorTest.propertySpecificVetoableListenersAreRegisteredAndRemoved(PropertyDescriptorTest.java:31)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:propertySpecificVetoableListenersAreRegisteredAndRemoved()]
+display-name: propertySpecificVetoableListenersAreRegisteredAndRemoved()
+]]></system-out>
+</testcase>
+<testcase name="namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
+<error message="Could not initialize class com.sun.javafx.property.MethodHelper" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.javafx.property.MethodHelper
+	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
+	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
+	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
+	at org_openjfx.javafx_base.PropertyDescriptorTest.namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved(PropertyDescriptorTest.java:51)
+	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
+	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
+	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
+	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
+	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
+	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
+]]></error>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()]
+display-name: namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()
+]]></system-out>
+</testcase>
+<testcase name="propertiesAndBindingsStayInSyncAcrossBindingModes()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:propertiesAndBindingsStayInSyncAcrossBindingModes()]
+display-name: propertiesAndBindingsStayInSyncAcrossBindingModes()
+]]></system-out>
+</testcase>
+<testcase name="filteredAndSortedListsReactToSourceAndElementChanges()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:filteredAndSortedListsReactToSourceAndElementChanges()]
+display-name: filteredAndSortedListsReactToSourceAndElementChanges()
+]]></system-out>
+</testcase>
+<testcase name="listPropertyTracksContentSizeAndAssignedLists()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:listPropertyTracksContentSizeAndAssignedLists()]
+display-name: listPropertyTracksContentSizeAndAssignedLists()
+]]></system-out>
+</testcase>
+<testcase name="observableMapAndSetListenersReportMutations()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:observableMapAndSetListenersReportMutations()]
+display-name: observableMapAndSetListenersReportMutations()
+]]></system-out>
+</testcase>
+<testcase name="eventDispatchChainUsesCustomDispatchersAndSupportsCopyFor()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:eventDispatchChainUsesCustomDispatchersAndSupportsCopyFor()]
+display-name: eventDispatchChainUsesCustomDispatchersAndSupportsCopyFor()
+]]></system-out>
+</testcase>
+<testcase name="observableIntegerArrayTracksChangesAndCopiesValues()" classname="org_openjfx.javafx_base.Javafx_baseTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.Javafx_baseTest]/[method:observableIntegerArrayTracksChangesAndCopiesValues()]
+display-name: observableIntegerArrayTracksChangesAndCopiesValues()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="3" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T11:14:52">
+<testsuite name="JUnit Jupiter" tests="11" skipped="0" failures="0" errors="0" time="0.001" hostname="kung-fu-workstation" timestamp="2026-05-03T11:20:00">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2049-9d64dafc/tests/src/org.openjfx/javafx-base/13-ea"/>
@@ -65,87 +64,18 @@ display-name: durationSentinelValuesPreserveSpecialStateAcrossOperations()
 ]]></system-out>
 </testcase>
 <testcase name="globalVetoableListenersAreRegisteredAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
-<error message="bouncer cannot be found" type="java.lang.InternalError"><![CDATA[java.lang.InternalError: bouncer cannot be found
-	at com.sun.javafx.reflect.MethodUtil.getTrampoline(MethodUtil.java:309)
-	at com.sun.javafx.reflect.MethodUtil.<clinit>(MethodUtil.java:86)
-	at com.sun.javafx.property.MethodHelper.<clinit>(MethodHelper.java:43)
-	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
-	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
-	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
-	at org_openjfx.javafx_base.PropertyDescriptorTest.globalVetoableListenersAreRegisteredAndRemoved(PropertyDescriptorTest.java:71)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-Caused by: java.security.PrivilegedActionException: java.lang.NoSuchMethodException: com.sun.javafx.reflect.Trampoline.invoke(java.lang.reflect.Method, java.lang.Object, [Ljava.lang.Object;)
-	at java.base@25.0.2/java.security.AccessController.wrapException(AccessController.java:394)
-	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:256)
-	at com.sun.javafx.reflect.MethodUtil.getTrampoline(MethodUtil.java:296)
-	... 18 more
-Caused by: java.lang.NoSuchMethodException: com.sun.javafx.reflect.Trampoline.invoke(java.lang.reflect.Method, java.lang.Object, [Ljava.lang.Object;)
-	at java.base@25.0.2/java.lang.Class.checkMethod(DynamicHub.java:1670)
-	at java.base@25.0.2/java.lang.Class.getDeclaredMethod(DynamicHub.java:1796)
-	at com.sun.javafx.reflect.MethodUtil$1.run(MethodUtil.java:303)
-	at com.sun.javafx.reflect.MethodUtil$1.run(MethodUtil.java:297)
-	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:251)
-	... 19 more
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:globalVetoableListenersAreRegisteredAndRemoved()]
 display-name: globalVetoableListenersAreRegisteredAndRemoved()
 ]]></system-out>
 </testcase>
 <testcase name="propertySpecificVetoableListenersAreRegisteredAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
-<error message="Could not initialize class com.sun.javafx.property.MethodHelper" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.javafx.property.MethodHelper
-	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
-	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
-	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
-	at org_openjfx.javafx_base.PropertyDescriptorTest.propertySpecificVetoableListenersAreRegisteredAndRemoved(PropertyDescriptorTest.java:31)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:propertySpecificVetoableListenersAreRegisteredAndRemoved()]
 display-name: propertySpecificVetoableListenersAreRegisteredAndRemoved()
 ]]></system-out>
 </testcase>
 <testcase name="namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()" classname="org_openjfx.javafx_base.PropertyDescriptorTest" time="0">
-<error message="Could not initialize class com.sun.javafx.property.MethodHelper" type="java.lang.NoClassDefFoundError"><![CDATA[java.lang.NoClassDefFoundError: Could not initialize class com.sun.javafx.property.MethodHelper
-	at javafx.beans.property.adapter.JavaBeanStringProperty.lambda$get$0(JavaBeanStringProperty.java:119)
-	at java.base@25.0.2/java.security.AccessController.doPrivileged(AccessController.java:138)
-	at javafx.beans.property.adapter.JavaBeanStringProperty.get(JavaBeanStringProperty.java:117)
-	at org_openjfx.javafx_base.PropertyDescriptorTest.namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved(PropertyDescriptorTest.java:51)
-	at java.base@25.0.2/java.lang.reflect.Method.invoke(Method.java:565)
-	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
-	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
-	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
-	at org.junit.jupiter.api.AssertTimeoutPreemptively.lambda$submitTask$3(AssertTimeoutPreemptively.java:95)
-	at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
-	at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
-	at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
-	at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:820)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:796)
-]]></error>
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_openjfx.javafx_base.PropertyDescriptorTest]/[method:namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()]
 display-name: namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved()

--- a/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:14:52">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:20:00">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2049-9d64dafc/tests/src/org.openjfx/javafx-base/13-ea"/>

--- a/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.openjfx/javafx-base/13-ea/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:14:52">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2049-9d64dafc/tests/src/org.openjfx/javafx-base/13-ea"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/org.openjfx/javafx-base/13-ea/user-code-filter.json
+++ b/tests/src/org.openjfx/javafx-base/13-ea/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.openjfx.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2049

This PR provides test fixes and new metadata for org.openjfx:javafx-base:13-ea, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 70257
- Cached input tokens: 895488
- Output tokens: 11037
- Metadata entries: 2
- Iterations: 2
- Library coverage percentage: 10.82
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 9.42

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `dbf45990418e92f227b0f362075bf4046d8cc67e`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.openjfx:javafx-base:11.0.2: 1/55 covered calls (1.82%)
- org.openjfx:javafx-base:13-ea: 18/58 covered calls (31.03%)

**Reflection:**
- org.openjfx:javafx-base:11.0.2: 1/54 covered calls (1.85%)
- org.openjfx:javafx-base:13-ea: 17/57 covered calls (29.82%)

**Resources:**
- org.openjfx:javafx-base:11.0.2: 0/1 covered calls (0.00%)
- org.openjfx:javafx-base:13-ea: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.openjfx:javafx-base:11.0.2: 5025/63455 (7.92%)
- org.openjfx:javafx-base:13-ea: 5818/63491 (9.16%)

**Line:**
- org.openjfx:javafx-base:11.0.2: 1345/14285 (9.42%)
- org.openjfx:javafx-base:13-ea: 1554/14360 (10.82%)

**Method:**
- org.openjfx:javafx-base:11.0.2: 411/4557 (9.02%)
- org.openjfx:javafx-base:13-ea: 460/4579 (10.05%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.openjfx/javafx-base/11.0.2/build.gradle 2/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
index 4b0b90bb5f..6f42678a10 100644
--- 1/tests/src/org.openjfx/javafx-base/11.0.2/build.gradle
+++ 2/tests/src/org.openjfx/javafx-base/13-ea/build.gradle
@@ -9,11 +9,12 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String dependencyVersion = libraryVersion == "13-ea" ? "13-ea+14b" : libraryVersion
 String osName = System.getProperty("os.name").toLowerCase()
 String javafxPlatform = osName.contains("win") ? "win" : osName.contains("mac") ? "mac" : "linux"
 
 dependencies {
-    testImplementation "org.openjfx:javafx-base:$libraryVersion:$javafxPlatform"
+    testImplementation "org.openjfx:javafx-base:$dependencyVersion:$javafxPlatform"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java 2/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java
new file mode 100644
index 0000000000..6887d8e1c3
--- /dev/null
+++ 2/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java
@@ -0,0 +1,155 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.beans.VetoableChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.beans.property.adapter.JavaBeanStringProperty;
+import javafx.beans.property.adapter.JavaBeanStringPropertyBuilder;
+import org.junit.jupiter.api.Test;
+
+public class PropertyDescriptorTest {
+
+    @Test
+    void propertySpecificVetoableListenersAreRegisteredAndRemoved() throws NoSuchMethodException {
+        PropertySpecificVetoableBean bean = new PropertySpecificVetoableBean("initial");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).isEmpty();
+            assertThat(property.get()).isEqualTo("initial");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).isEmpty();
+    }
+
+    @Test
+    void namedVetoableListenersAreRegisteredWithPropertyNameAndRemoved() throws NoSuchMethodException {
+        NamedVetoableBean bean = new NamedVetoableBean("named");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).containsExactly("title");
+            assertThat(property.get()).isEqualTo("named");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).containsExactly("title");
+    }
+
+    @Test
+    void globalVetoableListenersAreRegisteredAndRemoved() throws NoSuchMethodException {
+        GlobalVetoableBean bean = new GlobalVetoableBean("global");
+
+        JavaBeanStringProperty property = JavaBeanStringPropertyBuilder.create()
+                .bean(bean)
+                .name("title")
+                .build();
+        try {
+            assertThat(bean.addedListeners).hasSize(1);
+            assertThat(bean.addedProperties).isEmpty();
+            assertThat(property.get()).isEqualTo("global");
+        } finally {
+            property.dispose();
+        }
+
+        assertThat(bean.removedListeners).containsExactlyElementsOf(bean.addedListeners);
+        assertThat(bean.removedProperties).isEmpty();
+    }
+
+    public static final class PropertySpecificVetoableBean extends VetoableStringBean {
+        public PropertySpecificVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addTitleListener(VetoableChangeListener listener) {
+            recordAdded(null, listener);
+        }
+
+        public void removeTitleListener(VetoableChangeListener listener) {
+            recordRemoved(null, listener);
+        }
+    }
+
+    public static final class NamedVetoableBean extends VetoableStringBean {
+        public NamedVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+            recordAdded(propertyName, listener);
+        }
+
+        public void removeVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+            recordRemoved(propertyName, listener);
+        }
+    }
+
+    public static final class GlobalVetoableBean extends VetoableStringBean {
+        public GlobalVetoableBean(String title) {
+            super(title);
+        }
+
+        public void addVetoableChangeListener(VetoableChangeListener listener) {
+            recordAdded(null, listener);
+        }
+
+        public void removeVetoableChangeListener(VetoableChangeListener listener) {
+            recordRemoved(null, listener);
+        }
+    }
+
+    public abstract static class VetoableStringBean {
+        final List<String> addedProperties = new ArrayList<>();
+        final List<String> removedProperties = new ArrayList<>();
+        final List<VetoableChangeListener> addedListeners = new ArrayList<>();
+        final List<VetoableChangeListener> removedListeners = new ArrayList<>();
+        private String title;
+
+        VetoableStringBean(String title) {
+            this.title = title;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        void recordAdded(String propertyName, VetoableChangeListener listener) {
+            if (propertyName != null) {
+                addedProperties.add(propertyName);
+            }
+            addedListeners.add(listener);
+        }
+
+        void recordRemoved(String propertyName, VetoableChangeListener listener) {
+            if (propertyName != null) {
+                removedProperties.add(propertyName);
+            }
+            removedListeners.add(listener);
+        }
+    }
+}

```
