### PR TITLE
Enable optimistic dynamic-access strategy for library-update-request

### DIFF
--- a/forge/ai_workflows/improve_library_coverage.py
+++ b/forge/ai_workflows/improve_library_coverage.py
@@ -339,7 +339,8 @@ def main(argv=None) -> int:
         persistent_instructions=strategy_obj.persistent_instructions,
     )
 
-    workflow_status, iterations = strategy_obj.run(agent=agent)
+    run_result = strategy_obj.run(agent=agent)
+    workflow_status, iterations = run_result[0], run_result[1]
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         finalize_status, _ = strategy_obj._finalize_successful_iteration()

--- a/forge/ai_workflows/workflow_strategies/optimistic_dynamic_access_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/optimistic_dynamic_access_strategy.py
@@ -8,11 +8,17 @@ import subprocess
 
 from ai_workflows.workflow_strategies.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.dynamic_access_report import format_full_report, load_dynamic_access_coverage_report
+from utility_scripts.native_test_verification import (
+    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
+    global_output_dir,
+    verify_native_test_passes,
+)
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
 FALLBACK_STRATEGY_NAME = "basic_iterative_pi_gpt-5.4"
+DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 100
 
 
 @WorkflowStrategy.register("optimistic_dynamic_access")
@@ -29,6 +35,10 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         self.group, self.artifact, self.version = self.library.split(":")
         self.max_optimistic_iterations = self.parameters["max-optimistic-iterations"]
         self.max_test_iterations = self.parameters["max-test-iterations"]
+        self.max_native_test_verification_iterations = self._parameter_int(
+            "max-native-test-verification-iterations",
+            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
+        )
         self._last_dynamic_access_report_issue = "not_run"
         self.dynamic_access_report_path = os.path.join(
             self.reachability_repo_path,
@@ -150,6 +160,13 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
             successful_iterations += 1
 
+            if not self._run_native_test_verification_gate():
+                self._print_failure_analysis(
+                    "native_test_verification_gate_failed",
+                    issue="nativeTest_did_not_pass_within_verification_budget",
+                )
+                return RUN_STATUS_FAILURE, prompt_iterations, 0
+
             if current_report.total_calls == current_report.covered_calls:
                 self._print_message("all call sites covered")
                 break
@@ -157,6 +174,35 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         if successful_iterations > 0:
             return RUN_STATUS_SUCCESS, prompt_iterations, successful_iterations
         return RUN_STATUS_FAILURE, prompt_iterations, 0
+
+    def _run_native_test_verification_gate(self) -> bool:
+        """Run the bulk native-test verification gate; return True if PASSED."""
+        output_dir = global_output_dir(
+            self.reachability_repo_path, self.group, self.artifact, self.version,
+        )
+        self._print_detail(
+            f"native-test gate: starting output_dir={output_dir} "
+            f"budget={self.max_native_test_verification_iterations}",
+            indent_level=2,
+        )
+        result = verify_native_test_passes(
+            reachability_repo_path=self.reachability_repo_path,
+            coordinate=self.library,
+            output_dir=output_dir,
+            max_iterations=self.max_native_test_verification_iterations,
+        )
+        if result.status == NATIVE_TEST_GATE_FAILED:
+            log_path = result.last_native_test_log_path or "(none)"
+            self._print_message(
+                f"native-test gate FAILED after {result.iterations_used} cycles "
+                f"(last log: {log_path})"
+            )
+            return False
+        self._print_detail(
+            f"native-test gate {result.status} after {result.iterations_used} cycles",
+            indent_level=2,
+        )
+        return True
 
     def _run_basic_iterative_fallback(self, agent, **kwargs):
         """Instantiate a BasicIterativeStrategy and delegate to it."""

--- a/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md
+++ b/forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md
@@ -1,0 +1,18 @@
+Role: You are an expert JVM test engineer specializing in high-coverage integration testing for external libraries.
+
+Task:
+Extend the existing test suite for `{library}` to cover as many uncovered dynamic-access call sites as possible across all classes in the report below.
+
+Source Context:
+{source_context_overview}
+
+Iteration progress:
+{iteration_progress}
+
+Full dynamic-access coverage report, all classes with uncovered call sites:
+{dynamic_access_full_report}
+
+Rules:
+- Existing tests already pass. Add new tests, or refine in place only when strictly necessary; do not remove, rewrite, or weaken existing tests.
+- Add or refine tests so execution reaches as many of the uncovered call sites as possible, across all classes listed above. Be pragmatic — focus on the most straightforward call sites first and keep the generation concise.
+- After finishing this generation, create a git commit with a focused message describing the test changes.

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -775,16 +775,20 @@
   },
   {
     "name": "library_update_optimistic_pi_gpt-5.5",
-    "description": "Library-update strategy: bulk dynamic-access coverage in a single broad pass. Faster than the iterative class-by-class strategy but ignores large-library chunking, so prefer the iterative strategy for very large libraries.",
+    "description": "Library-update composite strategy: bulk dynamic-access coverage in one broad pass first, then per-class iterative refinement of any stragglers. Mirrors the iterative library-update strategy but starts with a faster bulk pass.",
     "agent": "pi",
-    "workflow": "optimistic_dynamic_access",
+    "workflow": "increase_dynamic_access_coverage",
+    "primary-workflow": "optimistic_dynamic_access",
     "model": "oca/gpt-5.5",
     "prompts": {
-      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md"
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md",
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
     },
     "parameters": {
       "max-optimistic-iterations": 3,
       "max-test-iterations": 3,
+      "max-iterations": 3,
+      "max-class-test-iterations": 2,
       "source-context-types": [
         "main"
       ]

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -772,5 +772,24 @@
     },
     "mcps": [],
     "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
+  },
+  {
+    "name": "library_update_optimistic_pi_gpt-5.5",
+    "description": "Library-update strategy: bulk dynamic-access coverage in a single broad pass. Faster than the iterative class-by-class strategy but ignores large-library chunking, so prefer the iterative strategy for very large libraries.",
+    "agent": "pi",
+    "workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md"
+    },
+    "parameters": {
+      "max-optimistic-iterations": 3,
+      "max-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": [],
+    "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
   }
 ]


### PR DESCRIPTION
## Summary

Makes the bulk (optimistic) dynamic-access strategy usable for `library-update-request` work and brings it up to the same native-image safety bar as the iterative strategy.

- `OptimisticDynamicAccessStrategy` now runs `verify_native_test_passes` after each successful bulk iteration, mirroring the per-class gate the iterative strategy already runs. Uses the global per-library output dir since optimistic has no class context. On gate failure the strategy returns `RUN_STATUS_FAILURE`.
- New predefined strategy `library_update_optimistic_pi_gpt-5.5`. It uses the `increase_dynamic_access_coverage` composite with `primary-workflow: optimistic_dynamic_access`: a fast bulk pass first, then per-class iterative refinement for any classes the bulk pass did not fully cover. This mirrors the shape of the existing iterative library-update strategy and keeps `large_library_progress_state` chunking via the iterative leg.
- New prompt `prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md` used for the optimistic primary; it tells the agent to extend the existing test suite rather than regenerate it. The iterative refinement leg keeps the standard `dynamic-access-iteration.md` prompt, which is already worded as "improve test coverage / add or refine tests".
- `improve_library_coverage.py` now tolerates both 2- and 3-tuple returns from `strategy.run`, so composite strategies whose primary returns a 3-tuple (like the optimistic primary) can be selected via that entry point.


Fixes #5194