### PR TITLE
Add JUnit Jupiter Params reachability metadata

### DIFF
--- a/metadata/org.junit.jupiter/junit-jupiter-params/5.9.2/reachability-metadata.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-params/5.9.2/reachability-metadata.json
@@ -1,0 +1,20 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.params.support.AnnotationConsumerInitializer"
+      },
+      "type" : "org.junit.jupiter.params.support.AnnotationConsumer",
+      "allDeclaredMethods" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.jupiter.params.support.AnnotationConsumerInitializer"
+      },
+      "type" : "org.junit.jupiter.params.provider.ArgumentsProvider",
+      "allDeclaredMethods" : true,
+      "allPublicMethods" : true
+    }
+  ]
+}

--- a/metadata/org.junit.jupiter/junit-jupiter-params/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-params/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.9.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/$version$/junit-jupiter-params-$version$-sources.jar",
+    "repository-url" : "https://github.com/junit-team/junit5",
+    "test-code-url" : "https://github.com/junit-team/junit5/tree/r5.9.2/junit-jupiter-params/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/$version$/junit-jupiter-params-$version$-javadoc.jar",
+    "description" : "JUnit Jupiter Params provides parameterized test support for JUnit Jupiter, including argument source annotations, built-in arguments providers, converters, aggregators, and extension support used to execute test templates with multiple argument sets.",
+    "tested-versions" : [
+      "5.9.2"
+    ],
+    "allowed-packages" : [
+      "org.junit.jupiter.params"
+    ]
+  }
+]

--- a/stats/org.junit.jupiter/junit-jupiter-params/5.9.2/stats.json
+++ b/stats/org.junit.jupiter/junit-jupiter-params/5.9.2/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "5.9.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 33
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 34
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1169,
+        "missed" : 48001,
+        "ratio" : 0.023775,
+        "total" : 49170
+      },
+      "line" : {
+        "covered" : 244,
+        "missed" : 10219,
+        "ratio" : 0.02332,
+        "total" : 10463
+      },
+      "method" : {
+        "covered" : 72,
+        "missed" : 2476,
+        "ratio" : 0.028257,
+        "total" : 2548
+      }
+    }
+  } ]
+}

--- a/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/build.gradle
+++ b/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/gradle.properties
+++ b/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.junit.jupiter:junit-jupiter-params:5.9.2
+library.version = 5.9.2
+metadata.dir = org.junit.jupiter/junit-jupiter-params/5.9.2/

--- a/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/settings.gradle
+++ b/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.junit.jupiter.junit-jupiter-params_tests'

--- a/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/src/test/java/org_junit_jupiter/junit_jupiter_params/JunitJupiterParamsTest.java
+++ b/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/src/test/java/org_junit_jupiter/junit_jupiter_params/JunitJupiterParamsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_junit_jupiter.junit_jupiter_params;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JunitJupiterParamsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"alpha", "beta"})
+    void providesArgumentsFromValueSource(String value) {
+        assertThat(value).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(WordArgumentsProvider.class)
+    void providesArgumentsFromCustomSource(String value, int length) {
+        assertThat(value).hasSize(length);
+    }
+
+    public static class WordArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("jupiter", 7),
+                    Arguments.of("params", 6));
+        }
+    }
+}

--- a/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/user-code-filter.json
+++ b/tests/src/org.junit.jupiter/junit-jupiter-params/5.9.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.junit.jupiter.params.**"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add reachability metadata for org.junit.jupiter:junit-jupiter-params:5.9.2
- Register method-query reflection for ArgumentsProvider and AnnotationConsumer
- Add a focused TCK test for parameterized value and custom argument sources

## Testing
- ./gradlew checkMetadataFiles -Pcoordinates=org.junit.jupiter:junit-jupiter-params:5.9.2 --stacktrace
- ./gradlew test -Pcoordinates=org.junit.jupiter:junit-jupiter-params:5.9.2 --stacktrace
- ./gradlew runNativeTraceImage -Pcoordinates=org.junit.jupiter:junit-jupiter-params:5.9.2 -PtraceMetadataPath=/tmp/junit-params-trace-metadata -PtraceBinaryExitFile=/tmp/junit-params-trace-exit --stacktrace

Fixes #5215