### PR TITLE
[Automation] Generated metadata for org.hibernate.orm:hibernate-core:7.3.0.Final

### DIFF
--- a/metadata/org.hibernate.orm/hibernate-core/7.3.0.Final/reachability-metadata.json
+++ b/metadata/org.hibernate.orm/hibernate-core/7.3.0.Final/reachability-metadata.json
@@ -18073,6 +18073,12 @@
   "resources" : [
     {
       "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      },
+      "glob" : "META-INF/persistence.xml"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.hibernate.internal.util.ConfigHelper"
       },
       "glob" : "hibernate.properties"

--- a/metadata/org.hibernate.orm/hibernate-core/7.3.0.Final/reachability-metadata.json
+++ b/metadata/org.hibernate.orm/hibernate-core/7.3.0.Final/reachability-metadata.json
@@ -1,2814 +1,2814 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "boolean[]"
+      "type" : "boolean[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "byte[]"
+      "type" : "byte[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "char[]"
+      "type" : "char[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
       },
-      "type": "com.arjuna.ats.jta.TransactionManager"
+      "type" : "com.arjuna.ats.jta.TransactionManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
       },
-      "type": "com.atomikos.icatch.jta.UserTransactionManager"
+      "type" : "com.atomikos.icatch.jta.UserTransactionManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.connections.internal.DriverConnectionCreator"
       },
-      "type": "com.ibm.icu.text.Collator"
+      "type" : "com.ibm.icu.text.Collator"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl$PooledConnections"
       },
-      "type": "com.ibm.icu.text.Collator"
+      "type" : "com.ibm.icu.text.Collator"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
       },
-      "type": "com.ibm.tx.jta.TransactionManagerFactory"
+      "type" : "com.ibm.tx.jta.TransactionManagerFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "double[]"
+      "type" : "double[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "float[]"
+      "type" : "float[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "int[]"
+      "type" : "int[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator"
       },
-      "type": "jakarta.enterprise.inject.spi.BeanManager"
+      "type" : "jakarta.enterprise.inject.spi.BeanManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Access",
-      "methods": [
+      "type" : "jakarta.persistence.Access",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AssociationOverride",
-      "methods": [
+      "type" : "jakarta.persistence.AssociationOverride",
+      "methods" : [
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "joinColumns",
-          "parameterTypes": []
+          "name" : "joinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "joinTable",
-          "parameterTypes": []
+          "name" : "joinTable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AbstractPropertyHolder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AbstractPropertyHolder"
       },
-      "type": "jakarta.persistence.AssociationOverride[]"
+      "type" : "jakarta.persistence.AssociationOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AssociationOverride[]"
+      "type" : "jakarta.persistence.AssociationOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AssociationOverrides",
-      "methods": [
+      "type" : "jakarta.persistence.AssociationOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation"
       },
-      "type": "jakarta.persistence.AssociationOverrides",
-      "methods": [
+      "type" : "jakarta.persistence.AssociationOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AttributeOverride",
-      "methods": [
+      "type" : "jakarta.persistence.AttributeOverride",
+      "methods" : [
         {
-          "name": "column",
-          "parameterTypes": []
+          "name" : "column",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AbstractPropertyHolder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AbstractPropertyHolder"
       },
-      "type": "jakarta.persistence.AttributeOverride[]"
+      "type" : "jakarta.persistence.AttributeOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AttributeOverride[]"
+      "type" : "jakarta.persistence.AttributeOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.AttributeOverrides",
-      "methods": [
+      "type" : "jakarta.persistence.AttributeOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation"
       },
-      "type": "jakarta.persistence.AttributeOverrides",
-      "methods": [
+      "type" : "jakarta.persistence.AttributeOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Basic",
-      "methods": [
+      "type" : "jakarta.persistence.Basic",
+      "methods" : [
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Cacheable",
-      "methods": [
+      "type" : "jakarta.persistence.Cacheable",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.CascadeType[]"
+      "type" : "jakarta.persistence.CascadeType[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.CheckConstraint",
-      "methods": [
+      "type" : "jakarta.persistence.CheckConstraint",
+      "methods" : [
         {
-          "name": "constraint",
-          "parameterTypes": []
+          "name" : "constraint",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.CheckConstraint[]"
+      "type" : "jakarta.persistence.CheckConstraint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.models.internal.NestedTypeDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.models.internal.NestedTypeDescriptor"
       },
-      "type": "jakarta.persistence.CheckConstraint[]"
+      "type" : "jakarta.persistence.CheckConstraint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.CollectionTable",
-      "methods": [
+      "type" : "jakarta.persistence.CollectionTable",
+      "methods" : [
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "joinColumns",
-          "parameterTypes": []
+          "name" : "joinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Column",
-      "methods": [
+      "type" : "jakarta.persistence.Column",
+      "methods" : [
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "length",
-          "parameterTypes": []
+          "name" : "length",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "nullable",
-          "parameterTypes": []
+          "name" : "nullable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "precision",
-          "parameterTypes": []
+          "name" : "precision",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "scale",
-          "parameterTypes": []
+          "name" : "scale",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "secondPrecision",
-          "parameterTypes": []
+          "name" : "secondPrecision",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "unique",
-          "parameterTypes": []
+          "name" : "unique",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ColumnResult",
-      "methods": [
+      "type" : "jakarta.persistence.ColumnResult",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ColumnResult[]"
+      "type" : "jakarta.persistence.ColumnResult[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "jakarta.persistence.Column[]"
+      "type" : "jakarta.persistence.Column[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ConstructorResult",
-      "methods": [
+      "type" : "jakarta.persistence.ConstructorResult",
+      "methods" : [
         {
-          "name": "columns",
-          "parameterTypes": []
+          "name" : "columns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetClass",
-          "parameterTypes": []
+          "name" : "targetClass",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ConstructorResult[]"
+      "type" : "jakarta.persistence.ConstructorResult[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Convert",
-      "methods": [
+      "type" : "jakarta.persistence.Convert",
+      "methods" : [
         {
-          "name": "attributeName",
-          "parameterTypes": []
+          "name" : "attributeName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "converter",
-          "parameterTypes": []
+          "name" : "converter",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "disableConversion",
-          "parameterTypes": []
+          "name" : "disableConversion",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.ClassPropertyHolder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.ClassPropertyHolder"
       },
-      "type": "jakarta.persistence.Convert[]"
+      "type" : "jakarta.persistence.Convert[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Convert[]"
+      "type" : "jakarta.persistence.Convert[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Converter",
-      "methods": [
+      "type" : "jakarta.persistence.Converter",
+      "methods" : [
         {
-          "name": "autoApply",
-          "parameterTypes": []
+          "name" : "autoApply",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Converts",
-      "methods": [
+      "type" : "jakarta.persistence.Converts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation"
       },
-      "type": "jakarta.persistence.Converts",
-      "methods": [
+      "type" : "jakarta.persistence.Converts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.DiscriminatorColumn",
-      "methods": [
+      "type" : "jakarta.persistence.DiscriminatorColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "discriminatorType",
-          "parameterTypes": []
+          "name" : "discriminatorType",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "length",
-          "parameterTypes": []
+          "name" : "length",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.DiscriminatorValue",
-      "methods": [
+      "type" : "jakarta.persistence.DiscriminatorValue",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ElementCollection",
-      "methods": [
+      "type" : "jakarta.persistence.ElementCollection",
+      "methods" : [
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetClass",
-          "parameterTypes": []
+          "name" : "targetClass",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Embeddable"
+      "type" : "jakarta.persistence.Embeddable"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Embedded"
+      "type" : "jakarta.persistence.Embedded"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.EmbeddedId"
+      "type" : "jakarta.persistence.EmbeddedId"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Entity",
-      "methods": [
+      "type" : "jakarta.persistence.Entity",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.EntityListeners",
-      "methods": [
+      "type" : "jakarta.persistence.EntityListeners",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.EntityResult",
-      "methods": [
+      "type" : "jakarta.persistence.EntityResult",
+      "methods" : [
         {
-          "name": "discriminatorColumn",
-          "parameterTypes": []
+          "name" : "discriminatorColumn",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "entityClass",
-          "parameterTypes": []
+          "name" : "entityClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fields",
-          "parameterTypes": []
+          "name" : "fields",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "lockMode",
-          "parameterTypes": []
+          "name" : "lockMode",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.EntityResult[]"
+      "type" : "jakarta.persistence.EntityResult[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Enumerated",
-      "methods": [
+      "type" : "jakarta.persistence.Enumerated",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.EnumeratedValue"
+      "type" : "jakarta.persistence.EnumeratedValue"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ExcludeDefaultListeners"
+      "type" : "jakarta.persistence.ExcludeDefaultListeners"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ExcludeSuperclassListeners"
+      "type" : "jakarta.persistence.ExcludeSuperclassListeners"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.FieldResult",
-      "methods": [
+      "type" : "jakarta.persistence.FieldResult",
+      "methods" : [
         {
-          "name": "column",
-          "parameterTypes": []
+          "name" : "column",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.FieldResult[]"
+      "type" : "jakarta.persistence.FieldResult[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ForeignKey",
-      "methods": [
+      "type" : "jakarta.persistence.ForeignKey",
+      "methods" : [
         {
-          "name": "foreignKeyDefinition",
-          "parameterTypes": []
+          "name" : "foreignKeyDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.GeneratedValue",
-      "methods": [
+      "type" : "jakarta.persistence.GeneratedValue",
+      "methods" : [
         {
-          "name": "generator",
-          "parameterTypes": []
+          "name" : "generator",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "strategy",
-          "parameterTypes": []
+          "name" : "strategy",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Id"
+      "type" : "jakarta.persistence.Id"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.IdClass",
-      "methods": [
+      "type" : "jakarta.persistence.IdClass",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Index",
-      "methods": [
+      "type" : "jakarta.persistence.Index",
+      "methods" : [
         {
-          "name": "columnList",
-          "parameterTypes": []
+          "name" : "columnList",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "unique",
-          "parameterTypes": []
+          "name" : "unique",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Index[]"
+      "type" : "jakarta.persistence.Index[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
       },
-      "type": "jakarta.persistence.Index[]"
+      "type" : "jakarta.persistence.Index[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
       },
-      "type": "jakarta.persistence.Index[]"
+      "type" : "jakarta.persistence.Index[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Inheritance",
-      "methods": [
+      "type" : "jakarta.persistence.Inheritance",
+      "methods" : [
         {
-          "name": "strategy",
-          "parameterTypes": []
+          "name" : "strategy",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.JoinColumn",
-      "methods": [
+      "type" : "jakarta.persistence.JoinColumn",
+      "methods" : [
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "nullable",
-          "parameterTypes": []
+          "name" : "nullable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "referencedColumnName",
-          "parameterTypes": []
+          "name" : "referencedColumnName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "unique",
-          "parameterTypes": []
+          "name" : "unique",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation"
       },
-      "type": "jakarta.persistence.JoinColumn",
-      "methods": [
+      "type" : "jakarta.persistence.JoinColumn",
+      "methods" : [
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.ColumnsBuilder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.ColumnsBuilder"
       },
-      "type": "jakarta.persistence.JoinColumn[]"
+      "type" : "jakarta.persistence.JoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.JoinColumn[]"
+      "type" : "jakarta.persistence.JoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
       },
-      "type": "jakarta.persistence.JoinColumn[]"
+      "type" : "jakarta.persistence.JoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.JoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.JoinColumns",
+      "methods" : [
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation"
       },
-      "type": "jakarta.persistence.JoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.JoinColumns",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.JoinTable",
-      "methods": [
+      "type" : "jakarta.persistence.JoinTable",
+      "methods" : [
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "inverseForeignKey",
-          "parameterTypes": []
+          "name" : "inverseForeignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "inverseJoinColumns",
-          "parameterTypes": []
+          "name" : "inverseJoinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "joinColumns",
-          "parameterTypes": []
+          "name" : "joinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
       },
-      "type": "jakarta.persistence.JoinTable",
-      "methods": [
+      "type" : "jakarta.persistence.JoinTable",
+      "methods" : [
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "inverseForeignKey",
-          "parameterTypes": []
+          "name" : "inverseForeignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "inverseJoinColumns",
-          "parameterTypes": []
+          "name" : "inverseJoinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "joinColumns",
-          "parameterTypes": []
+          "name" : "joinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "jakarta.persistence.JoinTable[]"
+      "type" : "jakarta.persistence.JoinTable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Lob"
+      "type" : "jakarta.persistence.Lob"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ManyToMany",
-      "methods": [
+      "type" : "jakarta.persistence.ManyToMany",
+      "methods" : [
         {
-          "name": "cascade",
-          "parameterTypes": []
+          "name" : "cascade",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "mappedBy",
-          "parameterTypes": []
+          "name" : "mappedBy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetEntity",
-          "parameterTypes": []
+          "name" : "targetEntity",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.ManyToOne",
-      "methods": [
+      "type" : "jakarta.persistence.ManyToOne",
+      "methods" : [
         {
-          "name": "cascade",
-          "parameterTypes": []
+          "name" : "cascade",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetEntity",
-          "parameterTypes": []
+          "name" : "targetEntity",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKey",
-      "methods": [
+      "type" : "jakarta.persistence.MapKey",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyClass",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyClass",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyColumn",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "length",
-          "parameterTypes": []
+          "name" : "length",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "nullable",
-          "parameterTypes": []
+          "name" : "nullable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "precision",
-          "parameterTypes": []
+          "name" : "precision",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "scale",
-          "parameterTypes": []
+          "name" : "scale",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "unique",
-          "parameterTypes": []
+          "name" : "unique",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyEnumerated",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyEnumerated",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyJoinColumn",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyJoinColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "nullable",
-          "parameterTypes": []
+          "name" : "nullable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "referencedColumnName",
-          "parameterTypes": []
+          "name" : "referencedColumnName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "unique",
-          "parameterTypes": []
+          "name" : "unique",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "jakarta.persistence.MapKeyJoinColumn[]"
+      "type" : "jakarta.persistence.MapKeyJoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyJoinColumn[]"
+      "type" : "jakarta.persistence.MapKeyJoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyJoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyJoinColumns",
+      "methods" : [
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation"
       },
-      "type": "jakarta.persistence.MapKeyJoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyJoinColumns",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapKeyTemporal",
-      "methods": [
+      "type" : "jakarta.persistence.MapKeyTemporal",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MappedSuperclass"
+      "type" : "jakarta.persistence.MappedSuperclass"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.MapsId",
-      "methods": [
+      "type" : "jakarta.persistence.MapsId",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedAttributeNode",
-      "methods": [
+      "type" : "jakarta.persistence.NamedAttributeNode",
+      "methods" : [
         {
-          "name": "keySubgraph",
-          "parameterTypes": []
+          "name" : "keySubgraph",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "subgraph",
-          "parameterTypes": []
+          "name" : "subgraph",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedAttributeNode[]"
+      "type" : "jakarta.persistence.NamedAttributeNode[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedEntityGraph",
-      "methods": [
+      "type" : "jakarta.persistence.NamedEntityGraph",
+      "methods" : [
         {
-          "name": "attributeNodes",
-          "parameterTypes": []
+          "name" : "attributeNodes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "includeAllAttributes",
-          "parameterTypes": []
+          "name" : "includeAllAttributes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "subclassSubgraphs",
-          "parameterTypes": []
+          "name" : "subclassSubgraphs",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "subgraphs",
-          "parameterTypes": []
+          "name" : "subgraphs",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "jakarta.persistence.NamedEntityGraph[]"
+      "type" : "jakarta.persistence.NamedEntityGraph[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedEntityGraph[]"
+      "type" : "jakarta.persistence.NamedEntityGraph[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedEntityGraphs",
-      "methods": [
+      "type" : "jakarta.persistence.NamedEntityGraphs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation"
       },
-      "type": "jakarta.persistence.NamedEntityGraphs",
-      "methods": [
+      "type" : "jakarta.persistence.NamedEntityGraphs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedNativeQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedNativeQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation"
       },
-      "type": "jakarta.persistence.NamedNativeQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedNativeQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedNativeQuery",
-      "methods": [
+      "type" : "jakarta.persistence.NamedNativeQuery",
+      "methods" : [
         {
-          "name": "classes",
-          "parameterTypes": []
+          "name" : "classes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "columns",
-          "parameterTypes": []
+          "name" : "columns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "entities",
-          "parameterTypes": []
+          "name" : "entities",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "hints",
-          "parameterTypes": []
+          "name" : "hints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultClass",
-          "parameterTypes": []
+          "name" : "resultClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultSetMapping",
-          "parameterTypes": []
+          "name" : "resultSetMapping",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedNativeQuery[]"
+      "type" : "jakarta.persistence.NamedNativeQuery[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation"
       },
-      "type": "jakarta.persistence.NamedQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedQuery",
-      "methods": [
+      "type" : "jakarta.persistence.NamedQuery",
+      "methods" : [
         {
-          "name": "hints",
-          "parameterTypes": []
+          "name" : "hints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "lockMode",
-          "parameterTypes": []
+          "name" : "lockMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultClass",
-          "parameterTypes": []
+          "name" : "resultClass",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedQuery[]"
+      "type" : "jakarta.persistence.NamedQuery[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedStoredProcedureQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedStoredProcedureQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation"
       },
-      "type": "jakarta.persistence.NamedStoredProcedureQueries",
-      "methods": [
+      "type" : "jakarta.persistence.NamedStoredProcedureQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedStoredProcedureQuery",
-      "methods": [
+      "type" : "jakarta.persistence.NamedStoredProcedureQuery",
+      "methods" : [
         {
-          "name": "hints",
-          "parameterTypes": []
+          "name" : "hints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "procedureName",
-          "parameterTypes": []
+          "name" : "procedureName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultClasses",
-          "parameterTypes": []
+          "name" : "resultClasses",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultSetMappings",
-          "parameterTypes": []
+          "name" : "resultSetMappings",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedStoredProcedureQuery[]"
+      "type" : "jakarta.persistence.NamedStoredProcedureQuery[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedSubgraph",
-      "methods": [
+      "type" : "jakarta.persistence.NamedSubgraph",
+      "methods" : [
         {
-          "name": "attributeNodes",
-          "parameterTypes": []
+          "name" : "attributeNodes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.NamedSubgraph[]"
+      "type" : "jakarta.persistence.NamedSubgraph[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.OneToMany",
-      "methods": [
+      "type" : "jakarta.persistence.OneToMany",
+      "methods" : [
         {
-          "name": "cascade",
-          "parameterTypes": []
+          "name" : "cascade",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "mappedBy",
-          "parameterTypes": []
+          "name" : "mappedBy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "orphanRemoval",
-          "parameterTypes": []
+          "name" : "orphanRemoval",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetEntity",
-          "parameterTypes": []
+          "name" : "targetEntity",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.OneToOne",
-      "methods": [
+      "type" : "jakarta.persistence.OneToOne",
+      "methods" : [
         {
-          "name": "cascade",
-          "parameterTypes": []
+          "name" : "cascade",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "mappedBy",
-          "parameterTypes": []
+          "name" : "mappedBy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "orphanRemoval",
-          "parameterTypes": []
+          "name" : "orphanRemoval",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "targetEntity",
-          "parameterTypes": []
+          "name" : "targetEntity",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.OrderBy",
-      "methods": [
+      "type" : "jakarta.persistence.OrderBy",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.OrderColumn",
-      "methods": [
+      "type" : "jakarta.persistence.OrderColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "nullable",
-          "parameterTypes": []
+          "name" : "nullable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PostLoad"
+      "type" : "jakarta.persistence.PostLoad"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PostPersist"
+      "type" : "jakarta.persistence.PostPersist"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PostRemove"
+      "type" : "jakarta.persistence.PostRemove"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PostUpdate"
+      "type" : "jakarta.persistence.PostUpdate"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PrePersist"
+      "type" : "jakarta.persistence.PrePersist"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PreRemove"
+      "type" : "jakarta.persistence.PreRemove"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PreUpdate"
+      "type" : "jakarta.persistence.PreUpdate"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PrimaryKeyJoinColumn",
-      "methods": [
+      "type" : "jakarta.persistence.PrimaryKeyJoinColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "referencedColumnName",
-          "parameterTypes": []
+          "name" : "referencedColumnName",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PrimaryKeyJoinColumn[]"
+      "type" : "jakarta.persistence.PrimaryKeyJoinColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.PrimaryKeyJoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.PrimaryKeyJoinColumns",
+      "methods" : [
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation"
       },
-      "type": "jakarta.persistence.PrimaryKeyJoinColumns",
-      "methods": [
+      "type" : "jakarta.persistence.PrimaryKeyJoinColumns",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.QueryHint",
-      "methods": [
+      "type" : "jakarta.persistence.QueryHint",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.QueryHint[]"
+      "type" : "jakarta.persistence.QueryHint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SecondaryTable",
-      "methods": [
+      "type" : "jakarta.persistence.SecondaryTable",
+      "methods" : [
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "foreignKey",
-          "parameterTypes": []
+          "name" : "foreignKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "pkJoinColumns",
-          "parameterTypes": []
+          "name" : "pkJoinColumns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "jakarta.persistence.SecondaryTable[]"
+      "type" : "jakarta.persistence.SecondaryTable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SecondaryTable[]"
+      "type" : "jakarta.persistence.SecondaryTable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SecondaryTables",
-      "methods": [
+      "type" : "jakarta.persistence.SecondaryTables",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation"
       },
-      "type": "jakarta.persistence.SecondaryTables",
-      "methods": [
+      "type" : "jakarta.persistence.SecondaryTables",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SequenceGenerator",
-      "methods": [
+      "type" : "jakarta.persistence.SequenceGenerator",
+      "methods" : [
         {
-          "name": "allocationSize",
-          "parameterTypes": []
+          "name" : "allocationSize",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "initialValue",
-          "parameterTypes": []
+          "name" : "initialValue",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sequenceName",
-          "parameterTypes": []
+          "name" : "sequenceName",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SequenceGenerator[]"
+      "type" : "jakarta.persistence.SequenceGenerator[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SequenceGenerators",
-      "methods": [
+      "type" : "jakarta.persistence.SequenceGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation"
       },
-      "type": "jakarta.persistence.SequenceGenerators",
-      "methods": [
+      "type" : "jakarta.persistence.SequenceGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SqlResultSetMapping",
-      "methods": [
+      "type" : "jakarta.persistence.SqlResultSetMapping",
+      "methods" : [
         {
-          "name": "classes",
-          "parameterTypes": []
+          "name" : "classes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "columns",
-          "parameterTypes": []
+          "name" : "columns",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "entities",
-          "parameterTypes": []
+          "name" : "entities",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SqlResultSetMapping[]"
+      "type" : "jakarta.persistence.SqlResultSetMapping[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.SqlResultSetMappings",
-      "methods": [
+      "type" : "jakarta.persistence.SqlResultSetMappings",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation"
       },
-      "type": "jakarta.persistence.SqlResultSetMappings",
-      "methods": [
+      "type" : "jakarta.persistence.SqlResultSetMappings",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.StoredProcedureParameter",
-      "methods": [
+      "type" : "jakarta.persistence.StoredProcedureParameter",
+      "methods" : [
         {
-          "name": "mode",
-          "parameterTypes": []
+          "name" : "mode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.StoredProcedureParameter[]"
+      "type" : "jakarta.persistence.StoredProcedureParameter[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Table",
-      "methods": [
+      "type" : "jakarta.persistence.Table",
+      "methods" : [
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
       },
-      "type": "jakarta.persistence.Table",
-      "methods": [
+      "type" : "jakarta.persistence.Table",
+      "methods" : [
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.TableGenerator",
-      "methods": [
+      "type" : "jakarta.persistence.TableGenerator",
+      "methods" : [
         {
-          "name": "allocationSize",
-          "parameterTypes": []
+          "name" : "allocationSize",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "indexes",
-          "parameterTypes": []
+          "name" : "indexes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "initialValue",
-          "parameterTypes": []
+          "name" : "initialValue",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "pkColumnName",
-          "parameterTypes": []
+          "name" : "pkColumnName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "pkColumnValue",
-          "parameterTypes": []
+          "name" : "pkColumnValue",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "uniqueConstraints",
-          "parameterTypes": []
+          "name" : "uniqueConstraints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "valueColumnName",
-          "parameterTypes": []
+          "name" : "valueColumnName",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.GeneratorAnnotationHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.GeneratorAnnotationHelper"
       },
-      "type": "jakarta.persistence.TableGenerator[]"
+      "type" : "jakarta.persistence.TableGenerator[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.TableGenerator[]"
+      "type" : "jakarta.persistence.TableGenerator[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.TableGenerators",
-      "methods": [
+      "type" : "jakarta.persistence.TableGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation"
       },
-      "type": "jakarta.persistence.TableGenerators",
-      "methods": [
+      "type" : "jakarta.persistence.TableGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Temporal",
-      "methods": [
+      "type" : "jakarta.persistence.Temporal",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Transient"
+      "type" : "jakarta.persistence.Transient"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "jakarta.persistence.Transient"
+      "type" : "jakarta.persistence.Transient"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.UniqueConstraint",
-      "methods": [
+      "type" : "jakarta.persistence.UniqueConstraint",
+      "methods" : [
         {
-          "name": "columnNames",
-          "parameterTypes": []
+          "name" : "columnNames",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.UniqueConstraint[]"
+      "type" : "jakarta.persistence.UniqueConstraint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
       },
-      "type": "jakarta.persistence.UniqueConstraint[]"
+      "type" : "jakarta.persistence.UniqueConstraint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation"
       },
-      "type": "jakarta.persistence.UniqueConstraint[]"
+      "type" : "jakarta.persistence.UniqueConstraint[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "jakarta.persistence.Version"
+      "type" : "jakarta.persistence.Version"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
       },
-      "type": "jakarta.validation.ConstraintViolation"
+      "type" : "jakarta.validation.ConstraintViolation"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "jakarta.xml.bind.annotation.XmlElement",
-      "methods": [
+      "type" : "jakarta.xml.bind.annotation.XmlElement",
+      "methods" : [
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "jakarta.xml.bind.annotation.XmlType",
-      "methods": [
+      "type" : "jakarta.xml.bind.annotation.XmlType",
+      "methods" : [
         {
-          "name": "factoryClass",
-          "parameterTypes": []
+          "name" : "factoryClass",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter",
-      "methods": [
+      "type" : "jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
-      "methods": [
+      "type" : "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
+      "methods" : [
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "java.lang.Class[]"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.util.ReflectHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.util.ReflectHelper"
       },
-      "type": "java.lang.Long[]"
+      "type" : "java.lang.Long[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.loader.ast.internal.MultiIdEntityLoaderArrayParam"
+      "condition" : {
+        "typeReached" : "org.hibernate.loader.ast.internal.MultiIdEntityLoaderArrayParam"
       },
-      "type": "java.lang.Long[]"
+      "type" : "java.lang.Long[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.Hibernate"
+      "condition" : {
+        "typeReached" : "org.hibernate.Hibernate"
       },
-      "type": "java.sql.Time"
+      "type" : "java.sql.Time"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.Hibernate"
+      "condition" : {
+        "typeReached" : "org.hibernate.Hibernate"
       },
-      "type": "java.sql.Timestamp"
+      "type" : "java.sql.Timestamp"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "java.util.ArrayList",
-      "methods": [
+      "type" : "java.util.ArrayList",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.MBeanOperationInfo",
-      "methods": [
+      "type" : "javax.management.MBeanOperationInfo",
+      "methods" : [
         {
-          "name": "getSignature",
-          "parameterTypes": []
+          "name" : "getSignature",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.MBeanServerBuilder",
-      "methods": [
+      "type" : "javax.management.MBeanServerBuilder",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.ObjectName"
+      "type" : "javax.management.ObjectName"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.openmbean.CompositeData"
+      "type" : "javax.management.openmbean.CompositeData"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.openmbean.CompositeData[]"
+      "type" : "javax.management.openmbean.CompositeData[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
+      "type" : "javax.management.openmbean.OpenMBeanOperationInfoSupport"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "javax.management.openmbean.TabularData"
+      "type" : "javax.management.openmbean.TabularData"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.JaxbLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.JaxbLogger"
       },
-      "type": "javax.smartcardio.CardPermission"
+      "type" : "javax.smartcardio.CardPermission"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "javax.smartcardio.CardPermission"
+      "type" : "javax.smartcardio.CardPermission"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.jpa.HibernatePersistenceProvider"
+      "condition" : {
+        "typeReached" : "org.hibernate.jpa.HibernatePersistenceProvider"
       },
-      "type": "javax.smartcardio.CardPermission"
+      "type" : "javax.smartcardio.CardPermission"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.models.internal.StandardAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.models.internal.StandardAnnotationDescriptor"
       },
-      "type": "jdk.internal.ValueBased"
+      "type" : "jdk.internal.ValueBased"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.ConfigurationInfo"
+      "type" : "jdk.management.jfr.ConfigurationInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.EventTypeInfo"
+      "type" : "jdk.management.jfr.EventTypeInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.FlightRecorderMXBean"
+      "type" : "jdk.management.jfr.FlightRecorderMXBean"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.FlightRecorderMXBeanImpl"
+      "type" : "jdk.management.jfr.FlightRecorderMXBeanImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.RecordingInfo"
+      "type" : "jdk.management.jfr.RecordingInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "jdk.management.jfr.SettingDescriptorInfo"
+      "type" : "jdk.management.jfr.SettingDescriptorInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "long[]"
+      "type" : "long[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$AllArguments"
+      "type" : "net.bytebuddy.asm.Advice$AllArguments"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Argument",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$Argument",
+      "methods" : [
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "typing",
-          "parameterTypes": []
+          "name" : "typing",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Enter"
+      "type" : "net.bytebuddy.asm.Advice$Enter"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Exit"
+      "type" : "net.bytebuddy.asm.Advice$Exit"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$FieldGetterHandle"
+      "type" : "net.bytebuddy.asm.Advice$FieldGetterHandle"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$FieldSetterHandle"
+      "type" : "net.bytebuddy.asm.Advice$FieldSetterHandle"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$FieldValue",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$FieldValue",
+      "methods" : [
         {
-          "name": "declaringType",
-          "parameterTypes": []
+          "name" : "declaringType",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "typing",
-          "parameterTypes": []
+          "name" : "typing",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Local"
+      "type" : "net.bytebuddy.asm.Advice$Local"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$OnMethodEnter",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$OnMethodEnter",
+      "methods" : [
         {
-          "name": "inline",
-          "parameterTypes": []
+          "name" : "inline",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "prependLineNumber",
-          "parameterTypes": []
+          "name" : "prependLineNumber",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "skipOn",
-          "parameterTypes": []
+          "name" : "skipOn",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "skipOnIndex",
-          "parameterTypes": []
+          "name" : "skipOnIndex",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "suppress",
-          "parameterTypes": []
+          "name" : "suppress",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$OnMethodExit",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$OnMethodExit",
+      "methods" : [
         {
-          "name": "backupArguments",
-          "parameterTypes": []
+          "name" : "backupArguments",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "inline",
-          "parameterTypes": []
+          "name" : "inline",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "onThrowable",
-          "parameterTypes": []
+          "name" : "onThrowable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "repeatOn",
-          "parameterTypes": []
+          "name" : "repeatOn",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "repeatOnIndex",
-          "parameterTypes": []
+          "name" : "repeatOnIndex",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "suppress",
-          "parameterTypes": []
+          "name" : "suppress",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Origin"
+      "type" : "net.bytebuddy.asm.Advice$Origin"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Return",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$Return",
+      "methods" : [
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "typing",
-          "parameterTypes": []
+          "name" : "typing",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$SelfCallHandle"
+      "type" : "net.bytebuddy.asm.Advice$SelfCallHandle"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$This",
-      "methods": [
+      "type" : "net.bytebuddy.asm.Advice$This",
+      "methods" : [
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "typing",
-          "parameterTypes": []
+          "name" : "typing",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.asm.Advice$Thrown"
+      "type" : "net.bytebuddy.asm.Advice$Thrown"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedMethodReturnType$Dispatcher"
+      "type" : "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedMethodReturnType$Dispatcher"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.as.jmx.framework.PortableMBeanFactory"
+      "type" : "oracle.as.jmx.framework.PortableMBeanFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.OracleJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.OracleJdbcHelper"
       },
-      "type": "oracle.jdbc.OracleConnection"
+      "type" : "oracle.jdbc.OracleConnection"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.OracleDriver"
+      "type" : "oracle.jdbc.OracleDriver"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.driver.DiagnosabilityMXBean"
+      "type" : "oracle.jdbc.driver.DiagnosabilityMXBean"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.driver.Message11",
-      "methods": [
+      "type" : "oracle.jdbc.driver.Message11",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.driver.OracleDiagnosabilityMBean"
+      "type" : "oracle.jdbc.driver.OracleDiagnosabilityMBean"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.logging.annotations.Feature",
-      "methods": [
+      "type" : "oracle.jdbc.logging.annotations.Feature",
+      "methods" : [
         {
-          "name": "values",
-          "parameterTypes": []
+          "name" : "values",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.logging.annotations.Supports",
-      "methods": [
+      "type" : "oracle.jdbc.logging.annotations.Supports",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.jdbc.logging.runtime.TraceController"
+      "type" : "oracle.jdbc.logging.runtime.TraceController"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.sql.AnyDataFactory"
+      "type" : "oracle.sql.AnyDataFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "oracle.sql.TypeDescriptorFactory"
+      "type" : "oracle.sql.TypeDescriptorFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.JaxbLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.JaxbLogger"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.jpa.HibernatePersistenceProvider"
+      "condition" : {
+        "typeReached" : "org.hibernate.jpa.HibernatePersistenceProvider"
       },
-      "type": "org.apache.logging.log4j.Logger"
+      "type" : "org.apache.logging.log4j.Logger"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.core.v2.model.nav.ReflectionNavigator",
-      "methods": [
+      "type" : "org.glassfish.jaxb.core.v2.model.nav.ReflectionNavigator",
+      "methods" : [
         {
-          "name": "getInstance",
-          "parameterTypes": []
+          "name" : "getInstance",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
-      "methods": [
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementLeafProperty",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
             "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
           ]
@@ -2816,14 +2816,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty",
-      "methods": [
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
             "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
           ]
@@ -2831,20 +2831,20 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayReferenceNodeProperty"
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.ArrayReferenceNodeProperty"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementLeafProperty",
-      "methods": [
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementLeafProperty",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
             "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
           ]
@@ -2852,14 +2852,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty",
-      "methods": [
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.glassfish.jaxb.runtime.v2.runtime.JAXBContextImpl",
             "org.glassfish.jaxb.runtime.v2.model.runtime.RuntimeElementPropertyInfo"
           ]
@@ -2867,6573 +2867,6573 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleMapNodeProperty"
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.SingleMapNodeProperty"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.glassfish.jaxb.runtime.v2.runtime.property.SingleReferenceNodeProperty"
+      "type" : "org.glassfish.jaxb.runtime.v2.runtime.property.SingleReferenceNodeProperty"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "org.h2.Driver"
+      "type" : "org.h2.Driver"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
       },
-      "type": "org.h2.Driver",
-      "methods": [
+      "type" : "org.h2.Driver",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.action.internal.ActionLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.action.internal.ActionLogging"
       },
-      "type": "org.hibernate.action.internal.ActionLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.action.internal.ActionLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Any",
-      "methods": [
+      "type" : "org.hibernate.annotations.Any",
+      "methods" : [
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminator",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyDiscriminator",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminatorImplicitValues",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyDiscriminatorImplicitValues",
+      "methods" : [
         {
-          "name": "implementation",
-          "parameterTypes": []
+          "name" : "implementation",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminatorValue",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyDiscriminatorValue",
+      "methods" : [
         {
-          "name": "discriminator",
-          "parameterTypes": []
+          "name" : "discriminator",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "entity",
-          "parameterTypes": []
+          "name" : "entity",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminatorValue[]"
+      "type" : "org.hibernate.annotations.AnyDiscriminatorValue[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminatorValues",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyDiscriminatorValues",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValuesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValuesAnnotation"
       },
-      "type": "org.hibernate.annotations.AnyDiscriminatorValues",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyDiscriminatorValues",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyKeyJavaClass",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyKeyJavaClass",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyKeyJavaType",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyKeyJavaType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyKeyJdbcType",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyKeyJdbcType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AnyKeyJdbcTypeCode",
-      "methods": [
+      "type" : "org.hibernate.annotations.AnyKeyJdbcTypeCode",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Array",
-      "methods": [
+      "type" : "org.hibernate.annotations.Array",
+      "methods" : [
         {
-          "name": "length",
-          "parameterTypes": []
+          "name" : "length",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AttributeAccessor"
+      "type" : "org.hibernate.annotations.AttributeAccessor"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.AttributeAccessor",
-      "methods": [
+      "type" : "org.hibernate.annotations.AttributeAccessor",
+      "methods" : [
         {
-          "name": "strategy",
-          "parameterTypes": []
+          "name" : "strategy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.AttributeBinderType",
-      "methods": [
+      "type" : "org.hibernate.annotations.AttributeBinderType",
+      "methods" : [
         {
-          "name": "binder",
-          "parameterTypes": []
+          "name" : "binder",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Bag"
+      "type" : "org.hibernate.annotations.Bag"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.BatchSize"
+      "type" : "org.hibernate.annotations.BatchSize"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.BatchSize",
-      "methods": [
+      "type" : "org.hibernate.annotations.BatchSize",
+      "methods" : [
         {
-          "name": "size",
-          "parameterTypes": []
+          "name" : "size",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Cache",
-      "methods": [
+      "type" : "org.hibernate.annotations.Cache",
+      "methods" : [
         {
-          "name": "includeLazy",
-          "parameterTypes": []
+          "name" : "includeLazy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "region",
-          "parameterTypes": []
+          "name" : "region",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "usage",
-          "parameterTypes": []
+          "name" : "usage",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Cascade",
-      "methods": [
+      "type" : "org.hibernate.annotations.Cascade",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CascadeType[]"
+      "type" : "org.hibernate.annotations.CascadeType[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Check",
-      "methods": [
+      "type" : "org.hibernate.annotations.Check",
+      "methods" : [
         {
-          "name": "constraints",
-          "parameterTypes": []
+          "name" : "constraints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.Check[]"
+      "type" : "org.hibernate.annotations.Check[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Check[]"
+      "type" : "org.hibernate.annotations.Check[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Checks",
-      "methods": [
+      "type" : "org.hibernate.annotations.Checks",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.ChecksAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.ChecksAnnotation"
       },
-      "type": "org.hibernate.annotations.Checks",
-      "methods": [
+      "type" : "org.hibernate.annotations.Checks",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Collate"
+      "type" : "org.hibernate.annotations.Collate"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.Collate",
-      "methods": [
+      "type" : "org.hibernate.annotations.Collate",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionId",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionId",
+      "methods" : [
         {
-          "name": "column",
-          "parameterTypes": []
+          "name" : "column",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "generator",
-          "parameterTypes": []
+          "name" : "generator",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "generatorImplementation",
-          "parameterTypes": []
+          "name" : "generatorImplementation",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation"
       },
-      "type": "org.hibernate.annotations.CollectionId",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionId",
+      "methods" : [
         {
-          "name": "column",
-          "parameterTypes": []
+          "name" : "column",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdJavaClass",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdJavaClass",
+      "methods" : [
         {
-          "name": "idType",
-          "parameterTypes": []
+          "name" : "idType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdJavaType",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdJavaType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdJdbcType",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdJdbcType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdJdbcTypeCode",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdJdbcTypeCode",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdMutability",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdMutability",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionIdType",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionIdType",
+      "methods" : [
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionType",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionType",
+      "methods" : [
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionTypeRegistration",
+      "methods" : [
         {
-          "name": "classification",
-          "parameterTypes": []
+          "name" : "classification",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CollectionTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CollectionTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CollectionTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.CollectionTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.CollectionTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ColumnDefault",
-      "methods": [
+      "type" : "org.hibernate.annotations.ColumnDefault",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ColumnTransformer",
-      "methods": [
+      "type" : "org.hibernate.annotations.ColumnTransformer",
+      "methods" : [
         {
-          "name": "forColumn",
-          "parameterTypes": []
+          "name" : "forColumn",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "read",
-          "parameterTypes": []
+          "name" : "read",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "write",
-          "parameterTypes": []
+          "name" : "write",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AbstractPropertyHolder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AbstractPropertyHolder"
       },
-      "type": "org.hibernate.annotations.ColumnTransformer[]"
+      "type" : "org.hibernate.annotations.ColumnTransformer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotatedColumn"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotatedColumn"
       },
-      "type": "org.hibernate.annotations.ColumnTransformer[]"
+      "type" : "org.hibernate.annotations.ColumnTransformer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ColumnTransformer[]"
+      "type" : "org.hibernate.annotations.ColumnTransformer[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ColumnTransformers",
-      "methods": [
+      "type" : "org.hibernate.annotations.ColumnTransformers",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.ColumnTransformersAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.ColumnTransformersAnnotation"
       },
-      "type": "org.hibernate.annotations.ColumnTransformers",
-      "methods": [
+      "type" : "org.hibernate.annotations.ColumnTransformers",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Columns",
-      "methods": [
+      "type" : "org.hibernate.annotations.Columns",
+      "methods" : [
         {
-          "name": "columns",
-          "parameterTypes": []
+          "name" : "columns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.ColumnsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.ColumnsAnnotation"
       },
-      "type": "org.hibernate.annotations.Columns",
-      "methods": [
+      "type" : "org.hibernate.annotations.Columns",
+      "methods" : [
         {
-          "name": "columns",
-          "parameterTypes": []
+          "name" : "columns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Comment"
+      "type" : "org.hibernate.annotations.Comment"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.Comment",
-      "methods": [
+      "type" : "org.hibernate.annotations.Comment",
+      "methods" : [
         {
-          "name": "on",
-          "parameterTypes": []
+          "name" : "on",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Comment[]"
+      "type" : "org.hibernate.annotations.Comment[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Comments"
+      "type" : "org.hibernate.annotations.Comments"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CommentsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CommentsAnnotation"
       },
-      "type": "org.hibernate.annotations.Comments",
-      "methods": [
+      "type" : "org.hibernate.annotations.Comments",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.Comments",
-      "methods": [
+      "type" : "org.hibernate.annotations.Comments",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CompositeType",
-      "methods": [
+      "type" : "org.hibernate.annotations.CompositeType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.CompositeTypeRegistration",
+      "methods" : [
         {
-          "name": "embeddableClass",
-          "parameterTypes": []
+          "name" : "embeddableClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "userType",
-          "parameterTypes": []
+          "name" : "userType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CompositeTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CompositeTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistration[]"
+      "type" : "org.hibernate.annotations.CompositeTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.CompositeTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.CompositeTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.CompositeTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ConcreteProxy"
+      "type" : "org.hibernate.annotations.ConcreteProxy"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ConverterRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.ConverterRegistration",
+      "methods" : [
         {
-          "name": "autoApply",
-          "parameterTypes": []
+          "name" : "autoApply",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "converter",
-          "parameterTypes": []
+          "name" : "converter",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "domainType",
-          "parameterTypes": []
+          "name" : "domainType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.ConverterRegistration[]"
+      "type" : "org.hibernate.annotations.ConverterRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ConverterRegistration[]"
+      "type" : "org.hibernate.annotations.ConverterRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.ConverterRegistration[]"
+      "type" : "org.hibernate.annotations.ConverterRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ConverterRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.ConverterRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.ConverterRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.ConverterRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.ConverterRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.ConverterRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CreationTimestamp",
-      "methods": [
+      "type" : "org.hibernate.annotations.CreationTimestamp",
+      "methods" : [
         {
-          "name": "source",
-          "parameterTypes": []
+          "name" : "source",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.CurrentTimestamp",
-      "methods": [
+      "type" : "org.hibernate.annotations.CurrentTimestamp",
+      "methods" : [
         {
-          "name": "event",
-          "parameterTypes": []
+          "name" : "event",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "source",
-          "parameterTypes": []
+          "name" : "source",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.Hibernate"
+      "condition" : {
+        "typeReached" : "org.hibernate.Hibernate"
       },
-      "type": "org.hibernate.annotations.DialectOverride"
+      "type" : "org.hibernate.annotations.DialectOverride"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Check",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Check",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotatedColumn"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotatedColumn"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Check[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Check[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Check[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Check[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Check[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Check[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Checks",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Checks",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenChecksAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenChecksAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Checks",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Checks",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$ColumnDefault",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$ColumnDefault",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotatedColumn"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotatedColumn"
       },
-      "type": "org.hibernate.annotations.DialectOverride$ColumnDefault[]"
+      "type" : "org.hibernate.annotations.DialectOverride$ColumnDefault[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$ColumnDefault[]"
+      "type" : "org.hibernate.annotations.DialectOverride$ColumnDefault[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$ColumnDefaults",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$ColumnDefaults",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultsAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$ColumnDefaults",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$ColumnDefaults",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$DiscriminatorFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$DiscriminatorFormula",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$DiscriminatorFormula[]"
+      "type" : "org.hibernate.annotations.DialectOverride$DiscriminatorFormula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$DiscriminatorFormula[]"
+      "type" : "org.hibernate.annotations.DialectOverride$DiscriminatorFormula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$DiscriminatorFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$DiscriminatorFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulasAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulasAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$DiscriminatorFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$DiscriminatorFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterDefOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$FilterDefOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefOverridesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefOverridesAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterDefOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$FilterDefOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterDefs",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$FilterDefs",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterDefs[]"
+      "type" : "org.hibernate.annotations.DialectOverride$FilterDefs[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$FilterOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenFilterOverridesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenFilterOverridesAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$FilterOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$FilterOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Filters",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Filters",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Filters[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Filters[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Filters[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Filters[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Formula",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Formula",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Formula[]"
+      "type" : "org.hibernate.annotations.DialectOverride$Formula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Formulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Formulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenFormulasAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenFormulasAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Formulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Formulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$GeneratedColumn",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$GeneratedColumn",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotatedColumn"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotatedColumn"
       },
-      "type": "org.hibernate.annotations.DialectOverride$GeneratedColumn[]"
+      "type" : "org.hibernate.annotations.DialectOverride$GeneratedColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$GeneratedColumn[]"
+      "type" : "org.hibernate.annotations.DialectOverride$GeneratedColumn[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$GeneratedColumns",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$GeneratedColumns",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnsAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$GeneratedColumns",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$GeneratedColumns",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$JoinFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$JoinFormula",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$JoinFormula[]"
+      "type" : "org.hibernate.annotations.DialectOverride$JoinFormula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$JoinFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$JoinFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulasAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulasAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$JoinFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$JoinFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDelete",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDelete",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeleteAll",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeleteAll",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeleteAll[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeleteAll[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeleteAll[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeleteAll[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeleteAlls",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeleteAlls",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllsAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeleteAlls",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeleteAlls",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDelete[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDelete[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDelete[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDelete[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeletes",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeletes",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeletesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeletesAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLDeletes",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLDeletes",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLInsert",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLInsert",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLInsert[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLInsert[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLInsert[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLInsert[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLInserts",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLInserts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertsAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLInserts",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLInserts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLOrder",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLOrder",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLOrder[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLOrder[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLOrder[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLOrder[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLOrders",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLOrders",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrdersAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrdersAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLOrders",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLOrders",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestriction",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestriction",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestriction[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestrictions",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestrictions",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionsAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLRestrictions",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLRestrictions",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLSelect",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLSelect",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLSelect[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLSelect[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLSelect[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLSelect[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLSelects",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLSelects",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLUpdate",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLUpdate",
+      "methods" : [
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "dialect",
-          "parameterTypes": []
+          "name" : "dialect",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "override",
-          "parameterTypes": []
+          "name" : "override",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sameOrAfter",
-          "parameterTypes": []
+          "name" : "sameOrAfter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLUpdate[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLUpdate[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLUpdate[]"
+      "type" : "org.hibernate.annotations.DialectOverride$SQLUpdate[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLUpdates",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLUpdates",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdatesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdatesAnnotation"
       },
-      "type": "org.hibernate.annotations.DialectOverride$SQLUpdates",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$SQLUpdates",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.DialectOverride$Version",
-      "methods": [
+      "type" : "org.hibernate.annotations.DialectOverride$Version",
+      "methods" : [
         {
-          "name": "major",
-          "parameterTypes": []
+          "name" : "major",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "minor",
-          "parameterTypes": []
+          "name" : "minor",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.DiscriminatorFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.DiscriminatorFormula",
+      "methods" : [
         {
-          "name": "discriminatorType",
-          "parameterTypes": []
+          "name" : "discriminatorType",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.DiscriminatorOptions"
+      "type" : "org.hibernate.annotations.DiscriminatorOptions"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.DiscriminatorOptions",
-      "methods": [
+      "type" : "org.hibernate.annotations.DiscriminatorOptions",
+      "methods" : [
         {
-          "name": "force",
-          "parameterTypes": []
+          "name" : "force",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insert",
-          "parameterTypes": []
+          "name" : "insert",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.DynamicInsert"
+      "type" : "org.hibernate.annotations.DynamicInsert"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.DynamicUpdate"
+      "type" : "org.hibernate.annotations.DynamicUpdate"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiator",
-      "methods": [
+      "type" : "org.hibernate.annotations.EmbeddableInstantiator",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistration",
+      "methods" : [
         {
-          "name": "embeddableClass",
-          "parameterTypes": []
+          "name" : "embeddableClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "instantiator",
-          "parameterTypes": []
+          "name" : "instantiator",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.EmbeddableInstantiatorRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.EmbeddableInstantiatorRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddedColumnNaming",
-      "methods": [
+      "type" : "org.hibernate.annotations.EmbeddedColumnNaming",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.EmbeddedTable",
-      "allPublicMethods": true
+      "type" : "org.hibernate.annotations.EmbeddedTable",
+      "allPublicMethods" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Fetch",
-      "methods": [
+      "type" : "org.hibernate.annotations.Fetch",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfile",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfile",
+      "methods" : [
         {
-          "name": "fetchOverrides",
-          "parameterTypes": []
+          "name" : "fetchOverrides",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfile$FetchOverride[]"
+      "type" : "org.hibernate.annotations.FetchProfile$FetchOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverride",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfileOverride",
+      "methods" : [
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "mode",
-          "parameterTypes": []
+          "name" : "mode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "profile",
-          "parameterTypes": []
+          "name" : "profile",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverride[]"
+      "type" : "org.hibernate.annotations.FetchProfileOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.ToOneBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.ToOneBinder"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverride[]"
+      "type" : "org.hibernate.annotations.FetchProfileOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverride[]"
+      "type" : "org.hibernate.annotations.FetchProfileOverride[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfileOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.FetchProfileOverridesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.FetchProfileOverridesAnnotation"
       },
-      "type": "org.hibernate.annotations.FetchProfileOverrides",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfileOverrides",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.FetchProfile[]"
+      "type" : "org.hibernate.annotations.FetchProfile[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfile[]"
+      "type" : "org.hibernate.annotations.FetchProfile[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FetchProfiles",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfiles",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.FetchProfilesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.FetchProfilesAnnotation"
       },
-      "type": "org.hibernate.annotations.FetchProfiles",
-      "methods": [
+      "type" : "org.hibernate.annotations.FetchProfiles",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Filter",
-      "methods": [
+      "type" : "org.hibernate.annotations.Filter",
+      "methods" : [
         {
-          "name": "aliases",
-          "parameterTypes": []
+          "name" : "aliases",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "condition",
-          "parameterTypes": []
+          "name" : "condition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "deduceAliasInjectionPoints",
-          "parameterTypes": []
+          "name" : "deduceAliasInjectionPoints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterDef",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterDef",
+      "methods" : [
         {
-          "name": "applyToLoadByKey",
-          "parameterTypes": []
+          "name" : "applyToLoadByKey",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "autoEnabled",
-          "parameterTypes": []
+          "name" : "autoEnabled",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "defaultCondition",
-          "parameterTypes": []
+          "name" : "defaultCondition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterDef[]"
+      "type" : "org.hibernate.annotations.FilterDef[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.FilterDef[]"
+      "type" : "org.hibernate.annotations.FilterDef[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterDefs",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterDefs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.FilterDefsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.FilterDefsAnnotation"
       },
-      "type": "org.hibernate.annotations.FilterDefs",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterDefs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterJoinTable",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterJoinTable",
+      "methods" : [
         {
-          "name": "aliases",
-          "parameterTypes": []
+          "name" : "aliases",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "condition",
-          "parameterTypes": []
+          "name" : "condition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "deduceAliasInjectionPoints",
-          "parameterTypes": []
+          "name" : "deduceAliasInjectionPoints",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.FilterJoinTable[]"
+      "type" : "org.hibernate.annotations.FilterJoinTable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterJoinTable[]"
+      "type" : "org.hibernate.annotations.FilterJoinTable[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FilterJoinTables",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterJoinTables",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.FilterJoinTablesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.FilterJoinTablesAnnotation"
       },
-      "type": "org.hibernate.annotations.FilterJoinTables",
-      "methods": [
+      "type" : "org.hibernate.annotations.FilterJoinTables",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.CollectionBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.CollectionBinder"
       },
-      "type": "org.hibernate.annotations.Filter[]"
+      "type" : "org.hibernate.annotations.Filter[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Filter[]"
+      "type" : "org.hibernate.annotations.Filter[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Filters",
-      "methods": [
+      "type" : "org.hibernate.annotations.Filters",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.FiltersAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.FiltersAnnotation"
       },
-      "type": "org.hibernate.annotations.Filters",
-      "methods": [
+      "type" : "org.hibernate.annotations.Filters",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Formula",
-      "methods": [
+      "type" : "org.hibernate.annotations.Formula",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.FractionalSeconds",
-      "methods": [
+      "type" : "org.hibernate.annotations.FractionalSeconds",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Generated",
-      "methods": [
+      "type" : "org.hibernate.annotations.Generated",
+      "methods" : [
         {
-          "name": "event",
-          "parameterTypes": []
+          "name" : "event",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writable",
-          "parameterTypes": []
+          "name" : "writable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.GeneratedColumn",
-      "methods": [
+      "type" : "org.hibernate.annotations.GeneratedColumn",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.GenericGenerator",
-      "methods": [
+      "type" : "org.hibernate.annotations.GenericGenerator",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "strategy",
-          "parameterTypes": []
+          "name" : "strategy",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.GenericGenerator[]"
+      "type" : "org.hibernate.annotations.GenericGenerator[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.GenericGenerators",
-      "methods": [
+      "type" : "org.hibernate.annotations.GenericGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.GenericGeneratorsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.GenericGeneratorsAnnotation"
       },
-      "type": "org.hibernate.annotations.GenericGenerators",
-      "methods": [
+      "type" : "org.hibernate.annotations.GenericGenerators",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.HQLSelect",
-      "methods": [
+      "type" : "org.hibernate.annotations.HQLSelect",
+      "methods" : [
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.IdGeneratorType",
-      "methods": [
+      "type" : "org.hibernate.annotations.IdGeneratorType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Immutable"
+      "type" : "org.hibernate.annotations.Immutable"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Imported",
-      "methods": [
+      "type" : "org.hibernate.annotations.Imported",
+      "methods" : [
         {
-          "name": "rename",
-          "parameterTypes": []
+          "name" : "rename",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Instantiator",
-      "methods": [
+      "type" : "org.hibernate.annotations.Instantiator",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JavaType",
-      "methods": [
+      "type" : "org.hibernate.annotations.JavaType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.JavaTypeRegistration",
+      "methods" : [
         {
-          "name": "descriptorClass",
-          "parameterTypes": []
+          "name" : "descriptorClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "javaType",
-          "parameterTypes": []
+          "name" : "javaType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JavaTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JavaTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JavaTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.JavaTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.JavaTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.JavaTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JdbcType",
-      "methods": [
+      "type" : "org.hibernate.annotations.JdbcType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JdbcTypeCode",
-      "methods": [
+      "type" : "org.hibernate.annotations.JdbcTypeCode",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.JdbcTypeRegistration",
+      "methods" : [
         {
-          "name": "registrationCode",
-          "parameterTypes": []
+          "name" : "registrationCode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JdbcTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JdbcTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistration[]"
+      "type" : "org.hibernate.annotations.JdbcTypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.JdbcTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.JdbcTypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.JdbcTypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JoinColumnOrFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.JoinColumnOrFormula",
+      "methods" : [
         {
-          "name": "column",
-          "parameterTypes": []
+          "name" : "column",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "formula",
-          "parameterTypes": []
+          "name" : "formula",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
       },
-      "type": "org.hibernate.annotations.JoinColumnOrFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.JoinColumnOrFormula",
+      "methods" : [
         {
-          "name": "formula",
-          "parameterTypes": []
+          "name" : "formula",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.ColumnsBuilder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.ColumnsBuilder"
       },
-      "type": "org.hibernate.annotations.JoinColumnOrFormula[]"
+      "type" : "org.hibernate.annotations.JoinColumnOrFormula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JoinColumnOrFormula[]"
+      "type" : "org.hibernate.annotations.JoinColumnOrFormula[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JoinColumnsOrFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.JoinColumnsOrFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnsOrFormulasAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnsOrFormulasAnnotation"
       },
-      "type": "org.hibernate.annotations.JoinColumnsOrFormulas",
-      "methods": [
+      "type" : "org.hibernate.annotations.JoinColumnsOrFormulas",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.JoinFormula",
-      "methods": [
+      "type" : "org.hibernate.annotations.JoinFormula",
+      "methods" : [
         {
-          "name": "referencedColumnName",
-          "parameterTypes": []
+          "name" : "referencedColumnName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.LazyGroup",
-      "methods": [
+      "type" : "org.hibernate.annotations.LazyGroup",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ListIndexBase",
-      "methods": [
+      "type" : "org.hibernate.annotations.ListIndexBase",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ListIndexJavaType",
-      "methods": [
+      "type" : "org.hibernate.annotations.ListIndexJavaType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ListIndexJdbcType",
-      "methods": [
+      "type" : "org.hibernate.annotations.ListIndexJdbcType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ListIndexJdbcTypeCode",
-      "methods": [
+      "type" : "org.hibernate.annotations.ListIndexJdbcTypeCode",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ManyToAny",
-      "methods": [
+      "type" : "org.hibernate.annotations.ManyToAny",
+      "methods" : [
         {
-          "name": "fetch",
-          "parameterTypes": []
+          "name" : "fetch",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyCompositeType",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyCompositeType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyJavaType",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyJavaType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyJdbcType",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyJdbcType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyJdbcTypeCode",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyJdbcTypeCode",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyMutability",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyMutability",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.MapKeyType",
-      "methods": [
+      "type" : "org.hibernate.annotations.MapKeyType",
+      "methods" : [
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Mutability",
-      "methods": [
+      "type" : "org.hibernate.annotations.Mutability",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedEntityGraph",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedEntityGraph",
+      "methods" : [
         {
-          "name": "graph",
-          "parameterTypes": []
+          "name" : "graph",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "root",
-          "parameterTypes": []
+          "name" : "root",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedEntityGraph[]"
+      "type" : "org.hibernate.annotations.NamedEntityGraph[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedEntityGraphs",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedEntityGraphs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsAnnotation"
       },
-      "type": "org.hibernate.annotations.NamedEntityGraphs",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedEntityGraphs",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedNativeQueries",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedNativeQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesAnnotation"
       },
-      "type": "org.hibernate.annotations.NamedNativeQueries",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedNativeQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedNativeQuery",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedNativeQuery",
+      "methods" : [
         {
-          "name": "cacheMode",
-          "parameterTypes": []
+          "name" : "cacheMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheRegion",
-          "parameterTypes": []
+          "name" : "cacheRegion",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheRetrieveMode",
-          "parameterTypes": []
+          "name" : "cacheRetrieveMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheStoreMode",
-          "parameterTypes": []
+          "name" : "cacheStoreMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheable",
-          "parameterTypes": []
+          "name" : "cacheable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetchSize",
-          "parameterTypes": []
+          "name" : "fetchSize",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "flush",
-          "parameterTypes": []
+          "name" : "flush",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "flushMode",
-          "parameterTypes": []
+          "name" : "flushMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "querySpaces",
-          "parameterTypes": []
+          "name" : "querySpaces",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultClass",
-          "parameterTypes": []
+          "name" : "resultClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultSetMapping",
-          "parameterTypes": []
+          "name" : "resultSetMapping",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "timeout",
-          "parameterTypes": []
+          "name" : "timeout",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedNativeQuery[]"
+      "type" : "org.hibernate.annotations.NamedNativeQuery[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedQueries",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.NamedQueriesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.NamedQueriesAnnotation"
       },
-      "type": "org.hibernate.annotations.NamedQueries",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedQueries",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedQuery",
-      "methods": [
+      "type" : "org.hibernate.annotations.NamedQuery",
+      "methods" : [
         {
-          "name": "cacheMode",
-          "parameterTypes": []
+          "name" : "cacheMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheRegion",
-          "parameterTypes": []
+          "name" : "cacheRegion",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheRetrieveMode",
-          "parameterTypes": []
+          "name" : "cacheRetrieveMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheStoreMode",
-          "parameterTypes": []
+          "name" : "cacheStoreMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "cacheable",
-          "parameterTypes": []
+          "name" : "cacheable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "fetchSize",
-          "parameterTypes": []
+          "name" : "fetchSize",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "flush",
-          "parameterTypes": []
+          "name" : "flush",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "flushMode",
-          "parameterTypes": []
+          "name" : "flushMode",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readOnly",
-          "parameterTypes": []
+          "name" : "readOnly",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultClass",
-          "parameterTypes": []
+          "name" : "resultClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "timeout",
-          "parameterTypes": []
+          "name" : "timeout",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NamedQuery[]"
+      "type" : "org.hibernate.annotations.NamedQuery[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Nationalized"
+      "type" : "org.hibernate.annotations.Nationalized"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NativeGenerator",
-      "methods": [
+      "type" : "org.hibernate.annotations.NativeGenerator",
+      "methods" : [
         {
-          "name": "sequenceForm",
-          "parameterTypes": []
+          "name" : "sequenceForm",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "tableForm",
-          "parameterTypes": []
+          "name" : "tableForm",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NaturalId",
-      "methods": [
+      "type" : "org.hibernate.annotations.NaturalId",
+      "methods" : [
         {
-          "name": "mutable",
-          "parameterTypes": []
+          "name" : "mutable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NaturalIdCache",
-      "methods": [
+      "type" : "org.hibernate.annotations.NaturalIdCache",
+      "methods" : [
         {
-          "name": "region",
-          "parameterTypes": []
+          "name" : "region",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.NotFound",
-      "methods": [
+      "type" : "org.hibernate.annotations.NotFound",
+      "methods" : [
         {
-          "name": "action",
-          "parameterTypes": []
+          "name" : "action",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.OnDelete",
-      "methods": [
+      "type" : "org.hibernate.annotations.OnDelete",
+      "methods" : [
         {
-          "name": "action",
-          "parameterTypes": []
+          "name" : "action",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.OptimisticLock",
-      "methods": [
+      "type" : "org.hibernate.annotations.OptimisticLock",
+      "methods" : [
         {
-          "name": "excluded",
-          "parameterTypes": []
+          "name" : "excluded",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.OptimisticLocking",
-      "methods": [
+      "type" : "org.hibernate.annotations.OptimisticLocking",
+      "methods" : [
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ParamDef",
-      "methods": [
+      "type" : "org.hibernate.annotations.ParamDef",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resolver",
-          "parameterTypes": []
+          "name" : "resolver",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "type",
-          "parameterTypes": []
+          "name" : "type",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ParamDef[]"
+      "type" : "org.hibernate.annotations.ParamDef[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Parameter",
-      "methods": [
+      "type" : "org.hibernate.annotations.Parameter",
+      "methods" : [
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Parameter[]"
+      "type" : "org.hibernate.annotations.Parameter[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Parent"
+      "type" : "org.hibernate.annotations.Parent"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.PartitionKey"
+      "type" : "org.hibernate.annotations.PartitionKey"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.PropertyRef",
-      "methods": [
+      "type" : "org.hibernate.annotations.PropertyRef",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.QueryCacheLayout",
-      "methods": [
+      "type" : "org.hibernate.annotations.QueryCacheLayout",
+      "methods" : [
         {
-          "name": "layout",
-          "parameterTypes": []
+          "name" : "layout",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.RowId",
-      "methods": [
+      "type" : "org.hibernate.annotations.RowId",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLDelete",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLDelete",
+      "methods" : [
         {
-          "name": "callable",
-          "parameterTypes": []
+          "name" : "callable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "verify",
-          "parameterTypes": []
+          "name" : "verify",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLDeleteAll",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLDeleteAll",
+      "methods" : [
         {
-          "name": "callable",
-          "parameterTypes": []
+          "name" : "callable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "verify",
-          "parameterTypes": []
+          "name" : "verify",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLDelete[]"
+      "type" : "org.hibernate.annotations.SQLDelete[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLDeletes",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLDeletes",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SQLDeletesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SQLDeletesAnnotation"
       },
-      "type": "org.hibernate.annotations.SQLDeletes",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLDeletes",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLInsert",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLInsert",
+      "methods" : [
         {
-          "name": "callable",
-          "parameterTypes": []
+          "name" : "callable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "verify",
-          "parameterTypes": []
+          "name" : "verify",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLInsert[]"
+      "type" : "org.hibernate.annotations.SQLInsert[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLInserts",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLInserts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SQLInsertsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SQLInsertsAnnotation"
       },
-      "type": "org.hibernate.annotations.SQLInserts",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLInserts",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLJoinTableRestriction",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLJoinTableRestriction",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLOrder",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLOrder",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLRestriction",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLRestriction",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLSelect",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLSelect",
+      "methods" : [
         {
-          "name": "querySpaces",
-          "parameterTypes": []
+          "name" : "querySpaces",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "resultSetMapping",
-          "parameterTypes": []
+          "name" : "resultSetMapping",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLUpdate",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLUpdate",
+      "methods" : [
         {
-          "name": "callable",
-          "parameterTypes": []
+          "name" : "callable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "check",
-          "parameterTypes": []
+          "name" : "check",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "sql",
-          "parameterTypes": []
+          "name" : "sql",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "verify",
-          "parameterTypes": []
+          "name" : "verify",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLUpdate[]"
+      "type" : "org.hibernate.annotations.SQLUpdate[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SQLUpdates",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLUpdates",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SQLUpdatesAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SQLUpdatesAnnotation"
       },
-      "type": "org.hibernate.annotations.SQLUpdates",
-      "methods": [
+      "type" : "org.hibernate.annotations.SQLUpdates",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SecondaryRow",
-      "methods": [
+      "type" : "org.hibernate.annotations.SecondaryRow",
+      "methods" : [
         {
-          "name": "optional",
-          "parameterTypes": []
+          "name" : "optional",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "owned",
-          "parameterTypes": []
+          "name" : "owned",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SecondaryRow[]"
+      "type" : "org.hibernate.annotations.SecondaryRow[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SecondaryRows",
-      "methods": [
+      "type" : "org.hibernate.annotations.SecondaryRows",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SecondaryRowsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SecondaryRowsAnnotation"
       },
-      "type": "org.hibernate.annotations.SecondaryRows",
-      "methods": [
+      "type" : "org.hibernate.annotations.SecondaryRows",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SoftDelete",
-      "methods": [
+      "type" : "org.hibernate.annotations.SoftDelete",
+      "methods" : [
         {
-          "name": "columnName",
-          "parameterTypes": []
+          "name" : "columnName",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "converter",
-          "parameterTypes": []
+          "name" : "converter",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "strategy",
-          "parameterTypes": []
+          "name" : "strategy",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SortComparator",
-      "methods": [
+      "type" : "org.hibernate.annotations.SortComparator",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SortNatural"
+      "type" : "org.hibernate.annotations.SortNatural"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Source",
-      "methods": [
+      "type" : "org.hibernate.annotations.Source",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SqlFragmentAlias",
-      "methods": [
+      "type" : "org.hibernate.annotations.SqlFragmentAlias",
+      "methods" : [
         {
-          "name": "alias",
-          "parameterTypes": []
+          "name" : "alias",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "entity",
-          "parameterTypes": []
+          "name" : "entity",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.SqlFragmentAlias[]"
+      "type" : "org.hibernate.annotations.SqlFragmentAlias[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Struct",
-      "methods": [
+      "type" : "org.hibernate.annotations.Struct",
+      "methods" : [
         {
-          "name": "attributes",
-          "parameterTypes": []
+          "name" : "attributes",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "catalog",
-          "parameterTypes": []
+          "name" : "catalog",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "schema",
-          "parameterTypes": []
+          "name" : "schema",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Subselect",
-      "methods": [
+      "type" : "org.hibernate.annotations.Subselect",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Synchronize",
-      "methods": [
+      "type" : "org.hibernate.annotations.Synchronize",
+      "methods" : [
         {
-          "name": "logical",
-          "parameterTypes": []
+          "name" : "logical",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TargetEmbeddable",
-      "methods": [
+      "type" : "org.hibernate.annotations.TargetEmbeddable",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TenantId"
+      "type" : "org.hibernate.annotations.TenantId"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.TenantId"
+      "type" : "org.hibernate.annotations.TenantId"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TimeZoneColumn",
-      "methods": [
+      "type" : "org.hibernate.annotations.TimeZoneColumn",
+      "methods" : [
         {
-          "name": "columnDefinition",
-          "parameterTypes": []
+          "name" : "columnDefinition",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "comment",
-          "parameterTypes": []
+          "name" : "comment",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "insertable",
-          "parameterTypes": []
+          "name" : "insertable",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "name",
-          "parameterTypes": []
+          "name" : "name",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "options",
-          "parameterTypes": []
+          "name" : "options",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "table",
-          "parameterTypes": []
+          "name" : "table",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "updatable",
-          "parameterTypes": []
+          "name" : "updatable",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TimeZoneStorage",
-      "methods": [
+      "type" : "org.hibernate.annotations.TimeZoneStorage",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.Type",
-      "methods": [
+      "type" : "org.hibernate.annotations.Type",
+      "methods" : [
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TypeBinderType"
+      "type" : "org.hibernate.annotations.TypeBinderType"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SpecializedAnnotationDescriptor"
       },
-      "type": "org.hibernate.annotations.TypeBinderType",
-      "methods": [
+      "type" : "org.hibernate.annotations.TypeBinderType",
+      "methods" : [
         {
-          "name": "binder",
-          "parameterTypes": []
+          "name" : "binder",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TypeRegistration",
-      "methods": [
+      "type" : "org.hibernate.annotations.TypeRegistration",
+      "methods" : [
         {
-          "name": "basicClass",
-          "parameterTypes": []
+          "name" : "basicClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "userType",
-          "parameterTypes": []
+          "name" : "userType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.AnnotationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.AnnotationBinder"
       },
-      "type": "org.hibernate.annotations.TypeRegistration[]"
+      "type" : "org.hibernate.annotations.TypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TypeRegistration[]"
+      "type" : "org.hibernate.annotations.TypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.annotations.TypeRegistration[]"
+      "type" : "org.hibernate.annotations.TypeRegistration[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.TypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.TypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.TypeRegistrationsAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.TypeRegistrationsAnnotation"
       },
-      "type": "org.hibernate.annotations.TypeRegistrations",
-      "methods": [
+      "type" : "org.hibernate.annotations.TypeRegistrations",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.UpdateTimestamp",
-      "methods": [
+      "type" : "org.hibernate.annotations.UpdateTimestamp",
+      "methods" : [
         {
-          "name": "source",
-          "parameterTypes": []
+          "name" : "source",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.UuidGenerator",
-      "methods": [
+      "type" : "org.hibernate.annotations.UuidGenerator",
+      "methods" : [
         {
-          "name": "algorithm",
-          "parameterTypes": []
+          "name" : "algorithm",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "style",
-          "parameterTypes": []
+          "name" : "style",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.ValueGenerationType",
-      "methods": [
+      "type" : "org.hibernate.annotations.ValueGenerationType",
+      "methods" : [
         {
-          "name": "generatedBy",
-          "parameterTypes": []
+          "name" : "generatedBy",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.annotations.View",
-      "methods": [
+      "type" : "org.hibernate.annotations.View",
+      "methods" : [
         {
-          "name": "query",
-          "parameterTypes": []
+          "name" : "query",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.BootLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.BootLogging"
       },
-      "type": "org.hibernate.boot.BootLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.BootLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.archive.scan.internal.ScannerLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.archive.scan.internal.ScannerLogger"
       },
-      "type": "org.hibernate.boot.archive.scan.internal.ScannerLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.boot.archive.scan.internal.ScannerLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.beanvalidation.BeanValidationLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.beanvalidation.BeanValidationLogger"
       },
-      "type": "org.hibernate.boot.beanvalidation.BeanValidationLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.beanvalidation.BeanValidationLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
       },
-      "type": "org.hibernate.boot.beanvalidation.TypeSafeActivator",
-      "methods": [
+      "type" : "org.hibernate.boot.beanvalidation.TypeSafeActivator",
+      "methods" : [
         {
-          "name": "activate",
-          "parameterTypes": [
+          "name" : "activate",
+          "parameterTypes" : [
             "org.hibernate.boot.beanvalidation.ActivationContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl"
       },
-      "type": "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl"
+      "type" : "org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.internal.Abstract"
+      "type" : "org.hibernate.boot.internal.Abstract"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.internal.AnyKeyType",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.AnyKeyType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.internal.AnyKeyType",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.AnyKeyType",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.internal.CollectionClassification",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.CollectionClassification",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.internal.CollectionClassification",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.CollectionClassification",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataImpl"
       },
-      "type": "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService"
+      "type" : "org.hibernate.boot.internal.DefaultSessionFactoryBuilderService"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.internal.Extends",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.Extends",
+      "methods" : [
         {
-          "name": "superType",
-          "parameterTypes": []
+          "name" : "superType",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.internal.Target",
-      "methods": [
+      "type" : "org.hibernate.boot.internal.Target",
+      "methods" : [
         {
-          "name": "value",
-          "parameterTypes": []
+          "name" : "value",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.JaxbLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.JaxbLogger"
       },
-      "type": "org.hibernate.boot.jaxb.JaxbLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.JaxbLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl",
-      "allDeclaredFields": true,
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl",
+      "allDeclaredFields" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl",
-      "allDeclaredFields": true,
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl",
+      "allDeclaredFields" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl",
-      "allDeclaredFields": true,
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl",
+      "allDeclaredFields" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.AbstractBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.AbstractBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl$JaxbPropertyImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl$JaxbPropertyImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl$JaxbPropertyImpl",
-      "allDeclaredFields": true,
-      "methods": [
+      "type" : "org.hibernate.boot.jaxb.configuration.spi.JaxbPersistenceImpl$JaxbPersistenceUnitImpl$JaxbPropertiesImpl$JaxbPropertyImpl",
+      "allDeclaredFields" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy",
-      "methods": [
+      "type" : "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl",
-      "methods": [
+      "type" : "org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.boot.model.relational.ColumnOrderingStrategyStandard",
-      "methods": [
+      "type" : "org.hibernate.boot.model.relational.ColumnOrderingStrategyStandard",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.DialectOverrideAnnotations",
-      "allPublicFields": true
+      "type" : "org.hibernate.boot.models.DialectOverrideAnnotations",
+      "allPublicFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.HibernateAnnotations",
-      "allPublicFields": true
+      "type" : "org.hibernate.boot.models.HibernateAnnotations",
+      "allPublicFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.JpaAnnotations",
-      "allPublicFields": true
+      "type" : "org.hibernate.boot.models.JpaAnnotations",
+      "allPublicFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.XmlAnnotations",
-      "allPublicFields": true
+      "type" : "org.hibernate.boot.models.XmlAnnotations",
+      "allPublicFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AbstractXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AbstractXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Access"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Access"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AccessJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.AccessJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AccessJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AccessJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Access",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Any",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyDiscriminator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorImplicitValuesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorImplicitValuesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyDiscriminatorImplicitValues",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValueAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValueAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyDiscriminatorValue",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValuesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyDiscriminatorValuesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyDiscriminatorValues",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.AnyKeyType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeyJavaClassAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeyJavaClassAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyKeyJavaClass",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeyJavaTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeyJavaTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyKeyJavaType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeyJdbcTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeyJdbcTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyKeyJdbcType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeyJdbcTypeCodeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeyJdbcTypeCodeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AnyKeyJdbcTypeCode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AnyKeyTypeXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AnyKeyTypeXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.AnyKeyType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ArrayAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ArrayAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Array",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.AssociationOverride"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.AssociationOverride"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.AssociationOverride",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.AssociationOverrides"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.AssociationOverrides"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AssociationOverridesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.AssociationOverrides",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeAccessorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeAccessorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AttributeAccessor",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeBinderTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeBinderTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.AttributeBinderType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.AttributeOverride"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.AttributeOverride"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeOverrideJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeOverrideJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeOverrideJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeOverrideJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.AttributeOverride",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.AttributeOverrides"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.AttributeOverrides"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.AttributeOverridesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.AttributeOverrides",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.BagAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.BagAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Bag",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Basic"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Basic"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.BasicJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.BasicJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.BasicJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.BasicJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Basic",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.BatchSizeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.BatchSizeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.BatchSize",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.EntityBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.EntityBinder"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Cache",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.models.internal.OrmAnnotationDescriptor$DynamicCreator"
+      "condition" : {
+        "typeReached" : "org.hibernate.models.internal.OrmAnnotationDescriptor$DynamicCreator"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.CacheAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Cacheable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Cacheable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CacheableJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.CacheableJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CacheableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CacheableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Cacheable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CascadeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CascadeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Cascade",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CheckAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CheckAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Check",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.CheckConstraint"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.CheckConstraint"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CheckConstraintJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.CheckConstraintJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CheckConstraintJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CheckConstraintJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.CheckConstraint",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ChecksAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ChecksAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Checks",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollateAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollateAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Collate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionClassificationXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionClassificationXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.CollectionClassification",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionClassificationXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionClassificationXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.CollectionClassification",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdJavaClassAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdJavaClassAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdJavaClass",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdJavaTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdJavaTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdJavaType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdJdbcTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdJdbcTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdJdbcType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdJdbcTypeCodeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdJdbcTypeCodeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdJdbcTypeCode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdMutabilityAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdMutabilityAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdMutability",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionIdTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionIdTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionIdType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.CollectionTable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.CollectionTable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.CollectionTable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionTypeRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CollectionTypeRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CollectionTypeRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnDefaultAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnDefaultAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ColumnDefault",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Column"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Column"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Column",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CollectionIdAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ColumnResult"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ColumnResult"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnResultJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnResultJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnResultJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnResultJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ColumnResult",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnTransformerAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnTransformerAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ColumnTransformer",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnTransformersAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnTransformersAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ColumnTransformers",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ColumnsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ColumnsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Columns",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CommentAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CommentAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Comment",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CommentsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CommentsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Comments",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CompositeTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CompositeTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CompositeType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CompositeTypeRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CompositeTypeRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CompositeTypeRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConcreteProxyAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConcreteProxyAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ConcreteProxy",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ConstructorResult"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ConstructorResult"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConstructorResultJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ConstructorResultJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConstructorResultJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConstructorResultJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ConstructorResult",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Convert"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Convert"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConvertJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ConvertJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConvertJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConvertJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Convert",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Converter"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Converter"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConverterJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ConverterJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConverterJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConverterJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Converter",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConverterRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConverterRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ConverterRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConverterRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConverterRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ConverterRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Converts"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Converts"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ConvertsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Converts",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CreationTimestampAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CreationTimestampAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CreationTimestamp",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.CurrentTimestampAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.CurrentTimestampAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CurrentTimestamp",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.DiscriminatorColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.DiscriminatorColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.DiscriminatorColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DiscriminatorFormula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorOptionsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorOptionsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DiscriminatorOptions",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.DiscriminatorValue"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.DiscriminatorValue"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorValueJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorValueJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DiscriminatorValueJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DiscriminatorValueJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.DiscriminatorValue",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DynamicInsertAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DynamicInsertAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DynamicInsert",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.DynamicUpdateAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.DynamicUpdateAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DynamicUpdate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ElementCollection"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ElementCollection"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ElementCollectionJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ElementCollectionJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ElementCollectionJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ElementCollectionJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ElementCollection",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.EmbeddableInstantiator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.EmbeddableInstantiatorRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableInstantiatorRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.EmbeddableInstantiatorRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Embeddable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedColumnNamingAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedColumnNamingAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedColumnNamingAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedColumnNamingAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.EmbeddedColumnNaming",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.EmbeddedId"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.EmbeddedId"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedIdJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.EmbeddedId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embeddable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embeddable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Embedded"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Embedded"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Embedded",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EmbeddedTableAnnotation",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EmbeddedTableAnnotation",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Entity"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Entity"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Entity",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Entity",
             "org.hibernate.models.spi.ModelsContext"
           ]
@@ -9441,91 +9441,91 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.EntityListeners"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.EntityListeners"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityListenersJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityListenersJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityListenersJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityListenersJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.EntityListeners",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.EntityResult"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.EntityResult"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityResultJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityResultJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EntityResultJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EntityResultJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.EntityResult",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Enumerated"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Enumerated"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Enumerated",
             "org.hibernate.models.spi.ModelsContext"
           ]
@@ -9533,6971 +9533,6971 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EnumeratedJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Enumerated",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.EnumeratedValue"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.EnumeratedValue"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EnumeratedValueJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.EnumeratedValueJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.EnumeratedValueJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.EnumeratedValueJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.EnumeratedValue",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ExcludeDefaultListeners"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ExcludeDefaultListeners"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ExcludeDefaultListenersJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ExcludeDefaultListenersJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ExcludeDefaultListenersJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ExcludeDefaultListenersJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ExcludeDefaultListeners",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ExcludeSuperclassListeners"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ExcludeSuperclassListeners"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ExcludeSuperclassListenersJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ExcludeSuperclassListenersJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ExcludeSuperclassListenersJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ExcludeSuperclassListenersJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ExcludeSuperclassListeners",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ExtendsXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ExtendsXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.Extends",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FetchAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FetchAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Fetch",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FetchProfileAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FetchProfileAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FetchProfile",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FetchProfileOverrideAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FetchProfileOverrideAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FetchProfileOverride",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FetchProfileOverridesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FetchProfileOverridesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FetchProfileOverrides",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FetchProfilesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FetchProfilesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FetchProfiles",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.FieldResult"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.FieldResult"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FieldResultJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.FieldResultJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FieldResultJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FieldResultJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.FieldResult",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FilterAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FilterAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Filter",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FilterDefAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FilterDefAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FilterDef",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FilterDefsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FilterDefsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FilterDefs",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FilterJoinTableAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FilterJoinTableAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FilterJoinTable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FilterJoinTablesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FilterJoinTablesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FilterJoinTables",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FiltersAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FiltersAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Filters",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ForeignKey"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ForeignKey"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ForeignKey",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.CollectionTableJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.models.internal.jdk.JdkNestedValueExtractor"
+      "condition" : {
+        "typeReached" : "org.hibernate.models.internal.jdk.JdkNestedValueExtractor"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ForeignKeyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Formula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.FractionalSecondsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.FractionalSecondsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.FractionalSeconds",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GeneratedAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.GeneratedAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Generated",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GeneratedColumnAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.GeneratedColumnAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.GeneratedColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.GeneratedValue"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.GeneratedValue"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyBinder"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.GeneratedValueJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.GeneratedValue",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GenericGeneratorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.GenericGeneratorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.GenericGenerator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.GenericGeneratorsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.GenericGeneratorsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.GenericGenerators",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.HQLSelectAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.HQLSelectAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.HQLSelect",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.IdClass"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.IdClass"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdClassJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.IdClassJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdClassJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.IdClassJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.IdClass",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdGeneratorTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.IdGeneratorTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.IdGeneratorType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Id"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Id"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyBinder"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.IdJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Id",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ImmutableAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ImmutableAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Immutable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ImportedAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ImportedAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Imported",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Index"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Index"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IndexJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.IndexJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.IndexJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.IndexJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Index",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Inheritance"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Inheritance"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.InheritanceJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.InheritanceJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.InheritanceJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.InheritanceJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Inheritance",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.InstantiatorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.InstantiatorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Instantiator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JavaTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JavaTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JavaType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JavaTypeRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JavaTypeRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JavaTypeRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JdbcTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JdbcTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JdbcType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JdbcTypeCodeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JdbcTypeCodeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JdbcTypeCode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JdbcTypeRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JdbcTypeRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JdbcTypeRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.JoinColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.JoinColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.JoinColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.models.internal.jdk.JdkNestedValueConverter"
+      "condition" : {
+        "typeReached" : "org.hibernate.models.internal.jdk.JdkNestedValueConverter"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JoinColumnOrFormula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.JoinColumns"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.JoinColumns"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.JoinColumns",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinColumnsOrFormulasAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinColumnsOrFormulasAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JoinColumnsOrFormulas",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.JoinFormula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.JoinColumnOrFormulaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinFormulaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinFormulaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.JoinTableJpaAnnotation"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.JoinTableJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.JoinTable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.AssociationOverrideJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.JoinTableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.LazyGroupAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.LazyGroupAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.LazyGroup",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ListIndexBaseAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ListIndexBaseAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ListIndexBase",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ListIndexJavaTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ListIndexJavaTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ListIndexJavaType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ListIndexJdbcTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ListIndexJdbcTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ListIndexJdbcType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ListIndexJdbcTypeCodeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ListIndexJdbcTypeCodeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ListIndexJdbcTypeCode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Lob"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Lob"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.LobJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.LobJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.LobJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.LobJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Lob",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToAnyAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToAnyAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ManyToAny",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ManyToMany"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ManyToMany"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToManyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ManyToMany",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.ManyToOne"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.ManyToOne"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ManyToOneJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.ManyToOne",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKey"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKey"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKey",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKey",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyClass"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyClass"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyClassJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyClassJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyClassJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyClassJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyClass",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyCompositeTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyCompositeTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyCompositeType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyEnumerated"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyEnumerated"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyEnumeratedJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyEnumeratedJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyEnumeratedJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyEnumeratedJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyEnumerated",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJavaTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJavaTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyJavaType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJdbcTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJdbcTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyJdbcType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJdbcTypeCodeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJdbcTypeCodeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyJdbcTypeCode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyJoinColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyJoinColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyJoinColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyJoinColumns"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyJoinColumns"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJoinColumnsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyJoinColumns",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKey"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKey"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKey",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyMutabilityAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyMutabilityAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyMutability",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapKeyTemporal"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapKeyTemporal"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyTemporalJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyTemporalJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyTemporalJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyTemporalJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapKeyTemporal",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapKeyTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapKeyTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.MapKeyType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MappedSuperclass"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MappedSuperclass"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MappedSuperclassJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MappedSuperclassJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MappedSuperclassJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MappedSuperclassJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MappedSuperclass",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.MapsId"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.MapsId"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapsIdJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.MapsIdJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MapsIdJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MapsIdJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.MapsId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.MutabilityAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.MutabilityAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Mutability",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedAttributeNode"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedAttributeNode"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedAttributeNodeJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedAttributeNodeJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedAttributeNodeJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedAttributeNodeJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedAttributeNode",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedEntityGraph",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedEntityGraph"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedEntityGraph"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedEntityGraphJpaAnnotation"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedEntityGraphJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedEntityGraph",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedEntityGraphs",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedEntityGraphs"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedEntityGraphs"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedEntityGraphsJpaAnnotation"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedEntityGraphsJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedEntityGraphsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedEntityGraphs",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedNativeQueries",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedNativeQueries"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedNativeQueries"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueriesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedNativeQueries",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueryAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueryAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedNativeQuery",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedNativeQuery"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedNativeQuery"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueryJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueryJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedNativeQueryJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedNativeQueryJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedNativeQuery",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueriesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueriesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedQueries",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedQueries"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedQueries"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueriesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedQueries",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueryAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueryAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NamedQuery",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedQuery"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedQuery"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueryJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueryJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedQueryJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedQueryJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedQuery",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedStoredProcedureQueries"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedStoredProcedureQueries"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueriesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedStoredProcedureQueries",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedStoredProcedureQuery"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedStoredProcedureQuery"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueryJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueryJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueryJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedStoredProcedureQueryJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedStoredProcedureQuery",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedStoredProcedures"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedStoredProcedures"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedStoredProceduresQueryJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedStoredProceduresQueryJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.NamedSubgraph"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.NamedSubgraph"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedSubgraphJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedSubgraphJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NamedSubgraphJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NamedSubgraphJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.NamedSubgraph",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NationalizedAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NationalizedAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Nationalized",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NativeGeneratorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NativeGeneratorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NativeGenerator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NaturalIdAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NaturalIdAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NaturalId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NaturalIdCacheAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NaturalIdCacheAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NaturalIdCache",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.NotFoundAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.NotFoundAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.NotFound",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OnDeleteAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OnDeleteAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.OnDelete",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.OneToMany"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.OneToMany"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToManyJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.OneToMany",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.OneToOne"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.OneToOne"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OneToOneJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.OneToOne",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OptimisticLockAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OptimisticLockAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.OptimisticLock",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OptimisticLockingAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OptimisticLockingAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.OptimisticLocking",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.OrderBy"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.OrderBy"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OrderByJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OrderByJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OrderByJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OrderByJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.OrderBy",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.OrderColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.OrderColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OrderColumnJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.OrderColumnJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OrderColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OrderColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.OrderColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenCheckAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenCheckAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Check",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenChecksAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenChecksAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Checks",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$ColumnDefault",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenColumnDefaultsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$ColumnDefaults",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$DiscriminatorFormula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulasAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenDiscriminatorFormulasAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$DiscriminatorFormulas",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefOverridesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefOverridesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$FilterDefOverrides",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFilterDefsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$FilterDefs",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFilterOverridesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFilterOverridesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$FilterOverrides",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFiltersAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFiltersAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Filters",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Formula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenFormulasAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenFormulasAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Formulas",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$GeneratedColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenGeneratedColumnsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$GeneratedColumns",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$JoinFormula",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulasAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenJoinFormulasAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$JoinFormulas",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLDeleteAll",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAllsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLDeleteAlls",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeleteAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLDelete",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeletesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLDeletesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLDeletes",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLInsert",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLInsertsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLInserts",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrderAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrderAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLOrder",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrdersAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLOrdersAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLOrders",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLRestriction",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLRestrictionsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLRestrictions",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLSelectAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLSelectAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLSelect",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLSelectsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLSelectsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdateAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdateAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLUpdate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdatesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverriddenSQLUpdatesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$SQLUpdates",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.DialectOverrideAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.DialectOverrideAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.OverrideVersionAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.OverrideVersionAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.DialectOverride$Version",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ParamDefAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ParamDefAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ParamDef",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ParameterAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ParameterAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Parameter",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ParentAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ParentAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Parent",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PartitionKeyAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PartitionKeyAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.PartitionKey",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PostLoad"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PostLoad"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostLoadJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PostLoadJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostLoadJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PostLoadJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PostLoad",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PostPersist"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PostPersist"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostPersistJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PostPersistJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostPersistJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PostPersistJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PostPersist",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PostRemove"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PostRemove"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostRemoveJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PostRemoveJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostRemoveJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PostRemoveJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PostRemove",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PostUpdate"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PostUpdate"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostUpdateJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PostUpdateJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PostUpdateJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PostUpdateJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PostUpdate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PrePersist"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PrePersist"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrePersistJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PrePersistJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrePersistJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PrePersistJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PrePersist",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PreRemove"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PreRemove"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PreRemoveJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PreRemoveJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PreRemoveJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PreRemoveJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PreRemove",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PreUpdate"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PreUpdate"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PreUpdateJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PreUpdateJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PreUpdateJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PreUpdateJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PreUpdate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PrimaryKeyJoinColumn"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PrimaryKeyJoinColumn"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PrimaryKeyJoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PrimaryKeyJoinColumnJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PrimaryKeyJoinColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PrimaryKeyJoinColumns"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PrimaryKeyJoinColumns"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeyJoinColumnsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.PrimaryKeyJoinColumns",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.PrimaryKeysJoinColumnJpaAnnotation"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.PrimaryKeysJoinColumnJpaAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PrimaryKeysJoinColumnJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.PrimaryKeysJoinColumnJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.PropertyRefAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.PropertyRefAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.PropertyRef",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.QueryCacheLayoutAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.QueryCacheLayoutAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.QueryCacheLayout",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.QueryHint"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.QueryHint"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.QueryHintJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.QueryHintJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.QueryHintJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.QueryHintJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.QueryHint",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.RowIdAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.RowIdAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.RowId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLDeleteAllAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLDeleteAllAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLDeleteAll",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLDeleteAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLDeleteAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLDelete",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLDeletesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLDeletesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLDeletes",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLInsertAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLInsertAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLInsert",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLInsertsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLInsertsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLInserts",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLJoinTableRestrictionAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLJoinTableRestrictionAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLJoinTableRestriction",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLOrderAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLOrderAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLOrder",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLRestrictionAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLRestrictionAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLRestriction",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLSelectAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLSelectAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLSelect",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLUpdateAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLUpdateAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLUpdate",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SQLUpdatesAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SQLUpdatesAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SQLUpdates",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryRowAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryRowAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SecondaryRow",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryRowsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryRowsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SecondaryRows",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SecondaryTable"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SecondaryTable"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryTableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SecondaryTable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SecondaryTables"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SecondaryTables"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SecondaryTablesJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SecondaryTables",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SequenceGenerator"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SequenceGenerator"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SequenceGeneratorJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SequenceGeneratorJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SequenceGeneratorJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SequenceGeneratorJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SequenceGenerator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SequenceGenerators"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SequenceGenerators"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SequenceGeneratorsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SequenceGenerators",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SoftDeleteAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SoftDeleteAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SoftDelete",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SortComparatorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SortComparatorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SortComparator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SortNaturalAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SortNaturalAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SortNatural",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SourceAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SourceAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Source",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlFragmentAliasAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlFragmentAliasAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SqlFragmentAlias",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SqlResultSetMapping"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SqlResultSetMapping"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SqlResultSetMapping",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.annotations.internal.SQLSelectAnnotation"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.annotations.internal.SQLSelectAnnotation"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SqlResultSetMappings"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SqlResultSetMappings"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.SqlResultSetsMappings"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.SqlResultSetsMappings"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SqlResultSetMappingsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.SqlResultSetMappings",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.StoredProcedureParameter"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.StoredProcedureParameter"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.StoredProcedureParameterJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.StoredProcedureParameterJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.StoredProcedureParameterJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.StoredProcedureParameterJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.StoredProcedureParameter",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.StructAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.StructAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Struct",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SubselectAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SubselectAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Subselect",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.SynchronizeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.SynchronizeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Synchronize",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.TableGenerator"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.TableGenerator"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableGeneratorJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TableGeneratorJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableGeneratorJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TableGeneratorJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.TableGenerator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.TableGenerators"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.TableGenerators"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TableGeneratorsJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.TableGenerators",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Table"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Table"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Table",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.internal.GlobalRegistrationsImpl"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TableJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TargetEmbeddableAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TargetEmbeddableAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TargetEmbeddable",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.XmlAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.XmlAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TargetXmlAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TargetXmlAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.boot.internal.Target",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Temporal"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Temporal"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.PropertyContainer"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.PropertyContainer"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TemporalJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Temporal",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TenantIdAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TenantIdAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TenantId",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TimeZoneColumnAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TimeZoneColumnAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TimeZoneColumn",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TimeZoneStorageAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TimeZoneStorageAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TimeZoneStorage",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Transient"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Transient"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TransientJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.TransientJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TransientJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TransientJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Transient",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Type",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TypeBinderTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TypeBinderTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TypeBinderType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TypeRegistrationAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TypeRegistrationAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TypeRegistration",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.TypeRegistrationsAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.TypeRegistrationsAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TypeRegistrations",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.UniqueConstraint"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.UniqueConstraint"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.UniqueConstraintJpaAnnotation",
-      "allDeclaredConstructors": true,
-      "allPublicConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.UniqueConstraintJpaAnnotation",
+      "allDeclaredConstructors" : true,
+      "allPublicConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.UniqueConstraintJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.UniqueConstraintJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.UniqueConstraint",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.UpdateTimestampAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.UpdateTimestampAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UpdateTimestamp",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.UuidGeneratorAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.UuidGeneratorAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ValueGenerationTypeAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ValueGenerationTypeAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.ValueGenerationType",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.persistence.Version"
+      "condition" : {
+        "typeReached" : "jakarta.persistence.Version"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.VersionJpaAnnotation",
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.boot.models.annotations.internal.VersionJpaAnnotation",
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.JpaAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.JpaAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.VersionJpaAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.VersionJpaAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "jakarta.persistence.Version",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.boot.models.annotations.internal.ViewAnnotation",
-      "methods": [
+      "type" : "org.hibernate.boot.models.annotations.internal.ViewAnnotation",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.Map",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.View",
             "org.hibernate.models.spi.ModelsContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.models.spi.ModelsContext"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$AreFieldsDirty"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$AreFieldsDirty"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$AreFieldsDirtyWithoutCollections"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$AreFieldsDirtyWithoutCollections"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearDirtyAttributes"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearDirtyAttributes"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearDirtyAttributesWithoutCollections"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearDirtyAttributesWithoutCollections"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearOwner"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$ClearOwner"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetCollectionTrackerWithoutCollections"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetCollectionTrackerWithoutCollections"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetDirtyAttributes"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetDirtyAttributes"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetDirtyAttributesWithoutCollections"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$GetDirtyAttributesWithoutCollections"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$InitializeLazyAttributeLoadingInterceptor"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$InitializeLazyAttributeLoadingInterceptor"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SetOwner"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SetOwner"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SetPersistenceInfo"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SetPersistenceInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuspendDirtyTracking"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuspendDirtyTracking"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImplConstants"
       },
-      "type": "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$TrackChange"
+      "type" : "org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$TrackChange"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging"
       },
-      "type": "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.bytecode.enhance.spi.interceptor.BytecodeInterceptorLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.cache.internal.DisabledCaching"
+      "type" : "org.hibernate.cache.internal.DisabledCaching"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.cache.internal.NoCachingRegionFactory"
+      "type" : "org.hibernate.cache.internal.NoCachingRegionFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.cache.spi.SecondLevelCacheLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.cache.spi.SecondLevelCacheLogger"
       },
-      "type": "org.hibernate.cache.spi.SecondLevelCacheLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.cache.spi.SecondLevelCacheLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.collection.internal.CollectionLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.collection.internal.CollectionLogger"
       },
-      "type": "org.hibernate.collection.internal.CollectionLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.collection.internal.CollectionLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.context.internal.CurrentSessionLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.context.internal.CurrentSessionLogging"
       },
-      "type": "org.hibernate.context.internal.CurrentSessionLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.context.internal.CurrentSessionLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.CockroachDialect"
+      "type" : "org.hibernate.dialect.CockroachDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.CockroachDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.CockroachDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.DialectLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.DialectLogging"
       },
-      "type": "org.hibernate.dialect.DialectLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.dialect.DialectLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.H2Dialect"
+      "type" : "org.hibernate.dialect.H2Dialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.H2Dialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.H2Dialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.HANADialect"
+      "type" : "org.hibernate.dialect.HANADialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.HANADialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.HANADialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.HSQLDialect"
+      "type" : "org.hibernate.dialect.HSQLDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.HSQLDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.HSQLDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.MariaDBDialect"
+      "type" : "org.hibernate.dialect.MariaDBDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.MariaDBDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.MariaDBDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.MySQLDialect"
+      "type" : "org.hibernate.dialect.MySQLDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.MySQLDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.MySQLDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.OracleDialect"
+      "type" : "org.hibernate.dialect.OracleDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.OracleDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.OracleDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.PostgreSQLDialect"
+      "type" : "org.hibernate.dialect.PostgreSQLDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.PostgreSQLDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.PostgreSQLDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.PostgresPlusDialect"
+      "type" : "org.hibernate.dialect.PostgresPlusDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.PostgresPlusDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.PostgresPlusDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
       },
-      "type": "org.hibernate.dialect.SQLServerDialect"
+      "type" : "org.hibernate.dialect.SQLServerDialect"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.dialect.SQLServerDialect",
-      "methods": [
+      "type" : "org.hibernate.dialect.SQLServerDialect",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.OracleJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.OracleJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.OracleArrayJdbcTypeConstructor",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.OracleArrayJdbcTypeConstructor",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.OracleJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.OracleJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.OracleNestedTableJdbcTypeConstructor",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.OracleNestedTableJdbcTypeConstructor",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.OracleJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.OracleJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.OracleStructJdbcType",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.OracleStructJdbcType",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.PostgreSQLInetJdbcType",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.PostgreSQLInetJdbcType",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.PostgreSQLIntervalSecondJdbcType",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.PostgreSQLIntervalSecondJdbcType",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.PostgreSQLJsonArrayPGObjectJsonbJdbcTypeConstructor",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.PostgreSQLJsonArrayPGObjectJsonbJdbcTypeConstructor",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.PostgreSQLJsonPGObjectJsonbType",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.PostgreSQLJsonPGObjectJsonbType",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.hibernate.dialect.type.PostgreSQLStructPGObjectJdbcType",
-      "methods": [
+      "type" : "org.hibernate.dialect.type.PostgreSQLStructPGObjectJdbcType",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.MetadataBuilderImpl$MetadataBuildingOptionsImpl"
       },
-      "type": "org.hibernate.engine.config.internal.ConfigurationServiceImpl"
+      "type" : "org.hibernate.engine.config.internal.ConfigurationServiceImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.internal.NaturalIdLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.internal.NaturalIdLogging"
       },
-      "type": "org.hibernate.engine.internal.NaturalIdLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.engine.internal.NaturalIdLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.internal.PersistenceContextLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.internal.PersistenceContextLogging"
       },
-      "type": "org.hibernate.engine.internal.PersistenceContextLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.engine.internal.PersistenceContextLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.internal.SessionMetricsLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.internal.SessionMetricsLogger"
       },
-      "type": "org.hibernate.engine.internal.SessionMetricsLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.engine.internal.SessionMetricsLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.internal.VersionLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.internal.VersionLogger"
       },
-      "type": "org.hibernate.engine.internal.VersionLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.engine.internal.VersionLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.JdbcLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.JdbcLogging"
       },
-      "type": "org.hibernate.engine.jdbc.JdbcLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.engine.jdbc.JdbcLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.batch.JdbcBatchLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.batch.JdbcBatchLogging"
       },
-      "type": "org.hibernate.engine.jdbc.batch.JdbcBatchLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.engine.jdbc.batch.JdbcBatchLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl"
+      "type" : "org.hibernate.engine.jdbc.batch.internal.BatchBuilderImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.connections.internal.ConnectionProviderLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.connections.internal.ConnectionProviderLogging"
       },
-      "type": "org.hibernate.engine.jdbc.connections.internal.ConnectionProviderLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.engine.jdbc.connections.internal.ConnectionProviderLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
+      "type" : "org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
       },
-      "type": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "type" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl"
       },
-      "type": "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet"
+      "type" : "org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.relational.Database"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.relational.Database"
       },
-      "type": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl"
+      "type" : "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.env.internal.LobCreationLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.env.internal.LobCreationLogging"
       },
-      "type": "org.hibernate.engine.jdbc.env.internal.LobCreationLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.engine.jdbc.env.internal.LobCreationLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.relational.Database"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.relational.Database"
       },
-      "type": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+      "type" : "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.persister.collection.mutation.InsertRowsCoordinatorStandard"
+      "condition" : {
+        "typeReached" : "org.hibernate.persister.collection.mutation.InsertRowsCoordinatorStandard"
       },
-      "type": "org.hibernate.engine.jdbc.mutation.internal.StandardMutationExecutorService"
+      "type" : "org.hibernate.engine.jdbc.mutation.internal.StandardMutationExecutorService"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.spi.SQLExceptionLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.spi.SQLExceptionLogging"
       },
-      "type": "org.hibernate.engine.jdbc.spi.SQLExceptionLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.engine.jdbc.spi.SQLExceptionLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
       },
-      "type": "org.hibernate.engine.jdbc.spi.SqlStatementLogger"
+      "type" : "org.hibernate.engine.jdbc.spi.SqlStatementLogger"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.SessionFactoryObserverForRegistration"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.SessionFactoryObserverForRegistration"
       },
-      "type": "org.hibernate.engine.jndi.internal.JndiServiceImpl"
+      "type" : "org.hibernate.engine.jndi.internal.JndiServiceImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.query.internal.QueryEngineImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.query.internal.QueryEngineImpl"
       },
-      "type": "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl"
+      "type" : "org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform"
+      "type" : "org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
       },
-      "type": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+      "type" : "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.internal.EntityCopyLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.internal.EntityCopyLogging"
       },
-      "type": "org.hibernate.event.internal.EntityCopyLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.event.internal.EntityCopyLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.internal.EventListenerLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.internal.EventListenerLogging"
       },
-      "type": "org.hibernate.event.internal.EventListenerLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.event.internal.EventListenerLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.AutoFlushEventListener[]"
+      "type" : "org.hibernate.event.spi.AutoFlushEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.DeleteEventListener[]"
+      "type" : "org.hibernate.event.spi.DeleteEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.DirtyCheckEventListener[]"
+      "type" : "org.hibernate.event.spi.DirtyCheckEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.spi.EventType"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.spi.EventType"
       },
-      "type": "org.hibernate.event.spi.EventType",
-      "allDeclaredFields": true
+      "type" : "org.hibernate.event.spi.EventType",
+      "allDeclaredFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.EvictEventListener[]"
+      "type" : "org.hibernate.event.spi.EvictEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.FlushEntityEventListener[]"
+      "type" : "org.hibernate.event.spi.FlushEntityEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.FlushEventListener[]"
+      "type" : "org.hibernate.event.spi.FlushEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.InitializeCollectionEventListener[]"
+      "type" : "org.hibernate.event.spi.InitializeCollectionEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.LoadEventListener[]"
+      "type" : "org.hibernate.event.spi.LoadEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.LockEventListener[]"
+      "type" : "org.hibernate.event.spi.LockEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.MergeEventListener[]"
+      "type" : "org.hibernate.event.spi.MergeEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PersistEventListener[]"
+      "type" : "org.hibernate.event.spi.PersistEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PostDeleteEventListener[]"
+      "type" : "org.hibernate.event.spi.PostDeleteEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PostInsertEventListener[]"
+      "type" : "org.hibernate.event.spi.PostInsertEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PostLoadEventListener[]"
+      "type" : "org.hibernate.event.spi.PostLoadEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PostUpdateEventListener[]"
+      "type" : "org.hibernate.event.spi.PostUpdateEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PostUpsertEventListener[]"
+      "type" : "org.hibernate.event.spi.PostUpsertEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PreFlushEventListener",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.event.spi.PreFlushEventListener",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PreFlushEventListener[]",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.event.spi.PreFlushEventListener[]",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.PreLoadEventListener[]"
+      "type" : "org.hibernate.event.spi.PreLoadEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.RefreshEventListener[]"
+      "type" : "org.hibernate.event.spi.RefreshEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.service.internal.EventListenerGroupImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.service.internal.EventListenerGroupImpl"
       },
-      "type": "org.hibernate.event.spi.ReplicateEventListener[]"
+      "type" : "org.hibernate.event.spi.ReplicateEventListener[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.models.HibernateAnnotations"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.models.HibernateAnnotations"
       },
-      "type": "org.hibernate.generator.EventType[]"
+      "type" : "org.hibernate.generator.EventType[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.CurrentTimestampGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.CurrentTimestampGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CreationTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CurrentTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UpdateTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16506,30 +16506,30 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.CurrentTimestampGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.CurrentTimestampGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CreationTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.CurrentTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UpdateTimestamp",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16538,86 +16538,86 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.GeneratedAlwaysGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.GeneratedAlwaysGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.GeneratedAlwaysGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.GeneratedAlwaysGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.GeneratedGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.GeneratedGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.EnumSet"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Generated"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.GeneratedGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.GeneratedGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.util.EnumSet"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Generated"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.SourceGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.SourceGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Source",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SourceType",
             "java.lang.Class",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16626,22 +16626,22 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.SourceGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.SourceGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.Source",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.SourceType",
             "java.lang.Class",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16650,14 +16650,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.TenantIdGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.TenantIdGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TenantId",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16666,14 +16666,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.TenantIdGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.TenantIdGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.TenantId",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
@@ -16682,242 +16682,242 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.generator.internal.VersionGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.VersionGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.metamodel.mapping.EntityVersionMapping"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.generator.internal.VersionGeneration",
-      "methods": [
+      "type" : "org.hibernate.generator.internal.VersionGeneration",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.metamodel.mapping.EntityVersionMapping"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.Assigned",
-      "methods": [
+      "type" : "org.hibernate.id.Assigned",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.Assigned",
-      "methods": [
+      "type" : "org.hibernate.id.Assigned",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.ForeignGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.ForeignGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.ForeignGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.ForeignGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.GUIDGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.GUIDGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.GUIDGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.GUIDGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.IdentityGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.IdentityGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.IdentityGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.IdentityGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.IncrementGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.IncrementGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.IncrementGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.IncrementGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.SelectGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.SelectGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.SelectGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.SelectGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.UUIDGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.UUIDGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.UUIDGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.UUIDGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.UUIDHexGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.UUIDHexGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.UUIDHexGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.UUIDHexGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.UUIDLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.UUIDLogger"
       },
-      "type": "org.hibernate.id.UUIDLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.id.UUIDLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.HiLoOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.HiLoOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -16925,14 +16925,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.LegacyHiLoAlgorithmOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.LegacyHiLoAlgorithmOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -16940,26 +16940,26 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentifierGeneratorHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentifierGeneratorHelper"
       },
-      "type": "org.hibernate.id.enhanced.LegacyNamingStrategy",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.LegacyNamingStrategy",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.NoopOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.NoopOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -16967,22 +16967,22 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerLogger"
       },
-      "type": "org.hibernate.id.enhanced.OptimizerLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.id.enhanced.OptimizerLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.PooledLoOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.PooledLoOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -16990,14 +16990,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.PooledLoThreadLocalOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.PooledLoThreadLocalOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -17005,14 +17005,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.id.enhanced.PooledOptimizer",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.PooledOptimizer",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "int"
           ]
@@ -17020,121 +17020,121 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.enhanced.SequenceStyleGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.enhanced.SequenceStyleGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.GeneratorBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.GeneratorBinder"
       },
-      "type": "org.hibernate.id.enhanced.SequenceStyleGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.SequenceStyleGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentifierGeneratorHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentifierGeneratorHelper"
       },
-      "type": "org.hibernate.id.enhanced.SingleNamingStrategy",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.SingleNamingStrategy",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentifierGeneratorHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentifierGeneratorHelper"
       },
-      "type": "org.hibernate.id.enhanced.StandardNamingStrategy",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.StandardNamingStrategy",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.model.internal.GeneratorBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.model.internal.GeneratorBinder"
       },
-      "type": "org.hibernate.id.enhanced.TableGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.TableGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.TableGeneratorLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.TableGeneratorLogger"
       },
-      "type": "org.hibernate.id.enhanced.TableGeneratorLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.id.enhanced.TableGeneratorLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.IdentityGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.IdentityGenerator"
       },
-      "type": "org.hibernate.id.uuid.UuidGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.uuid.UuidGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "java.lang.reflect.Member"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "org.hibernate.models.spi.MemberDetails"
           ]
@@ -17142,35 +17142,35 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory"
       },
-      "type": "org.hibernate.id.uuid.UuidGenerator",
-      "methods": [
+      "type" : "org.hibernate.id.uuid.UuidGenerator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "java.lang.reflect.Member"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "java.lang.reflect.Member",
             "org.hibernate.generator.GeneratorCreationContext"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.annotations.UuidGenerator",
             "org.hibernate.models.spi.MemberDetails"
           ]
@@ -17178,494 +17178,494 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.Version"
+      "condition" : {
+        "typeReached" : "org.hibernate.Version"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.beanvalidation.BeanValidationIntegrator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.beanvalidation.TypeSafeActivator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.beanvalidation.TypeSafeActivator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.cfg.Environment"
+      "condition" : {
+        "typeReached" : "org.hibernate.cfg.Environment"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.Dialect"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.Dialect"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.config.internal.ConfigurationServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.config.internal.ConfigurationServiceImpl"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.internal.StatefulPersistenceContext"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.internal.StatefulPersistenceContext"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jndi.internal.JndiServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jndi.internal.JndiServiceImpl"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.spi.CascadingActions"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.spi.CascadingActions"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.internal.AbstractFlushingEventListener"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.internal.AbstractFlushingEventListener"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.internal.DefaultAutoFlushEventListener"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.internal.DefaultAutoFlushEventListener"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.event.internal.DefaultLockEventListener"
+      "condition" : {
+        "typeReached" : "org.hibernate.event.internal.DefaultLockEventListener"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.PooledLoOptimizer"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.PooledLoOptimizer"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.PooledLoThreadLocalOptimizer"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.PooledLoThreadLocalOptimizer"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.PooledOptimizer"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.PooledOptimizer"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.TableGenerator"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.TableGenerator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.CoreLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.CoreLogging"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.jpa.internal.util.LogHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.jpa.internal.util.LogHelper"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.stat.internal.StatisticsInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.stat.internal.StatisticsInitiator"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.type.CollectionType"
+      "condition" : {
+        "typeReached" : "org.hibernate.type.CollectionType"
       },
-      "type": "org.hibernate.internal.CoreMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.CoreMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryLogging"
       },
-      "type": "org.hibernate.internal.SessionFactoryLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.internal.SessionFactoryLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryRegistryMessageLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryRegistryMessageLogger"
       },
-      "type": "org.hibernate.internal.SessionFactoryRegistryMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.SessionFactoryRegistryMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionLogging"
       },
-      "type": "org.hibernate.internal.SessionLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.internal.SessionLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.ConnectionAccessLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.ConnectionAccessLogger"
       },
-      "type": "org.hibernate.internal.log.ConnectionAccessLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.ConnectionAccessLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.ConnectionInfoLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.ConnectionInfoLogger"
       },
-      "type": "org.hibernate.internal.log.ConnectionInfoLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.ConnectionInfoLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.function.array.AbstractArrayContainsFunction"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.function.array.AbstractArrayContainsFunction"
       },
-      "type": "org.hibernate.internal.log.DeprecationLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.DeprecationLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.DeprecationLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.DeprecationLogger"
       },
-      "type": "org.hibernate.internal.log.DeprecationLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.DeprecationLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.IncubationLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.IncubationLogger"
       },
-      "type": "org.hibernate.internal.log.IncubationLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.IncubationLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.StatisticsLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.StatisticsLogger"
       },
-      "type": "org.hibernate.internal.log.StatisticsLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.internal.log.StatisticsLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.log.UrlMessageBundle"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.log.UrlMessageBundle"
       },
-      "type": "org.hibernate.internal.log.UrlMessageBundle_$logger",
-      "methods": [
+      "type" : "org.hibernate.internal.log.UrlMessageBundle_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.query.internal.QueryInterpretationCacheStandardImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.query.internal.QueryInterpretationCacheStandardImpl"
       },
-      "type": "org.hibernate.internal.util.cache.InternalCacheFactoryImpl"
+      "type" : "org.hibernate.internal.util.cache.InternalCacheFactoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.jpa.internal.JpaLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.jpa.internal.JpaLogger"
       },
-      "type": "org.hibernate.jpa.internal.JpaLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.jpa.internal.JpaLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.loader.ast.internal.MultiKeyLoadLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.loader.ast.internal.MultiKeyLoadLogging"
       },
-      "type": "org.hibernate.loader.ast.internal.MultiKeyLoadLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.loader.ast.internal.MultiKeyLoadLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.metamodel.mapping.MappingModelCreationLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.metamodel.mapping.MappingModelCreationLogging"
       },
-      "type": "org.hibernate.metamodel.mapping.MappingModelCreationLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.metamodel.mapping.MappingModelCreationLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.persister.internal.PersisterFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.persister.internal.PersisterFactoryImpl"
       },
-      "type": "org.hibernate.persister.collection.BasicCollectionPersister",
-      "methods": [
+      "type" : "org.hibernate.persister.collection.BasicCollectionPersister",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.mapping.Collection",
             "org.hibernate.cache.spi.access.CollectionDataAccess",
             "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
@@ -17674,14 +17674,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.persister.internal.PersisterFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.persister.internal.PersisterFactoryImpl"
       },
-      "type": "org.hibernate.persister.collection.OneToManyPersister",
-      "methods": [
+      "type" : "org.hibernate.persister.collection.OneToManyPersister",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.mapping.Collection",
             "org.hibernate.cache.spi.access.CollectionDataAccess",
             "org.hibernate.metamodel.spi.RuntimeModelCreationContext"
@@ -17690,14 +17690,14 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.persister.internal.PersisterFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.persister.internal.PersisterFactoryImpl"
       },
-      "type": "org.hibernate.persister.entity.SingleTableEntityPersister",
-      "methods": [
+      "type" : "org.hibernate.persister.entity.SingleTableEntityPersister",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.hibernate.mapping.PersistentClass",
             "org.hibernate.cache.spi.access.EntityDataAccess",
             "org.hibernate.cache.spi.access.NaturalIdDataAccess",
@@ -17707,435 +17707,429 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl"
       },
-      "type": "org.hibernate.persister.internal.PersisterFactoryImpl"
+      "type" : "org.hibernate.persister.internal.PersisterFactoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.persister.internal.PersisterFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.persister.internal.PersisterFactoryImpl"
       },
-      "type": "org.hibernate.persister.internal.StandardPersisterClassResolver"
+      "type" : "org.hibernate.persister.internal.StandardPersisterClassResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.mapping.Property"
+      "condition" : {
+        "typeReached" : "org.hibernate.mapping.Property"
       },
-      "type": "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl"
+      "type" : "org.hibernate.property.access.internal.PropertyAccessStrategyResolverStandardImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.query.QueryLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.query.QueryLogging"
       },
-      "type": "org.hibernate.query.QueryLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.query.QueryLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.query.hql.HqlLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.query.hql.HqlLogging"
       },
-      "type": "org.hibernate.query.hql.HqlLogging_$logger",
-      "methods": [
+      "type" : "org.hibernate.query.hql.HqlLogging_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.beans.internal.BeansMessageLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.beans.internal.BeansMessageLogger"
       },
-      "type": "org.hibernate.resource.beans.internal.BeansMessageLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.resource.beans.internal.BeansMessageLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.BootstrapContextImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.BootstrapContextImpl"
       },
-      "type": "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl"
+      "type" : "org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.jdbc.internal.LogicalConnectionLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.jdbc.internal.LogicalConnectionLogging"
       },
-      "type": "org.hibernate.resource.jdbc.internal.LogicalConnectionLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.resource.jdbc.internal.LogicalConnectionLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.jdbc.internal.ResourceRegistryLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.jdbc.internal.ResourceRegistryLogger"
       },
-      "type": "org.hibernate.resource.jdbc.internal.ResourceRegistryLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.resource.jdbc.internal.ResourceRegistryLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.internal.SessionFactoryOptionsBuilder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.internal.SessionFactoryOptionsBuilder"
       },
-      "type": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl"
+      "type" : "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator"
       },
-      "type": "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
-      "methods": [
+      "type" : "org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.transaction.backend.jta.internal.JtaLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.transaction.backend.jta.internal.JtaLogging"
       },
-      "type": "org.hibernate.resource.transaction.backend.jta.internal.JtaLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.resource.transaction.backend.jta.internal.JtaLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.resource.transaction.internal.SynchronizationLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.resource.transaction.internal.SynchronizationLogging"
       },
-      "type": "org.hibernate.resource.transaction.internal.SynchronizationLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.resource.transaction.internal.SynchronizationLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.service.internal.ServiceLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.service.internal.ServiceLogger"
       },
-      "type": "org.hibernate.service.internal.ServiceLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.service.internal.ServiceLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl"
+      "type" : "org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.jdbc.internal.JdbcServicesImpl"
       },
-      "type": "org.hibernate.sql.ast.internal.ParameterMarkerStrategyStandard"
+      "type" : "org.hibernate.sql.ast.internal.ParameterMarkerStrategyStandard"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.ast.tree.SqlAstTreeLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.ast.tree.SqlAstTreeLogger"
       },
-      "type": "org.hibernate.sql.ast.tree.SqlAstTreeLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.sql.ast.tree.SqlAstTreeLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.exec.SqlExecLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.exec.SqlExecLogger"
       },
-      "type": "org.hibernate.sql.exec.SqlExecLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.sql.exec.SqlExecLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.model.ModelMutationLogging"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.model.ModelMutationLogging"
       },
-      "type": "org.hibernate.sql.model.ModelMutationLogging_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.sql.model.ModelMutationLogging_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.results.LoadingLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.results.LoadingLogger"
       },
-      "type": "org.hibernate.sql.results.LoadingLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.sql.results.LoadingLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.results.ResultsLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.results.ResultsLogger"
       },
-      "type": "org.hibernate.sql.results.ResultsLogger_$logger",
-      "methods": [
+      "type" : "org.hibernate.sql.results.ResultsLogger_$logger",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "org.jboss.logging.Logger"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.sql.results.graph.embeddable.EmbeddableLoadingLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.sql.results.graph.embeddable.EmbeddableLoadingLogger"
       },
-      "type": "org.hibernate.sql.results.graph.embeddable.EmbeddableLoadingLogger_$logger",
-      "allPublicMethods": true,
-      "allDeclaredConstructors": true
+      "type" : "org.hibernate.sql.results.graph.embeddable.EmbeddableLoadingLogger_$logger",
+      "allPublicMethods" : true,
+      "allDeclaredConstructors" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.sql.results.jdbc.internal.JdbcValuesMappingProducerProviderStandard"
+      "type" : "org.hibernate.sql.results.jdbc.internal.JdbcValuesMappingProducerProviderStandard"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.SessionFactoryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.SessionFactoryImpl"
       },
-      "type": "org.hibernate.stat.internal.StatisticsImpl"
+      "type" : "org.hibernate.stat.internal.StatisticsImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator"
+      "condition" : {
+        "typeReached" : "org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator"
       },
-      "type": "org.hibernate.tool.schema.internal.HibernateSchemaManagementTool"
+      "type" : "org.hibernate.tool.schema.internal.HibernateSchemaManagementTool"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.tool.schema.internal.SchemaDropperImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.tool.schema.internal.SchemaDropperImpl"
       },
-      "type": "org.hibernate.tool.schema.internal.script.SingleLineSqlScriptExtractor"
+      "type" : "org.hibernate.tool.schema.internal.script.SingleLineSqlScriptExtractor"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.type.descriptor.JdbcTypeNameMapper"
+      "condition" : {
+        "typeReached" : "org.hibernate.type.descriptor.JdbcTypeNameMapper"
       },
-      "type": "org.hibernate.type.SqlTypes",
-      "allPublicFields": true
+      "type" : "org.hibernate.type.SqlTypes",
+      "allPublicFields" : true
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.JaxbLogger"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.JaxbLogger"
       },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "org.jboss.logmanager.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl"
       },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "org.jboss.logmanager.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.id.enhanced.OptimizerFactory"
+      "condition" : {
+        "typeReached" : "org.hibernate.id.enhanced.OptimizerFactory"
       },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "org.jboss.logmanager.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.jpa.HibernatePersistenceProvider"
+      "condition" : {
+        "typeReached" : "org.hibernate.jpa.HibernatePersistenceProvider"
       },
-      "type": "org.jboss.logmanager.LogManager"
+      "type" : "org.jboss.logmanager.LogManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "org.postgresql.Driver"
+      "type" : "org.postgresql.Driver"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.type.PgJdbcHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.type.PgJdbcHelper"
       },
-      "type": "org.postgresql.util.PGobject"
+      "type" : "org.postgresql.util.PGobject"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.engine.transaction.jta.platform.internal.StandardJtaPlatformResolver"
       },
-      "type": "org.wildfly.transaction.client.ContextTransactionManager"
+      "type" : "org.wildfly.transaction.client.ContextTransactionManager"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "short[]"
+      "type" : "short[]"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.ClassLoadingImpl"
+      "type" : "sun.management.ClassLoadingImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.CompilationImpl"
+      "type" : "sun.management.CompilationImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.ManagementFactoryHelper$1"
+      "type" : "sun.management.ManagementFactoryHelper$1"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl"
+      "type" : "sun.management.ManagementFactoryHelper$PlatformLoggingImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.MemoryImpl"
+      "type" : "sun.management.MemoryImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.MemoryManagerImpl"
+      "type" : "sun.management.MemoryManagerImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.MemoryPoolImpl"
+      "type" : "sun.management.MemoryPoolImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.dialect.OracleServerConfiguration"
+      "condition" : {
+        "typeReached" : "org.hibernate.dialect.OracleServerConfiguration"
       },
-      "type": "sun.management.RuntimeImpl"
+      "type" : "sun.management.RuntimeImpl"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.xml.bind.annotation.XmlAccessorType",
           "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.ConfigurationBinder"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter",
           "org.glassfish.jaxb.core.v2.model.annotation.Locatable"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl"
+      "condition" : {
+        "typeReached" : "org.hibernate.internal.util.ConfigHelper"
       },
-      "glob": "META-INF/persistence.xml"
+      "glob" : "hibernate.properties"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.internal.util.ConfigHelper"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
       },
-      "glob": "hibernate.properties"
+      "glob" : "org/hibernate/hibernate-configuration-2.0.dtd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
       },
-      "glob": "org/hibernate/hibernate-configuration-2.0.dtd"
+      "glob" : "org/hibernate/hibernate-configuration-3.0.dtd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
       },
-      "glob": "org/hibernate/hibernate-configuration-3.0.dtd"
+      "glob" : "org/hibernate/hibernate-mapping-3.0.dtd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
       },
-      "glob": "org/hibernate/hibernate-mapping-3.0.dtd"
+      "glob" : "org/hibernate/hibernate-mapping-4.0.dtd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.jaxb.internal.stax.LocalSchemaLocator"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.xsd.LocalXsdResolver"
       },
-      "glob": "org/hibernate/hibernate-mapping-4.0.dtd"
+      "glob" : "org/hibernate/jpa/persistence_2_0.xsd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.xsd.LocalXsdResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.xsd.LocalXsdResolver"
       },
-      "glob": "org/hibernate/jpa/persistence_2_0.xsd"
+      "glob" : "org/hibernate/jpa/persistence_3_0.xsd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.xsd.LocalXsdResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.xsd.LocalXsdResolver"
       },
-      "glob": "org/hibernate/jpa/persistence_3_0.xsd"
+      "glob" : "org/hibernate/jpa/persistence_3_1.xsd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.xsd.LocalXsdResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.xsd.LocalXsdResolver"
       },
-      "glob": "org/hibernate/jpa/persistence_3_1.xsd"
+      "glob" : "org/hibernate/jpa/persistence_3_2.xsd"
     },
     {
-      "condition": {
-        "typeReached": "org.hibernate.boot.xsd.LocalXsdResolver"
+      "condition" : {
+        "typeReached" : "org.hibernate.boot.xsd.LocalXsdResolver"
       },
-      "glob": "org/hibernate/jpa/persistence_3_2.xsd"
-    },
-    {
-      "condition": {
-        "typeReached": "org.hibernate.boot.xsd.LocalXsdResolver"
-      },
-      "glob": "org/hibernate/xsd/cfg/configuration-3.2.0.xsd"
+      "glob" : "org/hibernate/xsd/cfg/configuration-3.2.0.xsd"
     }
   ]
 }

--- a/metadata/org.hibernate.orm/hibernate-core/index.json
+++ b/metadata/org.hibernate.orm/hibernate-core/index.json
@@ -40,7 +40,12 @@
     "test-version": "7.1.0.Final",
     "tested-versions": [
       "7.3.0.Final"
-    ]
+    ],
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/$version$/hibernate-core-$version$-sources.jar",
+    "repository-url": "https://github.com/hibernate/hibernate-orm",
+    "test-code-url": "https://github.com/hibernate/hibernate-orm/tree/7.3.0/hibernate-core/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-core/$version$/hibernate-core-$version$-javadoc.jar",
+    "description": "Hibernate ORM provides object-relational mapping for Java applications and relational databases. It implements Jakarta Persistence (JPA) and also exposes native Hibernate APIs for querying, transactions, and entity lifecycle management."
   },
   {
     "default-for": "7\\.2\\..*",

--- a/stats/org.hibernate.orm/hibernate-core/7.3.0.Final/stats.json
+++ b/stats/org.hibernate.orm/hibernate-core/7.3.0.Final/stats.json
@@ -4,18 +4,18 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.118557,
-          "coveredCalls" : 46,
-          "totalCalls" : 388
+          "coverageRatio" : 0.120823,
+          "coveredCalls" : 47,
+          "totalCalls" : 389
         },
         "resources" : {
-          "coverageRatio" : 0.391304,
+          "coverageRatio" : 0.409091,
           "coveredCalls" : 9,
-          "totalCalls" : 23
+          "totalCalls" : 22
         }
       },
-      "coverageRatio" : 0.13382,
-      "coveredCalls" : 55,
+      "coverageRatio" : 0.136253,
+      "coveredCalls" : 56,
       "totalCalls" : 411
     },
     "libraryCoverage" : {


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#1086

This PR provides new metadata needed for the org.hibernate.orm:hibernate-core:7.3.0.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `org.hibernate.orm:hibernate-core:7.1.0.Final`): 3022
- Test-only metadata entries (previous `org.hibernate.orm:hibernate-core:7.1.0.Final`): 1
- Metadata entries (new `org.hibernate.orm:hibernate-core:7.3.0.Final`): 3105
- Test-only metadata entries (new `org.hibernate.orm:hibernate-core:7.3.0.Final`): 1
- Library coverage (previous): 18.12%
- Library coverage (new): 17.91%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7f8b568fda2a99f41d7256a289cfa4ce5ca50b05`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.hibernate.orm:hibernate-core:7.1.0.Final: 55/413 covered calls (13.32%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 56/411 covered calls (13.63%)

**Reflection:**
- org.hibernate.orm:hibernate-core:7.1.0.Final: 46/391 covered calls (11.76%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 47/389 covered calls (12.08%)

**Resources:**
- org.hibernate.orm:hibernate-core:7.1.0.Final: 9/22 covered calls (40.91%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 9/22 covered calls (40.91%)

#### Library coverage

**Instruction:**
- org.hibernate.orm:hibernate-core:7.1.0.Final: 160772/911455 (17.64%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 163781/944321 (17.34%)

**Line:**
- org.hibernate.orm:hibernate-core:7.1.0.Final: 40447/223156 (18.12%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 41446/231455 (17.91%)

**Method:**
- org.hibernate.orm:hibernate-core:7.1.0.Final: 12268/60571 (20.25%)
- org.hibernate.orm:hibernate-core:7.3.0.Final: 12641/63585 (19.88%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
