### PR TITLE
[GenAI] Mark org.jetbrains.compose.ui:ui as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.compose.ui/ui/index.json
+++ b/metadata/org.jetbrains.compose.ui/ui/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.compose.ui:ui-desktop:1.8.2.",
+    "replacement": "org.jetbrains.compose.ui:ui-desktop:1.8.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3624

This PR records `org.jetbrains.compose.ui:ui` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.compose.ui:ui-desktop:1.8.2.

Replacement guidance:
- org.jetbrains.compose.ui:ui-desktop:1.8.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ace7dc2dfe6d98933f62ea253ab4d05b7c0adaad`

### Local CI Verification

- Status: `success`
- Commands run: 9
- Fixup attempts: 0
