### PR TITLE
Sanitize Gradle Java home in Forge local CI

### DIFF
--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -207,6 +207,48 @@ class LocalCIVerificationTests(unittest.TestCase):
             self.assertEqual(result.commands[0].returncode, 1)
             self.assertIn("FAILED[javaTest]", result.commands[0].output_excerpt)
 
+    def test_run_recorded_command_removes_inherited_gradle_java_home_overrides(self) -> None:
+        captured_env: dict[str, str] = {}
+
+        def fake_run(
+                command: list[str],
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+                stdout=None,
+                stderr=None,
+                text: bool | None = None,
+                check: bool | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del cwd, stdout, stderr, text, check
+            captured_env.update(env or {})
+            return subprocess.CompletedProcess(command, 0, stdout="ok\n")
+
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+            with patch.dict(
+                    os.environ,
+                    {
+                        "GRADLE_OPTS": "-Xmx2g -Dorg.gradle.java.home=/wrong/jdk -Dfile.encoding=UTF-8",
+                        "JAVA_OPTS": "-Dorg.gradle.java.home=/other/jdk",
+                    },
+                    clear=True,
+            ), patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "command.log"),
+            ), patch("utility_scripts.local_ci_verification.subprocess.run", side_effect=fake_run):
+                failed = _run_recorded_command(
+                    repo_path,
+                    "run-consecutive-tests",
+                    ["bash", "script.sh"],
+                    result,
+                    env={"JAVA_HOME": "/matrix/jdk"},
+                )
+
+        self.assertIsNone(failed)
+        self.assertEqual(captured_env["JAVA_HOME"], "/matrix/jdk")
+        self.assertEqual(captured_env["GRADLE_OPTS"], "-Xmx2g -Dfile.encoding=UTF-8")
+        self.assertNotIn("JAVA_OPTS", captured_env)
+
     def test_test_matrix_skips_docker_networking_for_non_docker_coordinate(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")
         failed_record = CommandRecord(gate="run-consecutive-tests", command=["bash"], returncode=1)

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
@@ -717,6 +718,7 @@ def _run_recorded_command(
     command_env = dict(os.environ)
     display_env = dict(env or {})
     command_env.update(display_env)
+    _remove_gradle_java_home_overrides(command_env)
     log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
     sudo_reason = _sudo_usage_reason(repo_path, command)
     if sudo_reason:
@@ -761,6 +763,23 @@ def _run_recorded_command(
     if returncode != 0:
         return record
     return None
+
+
+def _remove_gradle_java_home_overrides(command_env: dict[str, str]) -> None:
+    """Let the selected `JAVA_HOME` drive Gradle instead of inherited local overrides."""
+    for env_name in ("GRADLE_OPTS", "JAVA_OPTS"):
+        value = command_env.get(env_name)
+        if not value:
+            continue
+        try:
+            tokens = shlex.split(value)
+        except ValueError:
+            continue
+        filtered_tokens = [token for token in tokens if not token.startswith("-Dorg.gradle.java.home=")]
+        if filtered_tokens:
+            command_env[env_name] = shlex.join(filtered_tokens)
+        else:
+            command_env.pop(env_name, None)
 
 
 def _run_recorded_command_without_new_docker_images(


### PR DESCRIPTION
### Summary
- Strip inherited `-Dorg.gradle.java.home=...` from `GRADLE_OPTS` and `JAVA_OPTS` before Forge runs local CI verification commands.
- Preserve the matrix-selected `JAVA_HOME`/`GRAALVM_HOME` and all other launcher options.
- Add unit coverage for the environment sanitization behavior.

### Testing
- `python3 -m unittest tests/test_local_ci_verification.py`

Fixes #5199