### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-iam-v1:1.40.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-iam-v1/1.40.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-iam-v1/1.40.1/reachability-metadata.json
@@ -1,0 +1,263 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.logging.AuditData",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.logging.AuditData$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.IamPolicyProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.PolicyDelta",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.PolicyDelta$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.BindingDelta",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.BindingDelta$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.AuditConfigDelta",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.iam.v1.AuditConfigDelta$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.type.Expr",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.iam.v1.logging.AuditData"
+      },
+      "type": "com.google.type.Expr$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-iam-v1/index.json
+++ b/metadata/com.google.api.grpc/proto-google-iam-v1/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.40.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-iam-v1/$version$/proto-google-iam-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/sdk-platform-java",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-iam-v1/$version$/proto-google-iam-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/api/grpc/proto-google-iam-v1/$version$/proto-google-iam-v1-$version$-javadoc.jar",
+    "description" : "This artifact contains the generated Java Protocol Buffer classes for Google Cloud IAM v1 policy, binding, audit configuration, and IAM policy request and response messages. It lets JVM clients serialize, deserialize, and reference Google IAM v1 protobuf messages used by Google API and gRPC client libraries.",
+    "tested-versions" : [
+      "1.40.1"
+    ],
+    "allowed-packages" : [
+      "com.google.iam.v1"
+    ]
+  }
+]

--- a/stats/com.google.api.grpc/proto-google-iam-v1/1.40.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-iam-v1/1.40.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T19:22:44.029750Z",
+    "library": "com.google.api.grpc:proto-google-iam-v1:1.40.1",
+    "starting_commit": "e525e1203b4b8bef63fa8e9ceb527f910eb1c58a",
+    "ending_commit": "df0342883b3679cb45d12d468bfc170cce87e46d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.40.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6402,
+          "missed": 9302,
+          "ratio": 0.407667,
+          "total": 15704
+        },
+        "line": {
+          "covered": 1742,
+          "missed": 2429,
+          "ratio": 0.417646,
+          "total": 4171
+        },
+        "method": {
+          "covered": 387,
+          "missed": 756,
+          "ratio": 0.338583,
+          "total": 1143
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 131618,
+      "cached_input_tokens_used": 796672,
+      "output_tokens_used": 13080,
+      "iterations": 3,
+      "cost_usd": 0.7907,
+      "generated_loc": 275,
+      "tested_library_loc": 1742,
+      "metadata_entries": 72,
+      "code_coverage_percent": 41.76
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-iam-v1/1.40.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-iam-v1/1.40.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-iam-v1/1.40.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.40.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6402,
+        "missed" : 9302,
+        "ratio" : 0.407667,
+        "total" : 15704
+      },
+      "line" : {
+        "covered" : 1742,
+        "missed" : 2429,
+        "ratio" : 0.417646,
+        "total" : 4171
+      },
+      "method" : {
+        "covered" : 387,
+        "missed" : 756,
+        "ratio" : 0.338583,
+        "total" : 1143
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-iam-v1:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-iam-v1:1.40.1
+library.version = 1.40.1
+metadata.dir = com.google.api.grpc/proto-google-iam-v1/1.40.1/

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-iam-v1_tests'

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_iam_v1;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_iam_v1Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
@@ -31,6 +31,7 @@ import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.iam.v1.logging.AuditData;
 import com.google.iam.v1.logging.AuditDataProto;
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors;
@@ -207,6 +208,27 @@ public class Proto_google_iam_v1Test {
         assertThat(PolicyDelta.parseFrom(delta.toByteArray())).isEqualTo(delta);
         assertThat(AuditData.parseFrom(auditData.toByteArray())).isEqualTo(auditData);
         assertThat(AuditData.parser().parseFrom(ByteString.copyFrom(auditData.toByteArray()))).isEqualTo(auditData);
+    }
+
+    @Test
+    void auditDataPacksIntoAnyServiceDataAndUnpacksByTypeUrl() throws Exception {
+        PolicyDelta policyDelta = PolicyDelta.newBuilder()
+                .addBindingDeltas(BindingDelta.newBuilder()
+                        .setAction(BindingDelta.Action.ADD)
+                        .setRole("roles/iam.securityReviewer")
+                        .setMember("group:security@example.com"))
+                .build();
+        AuditData auditData = AuditData.newBuilder()
+                .setPolicyDelta(policyDelta)
+                .build();
+
+        Any serviceData = Any.pack(auditData);
+
+        assertThat(serviceData.getTypeUrl()).isEqualTo("type.googleapis.com/google.iam.v1.logging.AuditData");
+        assertThat(serviceData.is(AuditData.class)).isTrue();
+        assertThat(serviceData.unpack(AuditData.class)).isEqualTo(auditData);
+        assertThat(serviceData.unpack(AuditData.class).getPolicyDelta().getBindingDeltas(0).getMember())
+                .isEqualTo("group:security@example.com");
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
@@ -6,11 +6,245 @@
  */
 package com_google_api_grpc.proto_google_iam_v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.api.AnnotationsProto;
+import com.google.api.ClientProto;
+import com.google.api.FieldBehavior;
+import com.google.api.FieldBehaviorProto;
+import com.google.api.HttpRule;
+import com.google.api.ResourceProto;
+import com.google.api.ResourceReference;
+import com.google.iam.v1.AuditConfig;
+import com.google.iam.v1.AuditConfigDelta;
+import com.google.iam.v1.AuditLogConfig;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.BindingDelta;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.GetPolicyOptions;
+import com.google.iam.v1.IamPolicyProto;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.PolicyDelta;
+import com.google.iam.v1.PolicyProto;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import com.google.iam.v1.logging.AuditData;
+import com.google.iam.v1.logging.AuditDataProto;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.FieldMask;
+import com.google.type.Expr;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_iam_v1Test {
+public class Proto_google_iam_v1Test {
+    private static final String RESOURCE = "projects/sample-project/topics/alerts";
+    private static final ByteString ETAG = ByteString.copyFromUtf8("policy-etag");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void policyWithConditionalBindingsAndAuditConfigsRoundTripsThroughPublicProtoApis() throws Exception {
+        Expr accessWindow = Expr.newBuilder()
+                .setTitle("business-hours")
+                .setDescription("Allow access only during business hours")
+                .setExpression("request.time.getHours() >= 9 && request.time.getHours() < 17")
+                .setLocation("iam-condition")
+                .build();
+        Binding viewerBinding = Binding.newBuilder()
+                .setRole("roles/viewer")
+                .addMembers("user:alice@example.com")
+                .addMembers("group:auditors@example.com")
+                .setCondition(accessWindow)
+                .build();
+        Binding writerBinding = Binding.newBuilder()
+                .setRole("roles/logging.logWriter")
+                .addMembers("serviceAccount:writer@example.iam.gserviceaccount.com")
+                .build();
+        AuditLogConfig readAudit = AuditLogConfig.newBuilder()
+                .setLogType(AuditLogConfig.LogType.DATA_READ)
+                .addExemptedMembers("user:breakglass@example.com")
+                .build();
+        AuditLogConfig adminAudit = AuditLogConfig.newBuilder()
+                .setLogType(AuditLogConfig.LogType.ADMIN_READ)
+                .build();
+        AuditConfig auditConfig = AuditConfig.newBuilder()
+                .setService("allServices")
+                .addAuditLogConfigs(readAudit)
+                .addAuditLogConfigs(adminAudit)
+                .build();
+
+        Policy policy = Policy.newBuilder()
+                .setVersion(3)
+                .addBindings(viewerBinding)
+                .addBindings(writerBinding)
+                .addAuditConfigs(auditConfig)
+                .setEtag(ETAG)
+                .build();
+
+        assertThat(policy.isInitialized()).isTrue();
+        assertThat(policy.getVersion()).isEqualTo(3);
+        assertThat(policy.getBindingsList()).containsExactly(viewerBinding, writerBinding);
+        assertThat(policy.getBindings(0).getCondition()).isEqualTo(accessWindow);
+        assertThat(policy.getAuditConfigs(0).getAuditLogConfigsList()).containsExactly(readAudit, adminAudit);
+        assertThat(policy.getEtag()).isEqualTo(ETAG);
+
+        byte[] bytes = policy.toByteArray();
+        assertThat(Policy.parseFrom(bytes)).isEqualTo(policy);
+        assertThat(Policy.parseFrom(ByteString.copyFrom(bytes))).isEqualTo(policy);
+        assertThat(Policy.parseFrom(ByteBuffer.wrap(bytes))).isEqualTo(policy);
+        assertThat(Policy.parser().parseFrom(bytes)).isEqualTo(policy);
+
+        ByteArrayOutputStream delimitedBytes = new ByteArrayOutputStream();
+        policy.writeDelimitedTo(delimitedBytes);
+        assertThat(Policy.parseDelimitedFrom(new ByteArrayInputStream(delimitedBytes.toByteArray()))).isEqualTo(policy);
+
+        Policy editedPolicy = policy.toBuilder()
+                .removeBindings(1)
+                .addBindings(writerBinding.toBuilder().addMembers("user:bob@example.com"))
+                .build();
+        assertThat(editedPolicy.getBindingsCount()).isEqualTo(2);
+        assertThat(editedPolicy.getBindings(1).getMembersList())
+                .containsExactly("serviceAccount:writer@example.iam.gserviceaccount.com", "user:bob@example.com");
+        assertThat(editedPolicy).isNotEqualTo(policy);
+    }
+
+    @Test
+    void iamPolicyRequestAndResponseMessagesPreserveNestedOptionsMasksAndRepeatedFields() throws Exception {
+        Policy policy = Policy.newBuilder()
+                .setVersion(1)
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/pubsub.viewer")
+                        .addMembers("domain:example.com"))
+                .setEtag(ETAG)
+                .build();
+        FieldMask updateMask = FieldMask.newBuilder()
+                .addPaths("bindings")
+                .addPaths("etag")
+                .build();
+        SetIamPolicyRequest setRequest = SetIamPolicyRequest.newBuilder()
+                .setResource(RESOURCE)
+                .setPolicy(policy)
+                .setUpdateMask(updateMask)
+                .build();
+
+        assertThat(setRequest.hasPolicy()).isTrue();
+        assertThat(setRequest.hasUpdateMask()).isTrue();
+        assertThat(setRequest.getResource()).isEqualTo(RESOURCE);
+        assertThat(setRequest.getResourceBytes()).isEqualTo(ByteString.copyFromUtf8(RESOURCE));
+        assertThat(SetIamPolicyRequest.parseFrom(setRequest.toByteArray())).isEqualTo(setRequest);
+
+        GetIamPolicyRequest getRequest = GetIamPolicyRequest.newBuilder()
+                .setResource(RESOURCE)
+                .setOptions(GetPolicyOptions.newBuilder().setRequestedPolicyVersion(3))
+                .build();
+        assertThat(getRequest.hasOptions()).isTrue();
+        assertThat(getRequest.getOptions().getRequestedPolicyVersion()).isEqualTo(3);
+        assertThat(GetIamPolicyRequest.parseFrom(new ByteArrayInputStream(getRequest.toByteArray())))
+                .isEqualTo(getRequest);
+
+        TestIamPermissionsRequest permissionsRequest = TestIamPermissionsRequest.newBuilder()
+                .setResource(RESOURCE)
+                .addPermissions("pubsub.topics.get")
+                .addPermissions("pubsub.topics.publish")
+                .build();
+        CodedInputStream codedInputStream = CodedInputStream.newInstance(permissionsRequest.toByteArray());
+        assertThat(TestIamPermissionsRequest.parseFrom(codedInputStream)).isEqualTo(permissionsRequest);
+        assertThat(permissionsRequest.getPermissionsList())
+                .containsExactly("pubsub.topics.get", "pubsub.topics.publish");
+
+        TestIamPermissionsResponse permissionsResponse = TestIamPermissionsResponse.newBuilder()
+                .addPermissions("pubsub.topics.get")
+                .build();
+        assertThat(TestIamPermissionsResponse.parseFrom(permissionsResponse.toByteArray()))
+                .isEqualTo(permissionsResponse);
+        assertThat(permissionsResponse.getPermissionsBytes(0)).isEqualTo(ByteString.copyFromUtf8("pubsub.topics.get"));
+    }
+
+    @Test
+    void policyDeltaAndLoggingAuditDataRetainBindingAndAuditChanges() throws Exception {
+        Expr condition = Expr.newBuilder()
+                .setTitle("expires-soon")
+                .setExpression("request.time < timestamp('2030-01-01T00:00:00Z')")
+                .build();
+        BindingDelta bindingAdded = BindingDelta.newBuilder()
+                .setAction(BindingDelta.Action.ADD)
+                .setRole("roles/storage.objectViewer")
+                .setMember("user:carol@example.com")
+                .setCondition(condition)
+                .build();
+        BindingDelta bindingRemoved = BindingDelta.newBuilder()
+                .setAction(BindingDelta.Action.REMOVE)
+                .setRole("roles/storage.legacyBucketReader")
+                .setMember("allAuthenticatedUsers")
+                .build();
+        AuditConfigDelta auditAdded = AuditConfigDelta.newBuilder()
+                .setAction(AuditConfigDelta.Action.ADD)
+                .setService("storage.googleapis.com")
+                .setExemptedMember("user:jose@example.com")
+                .setLogType("DATA_READ")
+                .build();
+        PolicyDelta delta = PolicyDelta.newBuilder()
+                .addBindingDeltas(bindingAdded)
+                .addBindingDeltas(bindingRemoved)
+                .addAuditConfigDeltas(auditAdded)
+                .build();
+        AuditData auditData = AuditData.newBuilder().setPolicyDelta(delta).build();
+
+        assertThat(BindingDelta.Action.forNumber(BindingDelta.Action.ADD_VALUE)).isEqualTo(BindingDelta.Action.ADD);
+        assertThat(AuditConfigDelta.Action.forNumber(AuditConfigDelta.Action.REMOVE_VALUE))
+                .isEqualTo(AuditConfigDelta.Action.REMOVE);
+        assertThat(AuditLogConfig.LogType.forNumber(AuditLogConfig.LogType.DATA_WRITE_VALUE))
+                .isEqualTo(AuditLogConfig.LogType.DATA_WRITE);
+        assertThat(auditData.hasPolicyDelta()).isTrue();
+        assertThat(auditData.getPolicyDelta().getBindingDeltasList()).containsExactly(bindingAdded, bindingRemoved);
+        assertThat(auditData.getPolicyDelta().getAuditConfigDeltasList()).containsExactly(auditAdded);
+        assertThat(auditData.getPolicyDelta().getBindingDeltas(0).getCondition()).isEqualTo(condition);
+
+        assertThat(PolicyDelta.parseFrom(delta.toByteArray())).isEqualTo(delta);
+        assertThat(AuditData.parseFrom(auditData.toByteArray())).isEqualTo(auditData);
+        assertThat(AuditData.parser().parseFrom(ByteString.copyFrom(auditData.toByteArray()))).isEqualTo(auditData);
+    }
+
+    @Test
+    void generatedDescriptorsExposeServiceHttpRulesAndIamFieldAnnotations() {
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        IamPolicyProto.registerAllExtensions(registry);
+        PolicyProto.registerAllExtensions(registry);
+        AuditDataProto.registerAllExtensions(registry);
+
+        Descriptors.FileDescriptor iamDescriptor = IamPolicyProto.getDescriptor();
+        Descriptors.ServiceDescriptor iamService = iamDescriptor.findServiceByName("IAMPolicy");
+        assertThat(iamService).isNotNull();
+        assertThat(iamService.getFullName()).isEqualTo("google.iam.v1.IAMPolicy");
+        assertThat(iamService.getOptions().getExtension(ClientProto.defaultHost))
+                .isEqualTo("iam-meta-api.googleapis.com");
+
+        Descriptors.MethodDescriptor setIamPolicy = iamService.findMethodByName("SetIamPolicy");
+        assertThat(setIamPolicy.getInputType().getFullName()).isEqualTo("google.iam.v1.SetIamPolicyRequest");
+        assertThat(setIamPolicy.getOutputType().getFullName()).isEqualTo("google.iam.v1.Policy");
+        HttpRule setRule = setIamPolicy.getOptions().getExtension(AnnotationsProto.http);
+        assertThat(setRule.getPost()).isEqualTo("/v1/{resource=**}:setIamPolicy");
+        assertThat(setRule.getBody()).isEqualTo("*");
+
+        Descriptors.MethodDescriptor testPermissions = iamService.findMethodByName("TestIamPermissions");
+        HttpRule testRule = testPermissions.getOptions().getExtension(AnnotationsProto.http);
+        assertThat(testRule.getPost()).isEqualTo("/v1/{resource=**}:testIamPermissions");
+        assertThat(testPermissions.getOutputType().getFullName())
+                .isEqualTo("google.iam.v1.TestIamPermissionsResponse");
+
+        Descriptors.FieldDescriptor resourceField = SetIamPolicyRequest.getDescriptor().findFieldByName("resource");
+        assertThat(resourceField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior))
+                .containsExactly(FieldBehavior.REQUIRED);
+        ResourceReference resourceReference = resourceField.getOptions().getExtension(ResourceProto.resourceReference);
+        assertThat(resourceReference.getType()).isEqualTo("*");
+
+        assertThat(Policy.getDescriptor().findFieldByName("bindings").getNumber())
+                .isEqualTo(Policy.BINDINGS_FIELD_NUMBER);
+        assertThat(AuditData.getDescriptor().findFieldByName("policy_delta").getMessageType().getFullName())
+                .isEqualTo("google.iam.v1.PolicyDelta");
     }
 }

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/src/test/java/com_google_api_grpc/proto_google_iam_v1/Proto_google_iam_v1Test.java
@@ -114,6 +114,39 @@ public class Proto_google_iam_v1Test {
     }
 
     @Test
+    void auditLogConfigPreservesForwardCompatibleLogTypeValues() {
+        int futureLogType = 8675309;
+        AuditLogConfig futureAuditLogConfig = AuditLogConfig.newBuilder()
+                .setLogTypeValue(futureLogType)
+                .addExemptedMembers("serviceAccount:future-auditor@example.iam.gserviceaccount.com")
+                .build();
+        AuditConfig auditConfig = AuditConfig.newBuilder()
+                .setService("storage.googleapis.com")
+                .addAuditLogConfigs(futureAuditLogConfig)
+                .build();
+
+        assertThat(futureAuditLogConfig.getLogTypeValue()).isEqualTo(futureLogType);
+        assertThat(futureAuditLogConfig.getLogType()).isEqualTo(AuditLogConfig.LogType.UNRECOGNIZED);
+        assertThat(auditConfig.getAuditLogConfigs(0).getLogTypeValue()).isEqualTo(futureLogType);
+        assertThat(auditConfig.getAuditLogConfigs(0).getExemptedMembersList())
+                .containsExactly("serviceAccount:future-auditor@example.iam.gserviceaccount.com");
+
+        AuditLogConfig recognizedAuditLogConfig = futureAuditLogConfig.toBuilder()
+                .setLogType(AuditLogConfig.LogType.DATA_WRITE)
+                .build();
+        assertThat(recognizedAuditLogConfig.getLogType()).isEqualTo(AuditLogConfig.LogType.DATA_WRITE);
+        assertThat(recognizedAuditLogConfig.getLogTypeValue())
+                .isEqualTo(AuditLogConfig.LogType.DATA_WRITE_VALUE);
+
+        AuditLogConfig clearedAuditLogConfig = recognizedAuditLogConfig.toBuilder()
+                .clearLogType()
+                .build();
+        assertThat(clearedAuditLogConfig.getLogType()).isEqualTo(AuditLogConfig.LogType.LOG_TYPE_UNSPECIFIED);
+        assertThat(clearedAuditLogConfig.getLogTypeValue())
+                .isEqualTo(AuditLogConfig.LogType.LOG_TYPE_UNSPECIFIED_VALUE);
+    }
+
+    @Test
     void iamPolicyRequestAndResponseMessagesPreserveNestedOptionsMasksAndRepeatedFields() throws Exception {
         Policy policy = Policy.newBuilder()
                 .setVersion(1)

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.iam.v1.**"
+      "includeClasses" : "com.google.iam.v1.**"
     }
   ]
 }

--- a/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-iam-v1/1.40.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.iam.v1.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4685

This PR introduces tests and metadata for com.google.api.grpc:proto-google-iam-v1:1.40.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 131618
- Cached input tokens: 796672
- Output tokens: 13080
- Metadata entries: 72
- Iterations: 3
- Library coverage percentage: 41.76
- Generated lines of code: 275
- Tested library lines of code: 1742

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d1d8ff09661a270e21076ee9fd4112ca62d43d5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 6402/15704 (40.77%)
- Line: 1742/4171 (41.76%)
- Method: 387/1143 (33.86%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
