### PR TITLE
[GenAI] Test fix for org.yaml:snakeyaml:2.0 using gpt-5.5

### DIFF
--- a/stats/org.yaml/snakeyaml/2.0/execution-metrics.json
+++ b/stats/org.yaml/snakeyaml/2.0/execution-metrics.json
@@ -1,10 +1,10 @@
 {
   "fix_javac_fail:2026-05-03": {
-    "timestamp": "2026-05-03T09:36:50.741345Z",
+    "timestamp": "2026-05-03T13:40:12.992116Z",
     "library": "org.yaml:snakeyaml:2.0",
-    "starting_commit": "845de303a9cf64e0868dee2218611981dd3499a1",
-    "ending_commit": "ad5253e03bb1b05e70a1a1e547a57c32a59bddce",
-    "previous_library": "org.yaml:snakeyaml:1.32",
+    "starting_commit": "f61596b70d21800530b9197d167c17b4d1cde2eb",
+    "ending_commit": "9603018a92b0d62d9a353cb7c89170d2f931b3c4",
+    "previous_library": "org.yaml:snakeyaml:2.0",
     "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -45,53 +45,53 @@
       }
     },
     "previous_library_stats": {
-      "version": "1.32",
+      "version": "2.0",
       "dynamicAccess": {
         "breakdown": {
           "reflection": {
             "coverageRatio": 1.0,
-            "coveredCalls": 37,
-            "totalCalls": 37
+            "coveredCalls": 36,
+            "totalCalls": 36
           }
         },
         "coverageRatio": 1.0,
-        "coveredCalls": 37,
-        "totalCalls": 37
+        "coveredCalls": 36,
+        "totalCalls": 36
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 9099,
-          "missed": 21383,
-          "ratio": 0.298504,
-          "total": 30482
+          "covered": 9329,
+          "missed": 21176,
+          "ratio": 0.305819,
+          "total": 30505
         },
         "line": {
-          "covered": 1990,
-          "missed": 4318,
-          "ratio": 0.315472,
-          "total": 6308
+          "covered": 2053,
+          "missed": 4270,
+          "ratio": 0.324688,
+          "total": 6323
         },
         "method": {
-          "covered": 454,
-          "missed": 654,
-          "ratio": 0.409747,
-          "total": 1108
+          "covered": 466,
+          "missed": 618,
+          "ratio": 0.429889,
+          "total": 1084
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 31979,
-      "cached_input_tokens_used": 347648,
-      "output_tokens_used": 3953,
+      "input_tokens_used": 49630,
+      "cached_input_tokens_used": 260608,
+      "output_tokens_used": 3311,
       "iterations": 1,
-      "cost_usd": 0.2924,
+      "cost_usd": 0.2296,
       "tested_library_loc": 2053,
       "metadata_entries": 14,
       "test_only_metadata_entries": 66,
-      "previous_library_metadata_entries": 0,
-      "previous_library_test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 14,
+      "previous_library_test_only_metadata_entries": 66,
       "code_coverage_percent": 32.47,
-      "previous_library_coverage_percent": 31.55
+      "previous_library_coverage_percent": 32.47
     },
     "artifacts": {
       "test_file": "tests/src/org.yaml/snakeyaml/2.0/src/test/java/org_yaml/snakeyaml/BaseConstructorTest.java",

--- a/tests/src/org.yaml/snakeyaml/2.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/org.yaml/snakeyaml/2.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="25" skipped="0" failures="0" errors="0" time="0.023" hostname="kung-fu-workstation" timestamp="2026-05-03T11:34:31">
+<testsuite name="JUnit Jupiter" tests="25" skipped="0" failures="0" errors="0" time="0.046" hostname="kung-fu-workstation" timestamp="2026-05-03T15:38:55">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.class-for-name-respects-class-loader" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-file-system-providers" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-resource-bundles" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,15 +47,16 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2004-f0ea5790/tests/src/org.yaml/snakeyaml/2.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/5186-bb208043/tests/src/org.yaml/snakeyaml/2.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="constructsTaggedBeanWhenContextClassLoaderCannotResolveTheTagClass()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0">
+<testcase name="constructsTaggedBeanWhenContextClassLoaderCannotResolveTheTagClass()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructScalarTest]/[method:constructsTaggedBeanWhenContextClassLoaderCannotResolveTheTagClass()]
 display-name: constructsTaggedBeanWhenContextClassLoaderCannotResolveTheTagClass()
@@ -63,7 +68,7 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.PropertySubstituteTe
 display-name: fillsArrayValuesThroughSingleElementAdder()
 ]]></system-out>
 </testcase>
-<testcase name="fillsCollectionValuesThroughSingleElementAdder()" classname="org_yaml.snakeyaml.PropertySubstituteTest" time="0">
+<testcase name="fillsCollectionValuesThroughSingleElementAdder()" classname="org_yaml.snakeyaml.PropertySubstituteTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.PropertySubstituteTest]/[method:fillsCollectionValuesThroughSingleElementAdder()]
 display-name: fillsCollectionValuesThroughSingleElementAdder()
@@ -81,19 +86,19 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.FieldPropertyTest]/[
 display-name: readsInheritedPrivateFieldThroughFieldProperty()
 ]]></system-out>
 </testcase>
-<testcase name="constructsDateSubclassWithPublicLongConstructor()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0">
+<testcase name="constructsDateSubclassWithPublicLongConstructor()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructScalarTest]/[method:constructsDateSubclassWithPublicLongConstructor()]
 display-name: constructsDateSubclassWithPublicLongConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="readsBeanValueThroughMethodPropertyGetter()" classname="org_yaml.snakeyaml.MethodPropertyTest" time="0">
+<testcase name="readsBeanValueThroughMethodPropertyGetter()" classname="org_yaml.snakeyaml.MethodPropertyTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.MethodPropertyTest]/[method:readsBeanValueThroughMethodPropertyGetter()]
 display-name: readsBeanValueThroughMethodPropertyGetter()
 ]]></system-out>
 </testcase>
-<testcase name="constructsBeanUsingPrivateNoArgConstructor()" classname="org_yaml.snakeyaml.BaseConstructorTest" time="0.004">
+<testcase name="constructsBeanUsingPrivateNoArgConstructor()" classname="org_yaml.snakeyaml.BaseConstructorTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.BaseConstructorTest]/[method:constructsBeanUsingPrivateNoArgConstructor()]
 display-name: constructsBeanUsingPrivateNoArgConstructor()
@@ -105,7 +110,7 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.PropertySubstituteTe
 display-name: fillsMapValuesThroughKeyValueAdder()
 ]]></system-out>
 </testcase>
-<testcase name="loadsCompactBeanBySimpleNameFromConfiguredPackage()" classname="org_yaml.snakeyaml.PackageCompactConstructorTest" time="0">
+<testcase name="loadsCompactBeanBySimpleNameFromConfiguredPackage()" classname="org_yaml.snakeyaml.PackageCompactConstructorTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.PackageCompactConstructorTest]/[method:loadsCompactBeanBySimpleNameFromConfiguredPackage()]
 display-name: loadsCompactBeanBySimpleNameFromConfiguredPackage()
@@ -123,25 +128,25 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.CompactConstructorTe
 display-name: constructsCompactBeanAndAppliesNamedProperties()
 ]]></system-out>
 </testcase>
-<testcase name="resolvesTaggedBeanWithProvidedClassLoaderWhenContextLoaderRejectsIt()" classname="org_yaml.snakeyaml.CustomClassLoaderConstructorTest" time="0.001">
+<testcase name="resolvesTaggedBeanWithProvidedClassLoaderWhenContextLoaderRejectsIt()" classname="org_yaml.snakeyaml.CustomClassLoaderConstructorTest" time="0.004">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.CustomClassLoaderConstructorTest]/[method:resolvesTaggedBeanWithProvidedClassLoaderWhenContextLoaderRejectsIt()]
 display-name: resolvesTaggedBeanWithProvidedClassLoaderWhenContextLoaderRejectsIt()
 ]]></system-out>
 </testcase>
-<testcase name="resolvesGenericArrayTypeArgumentsToArrayClasses()" classname="org_yaml.snakeyaml.GenericPropertyTest" time="0.002">
+<testcase name="resolvesGenericArrayTypeArgumentsToArrayClasses()" classname="org_yaml.snakeyaml.GenericPropertyTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.GenericPropertyTest]/[method:resolvesGenericArrayTypeArgumentsToArrayClasses()]
 display-name: resolvesGenericArrayTypeArgumentsToArrayClasses()
 ]]></system-out>
 </testcase>
-<testcase name="constructsImmutableObjectFromSequenceUsingSingleDeclaredConstructor()" classname="org_yaml.snakeyaml.ConstructorConstructSequenceTest" time="0.001">
+<testcase name="constructsImmutableObjectFromSequenceUsingSingleDeclaredConstructor()" classname="org_yaml.snakeyaml.ConstructorConstructSequenceTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructSequenceTest]/[method:constructsImmutableObjectFromSequenceUsingSingleDeclaredConstructor()]
 display-name: constructsImmutableObjectFromSequenceUsingSingleDeclaredConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="constructsRootBeanWhenRootTypeIsProvidedAsClassName()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0">
+<testcase name="constructsRootBeanWhenRootTypeIsProvidedAsClassName()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructScalarTest]/[method:constructsRootBeanWhenRootTypeIsProvidedAsClassName()]
 display-name: constructsRootBeanWhenRootTypeIsProvidedAsClassName()
@@ -153,19 +158,19 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstruct
 display-name: constructsRootBeanWhenRootTypeClassNameUsesCustomLoaderOptions()
 ]]></system-out>
 </testcase>
-<testcase name="constructsCompactBeanUsingPrivateDeclaredStringConstructor()" classname="org_yaml.snakeyaml.CompactConstructorTest" time="0.002">
+<testcase name="constructsCompactBeanUsingPrivateDeclaredStringConstructor()" classname="org_yaml.snakeyaml.CompactConstructorTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.CompactConstructorTest]/[method:constructsCompactBeanUsingPrivateDeclaredStringConstructor()]
 display-name: constructsCompactBeanUsingPrivateDeclaredStringConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="constructsCustomScalarWithStringConstructorWhenMultipleDeclaredConstructorsExist()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0">
+<testcase name="constructsCustomScalarWithStringConstructorWhenMultipleDeclaredConstructorsExist()" classname="org_yaml.snakeyaml.ConstructorConstructScalarTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructScalarTest]/[method:constructsCustomScalarWithStringConstructorWhenMultipleDeclaredConstructorsExist()]
 display-name: constructsCustomScalarWithStringConstructorWhenMultipleDeclaredConstructorsExist()
 ]]></system-out>
 </testcase>
-<testcase name="constructsImmutableObjectFromSequenceUsingMatchingConstructorAmongMultipleChoices()" classname="org_yaml.snakeyaml.ConstructorConstructSequenceTest" time="0.001">
+<testcase name="constructsImmutableObjectFromSequenceUsingMatchingConstructorAmongMultipleChoices()" classname="org_yaml.snakeyaml.ConstructorConstructSequenceTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstructSequenceTest]/[method:constructsImmutableObjectFromSequenceUsingMatchingConstructorAmongMultipleChoices()]
 display-name: constructsImmutableObjectFromSequenceUsingMatchingConstructorAmongMultipleChoices()
@@ -189,13 +194,13 @@ unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.ConstructorConstruct
 display-name: constructsCustomScalarWithSingleDeclaredConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="writesInheritedPrivateFieldThroughFieldProperty()" classname="org_yaml.snakeyaml.FieldPropertyTest" time="0">
+<testcase name="writesInheritedPrivateFieldThroughFieldProperty()" classname="org_yaml.snakeyaml.FieldPropertyTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.FieldPropertyTest]/[method:writesInheritedPrivateFieldThroughFieldProperty()]
 display-name: writesInheritedPrivateFieldThroughFieldProperty()
 ]]></system-out>
 </testcase>
-<testcase name="usesInheritedPrivateFieldWhenNoAccessorMethodsExist()" classname="org_yaml.snakeyaml.PropertySubstituteTest" time="0.001">
+<testcase name="usesInheritedPrivateFieldWhenNoAccessorMethodsExist()" classname="org_yaml.snakeyaml.PropertySubstituteTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:org_yaml.snakeyaml.PropertySubstituteTest]/[method:usesInheritedPrivateFieldWhenNoAccessorMethodsExist()]
 display-name: usesInheritedPrivateFieldWhenNoAccessorMethodsExist()

--- a/tests/src/org.yaml/snakeyaml/2.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/org.yaml/snakeyaml/2.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:34:31">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T15:38:55">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.class-for-name-respects-class-loader" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-file-system-providers" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-resource-bundles" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,9 +47,10 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge6/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2004-f0ea5790/tests/src/org.yaml/snakeyaml/2.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge5/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/5186-bb208043/tests/src/org.yaml/snakeyaml/2.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>


### PR DESCRIPTION
## What does this PR do?

Fixes: #5186

This PR provides test fixes and new metadata for org.yaml:snakeyaml:2.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 49630
- Cached input tokens: 260608
- Output tokens: 3311
- Metadata entries: 14
- Test-only metadata entries: 66
- Iterations: 1
- Library coverage percentage: 32.47
- Previous library version metadata entries: 14
- Previous library version test-only metadata entries: 66
- Previous library version coverage percentage: 32.47

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f61596b70d21800530b9197d167c17b4d1cde2eb`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.yaml:snakeyaml:2.0` and `org.yaml:snakeyaml:2.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
