### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-serialization-core as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-serialization-core/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-serialization-core/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.9.0.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.9.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3609

This PR records `org.jetbrains.kotlinx:kotlinx-serialization-core` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.9.0.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.9.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3d6a79aafb0a9cd59b1dc55bcad350c16540408b`

### Local CI Verification

- Status: `success`
- Commands run: 9
- Fixup attempts: 0
