### PR TITLE
Enforce no-sudo local CI verification

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -69,6 +69,10 @@ Required local tools depend on the work queue being processed:
 - `codex` for Codex-agent strategies and metadata fixups.
 - GraalVM available through `GRAALVM_HOME` or `JAVA_HOME`.
 
+Local Forge automation must run without `sudo`. Local CI verification fails
+fast instead of prompting for an administrator password if a command or script
+would require elevated privileges.
+
 ## Manual Workflows
 
 The top-level worker delegates to these lower-level entry points. Use them

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -145,6 +145,18 @@ commands, coordinates filter, native-image mode, JDK/GraalVM selection, and
 Docker/image setup must be derived from the same repo configuration that CI
 uses, including `ci.json` and the Gradle task contracts.
 
+Local verification runs must be non-privileged. Forge must not invoke `sudo`,
+must not run scripts that invoke `sudo`, and must not prompt for an
+administrator password during local automation. CI-only host mutation steps
+that require elevated privileges, such as changing system Docker networking,
+must be replaced by no-sudo local gates or omitted from local execution while
+preserving the rest of the CI-equivalent validation surface. A command that
+would require `sudo` is a local verification failure, not an interactive
+prompt. For Docker-backed tests, local verification must fail if tests create
+Docker images after the `pullAllowedDockerImages` gate, because that indicates
+the local run may have passed by pulling images that CI's disabled-network
+phase would reject.
+
 Forge must record the exact local verification commands and their outcomes in
 the run metrics and PR description. A task must not open a PR, mark a project
 item `Done`, return `RUN_STATUS_SUCCESS`, return

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -23,6 +23,7 @@ from utility_scripts.local_ci_verification import (
     _graalvm_home_for_java_version,
     _run_infrastructure_matrix_entries,
     _run_recorded_command,
+    _run_recorded_command_without_new_docker_images,
     _run_spring_aot_matrix_entries,
     _run_test_matrix_entries,
     _run_verification_once,
@@ -225,7 +226,11 @@ class LocalCIVerificationTests(unittest.TestCase):
                 return failed_record
             return None
 
-        with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+        with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
+                patch(
+                    "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
+                    side_effect=fake_run_recorded_command,
+                ):
             failed = _run_test_matrix_entries(
                 "/repo",
                 [{"coordinates": "org.example:demo:1.0.0", "versions": ["1.0.0"]}],
@@ -237,7 +242,7 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertNotIn("disable-docker-networking", gates)
         self.assertNotIn("restore-docker-networking", gates)
 
-    def test_test_matrix_isolates_docker_networking_for_coordinates_that_declare_docker_images(self) -> None:
+    def test_test_matrix_prepulls_docker_images_without_privileged_network_scripts(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             docker_test_dir = os.path.join(repo_path, "tests", "src", "org.example", "docker-demo", "1.0.0")
             os.makedirs(docker_test_dir)
@@ -259,7 +264,11 @@ class LocalCIVerificationTests(unittest.TestCase):
                 calls.append((gate, command))
                 return None
 
-            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
+                    patch(
+                        "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
+                        side_effect=fake_run_recorded_command,
+                    ):
                 failed = _run_test_matrix_entries(
                     repo_path,
                     [
@@ -279,8 +288,9 @@ class LocalCIVerificationTests(unittest.TestCase):
                     ),
                 ],
             )
-            self.assertIn("disable-docker-networking", [call[0] for call in calls])
-            self.assertEqual(calls[-1][0], "restore-docker-networking")
+            self.assertNotIn("disable-docker-networking", [call[0] for call in calls])
+            self.assertNotIn("restore-docker-networking", [call[0] for call in calls])
+            self.assertEqual([call[0] for call in calls].count("run-consecutive-tests"), 2)
 
     def test_test_matrix_resolves_docker_declaration_from_index_test_version(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
@@ -314,7 +324,11 @@ class LocalCIVerificationTests(unittest.TestCase):
                 calls.append((gate, command))
                 return None
 
-            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command):
+            with patch("utility_scripts.local_ci_verification._run_recorded_command", side_effect=fake_run_recorded_command), \
+                    patch(
+                        "utility_scripts.local_ci_verification._run_recorded_command_without_new_docker_images",
+                        side_effect=fake_run_recorded_command,
+                    ):
                 failed = _run_test_matrix_entries(
                     repo_path,
                     [{"coordinates": "org.example:demo:2.0.1", "versions": ["2.0.1"]}],
@@ -331,7 +345,115 @@ class LocalCIVerificationTests(unittest.TestCase):
                     ),
                 ],
             )
-            self.assertIn("disable-docker-networking", [call[0] for call in calls])
+            self.assertNotIn("disable-docker-networking", [call[0] for call in calls])
+            self.assertNotIn("restore-docker-networking", [call[0] for call in calls])
+
+    def test_run_recorded_command_rejects_sudo_command_without_running_it(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "command.log"),
+            ), patch("utility_scripts.local_ci_verification.subprocess.run") as run:
+                failed = _run_recorded_command(
+                    repo_path,
+                    "privileged-command",
+                    ["sudo", "systemctl", "restart", "docker"],
+                    result,
+                )
+
+            self.assertIsNotNone(failed)
+            run.assert_not_called()
+            self.assertEqual(result.commands[0].returncode, 1)
+            self.assertIn("must not invoke sudo", result.commands[0].output_excerpt)
+
+    def test_run_recorded_command_rejects_sudo_script_without_running_it(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            script_path = os.path.join(repo_path, "needs-sudo.sh")
+            with open(script_path, "w", encoding="utf-8") as file:
+                file.write("#!/bin/bash\nsudo systemctl restart docker\n")
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "command.log"),
+            ), patch("utility_scripts.local_ci_verification.subprocess.run") as run:
+                failed = _run_recorded_command(
+                    repo_path,
+                    "privileged-script",
+                    ["bash", "./needs-sudo.sh"],
+                    result,
+                )
+
+            self.assertIsNotNone(failed)
+            run.assert_not_called()
+            self.assertEqual(result.commands[0].returncode, 1)
+            self.assertIn("needs-sudo.sh", result.commands[0].output_excerpt)
+
+    def test_run_recorded_command_rejects_repo_local_script_without_suffix(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            script_path = os.path.join(repo_path, "gradlew")
+            with open(script_path, "w", encoding="utf-8") as file:
+                file.write("#!/bin/bash\nsudo systemctl restart docker\n")
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "command.log"),
+            ), patch("utility_scripts.local_ci_verification.subprocess.run") as run:
+                failed = _run_recorded_command(
+                    repo_path,
+                    "gradle-wrapper",
+                    ["./gradlew", "test"],
+                    result,
+                )
+
+            self.assertIsNotNone(failed)
+            run.assert_not_called()
+            self.assertEqual(result.commands[0].returncode, 1)
+            self.assertIn("gradlew", result.commands[0].output_excerpt)
+
+    def test_run_recorded_command_without_new_docker_images_fails_when_test_pulls_image(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            docker_outputs = [
+                "postgres:16 image-a\n",
+                "postgres:16 image-a\nredis:7 image-b\n",
+            ]
+
+            def fake_run(
+                    command: list[str],
+                    cwd: str | None = None,
+                    env: dict[str, str] | None = None,
+                    stdout=None,
+                    stderr=None,
+                    text: bool | None = None,
+                    check: bool | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                del cwd, env, stdout, stderr, text, check
+                if command[:3] == ["docker", "image", "ls"]:
+                    return subprocess.CompletedProcess(command, 0, stdout=docker_outputs.pop(0))
+                if command == ["bash", "run-tests"]:
+                    return subprocess.CompletedProcess(command, 0, stdout="tests passed\n")
+                raise AssertionError(f"unexpected command: {command}")
+
+            log_paths = [
+                os.path.join(log_path, "run.log"),
+                os.path.join(log_path, "docker.log"),
+            ]
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    side_effect=log_paths,
+            ), patch("utility_scripts.local_ci_verification.subprocess.run", side_effect=fake_run):
+                failed = _run_recorded_command_without_new_docker_images(
+                    repo_path,
+                    "run-consecutive-tests",
+                    ["bash", "run-tests"],
+                    result,
+                )
+
+            self.assertIsNotNone(failed)
+            self.assertEqual(failed.gate, "unexpected-docker-image-pull")
+            self.assertEqual(result.commands[-1].returncode, 1)
+            self.assertIn("redis:7 image-b", result.commands[-1].output_excerpt)
 
     def test_infrastructure_matrix_runs_test_infra_for_each_entry(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -27,6 +27,11 @@ CODEX_TIMEOUT_SECONDS = 1800
 DEFAULT_BASE_BRANCH = "master"
 SPRING_AOT_BRANCH = "main"
 SPRING_AOT_REPO_URL = "https://github.com/spring-projects/spring-aot-smoke-tests.git"
+NO_SUDO_FAILURE_MESSAGE = "ERROR: Local CI verification runs must not invoke sudo."
+UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE = (
+    "ERROR: Local CI verification detected Docker images created during the no-network-equivalent test gate."
+)
+DOCKER_IMAGE_LIST_COMMAND = ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}} {{.ID}}"]
 
 
 @dataclass
@@ -309,14 +314,12 @@ def _run_test_matrix_entries(
         return None
 
     pulled_coordinates: set[str] = set()
-    docker_coordinates: set[str] = set()
     for entry in entries:
         coordinates = str(entry.get("coordinates") or "").strip()
         if not coordinates or coordinates in pulled_coordinates:
             continue
         if not _coordinate_uses_docker(repo_path, coordinates):
             continue
-        docker_coordinates.add(coordinates)
         failed = _run_recorded_command(
             repo_path,
             "pull-allowed-docker-images",
@@ -327,55 +330,37 @@ def _run_test_matrix_entries(
             return failed
         pulled_coordinates.add(coordinates)
 
-    if docker_coordinates:
+    for entry in entries:
+        coordinates = str(entry.get("coordinates") or "").strip()
+        versions = entry.get("versions")
+        if not coordinates or not isinstance(versions, list):
+            continue
+        env = _matrix_env(entry)
         failed = _run_recorded_command(
             repo_path,
-            "disable-docker-networking",
-            ["bash", "./.github/workflows/scripts/disable-docker.sh"],
+            "check-metadata-files",
+            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
             result,
+            env=env,
         )
         if failed is not None:
             return failed
-
-    first_failed: CommandRecord | None = None
-    restore_failed: CommandRecord | None = None
-    try:
-        for entry in entries:
-            coordinates = str(entry.get("coordinates") or "").strip()
-            versions = entry.get("versions")
-            if not coordinates or not isinstance(versions, list):
-                continue
-            env = _matrix_env(entry)
-            failed = _run_recorded_command(
-                repo_path,
-                "check-metadata-files",
-                ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={coordinates}"],
-                result,
-                env=env,
-            )
-            if failed is not None:
-                first_failed = failed
-                break
-            failed = _run_recorded_command(
-                repo_path,
-                "run-consecutive-tests",
-                [
-                    "bash",
-                    "./.github/workflows/scripts/run-consecutive-tests.sh",
-                    coordinates,
-                    json.dumps([str(version) for version in versions]),
-                ],
-                result,
-                env=env,
-                failure_output_pattern=r"^FAILED",
-            )
-            if failed is not None:
-                first_failed = failed
-                break
-    finally:
-        if docker_coordinates:
-            restore_failed = _restore_docker_networking(repo_path, result)
-    return first_failed or restore_failed
+        failed = _run_recorded_command_without_new_docker_images(
+            repo_path,
+            "run-consecutive-tests",
+            [
+                "bash",
+                "./.github/workflows/scripts/run-consecutive-tests.sh",
+                coordinates,
+                json.dumps([str(version) for version in versions]),
+            ],
+            result,
+            env=env,
+            failure_output_pattern=r"^FAILED",
+        )
+        if failed is not None:
+            return failed
+    return None
 
 
 def _run_infrastructure_matrix_entries(
@@ -485,16 +470,6 @@ def _run_spring_aot_matrix_entries(
         if failed is not None:
             return failed
     return None
-
-
-def _restore_docker_networking(repo_path: str, result: LocalCIVerificationResult) -> CommandRecord | None:
-    """Restore Docker networking after a Docker-backed test phase."""
-    return _run_recorded_command(
-        repo_path,
-        "restore-docker-networking",
-        ["bash", "./.github/workflows/scripts/restore-docker.sh"],
-        result,
-    )
 
 
 def _run_index_validation(
@@ -743,6 +718,22 @@ def _run_recorded_command(
     display_env = dict(env or {})
     command_env.update(display_env)
     log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
+    sudo_reason = _sudo_usage_reason(repo_path, command)
+    if sudo_reason:
+        output = f"{NO_SUDO_FAILURE_MESSAGE} {sudo_reason}\n"
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            log_file.write(output)
+        record = CommandRecord(
+            gate=gate,
+            command=command,
+            returncode=1,
+            env=display_env,
+            log_path=display_log_path(log_path),
+            output_excerpt=output,
+        )
+        result.commands.append(record)
+        return record
+
     completed = subprocess.run(
         command,
         cwd=repo_path,
@@ -769,6 +760,154 @@ def _run_recorded_command(
     result.commands.append(record)
     if returncode != 0:
         return record
+    return None
+
+
+def _run_recorded_command_without_new_docker_images(
+        repo_path: str,
+        gate: str,
+        command: list[str],
+        result: LocalCIVerificationResult,
+        env: dict[str, str] | None = None,
+        failure_output_pattern: str | None = None,
+) -> CommandRecord | None:
+    try:
+        before_images = _docker_image_ids(repo_path)
+    except RuntimeError as exc:
+        output = f"ERROR: Cannot run local CI no-network-equivalent Docker validation. {exc}\n"
+        return _record_synthetic_failure(repo_path, "docker-image-baseline", command, result, env, output)
+
+    failed = _run_recorded_command(
+        repo_path,
+        gate,
+        command,
+        result,
+        env=env,
+        failure_output_pattern=failure_output_pattern,
+    )
+    if failed is not None:
+        return failed
+
+    try:
+        after_images = _docker_image_ids(repo_path)
+    except RuntimeError as exc:
+        output = f"ERROR: Cannot complete local CI no-network-equivalent Docker validation. {exc}\n"
+        return _record_synthetic_failure(repo_path, "docker-image-after-test", command, result, env, output)
+
+    new_images = sorted(after_images - before_images)
+    if not new_images:
+        return None
+
+    output = "\n".join([
+        UNEXPECTED_DOCKER_IMAGE_FAILURE_MESSAGE,
+        "CI disables Docker networking after `pullAllowedDockerImages`; local verification must not pass by pulling images on demand.",
+        "New Docker images:",
+        *[f"- {image}" for image in new_images],
+        "",
+    ])
+    return _record_synthetic_failure(repo_path, "unexpected-docker-image-pull", command, result, env, output)
+
+
+def _docker_image_ids(repo_path: str) -> set[str]:
+    try:
+        completed = subprocess.run(
+            DOCKER_IMAGE_LIST_COMMAND,
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(str(exc)) from exc
+    if completed.returncode != 0:
+        output = (completed.stdout or "").strip()
+        details = f" Output: {output}" if output else ""
+        raise RuntimeError(f"Cannot list Docker images for local CI no-network-equivalent verification.{details}")
+    images: set[str] = set()
+    for line in completed.stdout.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("<none>:<none>"):
+            images.add(stripped)
+    return images
+
+
+def _record_synthetic_failure(
+        repo_path: str,
+        gate: str,
+        command: list[str],
+        result: LocalCIVerificationResult,
+        env: dict[str, str] | None,
+        output: str,
+) -> CommandRecord:
+    log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(output)
+    record = CommandRecord(
+        gate=gate,
+        command=command,
+        returncode=1,
+        env=dict(env or {}),
+        log_path=display_log_path(log_path),
+        output_excerpt=_tail(output),
+    )
+    result.commands.append(record)
+    return record
+
+
+def _sudo_usage_reason(repo_path: str, command: list[str]) -> str | None:
+    """Return why a local command would require sudo, or None if it is allowed."""
+    if _contains_sudo_token(command):
+        return "The command line contains `sudo`."
+
+    script_path = _shell_script_path(repo_path, command)
+    if script_path is None or not os.path.isfile(script_path):
+        return None
+    sudo_line = _script_sudo_line(script_path)
+    if sudo_line is None:
+        return None
+    return f"The script `{os.path.relpath(script_path, repo_path)}` invokes `sudo`: {sudo_line}"
+
+
+def _contains_sudo_token(values: list[str]) -> bool:
+    return any(re.search(r"(?<![\w.-])sudo(?![\w.-])", value) for value in values)
+
+
+def _shell_script_path(repo_path: str, command: list[str]) -> str | None:
+    if not command:
+        return None
+    executable = os.path.basename(command[0])
+    if executable in {"bash", "sh"}:
+        for arg in command[1:]:
+            if arg == "-c":
+                return None
+            if arg.startswith("-"):
+                continue
+            return _resolve_command_path(repo_path, arg)
+        return None
+    if command[0].endswith(".sh") or _is_repo_local_path(command[0]):
+        return _resolve_command_path(repo_path, command[0])
+    return None
+
+
+def _is_repo_local_path(path: str) -> bool:
+    return not os.path.isabs(path) and (path.startswith("./") or path.startswith("../") or os.sep in path)
+
+
+def _resolve_command_path(repo_path: str, path: str) -> str:
+    if os.path.isabs(path):
+        return path
+    return os.path.normpath(os.path.join(repo_path, path))
+
+
+def _script_sudo_line(script_path: str) -> str | None:
+    with open(script_path, "r", encoding="utf-8", errors="ignore") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if re.search(r"(?<![\w.-])sudo(?![\w.-])", stripped):
+                return stripped
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #5174.

- Document local Forge verification as a non-privileged, no-sudo requirement.
- Fail local CI commands before execution when the command line or repository-local script invokes `sudo`, including scripts without a `.sh` suffix such as `./gradlew`.
- Replace privileged Docker network disable and restore calls with a no-sudo Docker image snapshot gate that fails if tests create new images after `pullAllowedDockerImages`.
- Preserve upstream Docker-coordinate detection so allowed images are pre-pulled only for coordinates that declare Docker requirements.

## Testing

- `python3 -m unittest tests.test_local_ci_verification`
- `python3 -m py_compile utility_scripts/local_ci_verification.py tests/test_local_ci_verification.py`

## Open question

- Is the Docker image snapshot gate sufficient as the local no-sudo replacement for CI disabled-network execution, or should Forge add a stricter unprivileged network isolation mechanism later?