### PR TITLE
Enforce complete reachability repo for Forge runs

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -36,7 +36,7 @@ from utility_scripts import metrics_writer
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
-from utility_scripts.repo_path_resolver import resolve_repo_roots
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics, validate_benchmark_run_metrics
 from utility_scripts.source_context import (
     discover_artifact_metadata,
@@ -270,6 +270,7 @@ def _metadata_already_exists(scaffold_proc: subprocess.CompletedProcess) -> bool
 
 
 def run_scaffold(library: str) -> bool:
+    require_complete_reachability_repo(os.getcwd())
     log_stage("scaffold", f"Running scaffold for {library}")
     # Run scaffold for the given coordinates
     scaffold_proc = subprocess.run(

--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -10,7 +10,7 @@ import sys
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts.library_finalization import run_library_finalization
-from utility_scripts.repo_path_resolver import resolve_repo_roots
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.source_context import populate_artifact_urls
 
 
@@ -53,6 +53,7 @@ def run_fix_test_native_image_run(
         new_version: str,
 ) -> subprocess.CompletedProcess[str]:
     """Run the fixTestNativeImageRun Gradle task."""
+    require_complete_reachability_repo(reachability_metadata_path)
     return subprocess.run(
         [
             "./gradlew", "fixTestNativeImageRun",
@@ -66,8 +67,9 @@ def run_fix_test_native_image_run(
 def run_gradle_test(
         reachability_metadata_path: str,
         coordinates: str,
-):
+) -> subprocess.CompletedProcess[str]:
     """Run Gradle tests for the provided coordinates."""
+    require_complete_reachability_repo(reachability_metadata_path)
     return subprocess.run(
         [
             "./gradlew", "test",

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -22,7 +22,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
-from utility_scripts.repo_path_resolver import resolve_repo_roots
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
 from utility_scripts.source_context import (
     normalize_source_context_types,
@@ -222,8 +222,9 @@ def copy_and_prepare_project_dir(
             file.write(gradle_props_content_updated)
 
 
-def run_gradle_task(task, coordinates):
+def run_gradle_task(task: str, coordinates: str) -> None:
     """Run a Gradle task for the provided dependency coordinates."""
+    require_complete_reachability_repo(os.getcwd())
     command = f"./gradlew {task} -Pcoordinates={coordinates}"
     subprocess.run(command, shell=True, check=True)
 

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -21,6 +21,7 @@ from ai_workflows.fix_post_generation_pi import (
 from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_persistent_instructions, load_prompt_template
 
@@ -135,6 +136,8 @@ class WorkflowStrategy(ABC):
     @staticmethod
     def _run_command(cmd: str) -> str:
         """Execute a shell command and return its combined stdout/stderr."""
+        if cmd.startswith("./gradlew"):
+            require_complete_reachability_repo(os.getcwd())
         result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         return result.stdout
 
@@ -255,6 +258,7 @@ class WorkflowStrategy(ABC):
 
     def _run_gradle_command_with_output(self, command: list[str]) -> subprocess.CompletedProcess[str]:
         """Run a Gradle command in the reachability repo and capture combined output."""
+        require_complete_reachability_repo(self.reachability_repo_path)
         return subprocess.run(
             command,
             cwd=self.reachability_repo_path,

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -119,6 +119,24 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - `FORGE_DO_WORK_STOP_FILE` overrides the shared stop marker path used by
   `do-work` loops. The default is `~/.metadata-forge-stop`.
 
+### 4.5 Repository availability for test and metadata artifacts
+
+- Every Forge workflow artifact that runs reachability-repo Gradle tasks for
+  testing, dynamic-access reporting, native metadata exploration, metadata
+  generation, or final verification must have the whole reachability repo
+  available. The runnable artifact must be rooted in a complete
+  `graalvm-reachability-metadata` checkout or worktree, not in a copied
+  per-library directory, extracted dependency artifact, or otherwise partial
+  tree.
+- Complete repo availability includes access to the repo root, `gradlew`,
+  Gradle build logic, shared test infrastructure, `metadata/`, `tests/`, and
+  `forge/` when the workflow records metrics, logs, or resumable state.
+- If Forge creates isolated worktrees, resumable artifacts, archives, or other
+  execution contexts for parallel work, tests, or metadata collection, each
+  context must preserve the complete reachability repo before running any
+  Gradle-backed test or metadata collection step. Missing repo context is a
+  hard setup failure.
+
 ## 5. Outputs
 
 - **Per-run metrics record** appended to

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -89,6 +89,7 @@ from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import (
     get_forge_subdir_name,
     get_repo_root,
+    require_complete_reachability_repo,
     resolve_repo_roots,
 )
 from utility_scripts.stage_logger import log_stage
@@ -3190,6 +3191,11 @@ def create_review_workspace(base_reachability_metadata_path: str, pr_number: int
         remove_worktree(base_reachability_metadata_path, review_worktree_path)
         print(f"ERROR: Failed to check out PR #{pr_number} in review worktree: {exc.stdout}", file=sys.stderr)
         raise
+    try:
+        require_complete_reachability_repo(review_worktree_path)
+    except SystemExit:
+        remove_worktree(base_reachability_metadata_path, review_worktree_path)
+        raise
     return review_worktree_path
 
 
@@ -3227,6 +3233,11 @@ def create_issue_workspace(
         DEFAULT_WORKTREE_BASE_REF,
         f"Failed to create worktree for issue #{issue_number}",
     )
+    try:
+        require_complete_reachability_repo(worktree_path)
+    except SystemExit:
+        remove_worktree(base_reachability_metadata_path, worktree_path)
+        raise
 
     scratch_metrics_repo_path = os.path.join(worktree_path, get_forge_subdir_name())
     copy_progress_artifacts(canonical_metrics_repo_path, scratch_metrics_repo_path, issue_number)

--- a/forge/tests/test_git_worktree_regressions.py
+++ b/forge/tests/test_git_worktree_regressions.py
@@ -10,9 +10,14 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import forge_metadata
 from git_scripts.common_git import get_origin_owner
 from utility_scripts.metrics_writer import commit_run_metrics_with_retry
-from utility_scripts.repo_path_resolver import ensure_local_metrics_repo, resolve_repo_roots
+from utility_scripts.repo_path_resolver import (
+    ensure_local_metrics_repo,
+    require_complete_reachability_repo,
+    resolve_repo_roots,
+)
 
 
 def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess:
@@ -47,15 +52,93 @@ def _commit_file(repo_root: str, relative_path: str, content: str, message: str)
     )
 
 
+def _create_reachability_repo(repo_root: str) -> str:
+    os.makedirs(repo_root, exist_ok=True)
+    _git(["init", "-b", "master"], cwd=repo_root)
+    for directory in ("forge", "metadata", "tests", os.path.join("gradle", "wrapper")):
+        os.makedirs(os.path.join(repo_root, directory), exist_ok=True)
+    _commit_file(repo_root, "gradlew", "#!/usr/bin/env sh\n", "add gradle wrapper")
+    _commit_file(repo_root, "settings.gradle", "rootProject.name = 'test'\n", "add settings")
+    _commit_file(repo_root, "build.gradle", "plugins { id 'java' }\n", "add build")
+    _commit_file(repo_root, "gradle/wrapper/gradle-wrapper.jar", "wrapper jar\n", "add wrapper jar")
+    _commit_file(
+        repo_root,
+        "gradle/wrapper/gradle-wrapper.properties",
+        "distributionUrl=https\\://services.gradle.org/distributions/gradle-bin.zip\n",
+        "add wrapper properties",
+    )
+    _commit_file(repo_root, "forge/.gitkeep", "", "add forge")
+    _commit_file(repo_root, "metadata/.gitkeep", "", "add metadata")
+    _commit_file(repo_root, "tests/.gitkeep", "", "add tests")
+    return repo_root
+
+
 class GitWorktreeRegressionTests(unittest.TestCase):
+    def test_complete_reachability_repo_validation_accepts_full_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
+
+            self.assertEqual(require_complete_reachability_repo(repo_root), repo_root)
+
+    def test_complete_reachability_repo_validation_rejects_partial_library_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            partial_dir = os.path.join(temp_dir, "tests", "src", "org.example", "demo", "1.0.0")
+            os.makedirs(partial_dir)
+
+            with self.assertRaises(SystemExit):
+                require_complete_reachability_repo(partial_dir)
+
+    def test_complete_reachability_repo_validation_rejects_downloaded_artifact_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_dir = os.path.join(temp_dir, "source_context", "org.example", "demo", "1.0.0", "main")
+            os.makedirs(artifact_dir)
+
+            with self.assertRaises(SystemExit):
+                require_complete_reachability_repo(artifact_dir)
+
+    def test_complete_reachability_repo_validation_rejects_checkout_missing_gradlew(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = os.path.join(temp_dir, "graalvm-reachability-metadata")
+            os.makedirs(repo_root)
+            _git(["init", "-b", "master"], cwd=repo_root)
+            for directory in ("forge", "metadata", "tests", os.path.join("gradle", "wrapper")):
+                os.makedirs(os.path.join(repo_root, directory), exist_ok=True)
+            _commit_file(repo_root, "settings.gradle", "rootProject.name = 'test'\n", "add settings")
+            _commit_file(repo_root, "build.gradle", "plugins { id 'java' }\n", "add build")
+            _commit_file(repo_root, "gradle/wrapper/gradle-wrapper.jar", "wrapper jar\n", "add wrapper jar")
+            _commit_file(
+                repo_root,
+                "gradle/wrapper/gradle-wrapper.properties",
+                "distributionUrl=https\\://services.gradle.org/distributions/gradle-bin.zip\n",
+                "add wrapper properties",
+            )
+            _commit_file(repo_root, "forge/.gitkeep", "", "add forge")
+            _commit_file(repo_root, "metadata/.gitkeep", "", "add metadata")
+            _commit_file(repo_root, "tests/.gitkeep", "", "add tests")
+
+            with self.assertRaises(SystemExit):
+                require_complete_reachability_repo(repo_root)
+
+    def test_complete_reachability_repo_validation_rejects_missing_gradle_build_logic(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = os.path.join(temp_dir, "graalvm-reachability-metadata")
+            os.makedirs(repo_root)
+            _git(["init", "-b", "master"], cwd=repo_root)
+            for directory in ("forge", "metadata", "tests"):
+                os.makedirs(os.path.join(repo_root, directory), exist_ok=True)
+            _commit_file(repo_root, "gradlew", "#!/usr/bin/env sh\n", "add gradle wrapper")
+            _commit_file(repo_root, "settings.gradle", "rootProject.name = 'test'\n", "add settings")
+            _commit_file(repo_root, "forge/.gitkeep", "", "add forge")
+            _commit_file(repo_root, "metadata/.gitkeep", "", "add metadata")
+            _commit_file(repo_root, "tests/.gitkeep", "", "add tests")
+
+            with self.assertRaises(SystemExit):
+                require_complete_reachability_repo(repo_root)
+
     def test_defaults_to_parent_repo_and_in_repo_forge_metrics(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            reachability_repo = os.path.join(temp_dir, "graalvm-reachability-metadata")
+            reachability_repo = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
             forge_root = os.path.join(reachability_repo, "forge")
-            os.makedirs(os.path.join(reachability_repo, "metadata"))
-            os.makedirs(os.path.join(reachability_repo, "tests"))
-            os.makedirs(forge_root)
-            _git(["init", "-b", "master"], cwd=reachability_repo)
 
             with patch("utility_scripts.repo_path_resolver.get_repo_root", return_value=forge_root):
                 reachability_root, metrics_root = resolve_repo_roots(
@@ -70,9 +153,8 @@ class GitWorktreeRegressionTests(unittest.TestCase):
 
     def test_explicit_reachability_path_uses_worktree_forge_metrics(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            worktree_path = os.path.join(temp_dir, "run-worktree")
+            worktree_path = _create_reachability_repo(os.path.join(temp_dir, "run-worktree"))
             forge_root = os.path.join(worktree_path, "forge")
-            os.makedirs(forge_root)
 
             reachability_root, metrics_root = resolve_repo_roots(
                 worktree_path,
@@ -83,6 +165,31 @@ class GitWorktreeRegressionTests(unittest.TestCase):
             self.assertEqual(metrics_root, forge_root)
             self.assertTrue(os.path.isdir(os.path.join(forge_root, "script_run_metrics")))
             self.assertTrue(os.path.isdir(os.path.join(forge_root, "benchmark_run_metrics")))
+
+    def test_explicit_reachability_path_rejects_partial_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            partial_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            os.makedirs(partial_dir)
+
+            with self.assertRaises(SystemExit):
+                resolve_repo_roots(partial_dir, None)
+
+    def test_create_issue_workspace_validates_created_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            reachability_repo = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
+            metrics_root = os.path.join(reachability_repo, "forge")
+
+            with patch.object(forge_metadata, "get_repo_root", return_value=metrics_root), \
+                    patch.object(forge_metadata, "require_complete_reachability_repo") as validate:
+                worktree_path, scratch_metrics_path = forge_metadata.create_issue_workspace(
+                    reachability_repo,
+                    metrics_root,
+                    issue_number=1412,
+                )
+
+            self.assertEqual(scratch_metrics_path, os.path.join(worktree_path, "forge"))
+            validate.assert_called_once_with(worktree_path)
+            _git(["worktree", "remove", "--force", worktree_path], cwd=reachability_repo)
 
     def test_ensure_local_metrics_repo_accepts_git_worktrees(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -222,6 +222,7 @@ class GateRoutingTests(unittest.TestCase):
     def setUp(self) -> None:
         self.repo = tempfile.mkdtemp(prefix="repo-")
         self.addCleanup(_rmtree, self.repo)
+        _make_complete_reachability_repo(self.repo)
         self.output_dir = os.path.join(
             tempfile.mkdtemp(prefix="output-"),
             "natively-collected",
@@ -470,6 +471,20 @@ class GateRoutingTests(unittest.TestCase):
 def _rmtree(path: str) -> None:
     import shutil
     shutil.rmtree(path, ignore_errors=True)
+
+
+def _make_complete_reachability_repo(path: str) -> None:
+    subprocess.run(["git", "init", "-b", "master"], cwd=path, check=True, stdout=subprocess.PIPE)
+    for directory in ("forge", "metadata", "tests", os.path.join("gradle", "wrapper")):
+        os.makedirs(os.path.join(path, directory), exist_ok=True)
+    Path(path, "gradlew").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+    Path(path, "settings.gradle").write_text("rootProject.name = 'test'\n", encoding="utf-8")
+    Path(path, "build.gradle").write_text("plugins { id 'java' }\n", encoding="utf-8")
+    Path(path, "gradle", "wrapper", "gradle-wrapper.jar").write_text("wrapper jar\n", encoding="utf-8")
+    Path(path, "gradle", "wrapper", "gradle-wrapper.properties").write_text(
+        "distributionUrl=https\\://services.gradle.org/distributions/gradle-bin.zip\n",
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/forge/utility_scripts/gradle_test_runner.py
+++ b/forge/utility_scripts/gradle_test_runner.py
@@ -16,6 +16,7 @@ import time
 
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 
 
 DEFAULT_GRADLE_TEST_TIMEOUT_SECONDS = 30 * 60
@@ -40,6 +41,7 @@ def run_gradle_test_command(
         timeout_seconds: int | None = None,
 ) -> str:
     """Run a Gradle test command and return output suitable for agent repair prompts."""
+    require_complete_reachability_repo(working_dir)
     resolved_library = library or _extract_coordinates(test_cmd)
     resolved_timeout = timeout_seconds or _timeout_from_environment()
     log_path = build_timestamped_task_log_path("gradle-test", resolved_library, "gradle-test")

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -10,11 +10,13 @@ import subprocess
 import sys
 
 from utility_scripts.style_checks import run_style_fix_and_checks
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 
 
 def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a Gradle command in the reachability repo and capture combined output."""
+    require_complete_reachability_repo(repo_path)
     return subprocess.run(
         command,
         cwd=repo_path,

--- a/forge/utility_scripts/native_metadata_exploration.py
+++ b/forge/utility_scripts/native_metadata_exploration.py
@@ -31,6 +31,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any
 
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import (
     build_timestamped_task_log_path,
@@ -86,6 +87,7 @@ def run_native_metadata_exploration(
 
     See ``forge/docs/native-metadata-exploration.md`` for the full contract.
     """
+    require_complete_reachability_repo(reachability_repo_path)
     if max_iterations < 1:
         raise ValueError("max_iterations must be >= 1")
     if not os.path.isabs(output_dir):

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -35,6 +35,7 @@ import subprocess
 from dataclasses import dataclass, field
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import (
     build_timestamped_task_log_path,
@@ -102,6 +103,7 @@ def verify_native_test_passes(
 
     See ``forge/docs/native-test-verification.md`` for the full contract.
     """
+    require_complete_reachability_repo(reachability_repo_path)
     if max_iterations < 1:
         raise ValueError("max_iterations must be >= 1")
     if not os.path.isabs(output_dir):

--- a/forge/utility_scripts/repo_path_resolver.py
+++ b/forge/utility_scripts/repo_path_resolver.py
@@ -10,7 +10,7 @@ import sys
 REACHABILITY_REPO_CLONE_URL = "git@github.com:oracle/graalvm-reachability-metadata.git"
 
 
-def get_repo_root():
+def get_repo_root() -> str:
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -54,7 +54,7 @@ def _is_git_checkout(repo_root: str) -> bool:
 def ensure_local_reachability_repo(reachability_root: str) -> str:
     """Clone the default reachability-metadata repository when it does not already exist."""
     if _is_git_checkout(reachability_root):
-        return reachability_root
+        return require_complete_reachability_repo(reachability_root)
 
     if os.path.exists(reachability_root) and os.listdir(reachability_root):
         print(
@@ -68,7 +68,7 @@ def ensure_local_reachability_repo(reachability_root: str) -> str:
 
     print(f"[Cloning graalvm-reachability-metadata into {reachability_root}...]")
     _run_git(["git", "clone", REACHABILITY_REPO_CLONE_URL, reachability_root], cwd=parent_dir)
-    return reachability_root
+    return require_complete_reachability_repo(reachability_root)
 
 
 def ensure_local_metrics_repo(metrics_root: str) -> str:
@@ -123,14 +123,56 @@ def ensure_in_repo_metrics_root(metrics_root: str) -> str:
     return metrics_root
 
 
+def _missing_reachability_repo_requirements(repo_root: str) -> list[str]:
+    """Return missing requirements for a complete reachability-metadata checkout."""
+    missing: list[str] = []
+    if not os.path.isdir(repo_root):
+        return ["directory"]
+    if not _is_git_checkout(repo_root):
+        missing.append("git checkout or worktree")
+    if not os.path.isfile(os.path.join(repo_root, "gradlew")):
+        missing.append("gradlew")
+    if not (
+            os.path.isfile(os.path.join(repo_root, "settings.gradle"))
+            or os.path.isfile(os.path.join(repo_root, "settings.gradle.kts"))
+    ):
+        missing.append("settings.gradle or settings.gradle.kts")
+    if not (
+            os.path.isfile(os.path.join(repo_root, "build.gradle"))
+            or os.path.isfile(os.path.join(repo_root, "build.gradle.kts"))
+    ):
+        missing.append("build.gradle or build.gradle.kts")
+    for directory in (get_forge_subdir_name(), "metadata", "tests", "gradle"):
+        if not os.path.isdir(os.path.join(repo_root, directory)):
+            missing.append(f"{directory}/")
+    for file_path in (
+            os.path.join("gradle", "wrapper", "gradle-wrapper.jar"),
+            os.path.join("gradle", "wrapper", "gradle-wrapper.properties"),
+    ):
+        if not os.path.isfile(os.path.join(repo_root, file_path)):
+            missing.append(file_path)
+    return missing
+
+
 def _looks_like_reachability_metadata_repo(repo_root: str) -> bool:
     """Return True when the path has the expected reachability-metadata repo shape."""
-    return (
-        _is_git_checkout(repo_root)
-        and os.path.isdir(os.path.join(repo_root, get_forge_subdir_name()))
-        and os.path.isdir(os.path.join(repo_root, "metadata"))
-        and os.path.isdir(os.path.join(repo_root, "tests"))
-    )
+    return not _missing_reachability_repo_requirements(repo_root)
+
+
+def require_complete_reachability_repo(repo_root: str) -> str:
+    """Require a complete reachability-metadata checkout or linked worktree."""
+    missing = _missing_reachability_repo_requirements(repo_root)
+    if missing:
+        print(
+            (
+                "ERROR: Reachability metadata path must be a complete "
+                f"graalvm-reachability-metadata checkout or worktree: {repo_root}. "
+                f"Missing: {', '.join(missing)}."
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return repo_root
 
 
 def resolve_parent_reachability_repo() -> str:
@@ -183,6 +225,7 @@ def resolve_repo_roots(
         resolved_reachability_root = explicit_reachability_path
     else:
         resolved_reachability_root = resolve_parent_reachability_repo()
+    require_complete_reachability_repo(resolved_reachability_root)
 
     # metrics root
     print("[Resolving Forge metrics root path...]")

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -17,6 +17,7 @@ from email.message import Message
 from typing import Any
 
 from utility_scripts.metadata_index import is_not_for_native_image_entry
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_task_log_path, display_log_path
 
@@ -132,6 +133,7 @@ def normalize_source_context_types(raw_value: Any) -> list[str]:
 
 
 def populate_artifact_urls(reachability_repo_path: str, coordinate: str, agent_command: str = DEFAULT_POPULATE_AGENT_COMMAND) -> None:
+    require_complete_reachability_repo(reachability_repo_path)
     log_path = build_task_log_path("populate-artifact-urls", coordinate, "populate_artifact_urls.log")
     log_path_display = display_log_path(log_path)
     log_stage("populate-artifact-urls", f"Populating artifact URLs for {coordinate}; output: {log_path_display}")
@@ -165,6 +167,7 @@ def discover_artifact_metadata(
         coordinate: str,
         agent_command: str = DEFAULT_POPULATE_AGENT_COMMAND,
 ) -> None:
+    require_complete_reachability_repo(reachability_repo_path)
     log_path = build_task_log_path("discover-artifact-metadata", coordinate, "discover_artifact_metadata.log")
     log_path_display = display_log_path(log_path)
     log_stage("discover-artifact-metadata", f"Discovering artifact metadata for {coordinate}; output: {log_path_display}")

--- a/forge/utility_scripts/style_checks.py
+++ b/forge/utility_scripts/style_checks.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from utility_scripts.pi_logs import build_pi_log_path
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.task_logs import display_log_path
 
 DEFAULT_PI_MODEL_NAME = "oca/gpt-5.4"
@@ -17,6 +18,7 @@ MAX_PI_CHECKSTYLE_ATTEMPTS = 3
 
 
 def _run_gradle_task(repo_path: str, command: list[str]) -> bool:
+    require_complete_reachability_repo(repo_path)
     result = subprocess.run(
         command,
         cwd=repo_path,
@@ -34,6 +36,7 @@ def _run_gradle_task(repo_path: str, command: list[str]) -> bool:
 
 def _run_checkstyle(repo_path: str, coordinate_arg: str) -> subprocess.CompletedProcess:
     """Run the checkstyle Gradle task and return the CompletedProcess."""
+    require_complete_reachability_repo(repo_path)
     return subprocess.run(
         ["./gradlew", "checkstyle", coordinate_arg],
         cwd=repo_path,
@@ -46,6 +49,7 @@ def _run_checkstyle(repo_path: str, coordinate_arg: str) -> subprocess.Completed
 
 def _run_test(repo_path: str, coordinate_arg: str) -> subprocess.CompletedProcess:
     """Run the test Gradle task and return the CompletedProcess."""
+    require_complete_reachability_repo(repo_path)
     return subprocess.run(
         ["./gradlew", "test", coordinate_arg],
         cwd=repo_path,

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -9,6 +9,7 @@ import sys
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 
 
@@ -76,6 +77,7 @@ def build_graalvm_environment(graalvm_home: str, base_env: dict[str, str] | None
 
 def run_gradle_test_with_graalvm(repo_path: str, library: str, graalvm_home: str) -> subprocess.CompletedProcess[str]:
     """Run the library test task with a specific GraalVM/JAVA_HOME."""
+    require_complete_reachability_repo(repo_path)
     return subprocess.run(
         ["./gradlew", "test", f"-Pcoordinates={library}"],
         cwd=repo_path,
@@ -143,12 +145,10 @@ def run_metadata_fix_until_tests_pass(
     return False
 
 
-def validate_repo_paths(reachability_repo_path: str, metrics_repo_path: str):
+def validate_repo_paths(reachability_repo_path: str, metrics_repo_path: str) -> None:
     """Validate required repository paths for workflow execution."""
-    if not os.path.exists(reachability_repo_path):
-        print(f"ERROR: Repository path does not exist: {os.path.relpath(reachability_repo_path)}")
-        sys.exit(1)
+    require_complete_reachability_repo(reachability_repo_path)
 
     if not os.path.exists(metrics_repo_path):
-        print(f"ERROR: Metrics repository path does not exist: {os.path.relpath(metrics_repo_path)}")
+        print(f"ERROR: Metrics repository path does not exist: {os.path.relpath(metrics_repo_path)}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## What does this PR do?

Closes #5172.

- Documents complete reachability-repo availability as a hard Forge requirement.
- Adds shared validation for complete `graalvm-reachability-metadata` checkouts/worktrees, including Gradle wrapper/build files, `forge/`, `metadata/`, and `tests/`.
- Validates isolated issue/review worktrees and Gradle-backed workflow helpers before running tests or metadata collection.
- Adds regression coverage for partial library directories, downloaded artifact directories, sparse Gradle trees, and valid full worktrees.

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/repo_path_resolver.py` inspects local filesystem paths and Git checkout/worktree shape before Gradle-backed execution.
- Gradle-backed Forge helpers now call the shared validator before invoking existing `./gradlew` tasks; this PR does not add new network, Docker, or external-service access.