### PR TITLE
Skip tested-version upper-bound validation for latest entries

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
@@ -173,7 +173,8 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
      * Ensures "tested-versions" are mapped to the most appropriate metadata entry.
      * <p>
      * Rule: A version in {@code tested-versions} must be strictly less than the
-     * next higher {@code metadata-version} available in the file.
+     * next higher {@code metadata-version} available in the file, unless the
+     * entry is explicitly marked as {@code latest}.
      * <p>
      * This prevents "stray" versions from being associated with obsolete metadata
      * when a more recent metadata entry exists.
@@ -215,6 +216,10 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
 
         // For each entry, enforce: tested-version < next(metadata-version), if next exists
         for (JsonNode entry : json) {
+            if (entry.path("latest").asBoolean(false)) {
+                continue;
+            }
+
             String underMetaStr = entry.path("metadata-version").isTextual() ? entry.get("metadata-version").asText() : null;
             if (underMetaStr == null) continue;
 


### PR DESCRIPTION
The index.json validator checks that tested versions on an entry are lower than the next higher metadata-version. That catches stale non-latest entries, but latest entries are explicit fallback selectors and can legitimately cover versions above another numerically sorted metadata entry.

This keeps schema and other index validation intact, while skipping only the tested-version upper-bound rule for entries marked latest.

Fixes #5209