### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
@@ -1,0 +1,46 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getRecordComponents",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ArrayReader"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "java.lang.reflect.RecordComponent",
+      "methods" : [
+        {
+          "name" : "getType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.21.0",
+    "tested-versions" : [
+      "2.21.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.jr"
+    ]
+  },
+  {
     "metadata-version" : "2.17.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-jr",

--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.21.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-jr",
+    "test-code-url" : "https://github.com/FasterXML/jackson-jr/tree/jackson-jr-parent-$version$/jr-objects/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/jr/jackson-jr-objects/$version$/jackson-jr-objects-$version$-javadoc.jar",
+    "description" : "Jackson Jr Objects is a lightweight data-binding module for reading JSON into maps, lists, strings, wrapper types, arrays, and Java beans, and for writing those values back as JSON. It builds on jackson-core with minimal dependencies and provides immutable JSON entry points plus builder-style composer APIs for direct JSON output.",
     "tested-versions" : [
       "2.21.0"
     ],

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
@@ -1,0 +1,89 @@
+{
+  "fix_javac_fail:2026-05-03": {
+    "timestamp": "2026-05-03T09:29:42.695665Z",
+    "library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0",
+    "starting_commit": "6eeec42128d0589b6740f1f54312ea6fac3a0ff9",
+    "ending_commit": "56b85ec4b0ba658740e5265a8e77e6f756d5b5a6",
+    "previous_library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.21.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5349,
+          "missed": 8361,
+          "ratio": 0.390153,
+          "total": 13710
+        },
+        "method": {
+          "covered": 286,
+          "missed": 419,
+          "ratio": 0.405674,
+          "total": 705
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4596,
+          "missed": 7891,
+          "ratio": 0.368063,
+          "total": 12487
+        },
+        "method": {
+          "covered": 255,
+          "missed": 411,
+          "ratio": 0.382883,
+          "total": 666
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 1115902,
+      "cached_input_tokens_used": 16345088,
+      "output_tokens_used": 125716,
+      "iterations": 22,
+      "cost_usd": 11.944,
+      "tested_library_loc": 0,
+      "metadata_entries": 7,
+      "test_only_metadata_entries": 129,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 47,
+      "code_coverage_percent": 39.02,
+      "previous_library_coverage_percent": 36.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
@@ -1,0 +1,32 @@
+{
+  "versions" : [ {
+    "version" : "2.21.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 21
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 21
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5349,
+        "missed" : 8361,
+        "ratio" : 0.390153,
+        "total" : 13710
+      },
+      "line" : "N/A",
+      "method" : {
+        "covered" : 286,
+        "missed" : 419,
+        "ratio" : 0.405674,
+        "total" : 705
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.jr:jackson-jr-objects:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0
+library.version = 2.21.0
+metadata.dir = com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.jr.jackson-jr-objects_tests'

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanConstructorsDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @BeforeEach
+    void resetConstructorCounters() {
+        PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
+        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+
+        PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
+        constructors.addNoArgsConstructor(constructor);
+        constructors.forceAccess();
+
+        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
+
+        assertThat(bean).isNotNull();
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    static final class AccessibleBeanConstructors extends BeanConstructors {
+        AccessibleBeanConstructors(Class<?> valueType) {
+            super(valueType);
+        }
+
+        Object createBean() throws Exception {
+            return create();
+        }
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -18,11 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanConstructorsDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final AtomicInteger RECORD_CTOR_CALLS = new AtomicInteger();
 
     @BeforeEach
     void resetConstructorCounters() {
         PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
         PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        RECORD_CTOR_CALLS.set(0);
     }
 
     @Test
@@ -59,6 +61,28 @@ public class BeanConstructorsDynamicAccessTest {
     }
 
     @Test
+    void createsRecordsDirectlyThroughCanonicalConstructors() throws Exception {
+        Constructor<RecordCtorBean> constructor = RecordCtorBean.class.getDeclaredConstructor(String.class, int.class);
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(RecordCtorBean.class);
+        constructors.addRecordConstructor(constructor);
+
+        RecordCtorBean bean = (RecordCtorBean) constructors.createRecordBean("Ada", 37);
+
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.age()).isEqualTo(37);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        RecordCtorBean bean = JSON.std.beanFrom(RecordCtorBean.class, "{\"name\":\"Ada\",\"age\":37}");
+
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.age()).isEqualTo(37);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+    }
+
+    @Test
     void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
         PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
                 "{\"name\":\"Ada\"}");
@@ -74,6 +98,10 @@ public class BeanConstructorsDynamicAccessTest {
 
         Object createBean() throws Exception {
             return create();
+        }
+
+        Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
         }
     }
 
@@ -94,6 +122,12 @@ public class BeanConstructorsDynamicAccessTest {
 
         private PrivateDefaultCtorBean() {
             CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public record RecordCtorBean(String name, int age) {
+        public RecordCtorBean {
+            RECORD_CTOR_CALLS.incrementAndGet();
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyIntrospectorDynamicAccessTest {
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+    private static final JSONWriter JSON_WRITER = new JSONWriter();
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final JSON JSON_WITH_FIELD_MATCHING_GETTERS = JSON_WITH_FORCE_ACCESS.with(
+            JSON.Feature.USE_FIELD_MATCHING_GETTERS);
+
+    @Test
+    void collectsDeclaredConstructorsForDeserialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
+
+        IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
+                "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
+        IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
+        IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
+
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(objectBean.getName()).isEqualTo("Ada");
+        assertThat(objectBean.isActive()).isTrue();
+        assertThat(objectBean.visible).isEqualTo(7);
+        assertThat(stringBean.getName()).isEqualTo("Ada");
+        assertThat(longBean.visible).isEqualTo(7);
+    }
+
+    @Test
+    void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
+        String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
+
+        assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
+        assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
+
+        POJODefinition.Prop visible = property(definition, "visible");
+        POJODefinition.Prop name = property(definition, "name");
+        POJODefinition.Prop active = property(definition, "active");
+
+        assertThat(visible.field).isNotNull();
+        assertThat(name.getter).isNotNull();
+        assertThat(name.setter).isNotNull();
+        assertThat(active.isGetter).isNotNull();
+        assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void supportsFieldNamedGettersWhenEnabled() throws Exception {
+        String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
+
+        assertThat(json).contains("\"title\":\"Ada\"");
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    private static POJODefinition.Prop property(POJODefinition definition, String name) {
+        return definition.getProperties().stream()
+                .filter(prop -> prop.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    static class BaseBean {
+        public int visible;
+    }
+
+    static final class IntrospectedBean extends BaseBean {
+        private String name;
+        private boolean active;
+
+        private IntrospectedBean() {
+        }
+
+        private IntrospectedBean(String name) {
+            this.name = name;
+        }
+
+        private IntrospectedBean(long visible) {
+            this.visible = (int) visible;
+        }
+
+        static IntrospectedBean create(String name, boolean active, int visible) {
+            IntrospectedBean bean = new IntrospectedBean();
+            bean.name = name;
+            bean.active = active;
+            bean.visible = visible;
+            return bean;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    static final class FieldNamedGetterBean {
+        private final String title;
+
+        FieldNamedGetterBean(String title) {
+            this.title = title;
+        }
+
+        public String title() {
+            return title;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -30,18 +30,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
     @Test
     void collectsDeclaredConstructorsForDeserialization() throws Exception {
+        BeanConstructors constructors = new BeanConstructors(IntrospectedBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(IntrospectedBean.class, constructors);
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
-        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
 
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
         IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
         IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
 
+        assertThat(constructors).isNotNull();
         assertThat(definition.constructors()).isNotNull();
-        assertThat(libraryDefinition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
-        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
         assertThat(objectBean.getName()).isEqualTo("Ada");
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
@@ -52,14 +52,9 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
-        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
-        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
-                BeanConstructors.class);
         String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
-        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
-        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
         assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");
@@ -71,6 +66,20 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(name.setter).isNotNull();
         assertThat(active.isGetter).isNotNull();
         assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void collectsIntegerConstructorsForNumericScalarDeserialization() throws Exception {
+        BeanConstructors constructors = new BeanConstructors(IntConstructorBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(IntConstructorBean.class, constructors);
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntConstructorBean.class);
+
+        IntConstructorBean bean = JSON.std.beanFrom(IntConstructorBean.class, "13");
+
+        assertThat(constructors).isNotNull();
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(propertyNames(definition)).contains("value");
+        assertThat(bean.getValue()).isEqualTo(13);
     }
 
     @Test
@@ -132,6 +141,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         public void setActive(boolean active) {
             this.active = active;
+        }
+    }
+
+    public static final class IntConstructorBean {
+        private final int value;
+
+        public IntConstructorBean(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{3});
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+    }
+
+    @Test
+    void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        reader.setValueFor(bean, new Object[]{"Ada"});
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldBackedBeanProperties() throws Exception {
+        FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(3);
+        assertThat(bean.y).isEqualTo(4);
+    }
+
+    @Test
+    void populatesPublicSetterBackedProperties() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFluentSetterBackedProperties() throws Exception {
+        FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPrivateSetterBackedProperties() throws Exception {
+        SetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(SetterBackedReaderBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    public static final class FieldBackedReaderBean {
+        private boolean constructed;
+        public int x;
+        public int y;
+
+        public FieldBackedReaderBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PublicSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public PublicSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class FluentSetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public FluentSetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public FluentSetterBackedReaderBean setName(String name) {
+            this.name = name;
+            setterCalls++;
+            return this;
+        }
+    }
+
+    public static final class SetterBackedReaderBean {
+        private String name;
+        private int setterCalls;
+
+        public SetterBackedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        private void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,10 +7,12 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
@@ -39,6 +41,31 @@ public class BeanPropertyReaderDynamicAccessTest {
     }
 
     @Test
+    void reportsFieldBackedAssignmentFailuresFromBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{"not an int"}))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to set property 'x' (raw type int) to value of type java.lang.String");
+        assertThat(bean.x).isZero();
+    }
+
+    @Test
+    void reportsSetterBackedInvocationFailuresFromBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{13}))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining(
+                        "Failed to set property 'name' (raw type java.lang.String) to value of type java.lang.Integer");
+        assertThat(bean.getName()).isNull();
+        assertThat(bean.getSetterCalls()).isZero();
+    }
+
+    @Test
     void populatesFieldBackedBeanProperties() throws Exception {
         FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
 
@@ -48,11 +75,29 @@ public class BeanPropertyReaderDynamicAccessTest {
     }
 
     @Test
+    void populatesPublicFieldsThroughDefaultJsonApi() throws Exception {
+        FieldBackedReaderBean bean = JSON.std.beanFrom(FieldBackedReaderBean.class, "{\"x\":5,\"y\":8}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(5);
+        assertThat(bean.y).isEqualTo(8);
+    }
+
+    @Test
     void populatesPublicSetterBackedProperties() throws Exception {
         PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
                 "{\"name\":\"Ada\"}");
 
         assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesPublicSettersThroughDefaultJsonApi() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON.std.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Grace\"}");
+
+        assertThat(bean.getName()).isEqualTo("Grace");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanPropertyWriterDynamicAccessTest {
+    private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.USE_FIELDS);
+    private static final JSON JSON_WITH_GETTER_ACCESS = JSON.std
+            .with(JSON.Feature.FORCE_REFLECTION_ACCESS)
+            .with(JSON.Feature.WRITE_READONLY_BEAN_PROPERTIES);
+
+    @Test
+    void serializesFieldBackedProperties() throws Exception {
+        String json = JSON_WITH_FIELD_ACCESS.asString(new FieldBackedWriterBean());
+
+        assertThat(json).isEqualTo("{\"id\":3}");
+    }
+
+    @Test
+    void serializesGetterBackedProperties() throws Exception {
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+        String json = JSON_WITH_GETTER_ACCESS.asString(bean);
+
+        assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    public static final class FieldBackedWriterBean {
+        public int id = 3;
+    }
+
+    public static final class GetterBackedWriterBean {
+        private int getterCalls;
+        private final String name;
+
+        public GetterBackedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            getterCalls++;
+            return name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,7 +6,12 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +37,40 @@ public class BeanPropertyWriterDynamicAccessTest {
         String json = JSON_WITH_GETTER_ACCESS.asString(bean);
 
         assertThat(json).isEqualTo("{\"name\":\"Ada\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    @Test
+    void serializesFieldAndGetterBackedPropertiesInOneWrite() throws Exception {
+        GetterBackedWriterBean getterBean = new GetterBackedWriterBean("Ada");
+
+        String json = JSON_WITH_FIELD_ACCESS.asString(List.of(
+                new FieldBackedWriterBean(),
+                getterBean));
+
+        assertThat(json).isEqualTo("[{\"id\":3},{\"name\":\"Ada\"}]");
+        assertThat(getterBean.getterCalls).isEqualTo(1);
+    }
+
+    @Test
+    void readsFieldBackedValuesThroughBeanPropertyWriter() throws Exception {
+        Field field = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
+
+        Object value = writer.getValueFor(new FieldBackedWriterBean());
+
+        assertThat(value).isEqualTo(3);
+    }
+
+    @Test
+    void invokesGetterBackedValuesThroughBeanPropertyWriter() throws Exception {
+        Method getter = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getter);
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+
+        Object value = writer.getValueFor(bean);
+
+        assertThat(value).isEqualTo("Ada");
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanReaderDynamicAccessTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanReaderDynamicAccessTest {
+    private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+
+    @Test
+    void createsBeansThroughPublicDefaultConstructors() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
+                "{\"name\":\"Ada\"}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.name).isEqualTo("Ada");
+    }
+
+    public static final class PublicDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        public PublicDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+
+    public static final class PrivateDefaultCtorBean {
+        private boolean constructed;
+        public String name;
+
+        private PrivateDefaultCtorBean() {
+            constructed = true;
+        }
+
+        public boolean isConstructed() {
+            return constructed;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionBuilderDynamicAccessTest {
+    @Test
+    void createsEmptyTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.emptyArray(elementType);
+
+        assertThat(values).isEmpty();
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsSingletonTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.singletonArray(elementType, new ArrayElement("solo"));
+
+        assertThat(values).singleElement().isInstanceOf(ArrayElement.class);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("solo");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void createsMultiValueTypedArraysDirectly() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        Object[] values = builder.start()
+                .add(new ArrayElement("left"))
+                .add(new ArrayElement("right"))
+                .buildArray(elementType);
+
+        assertThat(values).hasSize(2);
+        assertThat(((ArrayElement) values[0]).name).isEqualTo("left");
+        assertThat(((ArrayElement) values[1]).name).isEqualTo("right");
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsEmptyTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[]");
+
+        assertThat(values).isEmpty();
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsSingletonTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"solo\"]");
+
+        assertThat(values).containsExactly("solo");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void readsMultiValueTypedArraysThroughJsonApi() throws Exception {
+        Class<String> elementType = runtimeStringType();
+
+        Object[] values = JSON.std.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(values).containsExactly("left", "right");
+        assertThat(values).isInstanceOf(String[].class);
+        assertThat(values.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
+        return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<String> runtimeStringType() throws Exception {
+        return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    }
+
+    public static final class ArrayElement {
+        public String name;
+
+        public ArrayElement() {
+        }
+
+        public ArrayElement(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
@@ -85,6 +88,42 @@ public class CollectionBuilderDynamicAccessTest {
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
+    @Test
+    void readsPojoTypedArraysThroughJsonApiForEveryCardinality() throws Exception {
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        ArrayElement[] empty = JSON.std.arrayOfFrom(elementType, "[]");
+        ArrayElement[] singleton = JSON.std.arrayOfFrom(elementType, "[{\"name\":\"solo\"}]");
+        ArrayElement[] multiple = JSON.std.arrayOfFrom(elementType, "[{\"name\":\"left\"},{\"name\":\"right\"}]");
+
+        assertThat(empty).isEmpty();
+        assertThat(empty.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(singleton).extracting(value -> value.name).containsExactly("solo");
+        assertThat(singleton.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(multiple).extracting(value -> value.name).containsExactly("left", "right");
+        assertThat(multiple.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality() throws Exception {
+        RecordingCollectionBuilder builder = new RecordingCollectionBuilder();
+        JSON json = JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+        Class<String> elementType = runtimeStringType();
+
+        String[] empty = json.arrayOfFrom(elementType, "[]");
+        String[] singleton = json.arrayOfFrom(elementType, "[\"solo\"]");
+        String[] multiple = json.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(empty).isEmpty();
+        assertThat(singleton).containsExactly("solo");
+        assertThat(multiple).containsExactly("left", "right");
+        assertThat(builder.counts.emptyArrayCalls).isEqualTo(1);
+        assertThat(builder.counts.singletonArrayCalls).isEqualTo(1);
+        assertThat(builder.counts.buildArrayCalls).isEqualTo(1);
+    }
+
     @SuppressWarnings("unchecked")
     private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
         return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
@@ -104,5 +143,72 @@ public class CollectionBuilderDynamicAccessTest {
         public ArrayElement(String name) {
             this.name = name;
         }
+    }
+
+    static final class RecordingCollectionBuilder extends CollectionBuilder {
+        private final InvocationCounts counts;
+        private Collection<Object> current;
+
+        RecordingCollectionBuilder() {
+            this(0, null, new InvocationCounts());
+        }
+
+        private RecordingCollectionBuilder(int features, Class<?> collectionType, InvocationCounts counts) {
+            super(features, collectionType);
+            this.counts = counts;
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new RecordingCollectionBuilder(features, _collectionType, counts);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new RecordingCollectionBuilder(_features, collectionType, counts);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            current = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            current.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> result = current;
+            current = null;
+            return result;
+        }
+
+        @Override
+        public <T> T[] buildArray(Class<T> type) {
+            counts.buildArrayCalls++;
+            return super.buildArray(type);
+        }
+
+        @Override
+        public <T> T[] emptyArray(Class<T> type) {
+            counts.emptyArrayCalls++;
+            return super.emptyArray(type);
+        }
+
+        @Override
+        public <T> T[] singletonArray(Class<?> type, T value) {
+            counts.singletonArrayCalls++;
+            return super.singletonArray(type, value);
+        }
+    }
+
+    static final class InvocationCounts {
+        private int buildArrayCalls;
+        private int emptyArrayCalls;
+        private int singletonArrayCalls;
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBuilderDefaultDynamicAccessTest {
+    @BeforeEach
+    void resetConstructorCalls() {
+        ConstructorTrackingMap.CONSTRUCTOR_CALLS.set(0);
+    }
+
+    @Test
+    void readsMultiEntryJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"alpha\":1,\"beta\":2}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsEmptyJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void readsSingletonJsonObjectIntoConfiguredMapImplementation() throws Exception {
+        Map<String, Object> counts = jsonWithConfiguredMaps().mapFrom("{\"only\":99}");
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).containsEntry("only", 99);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void retainsConfiguredMapImplementationWhenRestartingABusyBuilder() {
+        MapBuilder builder = configuredMapBuilder();
+
+        Map<String, Object> counts = builder.start()
+                .put("discarded", true)
+                .start()
+                .put("kept", true)
+                .build();
+
+        assertThat(counts).isInstanceOf(ConstructorTrackingMap.class);
+        assertThat(counts).hasSize(1);
+        assertThat(counts).containsEntry("kept", true);
+        assertThat(counts).doesNotContainKey("discarded");
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    private static JSON jsonWithConfiguredMaps() {
+        return JSON.builder()
+                .mapBuilder(configuredMapBuilder())
+                .build();
+    }
+
+    private static MapBuilder configuredMapBuilder() {
+        return MapBuilder.defaultImpl().newBuilder(ConstructorTrackingMap.class);
+    }
+
+    public static final class ConstructorTrackingMap extends LinkedHashMap<String, Object> {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public ConstructorTrackingMap() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -66,6 +67,27 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
     }
 
+    @Test
+    void directBuilderFactoryMethodsInstantiateConfiguredMapImplementation() throws Exception {
+        MapBuilder builder = configuredMapBuilder().newBuilder(JSON.Feature.READ_ONLY.mask());
+
+        Map<String, Object> empty = builder.emptyMap();
+        Map<String, Object> singleton = builder.singletonMap("answer", 42);
+
+        assertThat(empty).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(singleton).isInstanceOf(ConstructorTrackingMap.class).containsEntry("answer", 42);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    @Test
+    void reportsConfiguredMapTypesThatCannotBeInstantiated() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(PrivateConstructorMap.class);
+
+        assertThatThrownBy(builder::start)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to create an instance of " + PrivateConstructorMap.class.getName());
+    }
+
     private static JSON jsonWithConfiguredMaps() {
         return JSON.builder()
                 .mapBuilder(configuredMapBuilder())
@@ -81,6 +103,11 @@ public class MapBuilderDefaultDynamicAccessTest {
 
         public ConstructorTrackingMap() {
             CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class PrivateConstructorMap extends LinkedHashMap<String, Object> {
+        private PrivateConstructorMap() {
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(),
+            MapBuilder.defaultImpl());
+
+    @Test
+    void findsCanonicalConstructorsForRecords() {
+        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(InventoryItem.class);
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+    }
+
+    @Test
+    void derivesRecordPropertiesFromCanonicalConstructor() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, InventoryItem.class);
+
+        assertThat(propertyNames(definition)).containsExactly("id", "quantity", "available");
+        assertThat(definition.constructors()).isNotNull();
+    }
+
+    @Test
+    void deserializesRecordsThroughJsonApi() throws Exception {
+        InventoryItem item = JSON.std.beanFrom(InventoryItem.class,
+                "{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+
+        assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+    }
+
+    @Test
+    void serializesRecordFieldsInDeclarationOrderThroughJsonApi() throws Exception {
+        String json = JSON_WITH_DECLARATION_ORDER.asString(new InventoryItem("A-1", 3, true));
+
+        assertThat(json).isEqualTo("{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    public record InventoryItem(String id, int quantity, boolean available) {
+        public InventoryItem(String id) {
+            this(id, 0, false);
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleValueReaderDynamicAccessTest {
+    @Test
+    void resolvesTopLevelClassesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
+
+        assertThat(resolved).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
+        String className = loadableClassName();
+
+        TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
+                "{\"type\":\"" + className + "\"}");
+
+        assertThat(holder.type).isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void resolvesClassesInsideTypedMapsAndLists() throws Exception {
+        String className = loadableClassName();
+
+        Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
+                "{\"primary\":\"" + className + "\"}");
+        List<Class> classes = JSON.std.listOfFrom(Class.class,
+                "[\"" + className + "\"]");
+
+        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
+        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+    }
+
+    private static String loadableClassName() {
+        String propertyName = "simple.value.reader.class." + System.nanoTime();
+        System.setProperty(propertyName, LoadableType.class.getName());
+        return System.getProperty(propertyName);
+    }
+
+    public static final class TypeHolder {
+        public Class<?> type;
+    }
+
+    public static final class LoadableType {
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -9,10 +9,17 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
 import org.junit.jupiter.api.Test;
 
+import static com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase.SER_CLASS;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
@@ -45,6 +52,29 @@ public class SimpleValueReaderDynamicAccessTest {
 
         assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
         assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+    }
+
+    @Test
+    void readsClassNamesWithSimpleValueReader() throws Exception {
+        String className = loadableClassName();
+        SimpleValueReader reader = new SimpleValueReader(Class.class, SER_CLASS);
+        JsonFactory jsonFactory = new JsonFactory();
+
+        try (JsonParser parser = jsonFactory.createParser('"' + className + '"')) {
+            parser.nextToken();
+            Object resolved = reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(LoadableType.class);
+        }
+    }
+
+    @Test
+    void reportsUnresolvableClassNames() {
+        String className = "missing." + getClass().getSimpleName() + System.nanoTime();
+
+        assertThatThrownBy(() -> JSON.std.beanFrom(Class.class, '"' + className + '"'))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessage("Failed to bind `java.lang.Class` from value '" + className + "'");
     }
 
     private static String loadableClassName() {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.type.ResolvedType;
+import com.fasterxml.jackson.jr.type.TypeBindings;
+import com.fasterxml.jackson.jr.type.TypeResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeResolverDynamicAccessTest {
+    @Test
+    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+        TypeResolver resolver = new TypeResolver();
+        Object runtimeComponentValue = runtimeComponentValue();
+        Class<?> componentClass = runtimeComponentValue.getClass();
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
+
+        ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
+    }
+
+    @Test
+    void resolvesGenericArrayTypesFromBoundTypeVariables() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        ResolvedType declaringType = resolver.resolve(
+                TypeBindings.emptyBindings(),
+                StringArrayContainer.class.getGenericSuperclass());
+        Type genericArrayType = GenericArrayContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedArrayType = resolver.resolve(declaringType.typeBindings(), genericArrayType);
+
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(String[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
+    }
+
+    static class GenericArrayContainer<T> {
+        private T[] values;
+
+        public T[] getValues() {
+            return values;
+        }
+
+        public void setValues(T[] values) {
+            this.values = values;
+        }
+    }
+
+    static final class StringArrayContainer extends GenericArrayContainer<String> {
+    }
+
+    private static Object runtimeComponentValue() {
+        if (Thread.currentThread().getName().isEmpty()) {
+            return Integer.valueOf(7);
+        }
+        return Thread.currentThread().getName();
+    }
+
+    static final class SyntheticGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        SyntheticGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -6,6 +6,7 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.type.ResolvedType;
 import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
@@ -13,22 +14,22 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
     @Test
-    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+    void resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes() {
         TypeResolver resolver = new TypeResolver();
-        Object runtimeComponentValue = runtimeComponentValue();
-        Class<?> componentClass = runtimeComponentValue.getClass();
-        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), POJODefinition.class);
         GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
 
         ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(POJODefinition[].class);
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(POJODefinition.class);
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
     }
 
@@ -49,6 +50,22 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
     }
 
+    @Test
+    void resolvesGenericArrayTypesNestedInParameterizedTypes() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type listWithGenericArrayElement = GenericArrayListContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedListType = resolver.resolve(TypeBindings.emptyBindings(), listWithGenericArrayElement);
+        ResolvedType resolvedArrayType = resolvedListType.typeParametersFor(List.class).get(0);
+
+        assertThat(resolvedListType.erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(POJODefinition[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(POJODefinition.class);
+    }
+
     static class GenericArrayContainer<T> {
         private T[] values;
 
@@ -64,11 +81,16 @@ public class TypeResolverDynamicAccessTest {
     static final class StringArrayContainer extends GenericArrayContainer<String> {
     }
 
-    private static Object runtimeComponentValue() {
-        if (Thread.currentThread().getName().isEmpty()) {
-            return Integer.valueOf(7);
+    static final class GenericArrayListContainer<T extends POJODefinition> {
+        private List<T[]> values;
+
+        public List<T[]> getValues() {
+            return values;
         }
-        return Thread.currentThread().getName();
+
+        public void setValues(List<T[]> values) {
+            this.values = values;
+        }
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueReaderLocatorDynamicAccessTest {
+    @Test
+    void readsEnumsFromModifierProvidedDefinitions() throws Exception {
+        Direction direction = enumAwareJson().beanFrom(Direction.class, "\"go-north\"");
+
+        assertThat(direction).isEqualTo(Direction.NORTH);
+    }
+
+    @Test
+    void readsModifierProvidedEnumDefinitionsCaseInsensitively() throws Exception {
+        Direction direction = enumAwareJson(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .beanFrom(Direction.class, "\"GO-SOUTH\"");
+
+        assertThat(direction).isEqualTo(Direction.SOUTH);
+    }
+
+    @Test
+    void createsEnumReadersFromModifierProvidedDefinitions() {
+        ValueReaderLocator locator = ValueReaderLocator.blueprint(null, new EnumDefinitionModifier());
+
+        ValueReader reader = locator.findReader(Direction.class);
+
+        assertThat(reader).isNotNull();
+    }
+
+    private static JSON enumAwareJson(JSON.Feature... features) {
+        return JSON.builder()
+                .enable(features)
+                .register(new EnumDefinitionExtension())
+                .build();
+    }
+
+    public enum Direction {
+        NORTH,
+        SOUTH
+    }
+
+    public static class EnumDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class EnumDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != Direction.class) {
+                return null;
+            }
+            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+        }
+
+        private static POJODefinition.Prop[] enumProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp("go-north", "NORTH"),
+                    enumProp("go-south", "SOUTH")
+            };
+        }
+
+        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        }
+
+        private static Field enumField(String enumConstantName) {
+            try {
+                return Direction.class.getField(enumConstantName);
+            } catch (NoSuchFieldException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -6,17 +6,20 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +48,25 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader).isNotNull();
     }
 
+    @Test
+    void readsLibraryEnumsFromModifierProvidedDefinitions() throws Exception {
+        JSON.Feature feature = enumAwareJson().beanFrom(JSON.Feature.class, "\"case-insensitive-enums\"");
+
+        assertThat(feature).isEqualTo(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+    }
+
+    @Test
+    void deserializesRecordPropertiesThroughValueReaderLocator() throws Exception {
+        ValueReaderLocator blueprint = ValueReaderLocator.blueprint(null, null);
+        JSONReader readContext = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+        ValueReader reader = blueprint.perOperationInstance(readContext, 0).findReader(InventoryItem.class);
+        InventoryItem item = JSON.std.beanFrom(InventoryItem.class,
+                "{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+
+        assertThat(reader).isNotNull();
+        assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -57,6 +79,9 @@ public class ValueReaderLocatorDynamicAccessTest {
         SOUTH
     }
 
+    public record InventoryItem(String id, int quantity, boolean available) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -67,26 +92,37 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != Direction.class) {
-                return null;
+            if (pojoType == Direction.class) {
+                return new POJODefinition(Direction.class, directionProps(), new BeanConstructors(Direction.class));
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            if (pojoType == JSON.Feature.class) {
+                return new POJODefinition(JSON.Feature.class, featureProps(), new BeanConstructors(JSON.Feature.class));
+            }
+            return null;
         }
 
-        private static POJODefinition.Prop[] enumProps() {
+        private static POJODefinition.Prop[] directionProps() {
             return new POJODefinition.Prop[] {
-                    enumProp("go-north", "NORTH"),
-                    enumProp("go-south", "SOUTH")
+                    enumProp(Direction.class, "go-north", "NORTH"),
+                    enumProp(Direction.class, "go-south", "SOUTH")
             };
         }
 
-        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        private static POJODefinition.Prop[] featureProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp(JSON.Feature.class, "case-insensitive-enums", "ACCEPT_CASE_INSENSITIVE_ENUMS"),
+                    enumProp(JSON.Feature.class, "force-reflection-access", "FORCE_REFLECTION_ACCESS")
+            };
         }
 
-        private static Field enumField(String enumConstantName) {
+        private static POJODefinition.Prop enumProp(Class<?> enumType, String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumConstantName, enumField(enumType, enumConstantName),
+                    null, null, null, null);
+        }
+
+        private static Field enumField(Class<?> enumType, String enumConstantName) {
             try {
-                return Direction.class.getField(enumConstantName);
+                return enumType.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,283 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.CollectionBuilder"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest$ArrayElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest$ConstructorTrackingMap",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.SimpleValueReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
+      "fields" : [
+        {
+          "name" : "NORTH"
+        },
+        {
+          "name" : "SOUTH"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -155,6 +155,29 @@
     },
     {
       "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
@@ -173,6 +196,52 @@
       "methods" : [
         {
           "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$RecordCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$RecordCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "age"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        },
+        {
+          "name" : "name",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "age",
           "parameterTypes" : [ ]
         }
       ]
@@ -267,6 +336,107 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$InventoryItem",
+      "fields" : [
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "quantity"
+        },
+        {
+          "name" : "available"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "id",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "quantity",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "available",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$InventoryItem",
+      "fields" : [
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "quantity"
+        },
+        {
+          "name" : "available"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        },
+        {
+          "name" : "id",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "quantity",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "available",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$InventoryItem",
+      "fields" : [
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "quantity"
+        },
+        {
+          "name" : "available"
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
       },
       "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$Direction",
@@ -278,6 +448,305 @@
           "name" : "SOUTH"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest$RecordCtorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$BaseBean",
+      "fields" : [
+        {
+          "name" : "visible"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntConstructorBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanConstructors"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest$IntrospectedBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setActive",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FieldBackedReaderBean",
+      "fields" : [
+        {
+          "name" : "x"
+        },
+        {
+          "name" : "y"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$FluentSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$PublicSetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest$SetterBackedReaderBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$FieldBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONWriter"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest$GetterBackedWriterBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PrivateDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest$PublicDefaultCtorBean",
+      "fields" : [
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest$InventoryItem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.JSONReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$TypeHolder",
+      "fields" : [
+        {
+          "name" : "type"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanReader"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$InventoryItem",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.RecordsHelpers"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$InventoryItem"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator"
+      },
+      "type" : "com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest$InventoryItem"
     }
   ]
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Jupiter" tests="58" skipped="0" failures="0" errors="0" time="0.057" hostname="kung-fu-workstation" timestamp="2026-05-03T11:28:44">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="simple.value.reader.class.216897410546714" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
+<property name="simple.value.reader.class.216897410685214" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
+<property name="simple.value.reader.class.216897410746261" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
+<property name="simple.value.reader.class.216897410820682" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-9e70594d/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<testcase name="readsSingletonTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsSingletonTypedArraysThroughJsonApi()]
+display-name: readsSingletonTypedArraysThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()]
+display-name: createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()
+]]></system-out>
+</testcase>
+<testcase name="deserializesRecordPropertiesThroughValueReaderLocator()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:deserializesRecordPropertiesThroughValueReaderLocator()]
+display-name: deserializesRecordPropertiesThroughValueReaderLocator()
+]]></system-out>
+</testcase>
+<testcase name="resolvesTopLevelClassesFromStringValues()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesTopLevelClassesFromStringValues()]
+display-name: resolvesTopLevelClassesFromStringValues()
+]]></system-out>
+</testcase>
+<testcase name="reportsUnresolvableClassNames()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:reportsUnresolvableClassNames()]
+display-name: reportsUnresolvableClassNames()
+]]></system-out>
+</testcase>
+<testcase name="readsPojoTypedArraysThroughJsonApiForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsPojoTypedArraysThroughJsonApiForEveryCardinality()]
+display-name: readsPojoTypedArraysThroughJsonApiForEveryCardinality()
+]]></system-out>
+</testcase>
+<testcase name="populatesPublicSettersThroughDefaultJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPublicSettersThroughDefaultJsonApi()]
+display-name: populatesPublicSettersThroughDefaultJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="createsEmptyTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsEmptyTypedArraysDirectly()]
+display-name: createsEmptyTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="derivesRecordPropertiesFromCanonicalConstructor()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:derivesRecordPropertiesFromCanonicalConstructor()]
+display-name: derivesRecordPropertiesFromCanonicalConstructor()
+]]></system-out>
+</testcase>
+<testcase name="createsMultiValueTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsMultiValueTypedArraysDirectly()]
+display-name: createsMultiValueTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()]
+display-name: directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="populatesPublicSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPublicSetterBackedProperties()]
+display-name: populatesPublicSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="createsRecordsDirectlyThroughCanonicalConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsDirectlyThroughCanonicalConstructors()]
+display-name: createsRecordsDirectlyThroughCanonicalConstructors()
+]]></system-out>
+</testcase>
+<testcase name="supportsFieldNamedGettersWhenEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:supportsFieldNamedGettersWhenEnabled()]
+display-name: supportsFieldNamedGettersWhenEnabled()
+]]></system-out>
+</testcase>
+<testcase name="resolvesGenericArrayTypesFromBoundTypeVariables()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesGenericArrayTypesFromBoundTypeVariables()]
+display-name: resolvesGenericArrayTypesFromBoundTypeVariables()
+]]></system-out>
+</testcase>
+<testcase name="readsModifierProvidedEnumDefinitionsCaseInsensitively()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsModifierProvidedEnumDefinitionsCaseInsensitively()]
+display-name: readsModifierProvidedEnumDefinitionsCaseInsensitively()
+]]></system-out>
+</testcase>
+<testcase name="createsRecordsThroughCanonicalConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.004">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsThroughCanonicalConstructorsWhenReadingObjects()]
+display-name: createsRecordsThroughCanonicalConstructorsWhenReadingObjects()
+]]></system-out>
+</testcase>
+<testcase name="readsFieldBackedValuesThroughBeanPropertyWriter()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:readsFieldBackedValuesThroughBeanPropertyWriter()]
+display-name: readsFieldBackedValuesThroughBeanPropertyWriter()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="reportsSetterBackedInvocationFailuresFromBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:reportsSetterBackedInvocationFailuresFromBeanPropertyReader()]
+display-name: reportsSetterBackedInvocationFailuresFromBeanPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="invokesSetterBackedValuesThroughBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:invokesSetterBackedValuesThroughBeanPropertyReader()]
+display-name: invokesSetterBackedValuesThroughBeanPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="serializesRecordFieldsInDeclarationOrderThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:serializesRecordFieldsInDeclarationOrderThroughJsonApi()]
+display-name: serializesRecordFieldsInDeclarationOrderThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="reportsFieldBackedAssignmentFailuresFromBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:reportsFieldBackedAssignmentFailuresFromBeanPropertyReader()]
+display-name: reportsFieldBackedAssignmentFailuresFromBeanPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="readsEmptyTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsEmptyTypedArraysThroughJsonApi()]
+display-name: readsEmptyTypedArraysThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="readsEmptyJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsEmptyJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsEmptyJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="readsLibraryEnumsFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsLibraryEnumsFromModifierProvidedDefinitions()]
+display-name: readsLibraryEnumsFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="serializesFieldAndGetterBackedPropertiesInOneWrite()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesFieldAndGetterBackedPropertiesInOneWrite()]
+display-name: serializesFieldAndGetterBackedPropertiesInOneWrite()
+]]></system-out>
+</testcase>
+<testcase name="deserializesRecordsThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:deserializesRecordsThroughJsonApi()]
+display-name: deserializesRecordsThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="setsFieldBackedValuesThroughBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:setsFieldBackedValuesThroughBeanPropertyReader()]
+display-name: setsFieldBackedValuesThroughBeanPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="findsCanonicalConstructorsForRecords()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:findsCanonicalConstructorsForRecords()]
+display-name: findsCanonicalConstructorsForRecords()
+]]></system-out>
+</testcase>
+<testcase name="populatesPublicFieldsThroughDefaultJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPublicFieldsThroughDefaultJsonApi()]
+display-name: populatesPublicFieldsThroughDefaultJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="readsMultiValueTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsMultiValueTypedArraysThroughJsonApi()]
+display-name: readsMultiValueTypedArraysThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="collectsDeclaredFieldsAndMethodsForSerialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsDeclaredFieldsAndMethodsForSerialization()]
+display-name: collectsDeclaredFieldsAndMethodsForSerialization()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructors()]
+display-name: createsBeansThroughPublicDefaultConstructors()
+]]></system-out>
+</testcase>
+<testcase name="resolvesClassesInsideTypedMapsAndLists()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesClassesInsideTypedMapsAndLists()]
+display-name: resolvesClassesInsideTypedMapsAndLists()
+]]></system-out>
+</testcase>
+<testcase name="readsEnumsFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsEnumsFromModifierProvidedDefinitions()]
+display-name: readsEnumsFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="reportsConfiguredMapTypesThatCannotBeInstantiated()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:reportsConfiguredMapTypesThatCannotBeInstantiated()]
+display-name: reportsConfiguredMapTypesThatCannotBeInstantiated()
+]]></system-out>
+</testcase>
+<testcase name="populatesFieldBackedBeanProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFieldBackedBeanProperties()]
+display-name: populatesFieldBackedBeanProperties()
+]]></system-out>
+</testcase>
+<testcase name="resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()]
+display-name: resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()
+]]></system-out>
+</testcase>
+<testcase name="resolvesGenericArrayTypesNestedInParameterizedTypes()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesGenericArrayTypesNestedInParameterizedTypes()]
+display-name: resolvesGenericArrayTypesNestedInParameterizedTypes()
+]]></system-out>
+</testcase>
+<testcase name="createsSingletonTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsSingletonTypedArraysDirectly()]
+display-name: createsSingletonTypedArraysDirectly()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.006">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality()]
+display-name: typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality()
+]]></system-out>
+</testcase>
+<testcase name="retainsConfiguredMapImplementationWhenRestartingABusyBuilder()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:retainsConfiguredMapImplementationWhenRestartingABusyBuilder()]
+display-name: retainsConfiguredMapImplementationWhenRestartingABusyBuilder()
+]]></system-out>
+</testcase>
+<testcase name="readsMultiEntryJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.01">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsMultiEntryJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsMultiEntryJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="readsClassNamesWithSimpleValueReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:readsClassNamesWithSimpleValueReader()]
+display-name: readsClassNamesWithSimpleValueReader()
+]]></system-out>
+</testcase>
+<testcase name="readsSingletonJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsSingletonJsonObjectIntoConfiguredMapImplementation()]
+display-name: readsSingletonJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="serializesGetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesGetterBackedProperties()]
+display-name: serializesGetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="resolvesClassTypedBeanPropertiesFromStringValues()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:resolvesClassTypedBeanPropertiesFromStringValues()]
+display-name: resolvesClassTypedBeanPropertiesFromStringValues()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansDirectlyThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughPublicDefaultConstructors()]
+display-name: createsBeansDirectlyThroughPublicDefaultConstructors()
+]]></system-out>
+</testcase>
+<testcase name="invokesGetterBackedValuesThroughBeanPropertyWriter()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:invokesGetterBackedValuesThroughBeanPropertyWriter()]
+display-name: invokesGetterBackedValuesThroughBeanPropertyWriter()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest]/[method:createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
+display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+]]></system-out>
+</testcase>
+<testcase name="collectsIntegerConstructorsForNumericScalarDeserialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsIntegerConstructorsForNumericScalarDeserialization()]
+display-name: collectsIntegerConstructorsForNumericScalarDeserialization()
+]]></system-out>
+</testcase>
+<testcase name="populatesPrivateSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.002">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPrivateSetterBackedProperties()]
+display-name: populatesPrivateSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="collectsDeclaredConstructorsForDeserialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsDeclaredConstructorsForDeserialization()]
+display-name: collectsDeclaredConstructorsForDeserialization()
+]]></system-out>
+</testcase>
+<testcase name="createsEnumReadersFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:createsEnumReadersFromModifierProvidedDefinitions()]
+display-name: createsEnumReadersFromModifierProvidedDefinitions()
+]]></system-out>
+</testcase>
+<testcase name="populatesFluentSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.001">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFluentSetterBackedProperties()]
+display-name: populatesFluentSetterBackedProperties()
+]]></system-out>
+</testcase>
+<testcase name="serializesFieldBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesFieldBackedProperties()]
+display-name: serializesFieldBackedProperties()
+]]></system-out>
+</testcase>
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]
+display-name: JUnit Jupiter
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:28:44">
+<properties>
+<property name="file.encoding" value="UTF-8"/>
+<property name="file.separator" value="/"/>
+<property name="java.class.path" value=""/>
+<property name="java.class.version" value="69.0"/>
+<property name="java.endorsed.dirs" value=""/>
+<property name="java.ext.dirs" value=""/>
+<property name="java.io.tmpdir" value="/tmp"/>
+<property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
+<property name="java.runtime.name" value="GraalVM Runtime Environment"/>
+<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.specification.name" value="Java Platform API Specification"/>
+<property name="java.specification.vendor" value="Oracle Corporation"/>
+<property name="java.specification.version" value="25"/>
+<property name="java.vendor" value="Oracle Corporation"/>
+<property name="java.vendor.url" value="https://www.graalvm.org/"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
+<property name="java.version" value="25.0.3"/>
+<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vm.info" value="serial gc, compressed references"/>
+<property name="java.vm.name" value="Substrate VM"/>
+<property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+<property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+<property name="java.vm.specification.version" value="25"/>
+<property name="java.vm.vendor" value="Oracle Corporation"/>
+<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="junit.jupiter.execution.timeout.default" value="60 s"/>
+<property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
+<property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
+<property name="line.separator" value="
+"/>
+<property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
+<property name="org.graalvm.nativeimage.kind" value="executable"/>
+<property name="os.arch" value="amd64"/>
+<property name="os.name" value="Linux"/>
+<property name="os.version" value="6.17.0-22-generic"/>
+<property name="path.separator" value=":"/>
+<property name="stderr.encoding" value="UTF-8"/>
+<property name="stdin.encoding" value="UTF-8"/>
+<property name="stdout.encoding" value="UTF-8"/>
+<property name="sun.arch.data.model" value="64"/>
+<property name="sun.jnu.encoding" value="UTF-8"/>
+<property name="user.country" value="US"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-9e70594d/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.home" value="/home/vjovanov"/>
+<property name="user.language" value="en"/>
+<property name="user.name" value="vjovanov"/>
+<property name="user.timezone" value="Europe/Zurich"/>
+</properties>
+<system-out><![CDATA[
+unique-id: [engine:junit-vintage]
+display-name: JUnit Vintage
+]]></system-out>
+</testsuite>

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.jr.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #2564

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 1115902
- Cached input tokens: 16345088
- Output tokens: 125716
- Metadata entries: 7
- Test-only metadata entries: 129
- Iterations: 22
- Library coverage percentage: 39.02
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 47
- Previous library version coverage percentage: 36.81

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5e0b2ac606599cfa86204b225fd8b7f110f5900c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

**Reflection:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 0/16 covered calls (0.00%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 0/21 covered calls (0.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 4596/12487 (36.81%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 5349/13710 (39.02%)

**Line:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: N/A
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: N/A

**Method:**
- com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0: 255/666 (38.29%)
- com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0: 286/705 (40.57%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
index 4b9e6fc27b..2c20025f75 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -18,11 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanConstructorsDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
+    private static final AtomicInteger RECORD_CTOR_CALLS = new AtomicInteger();
 
     @BeforeEach
     void resetConstructorCounters() {
         PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
         PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        RECORD_CTOR_CALLS.set(0);
     }
 
     @Test
@@ -58,6 +60,28 @@ public class BeanConstructorsDynamicAccessTest {
         assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
+    @Test
+    void createsRecordsDirectlyThroughCanonicalConstructors() throws Exception {
+        Constructor<RecordCtorBean> constructor = RecordCtorBean.class.getDeclaredConstructor(String.class, int.class);
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(RecordCtorBean.class);
+        constructors.addRecordConstructor(constructor);
+
+        RecordCtorBean bean = (RecordCtorBean) constructors.createRecordBean("Ada", 37);
+
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.age()).isEqualTo(37);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
+        RecordCtorBean bean = JSON.std.beanFrom(RecordCtorBean.class, "{\"name\":\"Ada\",\"age\":37}");
+
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.age()).isEqualTo(37);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+    }
+
     @Test
     void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
         PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
@@ -75,6 +99,10 @@ public class BeanConstructorsDynamicAccessTest {
         Object createBean() throws Exception {
             return create();
         }
+
+        Object createRecordBean(Object... components) throws Exception {
+            return createRecord(components);
+        }
     }
 
     public static final class PublicDefaultCtorBean {
@@ -96,4 +124,10 @@ public class BeanConstructorsDynamicAccessTest {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }
+
+    public record RecordCtorBean(String name, int age) {
+        public RecordCtorBean {
+            RECORD_CTOR_CALLS.incrementAndGet();
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
index bd54ecaf2c..a97f0a5a08 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -30,18 +30,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
     @Test
     void collectsDeclaredConstructorsForDeserialization() throws Exception {
+        BeanConstructors constructors = new BeanConstructors(IntrospectedBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(IntrospectedBean.class, constructors);
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
-        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, POJODefinition.class);
 
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
         IntrospectedBean stringBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "\"Ada\"");
         IntrospectedBean longBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class, "7");
 
+        assertThat(constructors).isNotNull();
         assertThat(definition.constructors()).isNotNull();
-        assertThat(libraryDefinition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
-        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
         assertThat(objectBean.getName()).isEqualTo("Ada");
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
@@ -52,14 +52,9 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
-        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, POJODefinition.class);
-        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
-                BeanConstructors.class);
         String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
-        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
-        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
         assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");
@@ -73,6 +68,20 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(active.setter).isNotNull();
     }
 
+    @Test
+    void collectsIntegerConstructorsForNumericScalarDeserialization() throws Exception {
+        BeanConstructors constructors = new BeanConstructors(IntConstructorBean.class);
+        BeanPropertyIntrospector.addNonRecordConstructors(IntConstructorBean.class, constructors);
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntConstructorBean.class);
+
+        IntConstructorBean bean = JSON.std.beanFrom(IntConstructorBean.class, "13");
+
+        assertThat(constructors).isNotNull();
+        assertThat(definition.constructors()).isNotNull();
+        assertThat(propertyNames(definition)).contains("value");
+        assertThat(bean.getValue()).isEqualTo(13);
+    }
+
     @Test
     void supportsFieldNamedGettersWhenEnabled() throws Exception {
         String json = JSON_WITH_FIELD_MATCHING_GETTERS.asString(new FieldNamedGetterBean("Ada"));
@@ -135,6 +144,18 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         }
     }
 
+    public static final class IntConstructorBean {
+        private final int value;
+
+        public IntConstructorBean(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
     static final class FieldNamedGetterBean {
         private final String title;
 
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
index ff55ef0382..0793145e0b 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -7,10 +7,12 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyReader;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeanPropertyReaderDynamicAccessTest {
     private static final JSON JSON_WITH_FORCE_ACCESS = JSON.std.with(JSON.Feature.FORCE_REFLECTION_ACCESS);
@@ -38,6 +40,31 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
+    @Test
+    void reportsFieldBackedAssignmentFailuresFromBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        FieldBackedReaderBean bean = new FieldBackedReaderBean();
+
+        assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{"not an int"}))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to set property 'x' (raw type int) to value of type java.lang.String");
+        assertThat(bean.x).isZero();
+    }
+
+    @Test
+    void reportsSetterBackedInvocationFailuresFromBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+        PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
+
+        assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{13}))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining(
+                        "Failed to set property 'name' (raw type java.lang.String) to value of type java.lang.Integer");
+        assertThat(bean.getName()).isNull();
+        assertThat(bean.getSetterCalls()).isZero();
+    }
+
     @Test
     void populatesFieldBackedBeanProperties() throws Exception {
         FieldBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FieldBackedReaderBean.class, "{\"x\":3,\"y\":4}");
@@ -47,6 +74,15 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.y).isEqualTo(4);
     }
 
+    @Test
+    void populatesPublicFieldsThroughDefaultJsonApi() throws Exception {
+        FieldBackedReaderBean bean = JSON.std.beanFrom(FieldBackedReaderBean.class, "{\"x\":5,\"y\":8}");
+
+        assertThat(bean.isConstructed()).isTrue();
+        assertThat(bean.x).isEqualTo(5);
+        assertThat(bean.y).isEqualTo(8);
+    }
+
     @Test
     void populatesPublicSetterBackedProperties() throws Exception {
         PublicSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PublicSetterBackedReaderBean.class,
@@ -56,6 +92,15 @@ public class BeanPropertyReaderDynamicAccessTest {
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
+    @Test
+    void populatesPublicSettersThroughDefaultJsonApi() throws Exception {
+        PublicSetterBackedReaderBean bean = JSON.std.beanFrom(PublicSetterBackedReaderBean.class,
+                "{\"name\":\"Grace\"}");
+
+        assertThat(bean.getName()).isEqualTo("Grace");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
     @Test
     void populatesFluentSetterBackedProperties() throws Exception {
         FluentSetterBackedReaderBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(FluentSetterBackedReaderBean.class,
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
index dd41a65a32..bd1e5ead86 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -6,7 +6,12 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +40,40 @@ public class BeanPropertyWriterDynamicAccessTest {
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 
+    @Test
+    void serializesFieldAndGetterBackedPropertiesInOneWrite() throws Exception {
+        GetterBackedWriterBean getterBean = new GetterBackedWriterBean("Ada");
+
+        String json = JSON_WITH_FIELD_ACCESS.asString(List.of(
+                new FieldBackedWriterBean(),
+                getterBean));
+
+        assertThat(json).isEqualTo("[{\"id\":3},{\"name\":\"Ada\"}]");
+        assertThat(getterBean.getterCalls).isEqualTo(1);
+    }
+
+    @Test
+    void readsFieldBackedValuesThroughBeanPropertyWriter() throws Exception {
+        Field field = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
+
+        Object value = writer.getValueFor(new FieldBackedWriterBean());
+
+        assertThat(value).isEqualTo(3);
+    }
+
+    @Test
+    void invokesGetterBackedValuesThroughBeanPropertyWriter() throws Exception {
+        Method getter = GetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getter);
+        GetterBackedWriterBean bean = new GetterBackedWriterBean("Ada");
+
+        Object value = writer.getValueFor(bean);
+
+        assertThat(value).isEqualTo("Ada");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
     public static final class FieldBackedWriterBean {
         public int id = 3;
     }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
index 994dafe71d..41c2730ff2 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollectionBuilderDynamicAccessTest {
@@ -85,6 +88,42 @@ public class CollectionBuilderDynamicAccessTest {
         assertThat(values.getClass().getComponentType()).isSameAs(elementType);
     }
 
+    @Test
+    void readsPojoTypedArraysThroughJsonApiForEveryCardinality() throws Exception {
+        Class<ArrayElement> elementType = runtimeArrayElementType();
+
+        ArrayElement[] empty = JSON.std.arrayOfFrom(elementType, "[]");
+        ArrayElement[] singleton = JSON.std.arrayOfFrom(elementType, "[{\"name\":\"solo\"}]");
+        ArrayElement[] multiple = JSON.std.arrayOfFrom(elementType, "[{\"name\":\"left\"},{\"name\":\"right\"}]");
+
+        assertThat(empty).isEmpty();
+        assertThat(empty.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(singleton).extracting(value -> value.name).containsExactly("solo");
+        assertThat(singleton.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(multiple).extracting(value -> value.name).containsExactly("left", "right");
+        assertThat(multiple.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
+    void typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality() throws Exception {
+        RecordingCollectionBuilder builder = new RecordingCollectionBuilder();
+        JSON json = JSON.builder()
+                .collectionBuilder(builder)
+                .build();
+        Class<String> elementType = runtimeStringType();
+
+        String[] empty = json.arrayOfFrom(elementType, "[]");
+        String[] singleton = json.arrayOfFrom(elementType, "[\"solo\"]");
+        String[] multiple = json.arrayOfFrom(elementType, "[\"left\",\"right\"]");
+
+        assertThat(empty).isEmpty();
+        assertThat(singleton).containsExactly("solo");
+        assertThat(multiple).containsExactly("left", "right");
+        assertThat(builder.counts.emptyArrayCalls).isEqualTo(1);
+        assertThat(builder.counts.singletonArrayCalls).isEqualTo(1);
+        assertThat(builder.counts.buildArrayCalls).isEqualTo(1);
+    }
+
     @SuppressWarnings("unchecked")
     private static Class<ArrayElement> runtimeArrayElementType() throws Exception {
         return (Class<ArrayElement>) JSON.std.beanFrom(Class.class, '"' + ArrayElement.class.getName() + '"');
@@ -105,4 +144,71 @@ public class CollectionBuilderDynamicAccessTest {
             this.name = name;
         }
     }
+
+    static final class RecordingCollectionBuilder extends CollectionBuilder {
+        private final InvocationCounts counts;
+        private Collection<Object> current;
+
+        RecordingCollectionBuilder() {
+            this(0, null, new InvocationCounts());
+        }
+
+        private RecordingCollectionBuilder(int features, Class<?> collectionType, InvocationCounts counts) {
+            super(features, collectionType);
+            this.counts = counts;
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(int features) {
+            return new RecordingCollectionBuilder(features, _collectionType, counts);
+        }
+
+        @Override
+        public CollectionBuilder newBuilder(Class<?> collectionType) {
+            return new RecordingCollectionBuilder(_features, collectionType, counts);
+        }
+
+        @Override
+        public CollectionBuilder start() {
+            current = new ArrayList<>();
+            return this;
+        }
+
+        @Override
+        public CollectionBuilder add(Object value) {
+            current.add(value);
+            return this;
+        }
+
+        @Override
+        public Collection<Object> buildCollection() {
+            Collection<Object> result = current;
+            current = null;
+            return result;
+        }
+
+        @Override
+        public <T> T[] buildArray(Class<T> type) {
+            counts.buildArrayCalls++;
+            return super.buildArray(type);
+        }
+
+        @Override
+        public <T> T[] emptyArray(Class<T> type) {
+            counts.emptyArrayCalls++;
+            return super.emptyArray(type);
+        }
+
+        @Override
+        public <T> T[] singletonArray(Class<?> type, T value) {
+            counts.singletonArrayCalls++;
+            return super.singletonArray(type, value);
+        }
+    }
+
+    static final class InvocationCounts {
+        private int buildArrayCalls;
+        private int emptyArrayCalls;
+        private int singletonArrayCalls;
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
index 2d801978bc..0e931d7552 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MapBuilderDefaultDynamicAccessTest {
     @BeforeEach
@@ -66,6 +67,27 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
     }
 
+    @Test
+    void directBuilderFactoryMethodsInstantiateConfiguredMapImplementation() throws Exception {
+        MapBuilder builder = configuredMapBuilder().newBuilder(JSON.Feature.READ_ONLY.mask());
+
+        Map<String, Object> empty = builder.emptyMap();
+        Map<String, Object> singleton = builder.singletonMap("answer", 42);
+
+        assertThat(empty).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
+        assertThat(singleton).isInstanceOf(ConstructorTrackingMap.class).containsEntry("answer", 42);
+        assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    @Test
+    void reportsConfiguredMapTypesThatCannotBeInstantiated() {
+        MapBuilder builder = MapBuilder.defaultImpl().newBuilder(PrivateConstructorMap.class);
+
+        assertThatThrownBy(builder::start)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to create an instance of " + PrivateConstructorMap.class.getName());
+    }
+
     private static JSON jsonWithConfiguredMaps() {
         return JSON.builder()
                 .mapBuilder(configuredMapBuilder())
@@ -83,4 +105,9 @@ public class MapBuilderDefaultDynamicAccessTest {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }
+
+    public static final class PrivateConstructorMap extends LinkedHashMap<String, Object> {
+        private PrivateConstructorMap() {
+        }
+    }
 }
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
new file mode 100644
index 0000000000..7adb778938
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -0,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_jr.jackson_jr_objects;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
+import com.fasterxml.jackson.jr.ob.impl.RecordsHelpers;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordsHelpersDynamicAccessTest {
+    private static final JSON JSON_WITH_DECLARATION_ORDER = JSON.std.with(
+            JSON.Feature.WRITE_RECORD_FIELDS_IN_DECLARATION_ORDER);
+    private static final BeanPropertyIntrospector INTROSPECTOR = BeanPropertyIntrospector.instance();
+    private static final JSONReader JSON_READER = new JSONReader(CollectionBuilder.defaultImpl(),
+            MapBuilder.defaultImpl());
+
+    @Test
+    void findsCanonicalConstructorsForRecords() {
+        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(InventoryItem.class);
+
+        assertThat(constructor).isNotNull();
+        assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
+    }
+
+    @Test
+    void derivesRecordPropertiesFromCanonicalConstructor() {
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, InventoryItem.class);
+
+        assertThat(propertyNames(definition)).containsExactly("id", "quantity", "available");
+        assertThat(definition.constructors()).isNotNull();
+    }
+
+    @Test
+    void deserializesRecordsThroughJsonApi() throws Exception {
+        InventoryItem item = JSON.std.beanFrom(InventoryItem.class,
+                "{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+
+        assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+    }
+
+    @Test
+    void serializesRecordFieldsInDeclarationOrderThroughJsonApi() throws Exception {
+        String json = JSON_WITH_DECLARATION_ORDER.asString(new InventoryItem("A-1", 3, true));
+
+        assertThat(json).isEqualTo("{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+    }
+
+    private static List<String> propertyNames(POJODefinition definition) {
+        return definition.getProperties().stream().map(prop -> prop.name).toList();
+    }
+
+    public record InventoryItem(String id, int quantity, boolean available) {
+        public InventoryItem(String id) {
+            this(id, 0, false);
+        }
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
index 9cb0bb785b..698ce80ff6 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -9,10 +9,17 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.impl.SimpleValueReader;
 import org.junit.jupiter.api.Test;
 
+import static com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase.SER_CLASS;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleValueReaderDynamicAccessTest {
     @Test
@@ -47,6 +54,29 @@ public class SimpleValueReaderDynamicAccessTest {
         assertThat(classes).singleElement().isEqualTo(LoadableType.class);
     }
 
+    @Test
+    void readsClassNamesWithSimpleValueReader() throws Exception {
+        String className = loadableClassName();
+        SimpleValueReader reader = new SimpleValueReader(Class.class, SER_CLASS);
+        JsonFactory jsonFactory = new JsonFactory();
+
+        try (JsonParser parser = jsonFactory.createParser('"' + className + '"')) {
+            parser.nextToken();
+            Object resolved = reader.read(null, parser);
+
+            assertThat(resolved).isEqualTo(LoadableType.class);
+        }
+    }
+
+    @Test
+    void reportsUnresolvableClassNames() {
+        String className = "missing." + getClass().getSimpleName() + System.nanoTime();
+
+        assertThatThrownBy(() -> JSON.std.beanFrom(Class.class, '"' + className + '"'))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessage("Failed to bind `java.lang.Class` from value '" + className + "'");
+    }
+
     private static String loadableClassName() {
         String propertyName = "simple.value.reader.class." + System.nanoTime();
         System.setProperty(propertyName, LoadableType.class.getName());
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
index 9e15382236..46f2408b18 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/TypeResolverDynamicAccessTest.java
@@ -6,6 +6,7 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.type.ResolvedType;
 import com.fasterxml.jackson.jr.type.TypeBindings;
 import com.fasterxml.jackson.jr.type.TypeResolver;
@@ -13,22 +14,22 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeResolverDynamicAccessTest {
     @Test
-    void resolvesSyntheticGenericArrayTypesFromRuntimeResolvedComponentTypes() {
+    void resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes() {
         TypeResolver resolver = new TypeResolver();
-        Object runtimeComponentValue = runtimeComponentValue();
-        Class<?> componentClass = runtimeComponentValue.getClass();
-        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), componentClass);
+        ResolvedType componentType = resolver.resolve(TypeBindings.emptyBindings(), POJODefinition.class);
         GenericArrayType genericArrayType = new SyntheticGenericArrayType(componentType);
 
         ResolvedType resolvedArrayType = resolver.resolve(TypeBindings.emptyBindings(), genericArrayType);
 
         assertThat(resolvedArrayType.isArray()).isTrue();
-        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(componentClass);
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(POJODefinition[].class);
+        assertThat(resolvedArrayType.erasedType().getComponentType()).isEqualTo(POJODefinition.class);
         assertThat(resolvedArrayType.elementType()).isEqualTo(componentType);
     }
 
@@ -49,6 +50,22 @@ public class TypeResolverDynamicAccessTest {
         assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(String.class);
     }
 
+    @Test
+    void resolvesGenericArrayTypesNestedInParameterizedTypes() throws Exception {
+        TypeResolver resolver = new TypeResolver();
+        Type listWithGenericArrayElement = GenericArrayListContainer.class
+                .getDeclaredField("values")
+                .getGenericType();
+
+        ResolvedType resolvedListType = resolver.resolve(TypeBindings.emptyBindings(), listWithGenericArrayElement);
+        ResolvedType resolvedArrayType = resolvedListType.typeParametersFor(List.class).get(0);
+
+        assertThat(resolvedListType.erasedType()).isEqualTo(List.class);
+        assertThat(resolvedArrayType.isArray()).isTrue();
+        assertThat(resolvedArrayType.erasedType()).isEqualTo(POJODefinition[].class);
+        assertThat(resolvedArrayType.elementType().erasedType()).isEqualTo(POJODefinition.class);
+    }
+
     static class GenericArrayContainer<T> {
         private T[] values;
 
@@ -64,11 +81,16 @@ public class TypeResolverDynamicAccessTest {
     static final class StringArrayContainer extends GenericArrayContainer<String> {
     }
 
-    private static Object runtimeComponentValue() {
-        if (Thread.currentThread().getName().isEmpty()) {
-            return Integer.valueOf(7);
+    static final class GenericArrayListContainer<T extends POJODefinition> {
+        private List<T[]> values;
+
+        public List<T[]> getValues() {
+            return values;
+        }
+
+        public void setValues(List<T[]> values) {
+            this.values = values;
         }
-        return Thread.currentThread().getName();
     }
 
     static final class SyntheticGenericArrayType implements GenericArrayType {
diff --git 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
index 703886be9a..a0f010f0fb 100644
--- 1/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.17.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ 2/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -6,18 +6,21 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
+import java.lang.reflect.Field;
+
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.api.CollectionBuilder;
 import com.fasterxml.jackson.jr.ob.api.ExtensionContext;
+import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ValueReaderLocatorDynamicAccessTest {
@@ -45,6 +48,25 @@ public class ValueReaderLocatorDynamicAccessTest {
         assertThat(reader).isNotNull();
     }
 
+    @Test
+    void readsLibraryEnumsFromModifierProvidedDefinitions() throws Exception {
+        JSON.Feature feature = enumAwareJson().beanFrom(JSON.Feature.class, "\"case-insensitive-enums\"");
+
+        assertThat(feature).isEqualTo(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+    }
+
+    @Test
+    void deserializesRecordPropertiesThroughValueReaderLocator() throws Exception {
+        ValueReaderLocator blueprint = ValueReaderLocator.blueprint(null, null);
+        JSONReader readContext = new JSONReader(CollectionBuilder.defaultImpl(), MapBuilder.defaultImpl());
+        ValueReader reader = blueprint.perOperationInstance(readContext, 0).findReader(InventoryItem.class);
+        InventoryItem item = JSON.std.beanFrom(InventoryItem.class,
+                "{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
+
+        assertThat(reader).isNotNull();
+        assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+    }
+
     private static JSON enumAwareJson(JSON.Feature... features) {
         return JSON.builder()
                 .enable(features)
@@ -57,6 +79,9 @@ public class ValueReaderLocatorDynamicAccessTest {
         SOUTH
     }
 
+    public record InventoryItem(String id, int quantity, boolean available) {
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
@@ -67,26 +92,37 @@ public class ValueReaderLocatorDynamicAccessTest {
     public static class EnumDefinitionModifier extends ReaderWriterModifier {
         @Override
         public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
-            if (pojoType != Direction.class) {
-                return null;
+            if (pojoType == Direction.class) {
+                return new POJODefinition(Direction.class, directionProps(), new BeanConstructors(Direction.class));
             }
-            return new POJODefinition(Direction.class, enumProps(), null, null, null);
+            if (pojoType == JSON.Feature.class) {
+                return new POJODefinition(JSON.Feature.class, featureProps(), new BeanConstructors(JSON.Feature.class));
+            }
+            return null;
+        }
+
+        private static POJODefinition.Prop[] directionProps() {
+            return new POJODefinition.Prop[] {
+                    enumProp(Direction.class, "go-north", "NORTH"),
+                    enumProp(Direction.class, "go-south", "SOUTH")
+            };
         }
 
-        private static POJODefinition.Prop[] enumProps() {
+        private static POJODefinition.Prop[] featureProps() {
             return new POJODefinition.Prop[] {
-                    enumProp("go-north", "NORTH"),
-                    enumProp("go-south", "SOUTH")
+                    enumProp(JSON.Feature.class, "case-insensitive-enums", "ACCEPT_CASE_INSENSITIVE_ENUMS"),
+                    enumProp(JSON.Feature.class, "force-reflection-access", "FORCE_REFLECTION_ACCESS")
             };
         }
 
-        private static POJODefinition.Prop enumProp(String externalName, String enumConstantName) {
-            return new POJODefinition.Prop(externalName, enumField(enumConstantName), null, null, null, null);
+        private static POJODefinition.Prop enumProp(Class<?> enumType, String externalName, String enumConstantName) {
+            return new POJODefinition.Prop(externalName, enumConstantName, enumField(enumType, enumConstantName),
+                    null, null, null, null);
         }
 
-        private static Field enumField(String enumConstantName) {
+        private static Field enumField(Class<?> enumType, String enumConstantName) {
             try {
-                return Direction.class.getField(enumConstantName);
+                return enumType.getField(enumConstantName);
             } catch (NoSuchFieldException ex) {
                 throw new IllegalStateException(ex);
             }

```
