### PR TITLE
Skip stale unsupported-version issues

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -413,6 +413,26 @@ jobs:
       - name: "❗ Create aggregated issues for unsupported library versions"
         if: steps.aggregate.outputs.has-failures == 'true'
         run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=1 origin +master:refs/remotes/origin/master
+
+          latest_master_supports_version() {
+            local name="$1"
+            local failed_version="$2"
+            local group="${name%%:*}"
+            local artifact="${name#*:}"
+            local index_path="metadata/$group/$artifact/index.json"
+
+            if ! git cat-file -e "origin/master:$index_path" 2>/dev/null; then
+              return 1
+            fi
+
+            git show "origin/master:$index_path" | jq -e --arg version "$failed_version" '
+              any(.[]?; (."metadata-version" == $version) or ((."tested-versions" // []) | index($version) != null))
+            ' >/dev/null
+          }
+
           jq -c '.failures[]' aggregate-results.json | while read -r library; do
             NAME="$(printf '%s' "$library" | jq -r '.name')"
             printf '%s' "$library" | jq -c '.failures[]' | while read -r failure; do
@@ -423,6 +443,11 @@ jobs:
               PRIMARY_FAILURE_TYPE="$(printf '%s' "$failure" | jq -r '.failureTypes | sort | .[0]')"
               TITLE="${{ env.ISSUE_TITLE_PREFIX }}$PRIMARY_FAILURE_TYPE$TITLE_END"
               FAILURE_LABEL="fails-$(printf '%s' "$PRIMARY_FAILURE_TYPE" | sed 's/ /-/g')"
+
+              if latest_master_supports_version "$NAME" "$FAILED_VERSION"; then
+                echo "Latest origin/master already supports $GAV_COORDINATES. Skipping stale failure issue."
+                continue
+              fi
 
               ISSUE_NUMBER=$(
                 gh issue list \


### PR DESCRIPTION
## Summary

The `Verify compatibility with latest library versions` workflow can open `[Automation] ... fails for <coordinates>` issues for versions that have, in the meantime, gained support on `master`. Concretely:

- Scheduled run starts at commit A where version X is unsupported.
- Mid-run, a PR adds support for X on `master` (new metadata block, or `addTestedVersion` extending an existing block) and closes the prior tracking issue.
- The run finishes with stale failure data and reaches the issue-creation step. The dedup check there only matches **open** issues by title, so the just-closed prior issue does not suppress it, and a new duplicate issue is filed.
- Forge then picks up the stale issue and produces a no-op PR (e.g. #5208 against #5186 for `org.yaml:snakeyaml:2.0`, which had been fixed by #5160).

This change adds a guard in the issue-creation step: before filing an issue for `(library, failedVersion)`, it consults the current `origin/master`'s `metadata/<group>/<artifact>/index.json` and skips if the version already appears either as a block's `metadata-version` (a new entry) or in any block's `tested-versions`. The check answers "is this version actually supported on master right now?" rather than relying on issue-state heuristics.
