### PR TITLE
Retry transient GitHub authentication lookups

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -62,6 +62,7 @@ from git_scripts.common_git import (
     is_github_rate_limit_text,
     log_github_query,
     run_github_json_with_retries,
+    run_github_with_retries,
 )
 from git_scripts.make_pr_javac_fix import main as run_make_pr_javac_fix
 from git_scripts.make_pr_java_run_fix import main as run_make_pr_java_run_fix
@@ -1094,7 +1095,7 @@ CLAIM_BACKOFF_MAX = 10  # Maximum seconds to wait before verifying claim
 
 def get_authenticated_user() -> str:
     """Return the GitHub username of the currently authenticated gh user."""
-    result = gh("api", "user", "--jq", ".login")
+    result = run_github_with_retries(gh, ("api", "user", "--jq", ".login"))
     return result.stdout.strip()
 
 

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -325,14 +325,46 @@ def run_github_json_with_retries(
     raise RuntimeError("GitHub JSON command exhausted retries")
 
 
+def run_github_with_retries(
+        gh_runner: Callable[..., subprocess.CompletedProcess],
+        args: tuple[str, ...],
+        *,
+        quiet: bool = False,
+        max_attempts: int = GITHUB_TRANSIENT_RETRY_ATTEMPTS,
+) -> subprocess.CompletedProcess:
+    """Run a read-only gh command, retrying transient GitHub failures."""
+    for attempt in range(1, max_attempts + 1):
+        command_quiet = quiet or attempt < max_attempts
+        try:
+            return gh_runner(*args, quiet=command_quiet)
+        except subprocess.CalledProcessError as exc:
+            error_text = _github_error_text_from_exception(exc)
+            if attempt < max_attempts and is_github_transient_failure_text(error_text):
+                _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+                time.sleep(_github_retry_delay_seconds(attempt))
+                continue
+            raise
+
+    raise RuntimeError("GitHub command exhausted retries")
+
+
 def gh_json(*args: str) -> Any:
     """Run a gh CLI command and parse its stdout as JSON."""
     return run_github_json_with_retries(gh, args)
 
 
+def gh_with_retries(*args: str, quiet: bool = False, cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run a read-only gh CLI command with retries for transient failures."""
+    return run_github_with_retries(
+        lambda *gh_args, quiet=False: gh(*gh_args, cwd=cwd, quiet=quiet),
+        args,
+        quiet=quiet,
+    )
+
+
 def get_authenticated_login(cwd=None) -> str:
     """Return the authenticated GitHub login used by gh."""
-    result = gh("api", "user", "--jq", ".login", cwd=cwd)
+    result = gh_with_retries("api", "user", "--jq", ".login", cwd=cwd)
     return result.stdout.strip()
 
 

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -162,6 +162,30 @@ class GitHubRateLimitTests(unittest.TestCase):
         self.assertEqual(gh.call_count, 2)
         sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
 
+    def test_get_authenticated_login_retries_transient_timeout(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr='Get "https://api.github.com/user": dial tcp 140.82.121.5:443: i/o timeout',
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="vjovanov\n",
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", side_effect=[failed_process, successful_process]) as run, \
+                patch.object(common_git.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO):
+            self.assertEqual(common_git.get_authenticated_login(cwd="/repo"), "vjovanov")
+
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[0].kwargs["cwd"], "/repo")
+        self.assertEqual(run.call_args_list[1].kwargs["cwd"], "/repo")
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -235,6 +235,32 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertIn("GitHub API transient failure", stderr.getvalue())
         self.assertNotIn("query=", stderr.getvalue())
 
+    def test_get_authenticated_user_retries_transient_timeout(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr='Get "https://api.github.com/user": dial tcp 140.82.121.5:443: i/o timeout',
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="vjovanov\n",
+            stderr="",
+        )
+
+        with patch.object(
+                forge_metadata.subprocess,
+                "run",
+                side_effect=[failed_process, successful_process],
+        ) as run, \
+                patch.object(common_git.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO):
+            self.assertEqual(forge_metadata.get_authenticated_user(), "vjovanov")
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+
     def test_preflight_fallback_does_not_continue_after_rate_limit(self) -> None:
         issue = {"number": 1412, "labels": []}
 


### PR DESCRIPTION
### Summary
- add a shared retry helper for non-JSON read-only GitHub CLI calls
- use it for authenticated user/login lookups in Forge finalization and failure-preservation paths
- cover transient api.github.com/user timeout retries in common_git and forge_metadata tests

### Tests
- python3 -m unittest tests.test_common_git tests.test_forge_metadata.IssueClaimPreflightTests.test_get_authenticated_user_retries_transient_timeout tests.test_forge_metadata.IssueClaimPreflightTests.test_gh_json_retries_transient_http_504
- python3 -m py_compile git_scripts/common_git.py forge_metadata.py tests/test_common_git.py tests/test_forge_metadata.py
- git diff --check -- git_scripts/common_git.py forge_metadata.py tests/test_common_git.py tests/test_forge_metadata.py

Fixes #5243