### PR TITLE
Make native-image fix metadata publication atomic

### DIFF
--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -4,6 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import argparse
+import os
 import subprocess
 import sys
 
@@ -118,6 +119,21 @@ def main(argv=None) -> int:
 
     if result.returncode != 0:
         library = f"{group}:{artifact}:{new_version}"
+        generated_metadata_file = os.path.join(
+            reachability_metadata_path,
+            "metadata",
+            group,
+            artifact,
+            new_version,
+            "reachability-metadata.json",
+        )
+        if not os.path.isfile(generated_metadata_file):
+            print(
+                "ERROR: fixTestNativeImageRun failed before generating "
+                f"{generated_metadata_file}. Skipping Codex metadata repair.",
+                file=sys.stderr,
+            )
+            return result.returncode
         print(f"[pipeline] Detected missing metadata entries for {library}. Running Codex fix.")
         codex_rc, _codex_log, _codex_timed_out = run_codex_metadata_fix(reachability_metadata_path, library)
         if codex_rc != 0:

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
@@ -9,14 +9,15 @@ package org.graalvm.internal.tck;
 import org.graalvm.internal.tck.utils.GeneralUtils;
 import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
-import org.gradle.api.GradleException;
 
 import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,6 +34,7 @@ import java.util.List;
  */
 public abstract class FixTestNativeImageRun extends DefaultTask {
     private static final String GRADLEW = "gradlew";
+    private static final String REACHABILITY_METADATA_FILE = "reachability-metadata.json";
 
     private String testLibraryCoordinates;
     private String newLibraryVersion;
@@ -82,7 +84,6 @@ public abstract class FixTestNativeImageRun extends DefaultTask {
         Coordinates baseCoords = Coordinates.parse(testLibraryCoordinates);
         String newCoordsString = baseCoords.group() + ":" + baseCoords.artifact() + ":" + newLibraryVersion;
         Coordinates newCoords = Coordinates.parse(newCoordsString);
-        MetadataGenerationUtils.makeVersionLatestInIndexJson(getLayout(), newCoords, baseCoords.version());
 
         Path metadataDirectory = GeneralUtils.computeMetadataDirectory(getLayout(), newCoordsString);
         Files.createDirectories(metadataDirectory);
@@ -94,29 +95,62 @@ public abstract class FixTestNativeImageRun extends DefaultTask {
             MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
         }
 
-        MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), newCoordsString, gradlewPath, newLibraryVersion);
+        MetadataGenerationUtils.collectMetadata(
+                getExecOperations(),
+                testsDirectory,
+                getLayout(),
+                newCoordsString,
+                gradlewPath,
+                newLibraryVersion
+        );
+        verifyGeneratedMetadata(metadataDirectory);
+        MetadataGenerationUtils.makeVersionLatestInIndexJson(getLayout(), newCoords, baseCoords.version());
 
         // At the end, attempt to run tests with the new library version.
         // If the build fails, it can be due agent's non-deterministic nature.
         GeneralUtils.printInfo("Running the test with updated metadata");
-        var execOutput = new java.io.ByteArrayOutputStream();
-        var testResult = runTestWithVersion(gradlewPath, testLibraryCoordinates, newLibraryVersion, execOutput);
+        var execOutput = new ByteArrayOutputStream();
+        var testResult = runTestWithVersion(gradlewPath, newCoordsString, newLibraryVersion, execOutput);
         if (testResult.getExitValue() != 0) {
             GeneralUtils.printInfo("Test run failed, running agent again");
-            MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), newCoordsString, gradlewPath);
-            testResult = runTestWithVersion(gradlewPath, testLibraryCoordinates, newLibraryVersion, execOutput);
+            MetadataGenerationUtils.collectMetadata(
+                    getExecOperations(),
+                    testsDirectory,
+                    getLayout(),
+                    newCoordsString,
+                    gradlewPath,
+                    newLibraryVersion
+            );
+            verifyGeneratedMetadata(metadataDirectory);
+            testResult = runTestWithVersion(gradlewPath, newCoordsString, newLibraryVersion, execOutput);
             if (testResult.getExitValue() != 0) {
                 throw new GradleException("Test run failed. See output:\n" + execOutput);
             }
         }
     }
 
-    private org.gradle.process.ExecResult runTestWithVersion(Path gradlewPath, String coords, String version, java.io.ByteArrayOutputStream execOutput) {
+    private void verifyGeneratedMetadata(Path metadataDirectory) {
+        Path metadataFile = metadataDirectory.resolve(REACHABILITY_METADATA_FILE);
+        if (!Files.isRegularFile(metadataFile)) {
+            throw new GradleException(
+                    "Metadata generation did not create " + metadataFile + ". Not updating index.json."
+            );
+        }
+    }
+
+    private org.gradle.process.ExecResult runTestWithVersion(
+            Path gradlewPath,
+            String coords,
+            String version,
+            ByteArrayOutputStream execOutput
+    ) {
         return getExecOperations().exec(execSpec -> {
             execSpec.setExecutable(gradlewPath.toString());
             execSpec.setArgs(List.of("test", "-Pcoordinates=" + coords));
             execSpec.environment("GVM_TCK_LV", version);
             execSpec.setStandardOutput(execOutput);
+            execSpec.setErrorOutput(execOutput);
+            execSpec.setIgnoreExitValue(true);
         });
     }
 }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/GeneralUtils.java
@@ -75,10 +75,12 @@ public final class GeneralUtils {
             execSpec.setExecutable(executable);
             execSpec.setArgs(args);
             execSpec.setStandardOutput(execOutput);
+            execSpec.setErrorOutput(execOutput);
+            execSpec.setIgnoreExitValue(true);
         });
 
         if (result.getExitValue() != 0) {
-            throw new RuntimeException(errorMessage + ". See: " + execOutput);
+            throw new RuntimeException(errorMessage + ". See output:\n" + execOutput.toString(StandardCharsets.UTF_8));
         }
     }
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FixTestNativeImageRunTests {
+    private static final String BASE_COORDINATES = "io.netty:netty-codec-smtp:4.1.74.Final";
+    private static final String NEW_VERSION = "4.2.2.Final";
+    private static final String NEW_COORDINATES = "io.netty:netty-codec-smtp:" + NEW_VERSION;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void runDoesNotUpdateIndexWhenMetadataGenerationFails() throws IOException {
+        Project project = createProject();
+        prepareLibraryProject();
+        String originalIndex = Files.readString(indexFile(), StandardCharsets.UTF_8);
+        createGradlewScript(true);
+        TestFixTestNativeImageRun task = registerTask(project);
+
+        assertThatThrownBy(task::run)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Cannot generate metadata")
+                .hasMessageContaining("agent failed");
+
+        assertThat(Files.readString(indexFile(), StandardCharsets.UTF_8)).isEqualTo(originalIndex);
+        assertThat(metadataFile(NEW_VERSION)).doesNotExist();
+        assertThat(readGradlewInvocations())
+                .contains("4.2.2.Final|-Pagent test")
+                .doesNotContain("metadataCopy")
+                .doesNotContain("test -Pcoordinates=" + NEW_COORDINATES);
+    }
+
+    @Test
+    void runUpdatesIndexAfterMetadataGenerationAndTestsNewCoordinates() throws IOException {
+        Project project = createProject();
+        prepareLibraryProject();
+        createGradlewScript(false);
+        TestFixTestNativeImageRun task = registerTask(project);
+
+        task.run();
+
+        assertThat(metadataFile(NEW_VERSION)).exists();
+        assertThat(Files.readString(indexFile(), StandardCharsets.UTF_8))
+                .contains("\"metadata-version\" : \"4.2.2.Final\"")
+                .contains("\"test-version\" : \"4.1.74.Final\"")
+                .contains("\"tested-versions\" : [\n      \"4.2.2.Final\"\n    ]");
+        assertThat(readGradlewInvocations())
+                .contains("4.2.2.Final|-Pagent test")
+                .contains("4.2.2.Final|metadataCopy --task test --dir " + metadataDirectory(NEW_VERSION))
+                .contains("4.2.2.Final|test -Pcoordinates=" + NEW_COORDINATES);
+    }
+
+    private Project createProject() {
+        return ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+    }
+
+    private TestFixTestNativeImageRun registerTask(Project project) {
+        TestFixTestNativeImageRun task = project.getTasks().register("fixTestNativeImageRun", TestFixTestNativeImageRun.class).get();
+        task.setTestLibraryCoordinates(BASE_COORDINATES);
+        task.setNewLibraryVersion(NEW_VERSION);
+        return task;
+    }
+
+    private void prepareLibraryProject() throws IOException {
+        Files.createDirectories(metadataDirectory("4.1.74.Final"));
+        Files.writeString(metadataFile("4.1.74.Final"), "{\"reflection\":[]}\n", StandardCharsets.UTF_8);
+        Files.writeString(
+                indexFile(),
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "4.1.74.Final",
+                    "tested-versions" : [
+                      "4.1.74.Final"
+                    ],
+                    "allowed-packages" : [
+                      "io.netty.handler.codec.smtp"
+                    ]
+                  }
+                ]
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        Path testDirectory = tempDir.resolve("tests/src/io.netty/netty-codec-smtp/4.1.74.Final");
+        Files.createDirectories(testDirectory);
+        Files.writeString(
+                testDirectory.resolve("build.gradle"),
+                """
+                plugins {
+                    id "java"
+                }
+
+                graalvmNative {
+                    agent {
+                        defaultMode = "conditional"
+                    }
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+    }
+
+    private void createGradlewScript(boolean failMetadataGeneration) throws IOException {
+        Path logFile = tempDir.resolve("gradlew-invocations.log");
+        Path gradlew = tempDir.resolve("gradlew");
+        String failureBlock = failMetadataGeneration
+                ? """
+                  echo 'agent failed' >&2
+                  exit 42
+                """
+                : "  exit 0\n";
+        Files.writeString(
+                gradlew,
+                """
+                #!/bin/sh
+                printf '%%s|%%s|%%s\\n' "$PWD" "$GVM_TCK_LV" "$*" >> '%s'
+                if [ "$1" = "-Pagent" ]; then
+                %s
+                fi
+                if [ "$1" = "metadataCopy" ]; then
+                  while [ "$#" -gt 0 ]; do
+                    if [ "$1" = "--dir" ]; then
+                      mkdir -p "$2"
+                      printf '{"reflection":[]}\\n' > "$2/reachability-metadata.json"
+                      break
+                    fi
+                    shift
+                  done
+                  exit 0
+                fi
+                if [ "$1" = "test" ]; then
+                  exit 0
+                fi
+                exit 0
+                """.formatted(logFile, failureBlock),
+                StandardCharsets.UTF_8
+        );
+        boolean executable = gradlew.toFile().setExecutable(true);
+        assertThat(executable).isTrue();
+    }
+
+    private String readGradlewInvocations() throws IOException {
+        Path logFile = tempDir.resolve("gradlew-invocations.log");
+        if (!Files.exists(logFile)) {
+            return "";
+        }
+        return Files.readString(logFile, StandardCharsets.UTF_8);
+    }
+
+    private Path indexFile() {
+        return tempDir.resolve("metadata/io.netty/netty-codec-smtp/index.json");
+    }
+
+    private Path metadataDirectory(String version) {
+        return tempDir.resolve("metadata/io.netty/netty-codec-smtp").resolve(version);
+    }
+
+    private Path metadataFile(String version) {
+        return metadataDirectory(version).resolve("reachability-metadata.json");
+    }
+
+    abstract static class TestFixTestNativeImageRun extends FixTestNativeImageRun {
+        @Inject
+        public TestFixTestNativeImageRun() {
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Delay fixTestNativeImageRun index.json updates until generated reachability metadata exists.
- Run post-generation verification against the new coordinate and keep stderr from nested Gradle failures.
- Skip Forge Codex metadata repair when fixTestNativeImageRun failed before producing the target reachability-metadata.json.
- Add focused tests for failed and successful native-image metadata publication paths.

### Testing
- ./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.FixTestNativeImageRunTests --stacktrace
- ./gradlew :tck-build-logic:test --stacktrace
- python3 -m py_compile ai_workflows/fix_ni_run.py
- git diff --check

Fixes #5213