### PR TITLE
Avoid Docker setup for non-Docker Forge local CI verification

### DIFF
--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -206,7 +206,7 @@ class LocalCIVerificationTests(unittest.TestCase):
             self.assertEqual(result.commands[0].returncode, 1)
             self.assertIn("FAILED[javaTest]", result.commands[0].output_excerpt)
 
-    def test_test_matrix_restores_docker_after_test_failure(self) -> None:
+    def test_test_matrix_skips_docker_networking_for_non_docker_coordinate(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")
         failed_record = CommandRecord(gate="run-consecutive-tests", command=["bash"], returncode=1)
         gates: list[str] = []
@@ -233,7 +233,105 @@ class LocalCIVerificationTests(unittest.TestCase):
             )
 
         self.assertIs(failed, failed_record)
-        self.assertEqual(gates[-1], "restore-docker-networking")
+        self.assertEqual(gates, ["check-metadata-files", "run-consecutive-tests"])
+        self.assertNotIn("disable-docker-networking", gates)
+        self.assertNotIn("restore-docker-networking", gates)
+
+    def test_test_matrix_isolates_docker_networking_for_coordinates_that_declare_docker_images(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "docker-demo", "1.0.0")
+            os.makedirs(docker_test_dir)
+            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
+                file.write("nginx:1-alpine-slim\n")
+
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            calls: list[tuple[str, list[str]]] = []
+
+            def fake_run_recorded_command(
+                    repo_path_arg: str,
+                    gate: str,
+                    command: list[str],
+                    local_result: LocalCIVerificationResult,
+                    env: dict[str, str] | None = None,
+                    failure_output_pattern: str | None = None,
+            ) -> CommandRecord | None:
+                del repo_path_arg, local_result, env, failure_output_pattern
+                calls.append((gate, command))
+                return None
+
+            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+                failed = _run_test_matrix_entries(
+                    repo_path,
+                    [
+                        {"coordinates": "org.example:plain-demo:1.0.0", "versions": ["1.0.0"]},
+                        {"coordinates": "org.example:docker-demo:1.0.0", "versions": ["1.0.0"]},
+                    ],
+                    result,
+                )
+
+            self.assertIsNone(failed)
+            self.assertEqual(
+                [call for call in calls if call[0] == "pull-allowed-docker-images"],
+                [
+                    (
+                        "pull-allowed-docker-images",
+                        ["./gradlew", "pullAllowedDockerImages", "-Pcoordinates=org.example:docker-demo:1.0.0"],
+                    ),
+                ],
+            )
+            self.assertIn("disable-docker-networking", [call[0] for call in calls])
+            self.assertEqual(calls[-1][0], "restore-docker-networking")
+
+    def test_test_matrix_resolves_docker_declaration_from_index_test_version(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            metadata_dir = os.path.join(repo_path, "metadata", "org.example", "demo")
+            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0")
+            os.makedirs(metadata_dir)
+            os.makedirs(docker_test_dir)
+            with open(os.path.join(metadata_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump([
+                    {
+                        "metadata-version": "2.0.0",
+                        "test-version": "1.0.0",
+                        "tested-versions": ["2.0.1"],
+                    },
+                ], file)
+            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
+                file.write("# comment\n\nnginx:1-alpine-slim\n")
+
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            calls: list[tuple[str, list[str]]] = []
+
+            def fake_run_recorded_command(
+                    repo_path_arg: str,
+                    gate: str,
+                    command: list[str],
+                    local_result: LocalCIVerificationResult,
+                    env: dict[str, str] | None = None,
+                    failure_output_pattern: str | None = None,
+            ) -> CommandRecord | None:
+                del repo_path_arg, local_result, env, failure_output_pattern
+                calls.append((gate, command))
+                return None
+
+            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+                failed = _run_test_matrix_entries(
+                    repo_path,
+                    [{"coordinates": "org.example:demo:2.0.1", "versions": ["2.0.1"]}],
+                    result,
+                )
+
+            self.assertIsNone(failed)
+            self.assertEqual(
+                [call for call in calls if call[0] == "pull-allowed-docker-images"],
+                [
+                    (
+                        "pull-allowed-docker-images",
+                        ["./gradlew", "pullAllowedDockerImages", "-Pcoordinates=org.example:demo:2.0.1"],
+                    ),
+                ],
+            )
+            self.assertIn("disable-docker-networking", [call[0] for call in calls])
 
     def test_infrastructure_matrix_runs_test_infra_for_each_entry(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")
@@ -263,7 +361,6 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(
             [call[0] for call in calls],
             [
-                "infrastructure-pull-allowed-docker-images",
                 "infrastructure-check-metadata-files",
                 "test-infra",
             ],
@@ -274,6 +371,45 @@ class LocalCIVerificationTests(unittest.TestCase):
         )
         self.assertEqual(calls[-1][2]["GRAALVM_HOME"], "/graalvm25")
         self.assertEqual(calls[-1][2]["GVM_TCK_NATIVE_IMAGE_MODE"], "future-defaults-all")
+
+    def test_infrastructure_matrix_pulls_docker_images_when_coordinate_declares_them(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "demo", "1.0.0")
+            os.makedirs(docker_test_dir)
+            with open(os.path.join(docker_test_dir, "required-docker-images.txt"), "w", encoding="utf-8") as file:
+                file.write("nginx:1-alpine-slim\n")
+
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            gates: list[str] = []
+
+            def fake_run_recorded_command(
+                    repo_path_arg: str,
+                    gate: str,
+                    command: list[str],
+                    local_result: LocalCIVerificationResult,
+                    env: dict[str, str] | None = None,
+                    failure_output_pattern: str | None = None,
+            ) -> CommandRecord | None:
+                del repo_path_arg, command, local_result, env, failure_output_pattern
+                gates.append(gate)
+                return None
+
+            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+                failed = _run_infrastructure_matrix_entries(
+                    repo_path,
+                    [{"coordinates": "org.example:demo:1.0.0"}],
+                    result,
+                )
+
+            self.assertIsNone(failed)
+            self.assertEqual(
+                gates,
+                [
+                    "infrastructure-pull-allowed-docker-images",
+                    "infrastructure-check-metadata-files",
+                    "test-infra",
+                ],
+            )
 
     def test_spring_aot_matrix_runs_triaged_smoke_test(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -309,10 +309,14 @@ def _run_test_matrix_entries(
         return None
 
     pulled_coordinates: set[str] = set()
+    docker_coordinates: set[str] = set()
     for entry in entries:
         coordinates = str(entry.get("coordinates") or "").strip()
         if not coordinates or coordinates in pulled_coordinates:
             continue
+        if not _coordinate_uses_docker(repo_path, coordinates):
+            continue
+        docker_coordinates.add(coordinates)
         failed = _run_recorded_command(
             repo_path,
             "pull-allowed-docker-images",
@@ -323,14 +327,15 @@ def _run_test_matrix_entries(
             return failed
         pulled_coordinates.add(coordinates)
 
-    failed = _run_recorded_command(
-        repo_path,
-        "disable-docker-networking",
-        ["bash", "./.github/workflows/scripts/disable-docker.sh"],
-        result,
-    )
-    if failed is not None:
-        return failed
+    if docker_coordinates:
+        failed = _run_recorded_command(
+            repo_path,
+            "disable-docker-networking",
+            ["bash", "./.github/workflows/scripts/disable-docker.sh"],
+            result,
+        )
+        if failed is not None:
+            return failed
 
     first_failed: CommandRecord | None = None
     restore_failed: CommandRecord | None = None
@@ -368,7 +373,8 @@ def _run_test_matrix_entries(
                 first_failed = failed
                 break
     finally:
-        restore_failed = _restore_docker_networking(repo_path, result)
+        if docker_coordinates:
+            restore_failed = _restore_docker_networking(repo_path, result)
     return first_failed or restore_failed
 
 
@@ -382,15 +388,16 @@ def _run_infrastructure_matrix_entries(
         if not coordinates:
             continue
         env = _matrix_env(entry)
-        failed = _run_recorded_command(
-            repo_path,
-            "infrastructure-pull-allowed-docker-images",
-            ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
-            result,
-            env=env,
-        )
-        if failed is not None:
-            return failed
+        if _coordinate_uses_docker(repo_path, coordinates):
+            failed = _run_recorded_command(
+                repo_path,
+                "infrastructure-pull-allowed-docker-images",
+                ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
+                result,
+                env=env,
+            )
+            if failed is not None:
+                return failed
         failed = _run_recorded_command(
             repo_path,
             "infrastructure-check-metadata-files",
@@ -481,7 +488,7 @@ def _run_spring_aot_matrix_entries(
 
 
 def _restore_docker_networking(repo_path: str, result: LocalCIVerificationResult) -> CommandRecord | None:
-    """Restore Docker networking after the CI-equivalent no-network test phase."""
+    """Restore Docker networking after a Docker-backed test phase."""
     return _run_recorded_command(
         repo_path,
         "restore-docker-networking",
@@ -632,6 +639,68 @@ def _matrix_env(entry: dict) -> dict[str, str]:
         env["GRAALVM_HOME"] = graalvm_home
         env["JAVA_HOME"] = graalvm_home
     return env
+
+
+def _coordinate_uses_docker(repo_path: str, coordinates: str) -> bool:
+    """Return whether the coordinate declares Docker images for its tests."""
+    required_images_path = _required_docker_images_path(repo_path, coordinates)
+    if required_images_path is None:
+        return False
+    with open(required_images_path, "r", encoding="utf-8") as required_images_file:
+        return any(_is_required_docker_image_line(line) for line in required_images_file)
+
+
+def _required_docker_images_path(repo_path: str, coordinates: str) -> str | None:
+    """Return the Docker declaration path for the coordinate's resolved test version."""
+    group, artifact, _version = parse_coordinate_parts(coordinates)
+    test_version = _resolve_coordinate_test_version(repo_path, coordinates)
+    if test_version is None:
+        return None
+    required_images_path = os.path.join(
+        repo_path,
+        "tests",
+        "src",
+        group,
+        artifact,
+        test_version,
+        "required-docker-images.txt",
+    )
+    if not os.path.isfile(required_images_path):
+        return None
+    return required_images_path
+
+
+def _resolve_coordinate_test_version(repo_path: str, coordinates: str) -> str | None:
+    """Resolve the test-version used by pullAllowedDockerImages for a coordinate."""
+    group, artifact, version = parse_coordinate_parts(coordinates)
+    index_path = os.path.join(repo_path, "metadata", group, artifact, "index.json")
+    if not os.path.isfile(index_path):
+        return version
+
+    with open(index_path, "r", encoding="utf-8") as index_file:
+        index_entries = json.load(index_file)
+    if not isinstance(index_entries, list):
+        return version
+
+    for entry in index_entries:
+        if not isinstance(entry, dict):
+            continue
+        tested_versions = entry.get("tested-versions")
+        if isinstance(tested_versions, list) and version in [str(tested_version) for tested_version in tested_versions]:
+            return str(entry.get("test-version") or entry.get("metadata-version") or version)
+
+    for entry in index_entries:
+        if not isinstance(entry, dict):
+            continue
+        if version == str(entry.get("metadata-version") or ""):
+            return str(entry.get("test-version") or entry.get("metadata-version") or version)
+
+    return version
+
+
+def _is_required_docker_image_line(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped and not stripped.startswith("#"))
 
 
 def _spring_aot_env(entry: dict) -> dict[str, str]:


### PR DESCRIPTION
### Summary

- Skip local Docker setup for Forge verification entries that do not declare Docker images.
- Preserve Docker network isolation for Docker-backed test runs so undeclared image pulls still fail locally.
- Resolve `required-docker-images.txt` through the index `test-version` mapping, matching Gradle `pullAllowedDockerImages`.
- Cover non-Docker, Docker-backed, shared test-version, and infrastructure matrix behavior with unit tests.

### Testing

- `python3 -m unittest tests.test_local_ci_verification`

Fixes #5167