### PR TITLE
[GenAI] Add support for com.softwaremill.sttp.model:core_3:1.7.12 using gpt-5.5

### DIFF
--- a/stats/com.softwaremill.sttp.model/core_3/1.7.12/execution-metrics.json
+++ b/stats/com.softwaremill.sttp.model/core_3/1.7.12/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-03": {
-    "timestamp": "2026-05-03T16:53:20.462639Z",
+    "timestamp": "2026-05-03T19:00:46.217230Z",
     "library": "com.softwaremill.sttp.model:core_3:1.7.12",
-    "starting_commit": "27416d0604ebdb1b92aa0b63fa9a27afd4b9886e",
-    "ending_commit": "60d19ec9edee1ce96dc5c50d2ecde315fe747fe7",
+    "starting_commit": "3da08fddbd440a7ace700c13403139445390fa52",
+    "ending_commit": "6fb972f347653b727c13b890e43f942ca092a142",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 15020,
-          "missed": 15130,
-          "ratio": 0.498176,
+          "covered": 16954,
+          "missed": 13196,
+          "ratio": 0.562322,
           "total": 30150
         },
         "line": {
-          "covered": 1475,
-          "missed": 614,
-          "ratio": 0.706079,
+          "covered": 1666,
+          "missed": 423,
+          "ratio": 0.797511,
           "total": 2089
         },
         "method": {
-          "covered": 1181,
-          "missed": 1923,
-          "ratio": 0.380477,
+          "covered": 1333,
+          "missed": 1771,
+          "ratio": 0.429446,
           "total": 3104
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 193296,
-      "cached_input_tokens_used": 2579456,
-      "output_tokens_used": 21883,
+      "input_tokens_used": 177228,
+      "cached_input_tokens_used": 1548288,
+      "output_tokens_used": 19224,
       "iterations": 3,
-      "cost_usd": 1.9462,
-      "generated_loc": 278,
-      "tested_library_loc": 1475,
+      "cost_usd": 1.3508,
+      "generated_loc": 473,
+      "tested_library_loc": 1666,
       "metadata_entries": 0,
-      "code_coverage_percent": 70.61
+      "code_coverage_percent": 79.75
     },
     "artifacts": {
       "test_file": "tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala",

--- a/stats/com.softwaremill.sttp.model/core_3/1.7.12/stats.json
+++ b/stats/com.softwaremill.sttp.model/core_3/1.7.12/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 15020,
-        "missed" : 15130,
-        "ratio" : 0.498176,
+        "covered" : 16954,
+        "missed" : 13196,
+        "ratio" : 0.562322,
         "total" : 30150
       },
       "line" : {
-        "covered" : 1475,
-        "missed" : 614,
-        "ratio" : 0.706079,
+        "covered" : 1666,
+        "missed" : 423,
+        "ratio" : 0.797511,
         "total" : 2089
       },
       "method" : {
-        "covered" : 1181,
-        "missed" : 1923,
-        "ratio" : 0.380477,
+        "covered" : 1333,
+        "missed" : 1771,
+        "ratio" : 0.429446,
         "total" : 3104
       }
     }

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
@@ -13,6 +13,7 @@ import sttp.model.Uri.UriContext
 import sttp.model.headers.*
 import sttp.model.sse.ServerSentEvent
 
+import java.net.URI as JavaUri
 import java.time.Instant
 import scala.concurrent.duration.*
 
@@ -53,6 +54,26 @@ class Core_3Test {
     val relative: Uri = Uri.pathRelative(Seq("child"), Seq(Uri.QuerySegment.KeyValue("x", "1")), Some("frag"))
     assertEquals("child?x=1#frag", relative.toString)
     assertEquals("https://user:secret@example.com:8443/api/v1/child?x=1#frag", parsed.resolve(relative).toString)
+  }
+
+  @Test
+  def javaUriInteroperabilityPreservesEncodedModelSemantics(): Unit = {
+    val modelUri: Uri = Uri("https", "example.com", Seq("a b", "c/d"))
+      .withParam("q", "hello world")
+      .fragment("frag ment")
+    val javaUri: JavaUri = modelUri.toJavaUri
+
+    assertEquals("https", javaUri.getScheme)
+    assertEquals("example.com", javaUri.getHost)
+    assertEquals("/a%20b/c%2Fd", javaUri.getRawPath)
+    assertEquals("q=hello+world", javaUri.getRawQuery)
+    assertEquals("frag%20ment", javaUri.getRawFragment)
+
+    val roundTripped: Uri = Uri(javaUri)
+    assertEquals(modelUri.toString, roundTripped.toString)
+    assertEquals(List("a b", "c/d"), roundTripped.path)
+    assertEquals(Some("hello world"), roundTripped.params.get("q"))
+    assertEquals(Some("frag ment"), roundTripped.fragment)
   }
 
   @Test

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
@@ -91,6 +91,31 @@ class Core_3Test {
   }
 
   @Test
+  def uriInterpolatorExpandsCollectionsAndOmitsMissingQueryValues(): Unit = {
+    val pathSegments: List[String] = List("team a", "report/42")
+    val optionalMode: Option[String] = Some("fast")
+    val queryPairs: Seq[(String, Option[String])] = Seq(
+      "lang" -> Some("scala 3"),
+      "debug" -> None,
+      "mode" -> optionalMode
+    )
+    val repeatedParams: QueryParams = QueryParams
+      .fromSeq(Seq("tag" -> "a+b", "tag" -> "x/y"))
+      .param("flag", Seq.empty)
+
+    val interpolated: Uri = uri"https://api.example.com/$pathSegments?fixed=1&$queryPairs&$repeatedParams"
+
+    assertEquals("https://api.example.com/team%20a/report%2F42?fixed=1&lang=scala+3&mode=fast&tag=a%2Bb&tag=x/y&flag", interpolated.toString)
+    assertEquals(List("team a", "report/42"), interpolated.path)
+    assertEquals(Some("1"), interpolated.params.get("fixed"))
+    assertEquals(Some("scala 3"), interpolated.params.get("lang"))
+    assertEquals(None, interpolated.params.get("debug"))
+    assertEquals(Some("fast"), interpolated.params.get("mode"))
+    assertEquals(Some(Seq("a+b", "x/y")), interpolated.params.getMulti("tag"))
+    assertEquals(Some(Seq.empty[String]), interpolated.params.getMulti("flag"))
+  }
+
+  @Test
   def queryParamsPreserveOrderMultiValuesAndEmptyValues(): Unit = {
     val queryParams: QueryParams = QueryParams
       .fromSeq(Seq("a" -> "1", "b" -> "two words", "a" -> "3"))

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/src/test/scala/com_softwaremill_sttp_model/core_3/Core_3Test.scala
@@ -314,6 +314,179 @@ class Core_3Test {
     assertEquals("/next", Header.location(Uri.relative(Seq("next"))).value)
   }
 
+  @Test
+  def uriFactoryValidationSegmentEncodingAndMutationMethodsCompose(): Unit = {
+    val ipv6Uri: Uri = Uri(
+      "https",
+      Some(Uri.Authority(None, Uri.HostSegment("2001:db8::1"), Some(443))),
+      Seq(Uri.PathSegment("a b")),
+      Seq(
+        Uri.QuerySegment.Plain("raw=1&kept=2&", Uri.QuerySegmentEncoding.Relaxed),
+        Uri.QuerySegment.Value("lonely value"),
+        Uri.QuerySegment.KeyValue("brackets[]", "x/y")
+      ),
+      Some(Uri.FragmentSegment("frag/part"))
+    )
+
+    assertEquals("https://[2001:db8::1]:443/a%20b?raw=1&kept=2&lonely+value&brackets%5B%5D=x/y#frag/part", ipv6Uri.toString)
+    assertEquals("2001:db8::1", ipv6Uri.authority.map(_.host).get)
+    assertEquals(Seq("a b"), ipv6Uri.path)
+
+    val relaxedQuery: Uri = Uri
+      .relative(Nil, Seq(Uri.QuerySegment.KeyValue("filter[]", "a b")), None)
+      .querySegmentsEncoding(Uri.QuerySegmentEncoding.RelaxedWithBrackets)
+    assertEquals("?filter[]=a+b", relaxedQuery.toString)
+
+    val normalized: Uri = Uri
+      .unsafeParse("https://example.com/root/")
+      .addPath("child")
+      .userInfo("user")
+      .port(None)
+      .fragment(None)
+    assertEquals("https://user@example.com/root/child", normalized.toString)
+    assertEquals(Some(Uri.UserInfo("user", None)), normalized.userInfo)
+    assertEquals(None, normalized.port)
+
+    assertEquals("mailto:user@example.com", Uri.unsafeApply("mailto", Seq("user@example.com")).toString)
+    assertTrue(Uri.safeApply("1https", "example.com").isLeft)
+    assertTrue(Uri.safeApply("https", "").isLeft)
+    assertTrue(Uri.Authority.safeApply("").isLeft)
+  }
+
+  @Test
+  def acceptNegotiationContentTypeRangesAndMediaTypePredicatesCoverWildcards(): Unit = {
+    assertEquals(Seq(ContentTypeRange.AnyRange), right(Accepts.parse(Nil)))
+    assertEquals(
+      Seq(
+        ContentTypeRange(ContentTypeRange.Wildcard, ContentTypeRange.Wildcard, "iso-8859-1", Map.empty),
+        ContentTypeRange(ContentTypeRange.Wildcard, ContentTypeRange.Wildcard, "utf-8", Map.empty)
+      ),
+      right(Accepts.parse(Seq(Header.acceptCharset("utf-8;q=0.2, iso-8859-1;q=0.9"))))
+    )
+
+    val versionedJson: MediaType = MediaType("Application", "JSON", otherParameters = Map("profile" -> "v1"))
+    val exactNoCharset: ContentTypeRange = ContentTypeRange.exactNoCharset(versionedJson.charset("utf-8"))
+    assertTrue(versionedJson.matches(exactNoCharset))
+    assertEquals(ContentTypeRange("Application", ContentTypeRange.Wildcard, ContentTypeRange.Wildcard, Map("profile" -> "v1")), exactNoCharset.anySubType)
+    assertEquals("Application/*; profile=v1", exactNoCharset.anySubType.toString)
+    assertTrue(versionedJson == MediaType("application", "json", otherParameters = Map("PROFILE" -> "V1")))
+    assertTrue(MediaType.safeApply("bad type", "json").isLeft)
+    assertTrue(Accepts.parse(Seq(Header.accept("text/plain;q=1.0000"))).isLeft)
+
+    assertTrue(MediaType("audio", "mpeg").isAudio)
+    assertTrue(MediaType("image", "png").isImage)
+    assertTrue(MediaType("message", "rfc822").isMessage)
+    assertTrue(MediaType("multipart", "mixed").isMultipart)
+    assertTrue(MediaType("video", "mp4").isVideo)
+    assertTrue(MediaType("font", "woff2").isFont)
+    assertTrue(MediaType("example", "demo").isExample)
+    assertTrue(MediaType("model", "gltf+json").isModel)
+  }
+
+  @Test
+  def headerFactoriesDatesAndSafetyHelpersHandleTypedValues(): Unit = {
+    val instant: Instant = Instant.parse("1994-11-06T08:49:37Z")
+    assertEquals(instant, right(Header.parseHttpDate("Sun, 06-Nov-94 08:49:37 GMT")))
+
+    assertEquals(Header(HeaderNames.Cookie, "a=1; b=2"), Header.cookie(Cookie("a", "1"), Cookie("b", "2")))
+    assertEquals(Header(HeaderNames.Etag, "W/\"abc\""), Header.etag(ETag("abc", weak = true)))
+    assertEquals(Header(HeaderNames.IfNoneMatch, "\"a\", W/\"b\""), Header.ifNoneMatch(List(ETag("a"), ETag("b", weak = true))))
+    assertEquals(Header(HeaderNames.Expires, Header.toHttpDateString(instant)), Header.expires(instant))
+    assertEquals(Header(HeaderNames.IfModifiedSince, Header.toHttpDateString(instant)), Header.ifModifiedSince(instant))
+    assertEquals(Header(HeaderNames.IfUnmodifiedSince, Header.toHttpDateString(instant)), Header.ifUnmodifiedSince(instant))
+    assertEquals(Header(HeaderNames.ContentEncoding, "gzip"), Header.contentEncoding("gzip"))
+    assertEquals(Header(HeaderNames.Vary, "Accept, Accept-Encoding"), Header.vary(HeaderNames.Accept, HeaderNames.AcceptEncoding))
+    assertEquals(Header(HeaderNames.ProxyAuthorization, "Basic dXNlcjpwYXNz"), Header.proxyAuthorization("Basic", "dXNlcjpwYXNz"))
+
+    assertTrue(HeaderNames.isContent(Header.contentType(MediaType.TextPlain)))
+    assertTrue(HeaderNames.isSensitive(Header.cookie(Cookie("session", "secret"))))
+    assertEquals(Seq("Authorization: ***", "X-Trace: visible"), Headers.toStringSafe(Seq(
+      Header.authorization("Bearer", "token"),
+      Header("X-Trace", "visible")
+    )))
+  }
+
+  @Test
+  def cookiesValueMetadataAndMutatorsValidateAndRenderAllDirectives(): Unit = {
+    val cookie: CookieWithMeta = CookieWithMeta("id", "1")
+      .value("2")
+      .expires(Some(Instant.parse("2024-05-01T12:00:00Z")))
+      .maxAge(Some(120L))
+      .domain(Some("example.com"))
+      .path(Some("/app"))
+      .secure(true)
+      .httpOnly(true)
+      .sameSite(Some(Cookie.SameSite.Lax))
+      .otherDirective("Priority" -> Some("High"))
+      .otherDirective("Partitioned" -> None)
+
+    val rendered: String = cookie.toString
+    assertTrue(rendered.contains("id=2; Expires=Wed, 01 May 2024 12:00:00 GMT; Max-Age=120"))
+    assertTrue(rendered.contains("; Domain=example.com; Path=/app; Secure; HttpOnly; SameSite=Lax"))
+    assertTrue(rendered.contains("; Priority=High"))
+    assertTrue(rendered.contains("; Partitioned"))
+
+    val parsed: CookieWithMeta = right(CookieWithMeta.parse("id=2; Expires=Wed, 01-May-24 12:00:00 GMT; Max-Age=120; Domain=example.com; Path=/app; Secure; HttpOnly; SameSite=None; Priority=High"))
+    assertEquals("id", parsed.name)
+    assertEquals("2", parsed.value)
+    assertEquals(Some(Instant.parse("2024-05-01T12:00:00Z")), parsed.expires)
+    assertEquals(Some(Cookie.SameSite.None), parsed.sameSite)
+    assertEquals(Map("Priority" -> Some("High")), parsed.otherDirectives)
+
+    assertTrue(CookieValueWithMeta.safeApply("ok", path = Some("bad;path")).isLeft)
+    assertTrue(CookieWithMeta.parse("id=1; SameSite=invalid").isLeft)
+    assertTrue(Cookie.parse("bad=va\u0001lue").isLeft)
+  }
+
+  @Test
+  def rangesContentRangesCacheDirectivesAndAuthenticationCoverVariantForms(): Unit = {
+    val suffixRange: Range = right(Range.safeApply(None, Some(500L), ContentRangeUnits.Bytes)).head
+    val openEndedRange: Range = right(Range.parse("bytes=500-")).head
+    assertEquals("bytes=-500", suffixRange.toString)
+    assertEquals("bytes=500-", openEndedRange.toString)
+    assertTrue(suffixRange.isValid(1000L))
+    assertTrue(openEndedRange.isValid(1000L))
+    assertEquals(0L, openEndedRange.contentLength)
+    assertEquals(ContentRange(ContentRangeUnits.Bytes, None, Some(1000L)), openEndedRange.toContentRange(1000L))
+    assertEquals(ContentRange(ContentRangeUnits.Bytes, None, Some(1234L)), right(ContentRange.parse("bytes */1234")))
+    assertTrue(ContentRange.parse("bytes */*").isLeft)
+    assertTrue(Range.safeApply(None, None, ContentRangeUnits.Bytes).isLeft)
+
+    assertEquals(
+      List(
+        Right(CacheDirective.MaxAge(1.second)),
+        Right(CacheDirective.MaxStale(Some(2.seconds))),
+        Right(CacheDirective.MaxStale(None)),
+        Right(CacheDirective.MinFresh(3.seconds)),
+        Right(CacheDirective.NoStore),
+        Right(CacheDirective.NoTransform),
+        Right(CacheDirective.OnlyIfCached),
+        Right(CacheDirective.MustRevalidate),
+        Right(CacheDirective.Public),
+        Right(CacheDirective.Private),
+        Right(CacheDirective.ProxyRevalidate),
+        Right(CacheDirective.SMaxage(4.seconds)),
+        Right(CacheDirective.Immutable),
+        Right(CacheDirective.StaleWhileRevalidate(5.seconds))
+      ),
+      CacheDirective.parse("max-age=1, max-stale=2, max-stale, min-fresh=3, no-store, no-transform, only-if-cached, must-revalidate, public, private, proxy-revalidate, s-maxage=4, immutable, stale-while-revalidate=5")
+    )
+    assertTrue(CacheDirective.parse("unknown").head.isLeft)
+
+    val digest: WWWAuthenticateChallenge = right(WWWAuthenticateChallenge.parseSingle(
+      "Digest realm=\"api\", nonce=\"n\", opaque=\"o\", qop=\"auth\", algorithm=\"MD5\", userhash=\"false\""
+    ))
+    assertEquals("Digest", digest.scheme)
+    assertEquals(Some("api"), digest.realm)
+    assertEquals(Some("n"), digest.param("nonce"))
+    assertEquals(Some("o"), digest.param("opaque"))
+    assertEquals(Some("auth"), digest.param("qop"))
+    assertEquals(Some("MD5"), digest.param("algorithm"))
+    assertEquals(Some("false"), digest.param("userhash"))
+    assertTrue(WWWAuthenticateChallenge.parseSingle("Digest realm=\"api\", opaque=\"o\", qop=\"auth\"").isLeft)
+    assertTrue(WWWAuthenticateChallenge.parseSingle("Basic realm=\"a\", charset=\"UTF-8\", extra=\"ignored\"").isLeft)
+  }
+
   private def right[A](either: Either[String, A]): A = either match {
     case Right(value) => value
     case Left(error)  => throw new AssertionError(s"Expected Right but got Left($error)")


### PR DESCRIPTION

## What does this PR do?

Fixes: #4990

This PR introduces tests and metadata for com.softwaremill.sttp.model:core_3:1.7.12, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 177228
- Cached input tokens: 1548288
- Output tokens: 19224
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 79.75
- Generated lines of code: 473
- Tested library lines of code: 1666

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3da08fddbd440a7ace700c13403139445390fa52`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 16954/30150 (56.23%)
- Line: 1666/2089 (79.75%)
- Method: 1333/3104 (42.94%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
