### PR TITLE
Route stalled native metadata verification to Codex

### DIFF
--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -25,9 +25,8 @@ code:
   earlier in this gate invocation).
 - `172`            -> metadata gap; append the cycle's trace dir to the
   running `metadataConfigDirs` so the next cycle's build sees it, then
-  continue. If a later `172` cycle produces no new trace metadata
-  entries, print the accumulated progress and fail fast because another
-  rebuild would repeat the same missing-metadata state.
+  continue. If later `172` cycles stop producing new trace metadata
+  entries, retry once and then route to codex with the native failure log.
 - any other non-0  -> code/test failure; route to codex (the coding
   agent). Codex finishes it: on codex success return
   `PASSED_WITH_INTERVENTION`; on codex failure return `FAILED`. The gate
@@ -88,9 +87,10 @@ flowchart TD
     Run --> Route{binary exit code}
     Route -- 0 --> Merge[mergeNativeTraceMetadata<br/>config_dirs &rarr; output_dir]
     Merge --> Pass([return PASSED<br/>or PASSED_WITH_INTERVENTION])
-    Route -- 172 --> Append[config_dirs += runs/cycle-i]
+    Route -- 172 + new metadata --> Append[config_dirs += runs/cycle-i]
     Append --> Bump[i = i + 1]
     Bump --> Outer
+    Route -- 172 + repeated no-progress --> Codex
     Route -- other --> Codex[run_codex_metadata_fix]
     Codex --> CodexOK{codex rc == 0?}
     CodexOK -- yes --> PassI([return PASSED_WITH_INTERVENTION])
@@ -118,10 +118,11 @@ Per-cycle semantics:
     metadata and returns.
   - `172` → `ExitStatus.MISSING_METADATA`. The trace dir captured at
     least one missing access; appending it to `config_dirs` makes the
-    next cycle's build see that metadata. Codex is **not** invoked. If
-    the current `172` cycle produces no new canonical metadata entries
-    compared with accepted trace dirs, the gate prints the accumulated
-    progress, prints the failure-log tail, and returns `FAILED`.
+    next cycle's build see that metadata. If the current `172` cycle
+    produces no new canonical metadata entries compared with accepted
+    trace dirs, the gate prints the accumulated progress and retries
+    once. A second consecutive no-progress `172` prints the failure-log
+    tail and routes to codex.
   - any other non-zero → the test or library code is broken in a way
     that more metadata cannot fix. Codex finishes it: codex is invoked
     once, and the gate returns based on codex's exit code. The gate does
@@ -136,7 +137,7 @@ Per-cycle semantics:
   failure is a real code/test bug we want surfaced.
 - **Two failure reasons, one status.** `FAILED` is returned on
   `metadata-gap-exhausted` (172 every cycle until the budget runs out) or
-  `code-failure` (codex did not converge on a non-172 failure). The
+  `code-failure` (codex did not converge after a routed failure). The
   diagnostic is recorded in the result's `intervention_records`,
   `accepted_run_dirs`, and `last_native_test_log_path`.
 - **Codex keeps prior config_dirs.** Codex's fixes are additive; the gate
@@ -174,7 +175,8 @@ The module composes existing helpers and owns no domain logic of its own:
 - `./gradlew mergeNativeTraceMetadata -PinputDirs=...
   -PoutputDir=<output_dir>` — single final merge on `PASSED`.
 - `run_codex_metadata_fix` — codex acts as the coding agent on non-172
-  failures and is the terminal step. Pi is **not** invoked.
+  failures and repeated no-progress 172 failures. It is the terminal step.
+  Pi is **not** invoked.
 
 The standalone trace-loop driver in
 [`utility_scripts/native_metadata_exploration.py`](native-metadata-exploration.md)
@@ -217,8 +219,11 @@ A `verify_native_test_passes(...)` invocation is correct iff:
    - `172` with new trace metadata entries → append
      `runs_dir/cycle-<i>` to the running config dirs and continue to the
      next outer cycle. Codex is **not** invoked.
-   - `172` with no new trace metadata entries → print the accumulated
-     progress and failure-log tail, then return `FAILED`.
+   - first consecutive `172` with no new trace metadata entries → print
+     the accumulated progress and retry once without changing config dirs.
+   - second consecutive `172` with no new trace metadata entries → print
+     the accumulated progress and failure-log tail, invoke
+     `run_codex_metadata_fix` once, and return based on its exit code.
    - any other non-zero → invoke `run_codex_metadata_fix` once and
      return based on its exit code: `PASSED_WITH_INTERVENTION` on codex
      success, `FAILED` on codex failure. The gate does not re-run

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -16,7 +16,8 @@ code. The gate routes on that exit code:
   earlier cycle).
 - ``172``   → metadata gap; append the cycle's trace dir to the running
   ``metadataConfigDirs`` so the next cycle's build sees it, then continue.
-  If a later ``172`` produces no new trace entries, print progress and fail.
+  If later ``172`` runs stop producing new trace entries, retry once and then
+  route to Codex with the native failure log.
 - any other → run ``run_codex_metadata_fix`` once. Codex finishes it: on
   codex success return ``PASSED_WITH_INTERVENTION``; on codex failure return
   ``FAILED``. The gate does not re-verify after codex.
@@ -66,6 +67,7 @@ _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 _AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
 _FAILURE_LOG_TAIL_LINE_LIMIT = 300
+_NO_PROGRESS_CODEX_THRESHOLD = 2
 
 
 @dataclass
@@ -125,6 +127,7 @@ def verify_native_test_passes(
     intervention_used = False
     last_log_path: str | None = None
     last_binary_rc: int | None = None
+    consecutive_no_progress_cycles = 0
 
     def _make_result(status: str, iterations_used: int) -> NativeTestVerificationResult:
         return NativeTestVerificationResult(
@@ -215,24 +218,38 @@ def verify_native_test_passes(
             metadata_entries = _metadata_entries(run_dir)
             added_entries = metadata_entries - accepted_metadata_entries
             if not added_entries:
+                consecutive_no_progress_cycles += 1
                 _print_metadata_progress(
                     accepted_run_dirs=accepted_run_dirs,
                     accepted_entry_count=len(accepted_metadata_entries),
                     current_entry_count=len(metadata_entries),
-                    reason="no new trace metadata entries",
+                    reason=(
+                        "no new trace metadata entries; "
+                        f"stall {consecutive_no_progress_cycles}/{_NO_PROGRESS_CODEX_THRESHOLD}"
+                    ),
                 )
+                if consecutive_no_progress_cycles < _NO_PROGRESS_CODEX_THRESHOLD:
+                    log_stage(
+                        _GATE_STAGE,
+                        (
+                            f"cycle {cycle + 1}: binary exited 172 but produced no new "
+                            "trace metadata; retrying once before codex fallback"
+                        ),
+                    )
+                    continue
                 _print_failure_log_tail(log_path, cycle + 1)
-                log_stage(
-                    _GATE_STAGE,
-                    f"cycle {cycle + 1}: binary exited 172 but produced no new trace metadata; failing fast",
+                return _route_to_codex(
+                    cycle,
+                    run_dir,
+                    "binary exited 172 twice without new trace metadata",
                 )
-                return _make_result(STATUS_FAILED, cycle + 1)
             log_stage(
                 _GATE_STAGE,
                 f"cycle {cycle + 1}: binary exited 172 (missing metadata); "
                 f"adding {os.path.basename(run_dir)} to config_dirs "
                 f"({len(added_entries)} new entr{'y' if len(added_entries) == 1 else 'ies'})",
             )
+            consecutive_no_progress_cycles = 0
             accepted_metadata_entries.update(added_entries)
             accepted_run_dirs.append(run_dir)
             continue


### PR DESCRIPTION
## Summary
- retry once when an exact-metadata 172 cycle produces no new trace entries
- route the second consecutive no-progress 172 cycle to the existing Codex metadata fix path
- update the native test verification spec to match the new fallback behavior

Fixes #5230