### PR TITLE
[GenAI] Mark io.netty.incubator:netty-incubator-transport-native-io_uring as not for Native Image

### DIFF
--- a/metadata/io.netty.incubator/netty-incubator-transport-native-io_uring/index.json
+++ b/metadata/io.netty.incubator/netty-incubator-transport-native-io_uring/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The default and platform classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.",
+    "replacement": "io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4827

This PR records `io.netty.incubator:netty-incubator-transport-native-io_uring` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The default and platform classifier JARs contain no JVM class files; they package Maven metadata and native library resources only.

Replacement guidance:
- io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.26.Final

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d1d8ff09661a270e21076ee9fd4112ca62d43d5`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
