### PR TITLE
[GenAI] Add support for org.jline:jline-terminal-jni:3.27.1 using gpt-5.5

### DIFF
--- a/metadata/org.jline/jline-terminal-jni/3.27.1/reachability-metadata.json
+++ b/metadata/org.jline/jline-terminal-jni/3.27.1/reachability-metadata.json
@@ -1,0 +1,138 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+      },
+      "type": "java.io.FileDescriptor",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "fd"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TCSADRAIN"
+        },
+        {
+          "name": "TCSAFLUSH"
+        },
+        {
+          "name": "TCSANOW"
+        },
+        {
+          "name": "TIOCGWINSZ"
+        },
+        {
+          "name": "TIOCSWINSZ"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "type": "org.jline.nativ.CLibrary$Termios",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "c_cc"
+        },
+        {
+          "name": "c_cflag"
+        },
+        {
+          "name": "c_iflag"
+        },
+        {
+          "name": "c_ispeed"
+        },
+        {
+          "name": "c_lflag"
+        },
+        {
+          "name": "c_oflag"
+        },
+        {
+          "name": "c_ospeed"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary$Termios",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary$WinSize",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        },
+        {
+          "name": "ws_col"
+        },
+        {
+          "name": "ws_row"
+        },
+        {
+          "name": "ws_xpixel"
+        },
+        {
+          "name": "ws_ypixel"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "glob": "META-INF/maven/org.jline/jline-native/pom.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "glob": "org/jline/nativ/Linux/x86_64/libjlinenative.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "glob": "org/jline/utils/capabilities.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "glob": "org/jline/utils/xterm-256color.caps"
+    }
+  ]
+}

--- a/metadata/org.jline/jline-terminal-jni/index.json
+++ b/metadata/org.jline/jline-terminal-jni/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.27.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-sources.jar",
+    "repository-url" : "https://github.com/jline/jline3",
+    "test-code-url" : "https://github.com/jline/jline3/tree/jline-$version$/terminal-jni/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-javadoc.jar",
+    "description" : "JLine JNI Terminal provides the JLine terminal provider implementation that uses JLine's JNI native library for low-level terminal and pseudoterminal access. It plugs into the JLine terminal API to support native console operations across supported platforms without relying on JNA or external process execution.",
+    "tested-versions" : [
+      "3.27.1"
+    ],
+    "allowed-packages" : [
+      "org.jline.terminal.impl.jni"
+    ]
+  }
+]

--- a/stats/org.jline/jline-terminal-jni/3.27.1/execution-metrics.json
+++ b/stats/org.jline/jline-terminal-jni/3.27.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T17:16:52.803704Z",
+    "library": "org.jline:jline-terminal-jni:3.27.1",
+    "starting_commit": "15e5b406d482e7193998df34a5b803f339e715eb",
+    "ending_commit": "4383a8da887f615c37b367071f0d97fece732d0a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.27.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1461,
+          "missed": 5892,
+          "ratio": 0.198694,
+          "total": 7353
+        },
+        "line": {
+          "covered": 231,
+          "missed": 935,
+          "ratio": 0.198113,
+          "total": 1166
+        },
+        "method": {
+          "covered": 37,
+          "missed": 84,
+          "ratio": 0.305785,
+          "total": 121
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 148511,
+      "cached_input_tokens_used": 1485312,
+      "output_tokens_used": 20182,
+      "iterations": 3,
+      "cost_usd": 1.3482,
+      "generated_loc": 198,
+      "tested_library_loc": 231,
+      "metadata_entries": 34,
+      "code_coverage_percent": 19.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java",
+      "metadata_file": "metadata/org.jline/jline-terminal-jni/3.27.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jline/jline-terminal-jni/3.27.1/stats.json
+++ b/stats/org.jline/jline-terminal-jni/3.27.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.27.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1461,
+        "missed" : 5892,
+        "ratio" : 0.198694,
+        "total" : 7353
+      },
+      "line" : {
+        "covered" : 231,
+        "missed" : 935,
+        "ratio" : 0.198113,
+        "total" : 1166
+      },
+      "method" : {
+        "covered" : 37,
+        "missed" : 84,
+        "ratio" : 0.305785,
+        "total" : 121
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/.gitignore
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/build.gradle
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jline:jline-terminal-jni:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/gradle.properties
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jline:jline-terminal-jni:3.27.1
+library.version = 3.27.1
+metadata.dir = org.jline/jline-terminal-jni/3.27.1/

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/settings.gradle
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jline.jline-terminal-jni_tests'

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -8,6 +8,7 @@ package org_jline.jline_terminal_jni;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -101,7 +102,7 @@ public class Jline_terminal_jniTest {
                 InputStream masterInput = pty.getMasterInput();
                 OutputStream slaveOutput = pty.getSlaveOutput();
                 ExecutorService executor = newDaemonSingleThreadExecutor("jni-pty-reader");
-                Future<byte[]> readFromMaster = executor.submit(() -> masterInput.readNBytes(payload.length));
+                Future<byte[]> readFromMaster = executor.submit(() -> readExactly(masterInput, payload.length));
 
                 try {
                     slaveOutput.write(payload);
@@ -190,6 +191,19 @@ public class Jline_terminal_jniTest {
             thread.setDaemon(true);
             return thread;
         });
+    }
+
+    private static byte[] readExactly(InputStream input, int length) throws Exception {
+        byte[] buffer = new byte[length];
+        int offset = 0;
+        while (offset < length) {
+            int read = input.read(buffer, offset, length - offset);
+            if (read < 0) {
+                throw new EOFException("Expected " + length + " bytes, read " + offset);
+            }
+            offset += read;
+        }
+        return buffer;
     }
 
     private static Terminal buildTerminal(ByteArrayOutputStream output) throws Exception {

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jline.jline_terminal_jni;
+
+import org.junit.jupiter.api.Test;
+
+class Jline_terminal_jniTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -6,11 +6,146 @@
  */
 package org_jline.jline_terminal_jni;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.impl.jni.JniNativePty;
+import org.jline.terminal.impl.jni.JniTerminalProvider;
+import org.jline.terminal.spi.Pty;
+import org.jline.terminal.spi.SystemStream;
+import org.jline.terminal.spi.TerminalExt;
+import org.jline.terminal.spi.TerminalProvider;
 import org.junit.jupiter.api.Test;
 
-class Jline_terminal_jniTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jline_terminal_jniTest {
+    private static final Set<String> SUPPORTED_POSIX_OS_PREFIXES = Set.of(
+            "Linux", "Mac", "Darwin", "Solaris", "SunOS", "FreeBSD");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void loadsJniTerminalProviderThroughPublicServiceApi() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+
+        assertThat(provider).isInstanceOf(JniTerminalProvider.class);
+        assertThat(provider.name()).isEqualTo("jni");
+        assertThat(provider).hasToString("TerminalProvider[jni]");
+
+        for (SystemStream stream : SystemStream.values()) {
+            assertThat(provider.systemStreamWidth(stream)).isGreaterThanOrEqualTo(-1);
+            assertThat(provider.isSystemStream(stream)).isIn(true, false);
+        }
+    }
+
+    @Test
+    void openCreatesConfiguredNativePtyOnSupportedPosixPlatforms() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(81, 27);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                assertThat(pty).isInstanceOf(JniNativePty.class);
+                assertThat(pty.getProvider()).isSameAs(provider);
+                assertThat(pty.getSystemStream()).isNull();
+
+                JniNativePty nativePty = (JniNativePty) pty;
+                assertThat(nativePty.getMaster()).isGreaterThan(0);
+                assertThat(nativePty.getSlave()).isGreaterThan(0);
+                assertThat(nativePty.getSlaveOut()).isEqualTo(nativePty.getSlave());
+                assertThat(nativePty.getMasterFD()).isNotNull();
+                assertThat(nativePty.getSlaveFD()).isNotNull();
+                assertThat(nativePty.getSlaveOutFD()).isSameAs(nativePty.getSlaveFD());
+                assertThat(nativePty.getName()).isNotBlank();
+                assertThat(nativePty).hasToString("NativePty[" + nativePty.getName() + "]");
+
+                assertThat(nativePty.getSize()).isEqualTo(requestedSize);
+                Size resized = new Size(100, 31);
+                nativePty.setSize(resized);
+                assertThat(nativePty.getSize()).isEqualTo(resized);
+
+                Attributes actualAttributes = nativePty.getAttr();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isFalse();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ICANON)).isTrue();
+                assertThat(actualAttributes.getInputFlag(Attributes.InputFlag.ICRNL)).isTrue();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VERASE)).isEqualTo(127);
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void terminalBuilderCreatesJniBackedTerminalForExplicitStreams() throws Exception {
+        if (isSupportedPosixOperatingSystem()) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (Terminal terminal = buildTerminal(output)) {
+                assertThat(terminal.getName()).isEqualTo("jni-test-terminal");
+                assertThat(terminal.getType()).isEqualTo("xterm-256color");
+                assertThat(terminal.encoding()).isEqualTo(StandardCharsets.UTF_8);
+                assertThat(terminal).isInstanceOf(TerminalExt.class);
+
+                TerminalExt terminalExt = (TerminalExt) terminal;
+                assertThat(terminalExt.getProvider().name()).isEqualTo("jni");
+                assertThat(terminalExt.getSystemStream()).isNull();
+
+                assertThat(terminal.getSize()).isEqualTo(new Size(90, 33));
+                terminal.setSize(new Size(91, 34));
+                assertThat(terminal.getWidth()).isEqualTo(91);
+                assertThat(terminal.getHeight()).isEqualTo(34);
+
+                assertThat(terminal.echo()).isFalse();
+                assertThat(terminal.canPauseResume()).isTrue();
+                assertThat(terminal.paused()).isTrue();
+                terminal.pause();
+                assertThat(terminal.paused()).isTrue();
+                assertThat(terminal.reader()).isNotNull();
+                assertThat(terminal.writer()).isNotNull();
+                assertThat(output.size()).isZero();
+            }
+        } else {
+            assertThatThrownBy(() -> buildTerminal(new ByteArrayOutputStream()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    private static Terminal buildTerminal(ByteArrayOutputStream output) throws Exception {
+        return TerminalBuilder.builder()
+                .provider("jni")
+                .system(false)
+                .name("jni-test-terminal")
+                .type("xterm-256color")
+                .encoding(StandardCharsets.UTF_8)
+                .streams(new ByteArrayInputStream(new byte[0]), output)
+                .attributes(attributesForPty())
+                .size(new Size(90, 33))
+                .nativeSignals(false)
+                .paused(true)
+                .build();
+    }
+
+    private static Attributes attributesForPty() {
+        Attributes attributes = new Attributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+        attributes.setLocalFlag(Attributes.LocalFlag.ICANON, true);
+        attributes.setInputFlag(Attributes.InputFlag.ICRNL, true);
+        attributes.setOutputFlag(Attributes.OutputFlag.OPOST, true);
+        attributes.setControlFlag(Attributes.ControlFlag.CREAD, true);
+        attributes.setControlChar(Attributes.ControlChar.VERASE, 127);
+        attributes.setControlChar(Attributes.ControlChar.VMIN, 1);
+        return attributes;
+    }
+
+    private static boolean isSupportedPosixOperatingSystem() {
+        String osName = System.getProperty("os.name", "");
+        return SUPPORTED_POSIX_OS_PREFIXES.stream().anyMatch(osName::startsWith);
     }
 }

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -121,6 +121,36 @@ public class Jline_terminal_jniTest {
     }
 
     @Test
+    void nativePtyAppliesAttributeChangesAfterOpen() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(80, 24);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                Attributes updatedAttributes = new Attributes(pty.getAttr());
+                updatedAttributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
+                updatedAttributes.setLocalFlag(Attributes.LocalFlag.ICANON, false);
+                updatedAttributes.setInputFlag(Attributes.InputFlag.ICRNL, false);
+                updatedAttributes.setControlChar(Attributes.ControlChar.VMIN, 0);
+                updatedAttributes.setControlChar(Attributes.ControlChar.VTIME, 1);
+
+                pty.setAttr(updatedAttributes);
+
+                Attributes actualAttributes = pty.getAttr();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isTrue();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ICANON)).isFalse();
+                assertThat(actualAttributes.getInputFlag(Attributes.InputFlag.ICRNL)).isFalse();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VMIN)).isZero();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VTIME)).isEqualTo(1);
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
     void terminalBuilderCreatesJniBackedTerminalForExplicitStreams() throws Exception {
         if (isSupportedPosixOperatingSystem()) {
             ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -8,8 +8,14 @@ package org_jline.jline_terminal_jni;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Size;
@@ -84,6 +90,37 @@ public class Jline_terminal_jniTest {
     }
 
     @Test
+    void nativePtyExposesConnectedMasterAndSlaveStreams() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(80, 24);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                byte[] payload = "jni-pty-payload".getBytes(StandardCharsets.UTF_8);
+                InputStream masterInput = pty.getMasterInput();
+                OutputStream slaveOutput = pty.getSlaveOutput();
+                ExecutorService executor = newDaemonSingleThreadExecutor("jni-pty-reader");
+                Future<byte[]> readFromMaster = executor.submit(() -> masterInput.readNBytes(payload.length));
+
+                try {
+                    slaveOutput.write(payload);
+                    slaveOutput.flush();
+
+                    assertThat(readFromMaster.get(5, TimeUnit.SECONDS)).containsExactly(payload);
+                } finally {
+                    readFromMaster.cancel(true);
+                    executor.shutdownNow();
+                    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+                }
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
     void terminalBuilderCreatesJniBackedTerminalForExplicitStreams() throws Exception {
         if (isSupportedPosixOperatingSystem()) {
             ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -115,6 +152,14 @@ public class Jline_terminal_jniTest {
             assertThatThrownBy(() -> buildTerminal(new ByteArrayOutputStream()))
                     .isInstanceOf(UnsupportedOperationException.class);
         }
+    }
+
+    private static ExecutorService newDaemonSingleThreadExecutor(String threadName) {
+        return Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, threadName);
+            thread.setDaemon(true);
+            return thread;
+        });
     }
 
     private static Terminal buildTerminal(ByteArrayOutputStream output) throws Exception {

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jline.terminal.impl.jni.**"
+      "includeClasses" : "org.jline.terminal.impl.jni.**"
     }
   ]
 }

--- a/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json
+++ b/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jline.terminal.impl.jni.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5080

This PR introduces tests and metadata for org.jline:jline-terminal-jni:3.27.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 148511
- Cached input tokens: 1485312
- Output tokens: 20182
- Metadata entries: 34
- Iterations: 3
- Library coverage percentage: 19.81
- Generated lines of code: 198
- Tested library lines of code: 231

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `83d4ae997db68eee6efa92ecbff71b962ab028e4`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1461/7353 (19.87%)
- Line: 231/1166 (19.81%)
- Method: 37/121 (30.58%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
