### PR TITLE
[GenAI] Add support for com.google.cloud:google-cloud-core-grpc:2.69.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.cloud/google-cloud-core-grpc/2.69.0/reachability-metadata.json
+++ b/metadata/com.google.cloud/google-cloud-core-grpc/2.69.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.GrpcTransportOptions"
+      },
+      "glob": "META-INF/services/com.google.cloud.grpc.GrpcTransportOptions$ExecutorFactory"
+    }
+  ]
+}

--- a/metadata/com.google.cloud/google-cloud-core-grpc/index.json
+++ b/metadata/com.google.cloud/google-cloud-core-grpc/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.69.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-core-grpc/$version$/google-cloud-core-grpc-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/sdk-platform-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-core-grpc/$version$/google-cloud-core-grpc-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-core-grpc/$version$/google-cloud-core-grpc-$version$-javadoc.jar",
+    "description" : "Google Cloud Core gRPC provides the shared gRPC transport support used by Google Cloud Java client libraries. It includes common transport options, service exception handling, and shared resource management for gRPC-based Google Cloud integrations.",
+    "tested-versions" : [
+      "2.69.0"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.grpc"
+    ]
+  }
+]

--- a/stats/com.google.cloud/google-cloud-core-grpc/2.69.0/execution-metrics.json
+++ b/stats/com.google.cloud/google-cloud-core-grpc/2.69.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T09:25:42.242536Z",
+    "library": "com.google.cloud:google-cloud-core-grpc:2.69.0",
+    "starting_commit": "e07b72ec743a716203bcbf069ce2e9741cf46752",
+    "ending_commit": "6263ff635964a7ebd5f66cce24b08c32c4fed339",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.69.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 352,
+          "missed": 183,
+          "ratio": 0.657944,
+          "total": 535
+        },
+        "line": {
+          "covered": 92,
+          "missed": 55,
+          "ratio": 0.62585,
+          "total": 147
+        },
+        "method": {
+          "covered": 32,
+          "missed": 9,
+          "ratio": 0.780488,
+          "total": 41
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 167863,
+      "cached_input_tokens_used": 2793984,
+      "output_tokens_used": 29183,
+      "iterations": 3,
+      "cost_usd": 2.2725,
+      "generated_loc": 383,
+      "tested_library_loc": 92,
+      "metadata_entries": 1,
+      "code_coverage_percent": 62.59
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java",
+      "metadata_file": "metadata/com.google.cloud/google-cloud-core-grpc/2.69.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.cloud/google-cloud-core-grpc/2.69.0/stats.json
+++ b/stats/com.google.cloud/google-cloud-core-grpc/2.69.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.69.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 352,
+        "missed" : 183,
+        "ratio" : 0.657944,
+        "total" : 535
+      },
+      "line" : {
+        "covered" : 92,
+        "missed" : 55,
+        "ratio" : 0.62585,
+        "total" : 147
+      },
+      "method" : {
+        "covered" : 32,
+        "missed" : 9,
+        "ratio" : 0.780488,
+        "total" : 41
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/.gitignore
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/build.gradle
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.cloud:google-cloud-core-grpc:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/gradle.properties
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.cloud:google-cloud-core-grpc:2.69.0
+library.version = 2.69.0
+metadata.dir = com.google.cloud/google-cloud-core-grpc/2.69.0/

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/settings.gradle
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.cloud.google-cloud-core-grpc_tests'

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
@@ -17,6 +17,7 @@ import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.Service;
 import com.google.cloud.ServiceDefaults;
@@ -29,7 +30,9 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.spi.ServiceRpcFactory;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -143,6 +146,27 @@ public class Google_cloud_core_grpcTest {
     }
 
     @Test
+    void credentialsProviderScopesGoogleCredentialsBeforeWrapping() throws IOException {
+        Set<String> scopes =
+                Collections.singleton("https://www.googleapis.com/auth/cloud-platform");
+        ScopingGoogleCredentials credentials = new ScopingGoogleCredentials();
+        TestServiceOptions serviceOptions =
+                newTestOptions("example.googleapis.com:443", credentials, scopes);
+
+        CredentialsProvider credentialsProvider =
+                GrpcTransportOptions.setUpCredentialsProvider(serviceOptions);
+
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+        assertThat(credentialsProvider.getCredentials())
+                .isInstanceOf(ScopingGoogleCredentials.class);
+        ScopingGoogleCredentials scopedCredentials =
+                (ScopingGoogleCredentials) credentialsProvider.getCredentials();
+        assertThat(scopedCredentials).isNotSameAs(credentials);
+        assertThat(scopedCredentials.scopes()).containsExactlyElementsOf(scopes);
+        assertThat(credentials.createScopedCalls()).isEqualTo(1);
+    }
+
+    @Test
     void grpcServiceExceptionCopiesRetryableApiExceptionDetails() {
         Throwable cause = new IllegalStateException("backend unavailable");
         StatusCode statusCode = new FixedStatusCode(StatusCode.Code.UNAVAILABLE, "grpc-14");
@@ -176,10 +200,16 @@ public class Google_cloud_core_grpcTest {
     }
 
     private static TestServiceOptions newTestOptions(String host, Credentials credentials) {
+        return newTestOptions(host, credentials, Collections.emptySet());
+    }
+
+    private static TestServiceOptions newTestOptions(
+            String host, Credentials credentials, Set<String> scopes) {
         return TestServiceOptions.newBuilder()
                 .setProjectId("test-project")
                 .setHost(host)
                 .setCredentials(credentials)
+                .setScopes(scopes)
                 .build();
     }
 
@@ -264,6 +294,40 @@ public class Google_cloud_core_grpcTest {
         }
     }
 
+    private static final class ScopingGoogleCredentials extends GoogleCredentials {
+        private static final long serialVersionUID = 1L;
+        private final Set<String> scopes;
+        private int createScopedCalls;
+
+        private ScopingGoogleCredentials() {
+            this(Collections.emptySet());
+        }
+
+        private ScopingGoogleCredentials(Collection<String> scopes) {
+            super();
+            this.scopes = Collections.unmodifiableSet(new LinkedHashSet<>(scopes));
+        }
+
+        @Override
+        public boolean createScopedRequired() {
+            return scopes.isEmpty();
+        }
+
+        @Override
+        public GoogleCredentials createScoped(Collection<String> scopes) {
+            createScopedCalls++;
+            return new ScopingGoogleCredentials(scopes);
+        }
+
+        Set<String> scopes() {
+            return scopes;
+        }
+
+        int createScopedCalls() {
+            return createScopedCalls;
+        }
+    }
+
     private interface TestService extends Service<TestServiceOptions> {
     }
 
@@ -322,6 +386,7 @@ public class Google_cloud_core_grpcTest {
     public static final class TestServiceOptions
             extends ServiceOptions<TestService, TestServiceOptions> {
         private static final long serialVersionUID = 1L;
+        private final Set<String> scopes;
 
         private TestServiceOptions(Builder builder) {
             super(
@@ -329,6 +394,7 @@ public class Google_cloud_core_grpcTest {
                     TestServiceRpcFactory.class,
                     builder,
                     TestServiceDefaults.INSTANCE);
+            this.scopes = builder.scopes;
         }
 
         static Builder newBuilder() {
@@ -342,7 +408,7 @@ public class Google_cloud_core_grpcTest {
 
         @Override
         protected Set<String> getScopes() {
-            return Collections.emptySet();
+            return scopes;
         }
 
         @Override
@@ -352,11 +418,19 @@ public class Google_cloud_core_grpcTest {
 
         public static final class Builder
                 extends ServiceOptions.Builder<TestService, TestServiceOptions, Builder> {
+            private Set<String> scopes = Collections.emptySet();
+
             private Builder() {
             }
 
             private Builder(TestServiceOptions options) {
                 super(options);
+                this.scopes = options.scopes;
+            }
+
+            private Builder setScopes(Set<String> scopes) {
+                this.scopes = Collections.unmodifiableSet(new LinkedHashSet<>(scopes));
+                return this;
             }
 
             @Override

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
@@ -167,6 +167,25 @@ public class Google_cloud_core_grpcTest {
     }
 
     @Test
+    void credentialsProviderPreservesAlreadyScopedGoogleCredentials() throws IOException {
+        Set<String> credentialScopes =
+                Collections.singleton("https://www.googleapis.com/auth/devstorage.read_only");
+        Set<String> serviceScopes =
+                Collections.singleton("https://www.googleapis.com/auth/cloud-platform");
+        ScopingGoogleCredentials credentials = new ScopingGoogleCredentials(credentialScopes);
+        TestServiceOptions serviceOptions =
+                newTestOptions("example.googleapis.com:443", credentials, serviceScopes);
+
+        CredentialsProvider credentialsProvider =
+                GrpcTransportOptions.setUpCredentialsProvider(serviceOptions);
+
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+        assertThat(credentialsProvider.getCredentials()).isSameAs(credentials);
+        assertThat(credentials.scopes()).containsExactlyElementsOf(credentialScopes);
+        assertThat(credentials.createScopedCalls()).isZero();
+    }
+
+    @Test
     void grpcServiceExceptionCopiesRetryableApiExceptionDetails() {
         Throwable cause = new IllegalStateException("backend unavailable");
         StatusCode statusCode = new FixedStatusCode(StatusCode.Code.UNAVAILABLE, "grpc-14");

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_cloud.google_cloud_core_grpc;
+
+import org.junit.jupiter.api.Test;
+
+class Google_cloud_core_grpcTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/src/test/java/com_google_cloud/google_cloud_core_grpc/Google_cloud_core_grpcTest.java
@@ -6,11 +6,363 @@
  */
 package com_google_cloud.google_cloud_core_grpc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.Service;
+import com.google.cloud.ServiceDefaults;
+import com.google.cloud.ServiceFactory;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.ServiceRpc;
+import com.google.cloud.TransportOptions;
+import com.google.cloud.grpc.BaseGrpcServiceException;
+import com.google.cloud.grpc.GrpcTransportOptions;
+import com.google.cloud.spi.ServiceRpcFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class Google_cloud_core_grpcTest {
+public class Google_cloud_core_grpcTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultTransportOptionsProvideSharedUsableExecutor()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        GrpcTransportOptions transportOptions = GrpcTransportOptions.newBuilder().build();
+        GrpcTransportOptions sameDefaults = GrpcTransportOptions.newBuilder().build();
+
+        assertThat(transportOptions).isEqualTo(sameDefaults);
+        assertThat(transportOptions.hashCode()).isEqualTo(sameDefaults.hashCode());
+
+        GrpcTransportOptions.ExecutorFactory<ScheduledExecutorService> executorFactory =
+                transportOptions.getExecutorFactory();
+        ScheduledExecutorService firstExecutor = executorFactory.get();
+        ScheduledExecutorService secondExecutor = executorFactory.get();
+        try {
+            assertThat(secondExecutor).isSameAs(firstExecutor);
+
+            Future<String> future =
+                    firstExecutor.schedule(() -> "scheduled", 1, TimeUnit.MILLISECONDS);
+
+            assertThat(future.get(5, TimeUnit.SECONDS)).isEqualTo("scheduled");
+        } finally {
+            executorFactory.release(secondExecutor);
+            executorFactory.release(firstExecutor);
+        }
+    }
+
+    @Test
+    void customExecutorFactoryIsPreservedByBuilderAndReleased()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        RecordingExecutorFactory executorFactory = new RecordingExecutorFactory();
+        GrpcTransportOptions transportOptions =
+                GrpcTransportOptions.newBuilder().setExecutorFactory(executorFactory).build();
+        GrpcTransportOptions rebuiltOptions = transportOptions.toBuilder().build();
+        GrpcTransportOptions equivalentOptions =
+                GrpcTransportOptions.newBuilder()
+                        .setExecutorFactory(new RecordingExecutorFactory())
+                        .build();
+
+        assertThat(transportOptions.getExecutorFactory()).isSameAs(executorFactory);
+        assertThat(rebuiltOptions).isEqualTo(transportOptions);
+        assertThat(rebuiltOptions.getExecutorFactory()).isSameAs(executorFactory);
+        assertThat(transportOptions).isEqualTo(equivalentOptions);
+        assertThat(transportOptions).isNotEqualTo(GrpcTransportOptions.newBuilder().build());
+
+        ScheduledExecutorService executor = transportOptions.getExecutorFactory().get();
+        try {
+            Future<Integer> future = executor.submit(() -> 42);
+
+            assertThat(future.get(5, TimeUnit.SECONDS)).isEqualTo(42);
+            assertThat(executorFactory.getCalls()).isEqualTo(1);
+        } finally {
+            transportOptions.getExecutorFactory().release(executor);
+        }
+
+        assertThat(executorFactory.releaseCalls()).isEqualTo(1);
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void channelProviderUsesServiceOptionsHost() {
+        String endpoint = "localhost:8443";
+        TestServiceOptions serviceOptions = newTestOptions(endpoint, NoCredentials.getInstance());
+
+        TransportChannelProvider channelProvider =
+                GrpcTransportOptions.setUpChannelProvider(
+                        InstantiatingGrpcChannelProvider.newBuilder(), serviceOptions);
+
+        assertThat(channelProvider).isInstanceOf(InstantiatingGrpcChannelProvider.class);
+        assertThat(channelProvider.getEndpoint()).isEqualTo(endpoint);
+        assertThat(channelProvider.getTransportName()).isEqualTo("grpc");
+        assertThat(channelProvider.needsEndpoint()).isFalse();
+    }
+
+    @Test
+    void credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()
+            throws IOException {
+        TestServiceOptions serviceOptions =
+                newTestOptions("example.googleapis.com:443", NoCredentials.getInstance());
+
+        CredentialsProvider credentialsProvider =
+                GrpcTransportOptions.setUpCredentialsProvider(serviceOptions);
+
+        assertThat(credentialsProvider).isInstanceOf(NoCredentialsProvider.class);
+        assertThat(credentialsProvider.getCredentials()).isNull();
+    }
+
+    @Test
+    void credentialsProviderWrapsScopedServiceCredentials() throws IOException {
+        TestCredentials credentials = new TestCredentials();
+        TestServiceOptions serviceOptions =
+                newTestOptions("example.googleapis.com:443", credentials);
+
+        CredentialsProvider credentialsProvider =
+                GrpcTransportOptions.setUpCredentialsProvider(serviceOptions);
+
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+        assertThat(credentialsProvider.getCredentials()).isSameAs(credentials);
+    }
+
+    @Test
+    void grpcServiceExceptionCopiesRetryableApiExceptionDetails() {
+        Throwable cause = new IllegalStateException("backend unavailable");
+        StatusCode statusCode = new FixedStatusCode(StatusCode.Code.UNAVAILABLE, "grpc-14");
+        ApiException apiException =
+                ApiExceptionFactory.createException("grpc request failed", cause, statusCode, true);
+
+        BaseGrpcServiceException exception = new BaseGrpcServiceException(apiException);
+
+        assertThat(exception).hasMessageContaining("grpc request failed");
+        assertThat(exception.getCause()).isSameAs(apiException);
+        assertThat(exception.getCode()).isEqualTo(StatusCode.Code.UNAVAILABLE.getHttpStatusCode());
+        assertThat(exception.getReason()).isEqualTo("UNAVAILABLE");
+        assertThat(exception.isRetryable()).isTrue();
+        assertThat(exception.getLocation()).isNull();
+        assertThat(exception.getDebugInfo()).isNull();
+    }
+
+    @Test
+    void grpcServiceExceptionCopiesNonRetryableApiExceptionDetails() {
+        StatusCode statusCode = new FixedStatusCode(StatusCode.Code.NOT_FOUND, "grpc-5");
+        ApiException apiException =
+                ApiExceptionFactory.createException("missing resource", null, statusCode, false);
+
+        BaseGrpcServiceException exception = new BaseGrpcServiceException(apiException);
+
+        assertThat(exception).hasMessageContaining("missing resource");
+        assertThat(exception.getCause()).isSameAs(apiException);
+        assertThat(exception.getCode()).isEqualTo(StatusCode.Code.NOT_FOUND.getHttpStatusCode());
+        assertThat(exception.getReason()).isEqualTo("NOT_FOUND");
+        assertThat(exception.isRetryable()).isFalse();
+    }
+
+    private static TestServiceOptions newTestOptions(String host, Credentials credentials) {
+        return TestServiceOptions.newBuilder()
+                .setProjectId("test-project")
+                .setHost(host)
+                .setCredentials(credentials)
+                .build();
+    }
+
+    private static final class RecordingExecutorFactory
+            implements GrpcTransportOptions.ExecutorFactory<ScheduledExecutorService> {
+        private final ScheduledExecutorService executor =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> {
+                            Thread thread =
+                                    new Thread(runnable, "google-cloud-core-grpc-test-executor");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+        private final AtomicInteger getCalls = new AtomicInteger();
+        private final AtomicInteger releaseCalls = new AtomicInteger();
+
+        @Override
+        public ScheduledExecutorService get() {
+            getCalls.incrementAndGet();
+            return executor;
+        }
+
+        @Override
+        public void release(ScheduledExecutorService executor) {
+            releaseCalls.incrementAndGet();
+            executor.shutdownNow();
+        }
+
+        int getCalls() {
+            return getCalls.get();
+        }
+
+        int releaseCalls() {
+            return releaseCalls.get();
+        }
+    }
+
+    private static final class FixedStatusCode implements StatusCode {
+        private final StatusCode.Code code;
+        private final Object transportCode;
+
+        private FixedStatusCode(StatusCode.Code code, Object transportCode) {
+            this.code = code;
+            this.transportCode = transportCode;
+        }
+
+        @Override
+        public StatusCode.Code getCode() {
+            return code;
+        }
+
+        @Override
+        public Object getTransportCode() {
+            return transportCode;
+        }
+    }
+
+    private static final class TestCredentials extends Credentials {
+        @Override
+        public String getAuthenticationType() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, List<String>> getRequestMetadata(URI uri) {
+            return Collections.singletonMap(
+                    "Authorization", Collections.singletonList("Bearer test-token"));
+        }
+
+        @Override
+        public boolean hasRequestMetadata() {
+            return true;
+        }
+
+        @Override
+        public boolean hasRequestMetadataOnly() {
+            return true;
+        }
+
+        @Override
+        public void refresh() {
+        }
+    }
+
+    private interface TestService extends Service<TestServiceOptions> {
+    }
+
+    public static final class TestServiceImpl implements TestService {
+        private final TestServiceOptions options;
+
+        private TestServiceImpl(TestServiceOptions options) {
+            this.options = options;
+        }
+
+        @Override
+        public TestServiceOptions getOptions() {
+            return options;
+        }
+    }
+
+    public static final class TestServiceRpc implements ServiceRpc {
+    }
+
+    public static final class TestServiceFactory
+            implements ServiceFactory<TestService, TestServiceOptions> {
+        @Override
+        public TestService create(TestServiceOptions options) {
+            return new TestServiceImpl(options);
+        }
+    }
+
+    public static final class TestServiceRpcFactory
+            implements ServiceRpcFactory<TestServiceOptions> {
+        @Override
+        public ServiceRpc create(TestServiceOptions options) {
+            return new TestServiceRpc();
+        }
+    }
+
+    private static final class TestServiceDefaults
+            implements ServiceDefaults<TestService, TestServiceOptions> {
+        private static final TestServiceDefaults INSTANCE = new TestServiceDefaults();
+
+        @Override
+        public ServiceFactory<TestService, TestServiceOptions> getDefaultServiceFactory() {
+            return new TestServiceFactory();
+        }
+
+        @Override
+        public ServiceRpcFactory<TestServiceOptions> getDefaultRpcFactory() {
+            return new TestServiceRpcFactory();
+        }
+
+        @Override
+        public TransportOptions getDefaultTransportOptions() {
+            return GrpcTransportOptions.newBuilder().build();
+        }
+    }
+
+    public static final class TestServiceOptions
+            extends ServiceOptions<TestService, TestServiceOptions> {
+        private static final long serialVersionUID = 1L;
+
+        private TestServiceOptions(Builder builder) {
+            super(
+                    TestServiceFactory.class,
+                    TestServiceRpcFactory.class,
+                    builder,
+                    TestServiceDefaults.INSTANCE);
+        }
+
+        static Builder newBuilder() {
+            return new Builder();
+        }
+
+        @Override
+        protected boolean projectIdRequired() {
+            return false;
+        }
+
+        @Override
+        protected Set<String> getScopes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Builder toBuilder() {
+            return new Builder(this);
+        }
+
+        public static final class Builder
+                extends ServiceOptions.Builder<TestService, TestServiceOptions, Builder> {
+            private Builder() {
+            }
+
+            private Builder(TestServiceOptions options) {
+                super(options);
+            }
+
+            @Override
+            public TestServiceOptions build() {
+                return new TestServiceOptions(this);
+            }
+        }
     }
 }

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T11:19:49">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T11:22:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -80,6 +80,12 @@ display-name: credentialsProviderScopesGoogleCredentialsBeforeWrapping()
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()]
 display-name: grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()
+]]></system-out>
+</testcase>
+<testcase name="credentialsProviderPreservesAlreadyScopedGoogleCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderPreservesAlreadyScopedGoogleCredentials()]
+display-name: credentialsProviderPreservesAlreadyScopedGoogleCredentials()
 ]]></system-out>
 </testcase>
 <testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T11:22:01">
+<testsuite name="JUnit Jupiter" tests="9" skipped="0" failures="0" errors="0" time="0.012" hostname="kung-fu-workstation" timestamp="2026-05-03T11:24:35">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4743-cf36c141/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0"/>
@@ -64,7 +63,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc
 display-name: credentialsProviderWrapsScopedServiceCredentials()
 ]]></system-out>
 </testcase>
-<testcase name="grpcServiceExceptionCopiesRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<testcase name="grpcServiceExceptionCopiesRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:grpcServiceExceptionCopiesRetryableApiExceptionDetails()]
 display-name: grpcServiceExceptionCopiesRetryableApiExceptionDetails()
@@ -82,19 +81,19 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc
 display-name: grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()
 ]]></system-out>
 </testcase>
-<testcase name="credentialsProviderPreservesAlreadyScopedGoogleCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<testcase name="credentialsProviderPreservesAlreadyScopedGoogleCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderPreservesAlreadyScopedGoogleCredentials()]
 display-name: credentialsProviderPreservesAlreadyScopedGoogleCredentials()
 ]]></system-out>
 </testcase>
-<testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
+<testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:defaultTransportOptionsProvideSharedUsableExecutor()]
 display-name: defaultTransportOptionsProvideSharedUsableExecutor()
 ]]></system-out>
 </testcase>
-<testcase name="credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<testcase name="credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()]
 display-name: credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-03T11:16:34">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4743-cf36c141/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="customExecutorFactoryIsPreservedByBuilderAndReleased()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:customExecutorFactoryIsPreservedByBuilderAndReleased()]
+display-name: customExecutorFactoryIsPreservedByBuilderAndReleased()
+]]></system-out>
+</testcase>
+<testcase name="credentialsProviderWrapsScopedServiceCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderWrapsScopedServiceCredentials()]
+display-name: credentialsProviderWrapsScopedServiceCredentials()
+]]></system-out>
+</testcase>
+<testcase name="grpcServiceExceptionCopiesRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:grpcServiceExceptionCopiesRetryableApiExceptionDetails()]
+display-name: grpcServiceExceptionCopiesRetryableApiExceptionDetails()
+]]></system-out>
+</testcase>
+<testcase name="grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()]
+display-name: grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()
+]]></system-out>
+</testcase>
+<testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:defaultTransportOptionsProvideSharedUsableExecutor()]
+display-name: defaultTransportOptionsProvideSharedUsableExecutor()
+]]></system-out>
+</testcase>
+<testcase name="credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()]
+display-name: credentialsProviderUsesNoCredentialsProviderWhenCredentialsAreDisabled()
+]]></system-out>
+</testcase>
+<testcase name="channelProviderUsesServiceOptionsHost()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:channelProviderUsesServiceOptionsHost()]
+display-name: channelProviderUsesServiceOptionsHost()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="7" skipped="0" failures="0" errors="0" time="0.011" hostname="kung-fu-workstation" timestamp="2026-05-03T11:16:34">
+<testsuite name="JUnit Jupiter" tests="8" skipped="0" failures="0" errors="0" time="0.004" hostname="kung-fu-workstation" timestamp="2026-05-03T11:19:49">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
@@ -52,22 +52,28 @@
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="customExecutorFactoryIsPreservedByBuilderAndReleased()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
+<testcase name="customExecutorFactoryIsPreservedByBuilderAndReleased()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:customExecutorFactoryIsPreservedByBuilderAndReleased()]
 display-name: customExecutorFactoryIsPreservedByBuilderAndReleased()
 ]]></system-out>
 </testcase>
-<testcase name="credentialsProviderWrapsScopedServiceCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
+<testcase name="credentialsProviderWrapsScopedServiceCredentials()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderWrapsScopedServiceCredentials()]
 display-name: credentialsProviderWrapsScopedServiceCredentials()
 ]]></system-out>
 </testcase>
-<testcase name="grpcServiceExceptionCopiesRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.003">
+<testcase name="grpcServiceExceptionCopiesRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:grpcServiceExceptionCopiesRetryableApiExceptionDetails()]
 display-name: grpcServiceExceptionCopiesRetryableApiExceptionDetails()
+]]></system-out>
+</testcase>
+<testcase name="credentialsProviderScopesGoogleCredentialsBeforeWrapping()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:credentialsProviderScopesGoogleCredentialsBeforeWrapping()]
+display-name: credentialsProviderScopesGoogleCredentialsBeforeWrapping()
 ]]></system-out>
 </testcase>
 <testcase name="grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0">
@@ -76,7 +82,7 @@ unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc
 display-name: grpcServiceExceptionCopiesNonRetryableApiExceptionDetails()
 ]]></system-out>
 </testcase>
-<testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.002">
+<testcase name="defaultTransportOptionsProvideSharedUsableExecutor()" classname="com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_google_cloud.google_cloud_core_grpc.Google_cloud_core_grpcTest]/[method:defaultTransportOptionsProvideSharedUsableExecutor()]
 display-name: defaultTransportOptionsProvideSharedUsableExecutor()

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:16:34">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4743-cf36c141/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:22:01">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:24:35">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
-<property name="java.version" value="25.0.2"/>
-<property name="java.version.date" value="2026-01-20"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.2+10-LTS"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
-<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
-<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,7 +43,6 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
-<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
 <property name="user.dir" value="/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/4743-cf36c141/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0"/>

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:16:34">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:19:49">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:19:49">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:22:01">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/user-code-filter.json
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.grpc.**"
+      "includeClasses" : "com.google.cloud.grpc.**"
     }
   ]
 }

--- a/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/user-code-filter.json
+++ b/tests/src/com.google.cloud/google-cloud-core-grpc/2.69.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.grpc.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4743

This PR introduces tests and metadata for com.google.cloud:google-cloud-core-grpc:2.69.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 167863
- Cached input tokens: 2793984
- Output tokens: 29183
- Metadata entries: 1
- Iterations: 3
- Library coverage percentage: 62.59
- Generated lines of code: 383
- Tested library lines of code: 92

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5e0b2ac606599cfa86204b225fd8b7f110f5900c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 352/535 (65.79%)
- Line: 92/147 (62.59%)
- Method: 32/41 (78.05%)
