### PR TITLE
Add JUnit reporting native metadata test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ bin/
 .gradletasknamecache
 gradle-app.setting
 !gradle-wrapper.jar
+**/test-results-native/
 
 ##############################
 ## IntelliJ

--- a/metadata/junit/junit/4.13.2/reachability-metadata.json
+++ b/metadata/junit/junit/4.13.2/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.engine.support.OpenTest4JAndJUnit4AwareThrowableCollector"
+      },
+      "type" : "org.junit.internal.AssumptionViolatedException"
+    }
+  ]
+}

--- a/metadata/junit/junit/index.json
+++ b/metadata/junit/junit/index.json
@@ -1,0 +1,18 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.13.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/junit/junit/$version$/junit-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit4",
+    "test-code-url" : "https://github.com/junit-team/junit4/tree/r4.13.2/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/junit/junit/$version$/junit-$version$-javadoc.jar",
+    "description" : "JUnit 4 provides the classic Java unit testing framework, including annotations, assertions, assumptions, runners, and rules used directly by tests and by compatibility layers in newer JUnit Platform engines.",
+    "tested-versions" : [
+      "4.13.2"
+    ],
+    "allowed-packages" : [
+      "junit",
+      "org.junit"
+    ]
+  }
+]

--- a/metadata/org.junit.platform/junit-platform-launcher/index.json
+++ b/metadata/org.junit.platform/junit-platform-launcher/index.json
@@ -12,6 +12,9 @@
     ],
     "allowed-packages" : [
       "org.junit.platform.launcher"
+    ],
+    "requires" : [
+      "org.junit.platform:junit-platform-reporting"
     ]
   }
 ]

--- a/metadata/org.junit.platform/junit-platform-reporting/1.9.2/reachability-metadata.json
+++ b/metadata/org.junit.platform/junit-platform-reporting/1.9.2/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "module" : "java.base",
+      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "module" : "java.xml",
+      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
+    }
+  ]
+}

--- a/metadata/org.junit.platform/junit-platform-reporting/index.json
+++ b/metadata/org.junit.platform/junit-platform-reporting/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.9.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-reporting/$version$/junit-platform-reporting-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit-framework",
+    "test-code-url" : "https://github.com/junit-team/junit-framework/tree/r5.9.2/platform-tests/src/test/java/org/junit/platform/reporting",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-reporting/$version$/junit-platform-reporting-$version$-javadoc.jar",
+    "description" : "JUnit Platform Reporting provides listeners and XML writers for legacy and Open Test Reporting formats. It is used by JUnit Platform launchers and native test integrations to generate test execution reports.",
+    "tested-versions" : [
+      "1.9.2"
+    ],
+    "allowed-packages" : [
+      "org.junit.platform.reporting"
+    ]
+  }
+]

--- a/stats/junit/junit/4.13.2/stats.json
+++ b/stats/junit/junit/4.13.2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.13.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 70
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 70
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 68,
+        "missed" : 21428,
+        "ratio" : 0.003163,
+        "total" : 21496
+      },
+      "line" : {
+        "covered" : 25,
+        "missed" : 4866,
+        "ratio" : 0.005111,
+        "total" : 4891
+      },
+      "method" : {
+        "covered" : 10,
+        "missed" : 1620,
+        "ratio" : 0.006135,
+        "total" : 1630
+      }
+    }
+  } ]
+}

--- a/stats/org.junit.platform/junit-platform-reporting/1.9.2/stats.json
+++ b/stats/org.junit.platform/junit-platform-reporting/1.9.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.9.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1005,
+        "missed" : 2844,
+        "ratio" : 0.261107,
+        "total" : 3849
+      },
+      "line" : {
+        "covered" : 219,
+        "missed" : 648,
+        "ratio" : 0.252595,
+        "total" : 867
+      },
+      "method" : {
+        "covered" : 71,
+        "missed" : 290,
+        "ratio" : 0.196676,
+        "total" : 361
+      }
+    }
+  } ]
+}

--- a/tests/src/junit/junit/4.13.2/.gitignore
+++ b/tests/src/junit/junit/4.13.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/junit/junit/4.13.2/build.gradle
+++ b/tests/src/junit/junit/4.13.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "junit:junit:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/junit/junit/4.13.2/gradle.properties
+++ b/tests/src/junit/junit/4.13.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = junit:junit:4.13.2
+library.version = 4.13.2
+metadata.dir = junit/junit/4.13.2/

--- a/tests/src/junit/junit/4.13.2/settings.gradle
+++ b/tests/src/junit/junit/4.13.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'junit.junit_tests'

--- a/tests/src/junit/junit/4.13.2/src/test/java/junit_junit/JunitTest.java
+++ b/tests/src/junit/junit/4.13.2/src/test/java/junit_junit/JunitTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit_junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.jupiter.api.Test;
+
+class JunitTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void createsAssumptionViolation() {
+        AssumptionViolatedException exception = new AssumptionViolatedException("skipped");
+
+        assertThat(exception.getMessage()).contains("skipped");
+    }
+}

--- a/tests/src/junit/junit/4.13.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/junit/junit/4.13.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineDiscoveryOrchestrator"
+      },
+      "type" : "junit_junit.JunitTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineExecutionOrchestrator"
+      },
+      "type" : "junit_junit.JunitTest",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/junit/junit/4.13.2/user-code-filter.json
+++ b/tests/src/junit/junit/4.13.2/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "junit.**"
+    },
+    {
+      "includeClasses" : "org.junit.**"
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/.gitignore
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/build.gradle
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.platform:junit-platform-reporting:$libraryVersion"
+    testImplementation "org.junit.platform:junit-platform-launcher:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/gradle.properties
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.platform:junit-platform-reporting:1.9.2
+library.version = 1.9.2
+metadata.dir = org.junit.platform/junit-platform-reporting/1.9.2/

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/settings.gradle
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.platform.junit-platform-reporting_tests'

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/src/test/java/org_junit_platform/junit_platform_reporting/Junit_platform_reportingTest.java
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/src/test/java/org_junit_platform/junit_platform_reporting/Junit_platform_reportingTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_platform.junit_platform_reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.EngineFilter.includeEngines;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+class Junit_platform_reportingTest {
+    @TempDir
+    Path reportsDir;
+
+    @Test
+    void legacyXmlReportListenerWritesReport() throws Exception {
+        StringWriter output = new StringWriter();
+        LegacyXmlReportGeneratingListener reportListener =
+                new LegacyXmlReportGeneratingListener(reportsDir, new PrintWriter(output));
+        LauncherConfig launcherConfig = LauncherConfig.builder()
+                .enableLauncherSessionListenerAutoRegistration(false)
+                .enableLauncherDiscoveryListenerAutoRegistration(false)
+                .enableTestExecutionListenerAutoRegistration(false)
+                .enablePostDiscoveryFilterAutoRegistration(false)
+                .enableTestEngineAutoRegistration(true)
+                .addTestExecutionListeners(reportListener)
+                .build();
+        Launcher launcher = LauncherFactory.create(launcherConfig);
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(SampleTestCase.class))
+                .filters(includeEngines("junit-jupiter"))
+                .build();
+
+        launcher.execute(request);
+
+        Path report = reportsDir.resolve("TEST-junit-jupiter.xml");
+        assertThat(report).exists();
+        assertThat(Files.readString(report)).contains("sampleTest");
+        try (Stream<Path> reports = Files.list(reportsDir)) {
+            List<Path> reportFiles = reports.toList();
+            assertThat(reportFiles).containsExactly(report);
+        }
+        assertThat(output.toString()).isEmpty();
+    }
+
+    static class SampleTestCase {
+        @Test
+        void sampleTest() {
+            assertThat("junit").startsWith("jun");
+        }
+    }
+}

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineDiscoveryOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_reporting.Junit_platform_reportingTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineExecutionOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_reporting.Junit_platform_reportingTest",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineDiscoveryOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_reporting.Junit_platform_reportingTest$SampleTestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.launcher.core.EngineExecutionOrchestrator"
+      },
+      "type" : "org_junit_platform.junit_platform_reporting.Junit_platform_reportingTest$SampleTestCase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/user-code-filter.json
+++ b/tests/src/org.junit.platform/junit-platform-reporting/1.9.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.junit.platform.reporting.**"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
- Add reachability metadata for org.junit.platform:junit-platform-reporting legacy XML report generation.
- Add a native test that exercises LegacyXmlReportGeneratingListener and verifies the generated XML report.
- Add junit:junit metadata/test coverage for the JUnit 4 assumption type reached by Jupiter internals.
- Link junit-platform-launcher metadata to junit-platform-reporting so native JUnit test images include the reporting metadata.
- Ignore generated test-results-native directories.

### Testing
- ./gradlew test -Pcoordinates=org.junit.platform:junit-platform-reporting:1.9.2 --stacktrace
- ./gradlew runNativeTraceImage -Pcoordinates=org.junit.platform:junit-platform-reporting:1.9.2 -PtraceMetadataPath=/tmp/junit-reporting-trace-repro/metadata-run-0 -PtraceMetadataConditionPackages=org.junit.platform.reporting --stacktrace
- ./gradlew test -Pcoordinates=junit:junit:4.13.2 --stacktrace
- ./gradlew checkMetadataFiles -Pcoordinates=org.junit.platform:junit-platform-reporting:1.9.2 --stacktrace
- ./gradlew checkMetadataFiles -Pcoordinates=org.junit.platform:junit-platform-launcher:1.9.2 --stacktrace
- ./gradlew checkMetadataFiles -Pcoordinates=junit:junit:4.13.2 --stacktrace
- ./gradlew checkstyle -Pcoordinates=org.junit.platform:junit-platform-reporting:1.9.2 --stacktrace
- ./gradlew checkstyle -Pcoordinates=junit:junit:4.13.2 --stacktrace

### Open question
- Flyway exact trace now gets past the JUnit XML reporting metadata failure and reaches a separate Flyway resource gap for db/callback. This PR keeps that follow-up out of scope.

Fixes #5198