### PR TITLE
Fail native verification when trace metadata stalls

### DIFF
--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -25,7 +25,9 @@ code:
   earlier in this gate invocation).
 - `172`            -> metadata gap; append the cycle's trace dir to the
   running `metadataConfigDirs` so the next cycle's build sees it, then
-  continue.
+  continue. If a later `172` cycle produces no new trace metadata
+  entries, print the accumulated progress and fail fast because another
+  rebuild would repeat the same missing-metadata state.
 - any other non-0  -> code/test failure; route to codex (the coding
   agent). Codex finishes it: on codex success return
   `PASSED_WITH_INTERVENTION`; on codex failure return `FAILED`. The gate
@@ -116,13 +118,15 @@ Per-cycle semantics:
     metadata and returns.
   - `172` → `ExitStatus.MISSING_METADATA`. The trace dir captured at
     least one missing access; appending it to `config_dirs` makes the
-    next cycle's build see that metadata. Codex is **not** invoked —
-    tracing is the authoritative way to fill metadata gaps.
+    next cycle's build see that metadata. Codex is **not** invoked. If
+    the current `172` cycle produces no new canonical metadata entries
+    compared with accepted trace dirs, the gate prints the accumulated
+    progress, prints the failure-log tail, and returns `FAILED`.
   - any other non-zero → the test or library code is broken in a way
     that more metadata cannot fix. Codex finishes it: codex is invoked
     once, and the gate returns based on codex's exit code. The gate does
     **not** re-run `runNativeTraceImage` after codex.
-- **Codex is terminal on non-172.** Codex with the
+- **Codex is terminal when invoked.** Codex with the
   `fix-missing-reachability-metadata` skill has full repo write access
   and validates its own work; the gate does not second-guess by re-
   verifying. This avoids the gate getting stuck in a codex/verify ping-
@@ -210,8 +214,11 @@ A `verify_native_test_passes(...)` invocation is correct iff:
      dirs as `-PinputDirs=` and the caller's `output_dir` as
      `-PoutputDir=`, then return `PASSED` (or
      `PASSED_WITH_INTERVENTION` if codex ran in an earlier cycle).
-   - `172` → append `runs_dir/cycle-<i>` to the running config dirs and
-     continue to the next outer cycle. Codex is **not** invoked.
+   - `172` with new trace metadata entries → append
+     `runs_dir/cycle-<i>` to the running config dirs and continue to the
+     next outer cycle. Codex is **not** invoked.
+   - `172` with no new trace metadata entries → print the accumulated
+     progress and failure-log tail, then return `FAILED`.
    - any other non-zero → invoke `run_codex_metadata_fix` once and
      return based on its exit code: `PASSED_WITH_INTERVENTION` on codex
      success, `FAILED` on codex failure. The gate does not re-run

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -234,6 +234,7 @@ class GateRoutingTests(unittest.TestCase):
             scripted_exits: list[int],
             metadata_exit_codes: set[int] | None = None,
             log_text: str = "BUILD SUCCESSFUL\n",
+            repeated_metadata: bool = False,
     ):
         """Build a subprocess.run replacement that consumes ``scripted_exits``.
 
@@ -269,8 +270,11 @@ class GateRoutingTests(unittest.TestCase):
                     Path(exit_file).write_text(str(rc), encoding="utf-8")
                 if run_dir and rc in metadata_exit_codes:
                     Path(run_dir).mkdir(parents=True, exist_ok=True)
+                    generated_type = "com.example.Generated"
+                    if not repeated_metadata:
+                        generated_type = f"{generated_type}{len(calls)}"
                     Path(run_dir, "reachability-metadata.json").write_text(
-                        json.dumps({"reflection": [{"type": f"com.example.Generated{len(calls)}"}]}),
+                        json.dumps({"reflection": [{"type": generated_type}]}),
                         encoding="utf-8",
                     )
                 # Gradle-side exit is always 0 (Exec uses ignoreExitValue).
@@ -306,6 +310,30 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.status, ntv.STATUS_PASSED)
         self.assertEqual(result.iterations_used, 3)
         self.assertEqual(len(result.accepted_run_dirs), 2)
+
+    def test_fails_fast_when_172_repeats_same_metadata(self) -> None:
+        fake, _calls = self._fake_run_factory([172, 172], repeated_metadata=True)
+        output = io.StringIO()
+        with patch(
+                "utility_scripts.native_test_verification.subprocess.run",
+                side_effect=fake,
+        ), redirect_stdout(output):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.iterations_used, 2)
+        self.assertEqual(len(result.accepted_run_dirs), 1)
+        printed = output.getvalue()
+        self.assertIn("metadata progress stalled (no new trace metadata entries)", printed)
+        self.assertIn("accepted_runs=1", printed)
+        self.assertIn("accepted_unique_entries=1", printed)
+        self.assertIn("current_cycle_entries=1", printed)
+        self.assertIn("produced no new trace metadata; failing fast", printed)
 
     def test_prints_aggregated_metadata_path_after_merge(self) -> None:
         fake, _calls = self._fake_run_factory([172, 0])

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -16,6 +16,7 @@ code. The gate routes on that exit code:
   earlier cycle).
 - ``172``   → metadata gap; append the cycle's trace dir to the running
   ``metadataConfigDirs`` so the next cycle's build sees it, then continue.
+  If a later ``172`` produces no new trace entries, print progress and fail.
 - any other → run ``run_codex_metadata_fix`` once. Codex finishes it: on
   codex success return ``PASSED_WITH_INTERVENTION``; on codex failure return
   ``FAILED``. The gate does not re-verify after codex.
@@ -27,6 +28,7 @@ must surface to the coding agent. See
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -118,6 +120,7 @@ def verify_native_test_passes(
     )
 
     accepted_run_dirs: list[str] = []
+    accepted_metadata_entries: set[str] = set()
     intervention_records: list[InterventionRecord] = []
     intervention_used = False
     last_log_path: str | None = None
@@ -133,6 +136,36 @@ def verify_native_test_passes(
             accepted_run_dirs=list(accepted_run_dirs),
             intervention_records=intervention_records,
         )
+
+    def _route_to_codex(cycle: int, run_dir: str, reason: str) -> NativeTestVerificationResult:
+        log_stage(
+            _GATE_STAGE,
+            f"cycle {cycle + 1}: {reason}; routing to codex (terminal)",
+        )
+        codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
+            reachability_repo_path,
+            coordinate,
+            reproduction_command=_run_native_trace_image_command(
+                coordinate=coordinate,
+                run_dir=run_dir,
+                metadata_config_dirs=accepted_run_dirs,
+            ),
+        )
+        intervention_records.append(
+            InterventionRecord(
+                stage=f"cycle-{cycle + 1}-codex",
+                kind="codex",
+                log_path=codex_log_path,
+            )
+        )
+        if codex_timed_out or codex_rc != 0:
+            log_stage(
+                _GATE_STAGE,
+                f"codex did not converge (timed_out={codex_timed_out}, rc={codex_rc}); FAILED",
+            )
+            return _make_result(STATUS_FAILED, cycle + 1)
+        log_stage(_GATE_STAGE, "codex finished; trusting codex's outcome")
+        return _make_result(STATUS_PASSED_WITH_INTERVENTION, cycle + 1)
 
     for cycle in range(max_iterations):
         log_stage(_GATE_STAGE, f"cycle {cycle + 1}/{max_iterations}")
@@ -179,45 +212,38 @@ def verify_native_test_passes(
                 )
                 _print_failure_log_tail(log_path, cycle + 1)
                 return _make_result(STATUS_FAILED, cycle + 1)
+            metadata_entries = _metadata_entries(run_dir)
+            added_entries = metadata_entries - accepted_metadata_entries
+            if not added_entries:
+                _print_metadata_progress(
+                    accepted_run_dirs=accepted_run_dirs,
+                    accepted_entry_count=len(accepted_metadata_entries),
+                    current_entry_count=len(metadata_entries),
+                    reason="no new trace metadata entries",
+                )
+                _print_failure_log_tail(log_path, cycle + 1)
+                log_stage(
+                    _GATE_STAGE,
+                    f"cycle {cycle + 1}: binary exited 172 but produced no new trace metadata; failing fast",
+                )
+                return _make_result(STATUS_FAILED, cycle + 1)
             log_stage(
                 _GATE_STAGE,
                 f"cycle {cycle + 1}: binary exited 172 (missing metadata); "
-                f"adding {os.path.basename(run_dir)} to config_dirs",
+                f"adding {os.path.basename(run_dir)} to config_dirs "
+                f"({len(added_entries)} new entr{'y' if len(added_entries) == 1 else 'ies'})",
             )
+            accepted_metadata_entries.update(added_entries)
             accepted_run_dirs.append(run_dir)
             continue
 
-        log_stage(
-            _GATE_STAGE,
-            f"cycle {cycle + 1}: binary failed (gradle_exit={gradle_rc}, binary_exit={binary_rc}); "
-            "routing to codex (terminal)",
-        )
         if not collected_metadata_files:
             _print_failure_log_tail(log_path, cycle + 1)
-        codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
-            reachability_repo_path,
-            coordinate,
-            reproduction_command=_run_native_trace_image_command(
-                coordinate=coordinate,
-                run_dir=run_dir,
-                metadata_config_dirs=accepted_run_dirs,
-            ),
+        return _route_to_codex(
+            cycle,
+            run_dir,
+            f"binary failed (gradle_exit={gradle_rc}, binary_exit={binary_rc})",
         )
-        intervention_records.append(
-            InterventionRecord(
-                stage=f"cycle-{cycle + 1}-codex",
-                kind="codex",
-                log_path=codex_log_path,
-            )
-        )
-        if codex_timed_out or codex_rc != 0:
-            log_stage(
-                _GATE_STAGE,
-                f"codex did not converge (timed_out={codex_timed_out}, rc={codex_rc}); FAILED",
-            )
-            return _make_result(STATUS_FAILED, cycle + 1)
-        log_stage(_GATE_STAGE, "codex finished; trusting codex's outcome")
-        return _make_result(STATUS_PASSED_WITH_INTERVENTION, cycle + 1)
 
     log_stage(
         _GATE_STAGE,
@@ -336,6 +362,30 @@ def _print_failure_log_tail(log_path: str, cycle_number: int) -> None:
         log_stage(_GATE_STAGE, line, indent_level=2)
 
 
+def _print_metadata_progress(
+        accepted_run_dirs: list[str],
+        accepted_entry_count: int,
+        current_entry_count: int,
+        reason: str,
+) -> None:
+    """Print trace-loop progress before a no-progress failure."""
+    log_stage(
+        _GATE_STAGE,
+        (
+            f"metadata progress stalled ({reason}): "
+            f"accepted_runs={len(accepted_run_dirs)}, "
+            f"accepted_unique_entries={accepted_entry_count}, "
+            f"current_cycle_entries={current_entry_count}"
+        ),
+        indent_level=1,
+    )
+    if not accepted_run_dirs:
+        return
+    log_stage(_GATE_STAGE, "accepted run dirs:", indent_level=1)
+    for run_dir in accepted_run_dirs:
+        log_stage(_GATE_STAGE, run_dir, indent_level=2)
+
+
 def _extract_failure_log_tail(log_path: str) -> str:
     """Extract a bounded tail from a native trace run log."""
     try:
@@ -382,6 +432,53 @@ def _metadata_file_has_entries(path: str) -> bool:
     except OSError:
         return False
     return _json_has_entries(data)
+
+
+def _metadata_entries(run_dir: str) -> set[str]:
+    """Return canonical metadata entries collected in ``run_dir``."""
+    entries: set[str] = set()
+    for metadata_file in _metadata_files(run_dir):
+        relative_path = os.path.relpath(metadata_file, run_dir)
+        try:
+            with open(metadata_file, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            opaque_digest = _opaque_file_digest(metadata_file)
+            if opaque_digest is not None:
+                entries.add(f"{relative_path}::raw::{opaque_digest}")
+            continue
+        except OSError:
+            continue
+        entries.update(
+            f"{relative_path}::{entry}"
+            for entry in _flatten_metadata_entries("", data)
+        )
+    return entries
+
+
+def _flatten_metadata_entries(path: str, value: object) -> list[str]:
+    """Flatten metadata JSON into stable entry strings."""
+    if isinstance(value, list):
+        return [
+            f"{path}::{json.dumps(item, sort_keys=True)}"
+            for item in value
+        ]
+    if isinstance(value, dict):
+        result: list[str] = []
+        for key in sorted(value.keys()):
+            child_path = f"{path}/{key}" if path else key
+            result.extend(_flatten_metadata_entries(child_path, value[key]))
+        return result
+    return [f"{path}::{json.dumps(value, sort_keys=True)}"]
+
+
+def _opaque_file_digest(path: str) -> str | None:
+    """Return a stable digest for non-JSON metadata files."""
+    try:
+        with open(path, "rb") as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
+    except OSError:
+        return None
 
 
 def _json_has_entries(value: object) -> bool:


### PR DESCRIPTION
## Summary
- Track canonical trace metadata entries accepted by the native test verification loop.
- Fail fast when a 172 missing-metadata cycle repeats without adding new entries.
- Print accumulated progress and the failure log tail for the stalled loop.

## Testing
- python3 -m unittest tests.test_native_test_verification

Fixes #5191