### PR TITLE
Limit changed metadata tests to added versions

### DIFF
--- a/.github/workflows/scripts/run-consecutive-tests.sh
+++ b/.github/workflows/scripts/run-consecutive-tests.sh
@@ -25,6 +25,21 @@ VERSIONS_JSON="${VERSIONS_JSON%"${VERSIONS_JSON##*[!\']}"}"
 readarray -t VERSIONS < <(echo "$VERSIONS_JSON" | jq -r '.[]')
 export DELIMITER="========================================================================================"
 
+echo "$DELIMITER"
+echo " run-consecutive-tests input"
+echo "$DELIMITER"
+echo "Coordinates: $TEST_COORDINATES"
+echo "Raw versions JSON: $VERSIONS_JSON"
+echo "Parsed version count: ${#VERSIONS[@]}"
+if [ "${#VERSIONS[@]}" -gt 0 ]; then
+  printf 'Parsed versions:'
+  printf ' %s' "${VERSIONS[@]}"
+  printf '\n'
+else
+  echo "Parsed versions: <none>"
+fi
+echo "Timeout per Gradle invocation: $TIMEOUT"
+
 run_multiple_attempts() {
   local stage="$1"
   local max_attempts="$2"
@@ -48,8 +63,17 @@ run_multiple_attempts() {
       echo "Re-running stage '$stage' (attempt $((attempt + 1))/$max_attempts)"
     fi
 
+    local started_at
+    local finished_at
+    started_at=$(date +%s)
+    echo "Starting stage '$stage' for $VERSION at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "Command: $cmd_str"
+
     timeout --signal=QUIT --kill-after=20s "$TIMEOUT" bash -c "$cmd_str"
     result=$?
+
+    finished_at=$(date +%s)
+    echo "Finished stage '$stage' for $VERSION at $(date -u '+%Y-%m-%dT%H:%M:%SZ') with exit code $result after $((finished_at - started_at))s"
 
     if [ "$result" -eq 0 ]; then
       return 0

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -243,7 +243,7 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertNotIn("disable-docker-networking", gates)
         self.assertNotIn("restore-docker-networking", gates)
 
-    def test_merge_test_matrix_prefers_added_tested_versions_for_same_environment(self) -> None:
+    def test_merge_test_matrix_preserves_metadata_batches_when_added_versions_exist(self) -> None:
         metadata_entries = [
             {
                 "coordinates": "org.example:demo:1.0.0",
@@ -275,6 +275,7 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(
             merged,
             [
+                metadata_entries[0],
                 metadata_entries[1],
                 added_version_entries[0],
             ],

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -21,6 +21,7 @@ from utility_scripts.local_ci_verification import (
     run_local_ci_verification,
     _github_repo_slug_from_url,
     _graalvm_home_for_java_version,
+    _merge_test_matrix_entries,
     _run_infrastructure_matrix_entries,
     _run_recorded_command,
     _run_recorded_command_without_new_docker_images,
@@ -241,6 +242,43 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(gates, ["check-metadata-files", "run-consecutive-tests"])
         self.assertNotIn("disable-docker-networking", gates)
         self.assertNotIn("restore-docker-networking", gates)
+
+    def test_merge_test_matrix_prefers_added_tested_versions_for_same_environment(self) -> None:
+        metadata_entries = [
+            {
+                "coordinates": "org.example:demo:1.0.0",
+                "versions": ["1.0.0", "1.0.1"],
+                "version": "25",
+                "os": "ubuntu-22.04",
+                "nativeImageMode": "current-defaults",
+            },
+            {
+                "coordinates": "org.example:other:2.0.0",
+                "versions": ["2.0.0"],
+                "version": "25",
+                "os": "ubuntu-22.04",
+                "nativeImageMode": "current-defaults",
+            },
+        ]
+        added_version_entries = [
+            {
+                "coordinates": "org.example:demo:1.0.0",
+                "versions": ["1.0.1"],
+                "version": "25",
+                "os": "ubuntu-22.04",
+                "nativeImageMode": "current-defaults",
+            },
+        ]
+
+        merged = _merge_test_matrix_entries(metadata_entries, added_version_entries)
+
+        self.assertEqual(
+            merged,
+            [
+                metadata_entries[1],
+                added_version_entries[0],
+            ],
+        )
 
     def test_test_matrix_prepulls_docker_images_without_privileged_network_scripts(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -607,24 +607,8 @@ def _matrix_entries(matrix: dict) -> list[dict]:
 
 
 def _merge_test_matrix_entries(changed_metadata_entries: list[dict], changed_tested_version_entries: list[dict]) -> list[dict]:
-    """Prefer added tested-version entries over full metadata batches for the same CI environment."""
-    added_version_keys = {_matrix_environment_key(entry) for entry in changed_tested_version_entries}
-    merged: list[dict] = []
-    for entry in changed_metadata_entries:
-        if _matrix_environment_key(entry) in added_version_keys:
-            continue
-        merged.append(entry)
-    merged.extend(changed_tested_version_entries)
-    return _deduplicate_test_matrix_entries(merged)
-
-
-def _matrix_environment_key(entry: dict) -> tuple[str, str, str, str]:
-    return (
-        str(entry.get("coordinates") or ""),
-        str(entry.get("version") or ""),
-        str(entry.get("os") or ""),
-        str(entry.get("nativeImageMode") or ""),
-    )
+    """Preserve changed-metadata batches and added tested-version entries without exact duplicates."""
+    return _deduplicate_test_matrix_entries(changed_metadata_entries + changed_tested_version_entries)
 
 
 def _deduplicate_test_matrix_entries(entries: list[dict]) -> list[dict]:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -262,7 +262,10 @@ def _run_verification_once(
     except _GradleOutputFailure as exc:
         return exc.record
 
-    test_entries = _matrix_entries(changed_metadata_matrix) + _matrix_entries(changed_tested_versions_matrix)
+    test_entries = _merge_test_matrix_entries(
+        _matrix_entries(changed_metadata_matrix),
+        _matrix_entries(changed_tested_versions_matrix),
+    )
     failed = _run_test_matrix_entries(repo_path, test_entries, result)
     if failed is not None:
         return failed
@@ -601,6 +604,47 @@ def _matrix_entries(matrix: dict) -> list[dict]:
     if isinstance(include, list):
         return [entry for entry in include if isinstance(entry, dict)]
     return []
+
+
+def _merge_test_matrix_entries(changed_metadata_entries: list[dict], changed_tested_version_entries: list[dict]) -> list[dict]:
+    """Prefer added tested-version entries over full metadata batches for the same CI environment."""
+    added_version_keys = {_matrix_environment_key(entry) for entry in changed_tested_version_entries}
+    merged: list[dict] = []
+    for entry in changed_metadata_entries:
+        if _matrix_environment_key(entry) in added_version_keys:
+            continue
+        merged.append(entry)
+    merged.extend(changed_tested_version_entries)
+    return _deduplicate_test_matrix_entries(merged)
+
+
+def _matrix_environment_key(entry: dict) -> tuple[str, str, str, str]:
+    return (
+        str(entry.get("coordinates") or ""),
+        str(entry.get("version") or ""),
+        str(entry.get("os") or ""),
+        str(entry.get("nativeImageMode") or ""),
+    )
+
+
+def _deduplicate_test_matrix_entries(entries: list[dict]) -> list[dict]:
+    seen: set[tuple[str, tuple[str, ...], str, str, str]] = set()
+    deduplicated: list[dict] = []
+    for entry in entries:
+        versions = entry.get("versions")
+        version_tuple = tuple(str(version) for version in versions) if isinstance(versions, list) else ()
+        key = (
+            str(entry.get("coordinates") or ""),
+            version_tuple,
+            str(entry.get("version") or ""),
+            str(entry.get("os") or ""),
+            str(entry.get("nativeImageMode") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(entry)
+    return deduplicated
 
 
 def _matrix_env(entry: dict) -> dict[str, str]:

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -495,9 +495,6 @@ List<Map<String, Object>> changedMetadataTestEntries(
         List<String> changedCoordinates
 ) {
     List<Map<String, Object>> addedVersionEntries = flattenChangedTestedVersionEntries(tck.diffIndexTestedVersions(base, head))
-    Set<String> addedVersionCoordinates = addedVersionEntries
-            .collect { it["coordinates"].toString() }
-            .toSet()
     List<Map<String, Object>> entries = []
     entries.addAll(addedVersionEntries.collect { Map<String, Object> entry ->
         [
@@ -506,9 +503,7 @@ List<Map<String, Object>> changedMetadataTestEntries(
                 "batch"      : "added"
         ]
     })
-    entries.addAll(changedCoordinates
-            .findAll { coordinate -> !addedVersionCoordinates.contains(coordinate) }
-            .collectMany { coordinate -> tck.testedVersionBatches(coordinate, versionsPerJob) })
+    entries.addAll(changedCoordinates.collectMany { coordinate -> tck.testedVersionBatches(coordinate, versionsPerJob) })
     entries
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -476,6 +476,42 @@ List<Map<String, Object>> expandChangedTestedVersionsMatrix(List<Map<String, Obj
     include
 }
 
+List<Map<String, Object>> flattenChangedTestedVersionEntries(List<Map<String, Object>> entries) {
+    List<Map<String, Object>> flattened = []
+    entries.each { Map<String, Object> entry ->
+        if (entry.containsKey("entries")) {
+            flattened.addAll(entry["entries"] as List<Map<String, Object>>)
+        } else {
+            flattened.add(entry)
+        }
+    }
+    flattened
+}
+
+List<Map<String, Object>> changedMetadataTestEntries(
+        String base,
+        String head,
+        int versionsPerJob,
+        List<String> changedCoordinates
+) {
+    List<Map<String, Object>> addedVersionEntries = flattenChangedTestedVersionEntries(tck.diffIndexTestedVersions(base, head))
+    Set<String> addedVersionCoordinates = addedVersionEntries
+            .collect { it["coordinates"].toString() }
+            .toSet()
+    List<Map<String, Object>> entries = []
+    entries.addAll(addedVersionEntries.collect { Map<String, Object> entry ->
+        [
+                "coordinates": entry["coordinates"],
+                "versions"   : entry["versions"],
+                "batch"      : "added"
+        ]
+    })
+    entries.addAll(changedCoordinates
+            .findAll { coordinate -> !addedVersionCoordinates.contains(coordinate) }
+            .collectMany { coordinate -> tck.testedVersionBatches(coordinate, versionsPerJob) })
+    entries
+}
+
 // gradle generateMatrixMatchingCoordinates -Pcoordinates=<maven-coordinates>
 Provider<Task> generateMatrixMatchingCoordinates = tasks.register("generateMatrixMatchingCoordinates", DefaultTask) { task ->
     task.setDescription("Returns matrix definition populated with all matching coordinates")
@@ -571,16 +607,20 @@ Provider<Task> generateChangedMetadataTestMatrix = tasks.register("generateChang
         }
 
         int versionsPerJob = versionsPerJobFor("generateChangedMetadataTestMatrix")
-        boolean noneFound = diffCoordinates.isEmpty()
+        String base = project.property("baseCommit")
+        String head = project.findProperty("newCommit") ?: "HEAD"
+        List<Map<String, Object>> testEntries = changedMetadataTestEntries(base, head, versionsPerJob, diffCoordinates)
+        boolean noneFound = testEntries.isEmpty()
         List<Map<String, Object>> include = noneFound
                 ? []
-                : expandMatrixEntries(
-                        diffCoordinates.collectMany { coordinate -> tck.testedVersionBatches(coordinate, versionsPerJob) },
-                        "generateChangedMetadataTestMatrix"
-                )
+                : expandMatrixEntries(testEntries, "generateChangedMetadataTestMatrix")
         def matrix = [include: include]
         if (noneFound) {
-            println "No changed coordinates were found!"
+            println "No changed metadata test entries were found!"
+        }
+        println "Changed metadata test entries:"
+        testEntries.each { entry ->
+            println " - ${entry["coordinates"]}: ${(entry["versions"] as List<?>).join(", ")}"
         }
 
         writeGithubOutput("matrix", JsonOutput.toJson(matrix))


### PR DESCRIPTION
### Summary
- log the selected versions, command, timestamps, exit code, and elapsed time in run-consecutive-tests.sh
- make the changed-metadata matrix prefer newly added tested-version diffs over full tested-version batches
- deduplicate Forge local CI test matrix entries so added-version jobs are not rerun through full metadata batches

### Testing
- python3 -m unittest tests.test_local_ci_verification
- ./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.harness.TckExtensionTests --stacktrace
- bash -n .github/workflows/scripts/run-consecutive-tests.sh
- git diff --check
- smoke checked generateChangedMetadataTestMatrix against the grpc-googleapis branch and confirmed it selected only 1.68.0

Fixes #5190