### PR TITLE
[GenAI] Mark io.netty:netty-tcnative-boringssl-static as not for Native Image

### DIFF
--- a/forge/tests/test_native_image_artifact.py
+++ b/forge/tests/test_native_image_artifact.py
@@ -1,0 +1,97 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import io
+import unittest
+from unittest.mock import patch
+import zipfile
+
+from utility_scripts import native_image_artifact as nia
+
+
+def _jar_with(*names: str) -> io.BytesIO:
+    jar_bytes = io.BytesIO()
+    with zipfile.ZipFile(jar_bytes, "w") as jar:
+        for name in names:
+            jar.writestr(name, b"")
+    jar_bytes.seek(0)
+    return jar_bytes
+
+
+class NativeImageArtifactTests(unittest.TestCase):
+    def test_module_info_only_artifact_uses_non_literal_no_class_reason(self) -> None:
+        pom = """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example</groupId>
+  <artifactId>descriptor-only</artifactId>
+  <version>1.0.0</version>
+</project>
+"""
+
+        def fake_fetch_url(url: str) -> io.BytesIO | None:
+            if url.endswith(".pom"):
+                return io.BytesIO(pom.encode("utf-8"))
+            if url.endswith(".jar"):
+                return _jar_with("META-INF/versions/11/module-info.class")
+            return None
+
+        with patch.object(nia, "fetch_url", side_effect=fake_fetch_url):
+            result = nia.inspect_maven_artifact("org.example:descriptor-only:1.0.0")
+
+        self.assertTrue(result.not_for_native_image)
+        self.assertIn("beyond module-info.class", result.reason or "")
+        self.assertNotIn("contains no JVM class files", result.reason or "")
+        self.assertIsNone(result.replacement)
+
+    def test_netty_native_artifact_infers_classes_replacement_from_pom(self) -> None:
+        pom = """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.netty</groupId>
+  <artifactId>netty-tcnative-boringssl-static</artifactId>
+  <version>2.0.73.Final</version>
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-classes</artifactId>
+      <version>2.0.73.Final</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-jni-util</artifactId>
+      <version>0.0.9.Final</version>
+      <classifier>sources</classifier>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>
+"""
+
+        def fake_fetch_url(url: str) -> io.BytesIO | None:
+            if url.endswith(".pom"):
+                return io.BytesIO(pom.encode("utf-8"))
+            if url.endswith(".jar"):
+                return _jar_with(
+                    "META-INF/versions/11/module-info.class",
+                    "META-INF/maven/io.netty/netty-tcnative-boringssl-static/pom.xml",
+                )
+            return None
+
+        with patch.object(nia, "fetch_url", side_effect=fake_fetch_url):
+            result = nia.inspect_maven_artifact(
+                "io.netty:netty-tcnative-boringssl-static:2.0.73.Final"
+            )
+
+        self.assertTrue(result.not_for_native_image)
+        self.assertEqual(
+            "io.netty:netty-tcnative-classes:2.0.73.Final",
+            result.replacement,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/native_image_artifact.py
+++ b/forge/utility_scripts/native_image_artifact.py
@@ -28,6 +28,25 @@ class NativeImageEligibility:
     replacement: str | None = None
 
 
+@dataclass(frozen=True)
+class MavenDependency:
+    """Dependency coordinates declared by a Maven POM."""
+
+    group: str
+    artifact: str
+    version: str
+    scope: str | None = None
+    classifier: str | None = None
+
+
+@dataclass(frozen=True)
+class MavenPomMetadata:
+    """Small subset of Maven POM metadata used for artifact classification."""
+
+    packaging: str | None
+    dependencies: tuple[MavenDependency, ...]
+
+
 def discovery_file_path(repo_path: str, coordinate: str) -> str:
     """Return the Gradle build-local discovery file path for a coordinate."""
     sanitized = coordinate.replace(":", "-").replace("/", "-")
@@ -130,7 +149,8 @@ def inspect_maven_artifact(coordinate: str) -> NativeImageEligibility:
     base_path = "/".join([group.replace(".", "/"), artifact, version])
     base_url = f"{MAVEN_CENTRAL}/{base_path}/{artifact}-{version}"
 
-    packaging = read_maven_packaging(f"{base_url}.pom")
+    pom_metadata = read_maven_pom_metadata(f"{base_url}.pom")
+    packaging = pom_metadata.packaging if pom_metadata else None
     if packaging in {"aar", "klib"}:
         return NativeImageEligibility(
             True,
@@ -155,29 +175,55 @@ def inspect_maven_artifact(coordinate: str) -> NativeImageEligibility:
     if class_files:
         return NativeImageEligibility(False)
 
+    replacement = (
+        netty_classes_replacement(group, artifact, pom_metadata)
+        or jvm_artifact_replacement(artifact)
+    )
+
     if any(name.endswith(".sjsir") for name in names):
         return NativeImageEligibility(
             True,
             "Artifact JAR contains Scala.js IR and no JVM class files.",
-            jvm_artifact_replacement(artifact),
+            replacement,
         )
 
     if any(name.endswith(".klib") or name.startswith("default/linkdata/") for name in names):
         return NativeImageEligibility(
             True,
             "Artifact contains Kotlin Native metadata and no JVM class files.",
-            jvm_artifact_replacement(artifact),
+            replacement,
+        )
+
+    module_info_files = [
+        name for name in names
+        if name.endswith("module-info.class")
+    ]
+    if module_info_files:
+        reason = (
+            "Artifact JAR contains no application/library JVM class files beyond "
+            "module-info.class, so there is no library code for native-image metadata."
+        )
+    else:
+        reason = (
+            "Artifact JAR contains no JVM class files, so there is no library code "
+            "for native-image metadata."
         )
 
     return NativeImageEligibility(
         True,
-        "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.",
-        jvm_artifact_replacement(artifact),
+        reason,
+        replacement,
     )
 
 
 def read_maven_packaging(pom_url: str) -> str | None:
     """Read the Maven POM packaging value, defaulting to jar when omitted."""
+    metadata = read_maven_pom_metadata(pom_url)
+    return metadata.packaging if metadata else None
+
+
+def read_maven_pom_metadata(pom_url: str) -> MavenPomMetadata | None:
+    """Read the Maven POM packaging and direct dependencies."""
     pom_bytes = fetch_url(pom_url)
     if pom_bytes is None:
         return None
@@ -188,7 +234,29 @@ def read_maven_packaging(pom_url: str) -> str | None:
     namespace_match = re.match(r"\{.*\}", root.tag)
     namespace = namespace_match.group(0) if namespace_match else ""
     packaging = root.findtext(f"{namespace}packaging")
-    return packaging.strip() if packaging else "jar"
+    dependencies: list[MavenDependency] = []
+    for dependency in root.findall(f"{namespace}dependencies/{namespace}dependency"):
+        dependency_group = _find_stripped_text(dependency, namespace, "groupId")
+        dependency_artifact = _find_stripped_text(dependency, namespace, "artifactId")
+        dependency_version = _find_stripped_text(dependency, namespace, "version")
+        if not dependency_group or not dependency_artifact or not dependency_version:
+            continue
+        dependencies.append(
+            MavenDependency(
+                dependency_group,
+                dependency_artifact,
+                dependency_version,
+                _find_stripped_text(dependency, namespace, "scope"),
+                _find_stripped_text(dependency, namespace, "classifier"),
+            )
+        )
+    return MavenPomMetadata(packaging.strip() if packaging else "jar", tuple(dependencies))
+
+
+def _find_stripped_text(element: ET.Element, namespace: str, child: str) -> str | None:
+    """Return trimmed text for an XML child element."""
+    text = element.findtext(f"{namespace}{child}")
+    return text.strip() if text else None
 
 
 def fetch_url(url: str):
@@ -218,4 +286,28 @@ def jvm_artifact_replacement(artifact: str) -> str | None:
         replacement = re.sub(pattern, "", artifact)
         if replacement != artifact and replacement:
             return f"Use `{replacement}` if a JVM artifact is available."
+    return None
+
+
+def netty_classes_replacement(
+        group: str,
+        artifact: str,
+        pom_metadata: MavenPomMetadata | None,
+) -> str | None:
+    """Infer Netty native package replacements from compile dependencies."""
+    if pom_metadata is None or not group.startswith("io.netty"):
+        return None
+    if "-native" not in artifact and "tcnative" not in artifact:
+        return None
+
+    for dependency in pom_metadata.dependencies:
+        if dependency.group != group:
+            continue
+        if dependency.artifact == artifact or "-classes" not in dependency.artifact:
+            continue
+        if dependency.classifier:
+            continue
+        if dependency.scope not in (None, "", "compile"):
+            continue
+        return f"{dependency.group}:{dependency.artifact}:{dependency.version}"
     return None

--- a/metadata/io.netty/netty-tcnative-boringssl-static/index.json
+++ b/metadata/io.netty/netty-tcnative-boringssl-static/index.json
@@ -1,6 +1,7 @@
 [
   {
     "not-for-native-image": true,
-    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+    "reason": "The default JAR contains only Maven metadata plus META-INF/versions/11/module-info.class, not application/library JVM classes for Native Image metadata; Java classes are published separately.",
+    "replacement": "io.netty:netty-tcnative-classes:2.0.73.Final"
   }
 ]

--- a/metadata/io.netty/netty-tcnative-boringssl-static/index.json
+++ b/metadata/io.netty/netty-tcnative-boringssl-static/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Fixes: #4816

Addresses the human-intervention item on PR #5242.

This PR records `io.netty:netty-tcnative-boringssl-static` as `not-for-native-image`, with wording that reflects the actual artifact contents and a replacement pointing at the JVM classes artifact:

- `replacement`: `io.netty:netty-tcnative-classes:2.0.73.Final`
- Reason: the default JAR contains Maven metadata plus `META-INF/versions/11/module-info.class`, but no application/library JVM classes for Native Image metadata; Java classes are published separately.

It also hardens Forge so future module-info-only artifacts do not get a literal "no JVM class files" reason, and Netty native/tcnative artifacts can infer a direct compile-scope `*-classes` replacement from their POM.

## Root cause

Forge intentionally ignored `module-info.class` while classifying native marker artifacts, but reused a human-facing reason that said the JAR had no JVM class files. For Netty tcnative, the POM already declares `io.netty:netty-tcnative-classes:2.0.73.Final` as the JVM classes dependency, but Forge replacement inference only covered generic artifact-name patterns and missed this Netty native-to-classes relationship.

## GitHub items addressed

- PR #5242 human-intervention review finding: corrected the marker reason and replacement.
- Issue #4816: remains the library request closed by this not-for-native-image marker.

## Validation

- `PYTHONPATH=$PWD python3 -m unittest tests.test_native_image_artifact` from `forge/`: passed, 2 tests.
- `python3 -m py_compile forge/utility_scripts/native_image_artifact.py forge/tests/test_native_image_artifact.py`: passed.
- `git diff --check`: passed.
- `./gradlew --no-daemon validateIndexFiles -Pcoordinates=io.netty:netty-tcnative-boringssl-static:2.0.73.Final`: passed.
- `./gradlew --no-daemon checkMetadataFiles -Pcoordinates=io.netty:netty-tcnative-boringssl-static:2.0.73.Final`: passed; no matching metadata files were found for this marker-only coordinate.
- Live Forge inspection for `io.netty:netty-tcnative-boringssl-static:2.0.73.Final`: returned `not_for_native_image=True`, module-info-aware reason text, and replacement `io.netty:netty-tcnative-classes:2.0.73.Final`.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d1d8ff09661a270e21076ee9fd4112ca62d43d5`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 1