### PR TITLE
Derive native trace packages from user-code-filter

### DIFF
--- a/forge/utility_scripts/native_metadata_exploration.py
+++ b/forge/utility_scripts/native_metadata_exploration.py
@@ -78,7 +78,6 @@ def run_native_metadata_exploration(
         reachability_repo_path: str,
         coordinate: str,
         output_dir: str,
-        condition_packages: list[str] | None = None,
         max_iterations: int = 5,
         step_timeout_seconds: int = DEFAULT_TRACE_STEP_TIMEOUT_SECONDS,
 ) -> NativeExplorationResult:
@@ -90,10 +89,6 @@ def run_native_metadata_exploration(
         raise ValueError("max_iterations must be >= 1")
     if not os.path.isabs(output_dir):
         raise ValueError("output_dir must be an absolute path")
-
-    group = coordinate.split(":", 1)[0]
-    packages = list(condition_packages) if condition_packages else [group]
-    condition_packages_arg = ",".join(packages)
 
     runs_dir = os.path.normpath(os.path.join(output_dir, "..", "runs"))
     _reset_directory(output_dir)
@@ -149,7 +144,6 @@ def run_native_metadata_exploration(
             "runNativeTraceImage",
             f"-Pcoordinates={coordinate}",
             f"-PtraceMetadataPath={run_i}",
-            f"-PtraceMetadataConditionPackages={condition_packages_arg}",
         ]
         run_log = _new_log_path(coordinate, f"run-iter-{i}")
         run_log_paths.append(run_log)

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -94,7 +94,6 @@ def verify_native_test_passes(
         reachability_repo_path: str,
         coordinate: str,
         output_dir: str,
-        condition_packages: list[str] | None = None,
         max_iterations: int = 100,
         cycle_timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
 ) -> NativeTestVerificationResult:
@@ -106,10 +105,6 @@ def verify_native_test_passes(
         raise ValueError("max_iterations must be >= 1")
     if not os.path.isabs(output_dir):
         raise ValueError("output_dir must be an absolute path")
-
-    group = coordinate.split(":", 1)[0]
-    packages = list(condition_packages) if condition_packages else [group]
-    condition_packages_arg = ",".join(packages)
 
     runs_dir = os.path.normpath(os.path.join(output_dir, "..", "runs"))
     _reset_directory(output_dir)
@@ -147,7 +142,6 @@ def verify_native_test_passes(
             reachability_repo_path=reachability_repo_path,
             coordinate=coordinate,
             run_dir=run_dir,
-            condition_packages_arg=condition_packages_arg,
             metadata_config_dirs=accepted_run_dirs,
             log_path=log_path,
             timeout_seconds=cycle_timeout_seconds,
@@ -204,7 +198,6 @@ def verify_native_test_passes(
             reproduction_command=_run_native_trace_image_command(
                 coordinate=coordinate,
                 run_dir=run_dir,
-                condition_packages_arg=condition_packages_arg,
                 metadata_config_dirs=accepted_run_dirs,
             ),
         )
@@ -235,14 +228,12 @@ def verify_native_test_passes(
 def _run_native_trace_image_command(
         coordinate: str,
         run_dir: str,
-        condition_packages_arg: str,
         metadata_config_dirs: list[str],
 ) -> str:
     parts = [
         "./gradlew runNativeTraceImage",
         f"-Pcoordinates={coordinate}",
         f"-PtraceMetadataPath={run_dir}",
-        f"-PtraceMetadataConditionPackages={condition_packages_arg}",
     ]
     if metadata_config_dirs:
         parts.append(f"-PmetadataConfigDirs={','.join(metadata_config_dirs)}")
@@ -253,7 +244,6 @@ def _run_native_trace_image(
         reachability_repo_path: str,
         coordinate: str,
         run_dir: str,
-        condition_packages_arg: str,
         metadata_config_dirs: list[str],
         log_path: str,
         timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
@@ -274,7 +264,6 @@ def _run_native_trace_image(
         "runNativeTraceImage",
         f"-Pcoordinates={coordinate}",
         f"-PtraceMetadataPath={run_dir}",
-        f"-PtraceMetadataConditionPackages={condition_packages_arg}",
         f"-PtraceBinaryExitFile={exit_file}",
     ]
     if metadata_config_dirs:

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -187,7 +187,6 @@ tasks.register("nativeTraceImage", NativeTraceImageInvocationTask.class) { task 
 }
 
 // gradle runNativeTraceImage -Pcoordinates=<maven-coordinates> -PtraceMetadataPath=<path>
-//     -PtraceMetadataConditionPackages=<pkg1,pkg2,...>
 tasks.register("runNativeTraceImage", RunNativeTraceImageInvocationTask.class) { task ->
     task.setDescription("Runs trace-enabled native tests once for matching coordinates")
     task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
@@ -196,7 +195,6 @@ tasks.register("runNativeTraceImage", RunNativeTraceImageInvocationTask.class) {
             requiredDirectoryListProperty("metadataConfigDirs", false)
         }
         requiredAbsolutePathProperty("traceMetadataPath")
-        requiredGradleProperty("traceMetadataConditionPackages")
     }
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -218,7 +218,6 @@ Closure<String> nativeImageTool = { String toolName ->
 
 if (runNativeTraceImageTaskRequested) {
     requiredAbsolutePathProperty("traceMetadataPath")
-    requiredGradleProperty("traceMetadataConditionPackages")
 }
 if (nativeTraceImageTaskRequested && project.hasProperty("metadataConfigDirs")) {
     requiredDirectoryListProperty("metadataConfigDirs", false)
@@ -360,9 +359,56 @@ tasks.named("nativeTestCompile", BuildNativeImageTask).configure { BuildNativeIm
     if (runNativeTraceImageTaskRequested) {
         task.doFirst {
             requiredGradleProperty("traceMetadataPath")
-            requiredGradleProperty("traceMetadataConditionPackages")
         }
     }
+}
+
+Closure<String> deriveTraceMetadataConditionPackages = {
+    String explicitConditionPackages = providers.gradleProperty("traceMetadataConditionPackages").getOrElse("").trim()
+    if (!explicitConditionPackages.isBlank()) {
+        return explicitConditionPackages
+    }
+
+    String userCodeFilterPath = graalvmNative.agent.modes.conditional.userCodeFilterPath.getOrElse("user-code-filter.json")
+    File userCodeFilterFile = file(userCodeFilterPath)
+    if (!userCodeFilterFile.isFile()) {
+        String fallbackPackage = libraryGAV.split(":", 2)[0]
+        logger.warn("Cannot derive TraceMetadataConditionPackages for {}: {} does not exist. Falling back to {}.", libraryGAV, userCodeFilterPath, fallbackPackage)
+        return fallbackPackage
+    }
+
+    def parsed = new JsonSlurper().parse(userCodeFilterFile)
+    def rules = parsed instanceof Map ? parsed.rules : null
+    if (!(rules instanceof List)) {
+        throw new GradleException("Cannot derive TraceMetadataConditionPackages for ${libraryGAV}: ${userCodeFilterPath} must contain a rules array.")
+    }
+
+    List<String> packages = []
+    rules.each { rule ->
+        if (!(rule instanceof Map) || !(rule.includeClasses instanceof String)) {
+            return
+        }
+        String includeClasses = rule.includeClasses.trim()
+        if (includeClasses.isBlank() || includeClasses == "**") {
+            return
+        }
+        String packageName = includeClasses
+        if (packageName.endsWith(".**")) {
+            packageName = packageName.substring(0, packageName.length() - 3)
+        } else if (packageName.endsWith(".*")) {
+            packageName = packageName.substring(0, packageName.length() - 2)
+        } else if (packageName.contains(".")) {
+            packageName = packageName.substring(0, packageName.lastIndexOf("."))
+        }
+        if (!packageName.isBlank() && !packages.contains(packageName)) {
+            packages.add(packageName)
+        }
+    }
+
+    if (packages.isEmpty()) {
+        throw new GradleException("Cannot derive TraceMetadataConditionPackages for ${libraryGAV}: ${userCodeFilterPath} has no includeClasses package rules.")
+    }
+    return packages.join(",")
 }
 
 tasks.register("nativeTraceImage") { task ->
@@ -378,7 +424,7 @@ tasks.register("runNativeTraceImage", Exec) { Exec task ->
     task.ignoreExitValue = true
     task.doFirst {
         String traceMetadataPath = requiredAbsolutePathProperty("traceMetadataPath")
-        String traceMetadataConditionPackages = requiredGradleProperty("traceMetadataConditionPackages")
+        String traceMetadataConditionPackages = deriveTraceMetadataConditionPackages()
         BuildNativeImageTask nativeTestCompile = tasks.named("nativeTestCompile", BuildNativeImageTask).get()
         NativeRunTask nativeTest = tasks.named("nativeTest", NativeRunTask).get()
         File imageFile = nativeTestCompile.outputFile.get().asFile

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
@@ -23,7 +23,6 @@ public abstract class RunNativeTraceImageInvocationTask extends AllCoordinatesEx
         ));
         appendProperty(command, "metadataConfigDirs");
         appendProperty(command, "traceMetadataPath");
-        appendProperty(command, "traceMetadataConditionPackages");
         appendProperty(command, "traceBinaryExitFile");
         return command;
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #5169.

This makes the resolved library JAR the single source of truth for metadata package lists:

- derives the complete sorted Java package list from the non-transitive target JAR
- writes that list to `allowed-packages` during scaffold, generateMetadata, contribution, version update, and finalization flows
- derives `TraceMetadataConditionPackages` inside Gradle instead of accepting `-PtraceMetadataConditionPackages` from Forge callers
- removes the `checkMetadataFiles` allowed-packages auto-repair path so packages are not inferred from checker output
- documents the invariant in both functional specs and workflow docs

Validation run:

- `./gradlew -p tests/tck-build-logic test --stacktrace`
- `python3 -m unittest forge.tests.test_native_test_verification`
- `python3 -m py_compile forge/utility_scripts/native_test_verification.py forge/utility_scripts/native_metadata_exploration.py forge/utility_scripts/library_finalization.py forge/ai_workflows/workflow_strategies/workflow_strategy.py`
- `git diff --check`
- `./gradlew runNativeTraceImage -Pcoordinates=commons-cli:commons-cli:1.5.0 -PtraceMetadataPath=/tmp/forge-trace-commons-cli-1.5.0 --stacktrace` completed without the previous trace package parser failure

## Code sections where the PR accesses files, network, docker or some external service

- `tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java`: resolves the target coordinate JAR through Gradle dependency resolution and scans `.class` entries.
- `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle`: derives runtime trace condition packages from the resolved JAR before launching the trace-enabled native image.
- `forge/utility_scripts/library_finalization.py`: invokes `./gradlew updateAllowedPackages` during finalization before `checkMetadataFiles`.
