### PR TITLE
[GenAI] Add support for org.sangria-graphql:sangria-marshalling-api_3:1.0.8 using gpt-5.5

### DIFF
--- a/metadata/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/reachability-metadata.json
+++ b/metadata/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "sangria.marshalling.ArrayMapBuilder"
+      },
+      "type" : "sangria.marshalling.ArrayMapBuilder",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.sangria-graphql/sangria-marshalling-api_3/index.json
+++ b/metadata/org.sangria-graphql/sangria-marshalling-api_3/index.json
@@ -1,0 +1,22 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0.8",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_3/$version$/sangria-marshalling-api_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/sangria-graphql/sangria-marshalling-api",
+    "test-code-url" : "https://github.com/sangria-graphql/sangria-marshalling-api/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/sangria-graphql/sangria-marshalling-api_3/$version$/sangria-marshalling-api_3-$version$-javadoc.jar",
+    "description" : "Sangria Marshalling API defines the common marshalling and unmarshalling abstractions used by Sangria GraphQL integrations. It lets JSON or other data-format modules plug into Sangria by converting GraphQL inputs and results to and from Scala values.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.0.8"
+    ],
+    "allowed-packages" : [
+      "sangria.marshalling",
+      "sangria.util"
+    ]
+  }
+]

--- a/stats/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/execution-metrics.json
+++ b/stats/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T19:51:03.359641Z",
+    "library": "org.sangria-graphql:sangria-marshalling-api_3:1.0.8",
+    "starting_commit": "c7977d41d756a1230bcfa89de2c1dd2c2b965915",
+    "ending_commit": "1b707ba6a344fe7889c6ee155f15d5f51fea4d30",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.8",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1318,
+          "missed": 1232,
+          "ratio": 0.516863,
+          "total": 2550
+        },
+        "line": {
+          "covered": 199,
+          "missed": 20,
+          "ratio": 0.908676,
+          "total": 219
+        },
+        "method": {
+          "covered": 149,
+          "missed": 190,
+          "ratio": 0.439528,
+          "total": 339
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 259408,
+      "cached_input_tokens_used": 1492480,
+      "output_tokens_used": 25915,
+      "iterations": 6,
+      "cost_usd": 1.5236,
+      "generated_loc": 296,
+      "tested_library_loc": 199,
+      "metadata_entries": 2,
+      "code_coverage_percent": 90.87
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala",
+      "metadata_file": "metadata/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/stats.json
+++ b/stats/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.8",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1318,
+        "missed" : 1232,
+        "ratio" : 0.516863,
+        "total" : 2550
+      },
+      "line" : {
+        "covered" : 199,
+        "missed" : 20,
+        "ratio" : 0.908676,
+        "total" : 219
+      },
+      "method" : {
+        "covered" : 149,
+        "missed" : 190,
+        "ratio" : 0.439528,
+        "total" : 339
+      }
+    }
+  } ]
+}

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/.gitignore
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.sangria-graphql:sangria-marshalling-api_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/gradle.properties
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.sangria-graphql:sangria-marshalling-api_3:1.0.8
+library.version = 1.0.8
+metadata.dir = org.sangria-graphql/sangria-marshalling-api_3/1.0.8/

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/settings.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.sangria-graphql.sangria-marshalling-api_3_tests'

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
@@ -122,6 +122,34 @@ class Sangria_marshalling_api_3Test {
   }
 
   @Test
+  def inputUnmarshallerVariableMapFactoriesCreateTaggedScalaInputs(): Unit = {
+    val unmarshaller: InputUnmarshaller[Any @@ ScalaInput] = InputUnmarshaller.scalaInputUnmarshaller[Any]
+    val variablesFromPairs: Any @@ ScalaInput = InputUnmarshaller.mapVars(
+      "id" -> 42,
+      "name" -> "Ada"
+    )
+    val variablesFromMap: Any @@ ScalaInput = InputUnmarshaller.mapVars(Map[String, Any](
+      "enabled" -> true,
+      "limit" -> 10
+    ))
+    val emptyVariables: Any @@ ScalaInput = InputUnmarshaller.emptyMapVars
+
+    assertTrue(unmarshaller.isMapNode(variablesFromPairs))
+    assertEquals(Set("id", "name"), unmarshaller.getMapKeys(variablesFromPairs).toSet)
+    assertEquals(Some(42), unmarshaller.getRootMapValue(variablesFromPairs, "id"))
+    assertEquals(Some("Ada"), unmarshaller.getRootMapValue(variablesFromPairs, "name"))
+    assertEquals(None, unmarshaller.getRootMapValue(variablesFromPairs, "missing"))
+
+    assertTrue(unmarshaller.isMapNode(variablesFromMap))
+    assertEquals(Some(true), unmarshaller.getRootMapValue(variablesFromMap, "enabled"))
+    assertEquals(Some(10), unmarshaller.getRootMapValue(variablesFromMap, "limit"))
+
+    assertTrue(unmarshaller.isMapNode(emptyVariables))
+    assertEquals(Nil, unmarshaller.getMapKeys(emptyVariables).toList)
+    assertEquals(None, unmarshaller.getRootMapValue(emptyVariables, "id"))
+  }
+
+  @Test
   def toInputInstancesExposeScalarsThroughScalaInputUnmarshaller(): Unit = {
     assertScalarToInput(ToInput.intInput, 42)
     assertScalarToInput(ToInput.longInput, 42L)

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
@@ -225,6 +225,32 @@ class Sangria_marshalling_api_3Test {
   }
 
   @Test
+  def marshallingUtilUsesEnumNodesForStringEnumInputs(): Unit = {
+    given InputUnmarshaller[NamedInputValue] = new InputUnmarshaller[NamedInputValue] {
+      override def getRootMapValue(node: NamedInputValue, key: String): Option[NamedInputValue] = None
+      override def isMapNode(node: NamedInputValue): Boolean = false
+      override def getMapValue(node: NamedInputValue, key: String): Option[NamedInputValue] = None
+      override def getMapKeys(node: NamedInputValue): Iterable[String] = Nil
+      override def isListNode(node: NamedInputValue): Boolean = false
+      override def getListValue(node: NamedInputValue): Seq[NamedInputValue] = Nil
+      override def isDefined(node: NamedInputValue): Boolean = true
+      override def isScalarNode(node: NamedInputValue): Boolean = true
+      override def isEnumNode(node: NamedInputValue): Boolean = node.isEnum
+      override def isVariableNode(node: NamedInputValue): Boolean = false
+      override def getScalarValue(node: NamedInputValue): Any = node.value
+      override def getScalaScalarValue(node: NamedInputValue): Any = node.value
+      override def getVariableName(node: NamedInputValue): String = throw new IllegalArgumentException("variables are not supported")
+      override def render(node: NamedInputValue): String = node.value.toString
+    }
+
+    val marshaller: LabeledScalarMarshaller = new LabeledScalarMarshaller
+    given ResultMarshallerForType[String] = SimpleResultMarshallerForType[String](marshaller)
+
+    assertEquals("enum:Conversion:ACTIVE", MarshallingUtil.convert[NamedInputValue, String](NamedInputValue("ACTIVE", isEnum = true)))
+    assertEquals("scalar:Conversion:15", MarshallingUtil.convert[NamedInputValue, String](NamedInputValue(15, isEnum = true)))
+  }
+
+  @Test
   def marshallingUtilRejectsVariableNodesDuringConversion(): Unit = {
     given InputUnmarshaller[VariableInput] = new InputUnmarshaller[VariableInput] {
       override def getRootMapValue(node: VariableInput, key: String): Option[VariableInput] = None
@@ -292,5 +318,23 @@ class Sangria_marshalling_api_3Test {
     assertEquals(value, unmarshaller.getScalaScalarValue(rawValue))
   }
 
+  private final class LabeledScalarMarshaller extends ResultMarshaller {
+    override type Node = String
+    override type MapBuilder = Vector[(String, Node)]
+
+    override def emptyMapNode(keys: Seq[String]): MapBuilder = Vector.empty
+    override def addMapNodeElem(builder: MapBuilder, key: String, value: Node, optional: Boolean): MapBuilder = builder :+ (key -> value)
+    override def mapNode(builder: MapBuilder): Node = builder.map { case (key, value) => s"$key=$value" }.mkString("map(", ",", ")")
+    override def mapNode(keyValues: Seq[(String, Node)]): Node = keyValues.map { case (key, value) => s"$key=$value" }.mkString("map(", ",", ")")
+    override def arrayNode(values: Vector[Node]): Node = values.mkString("list(", ",", ")")
+    override def optionalArrayNodeValue(value: Option[Node]): Node = value.getOrElse(nullNode)
+    override def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]): Node = s"scalar:$typeName:$value"
+    override def enumNode(value: String, typeName: String): Node = s"enum:$typeName:$value"
+    override def nullNode: Node = "null"
+    override def renderCompact(node: Node): String = node
+    override def renderPretty(node: Node): String = node
+  }
+
+  private final case class NamedInputValue(value: Any, isEnum: Boolean)
   private final case class VariableInput(name: String)
 }

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
@@ -6,11 +6,263 @@
  */
 package org_sangria_graphql.sangria_marshalling_api_3
 
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNull, assertSame, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
+import sangria.marshalling.*
+import sangria.marshalling.MarshallingUtil.ResultMarshallerOps
+import sangria.util.tag.@@
+
+import scala.collection.immutable.ListMap
+import scala.util.Try
 
 class Sangria_marshalling_api_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def arrayMapBuilderPreservesDeclaredFieldOrderAndExposesCollectionViews(): Unit = {
+    val builder: ArrayMapBuilder[Int] = new ArrayMapBuilder[Int](Seq("id", "name", "active"))
+      .add("active", 1)
+      .add("id", 2)
+      .add("active", 3)
+
+    val expectedEntries: Seq[(String, Int)] = Seq("id" -> 2, "active" -> 3)
+    assertEquals(expectedEntries.toList, builder.toList)
+    assertEquals(expectedEntries.toVector, builder.toVector)
+    assertEquals(expectedEntries, builder.toSeq)
+    assertEquals(ListMap("id" -> 2, "active" -> 3), builder.toListMap)
+    assertEquals(Map("id" -> 2, "active" -> 3), builder.toMap)
+    assertTrue(builder.exists(_ == ("active" -> 3)))
+    assertFalse(builder.exists(_._1 == "name"))
+
+    val exception: NoSuchElementException = assertThrows(
+      classOf[NoSuchElementException],
+      () => builder.add("unknown", 4)
+    )
+    assertEquals("key not found: unknown", exception.getMessage)
   }
+
+  @Test
+  def scalaResultMarshallerBuildsScalarListMapAndOptionalNodes(): Unit = {
+    val marshaller: ScalaResultMarshaller = new ScalaResultMarshaller
+    val builder: marshaller.MapBuilder = marshaller.emptyMapNode(Seq("second", "first", "third"))
+    val withFirst: marshaller.MapBuilder = marshaller.addMapNodeElem(builder, "first", 1, optional = false)
+    val withBoth: marshaller.MapBuilder = marshaller.addMapNodeElem(withFirst, "second", "two", optional = true)
+
+    assertEquals("value", marshaller.scalarNode("value", "String", Set.empty))
+    assertEquals("ADMIN", marshaller.enumNode("ADMIN", "Role"))
+    assertEquals(Vector(1, "two", true), marshaller.arrayNode(Vector(1, "two", true)))
+    assertEquals("present", marshaller.optionalArrayNodeValue(Some("present")))
+    assertNull(marshaller.optionalArrayNodeValue(None))
+    assertNull(marshaller.nullNode)
+    assertEquals(ListMap("second" -> "two", "first" -> 1), marshaller.mapNode(withBoth))
+    assertEquals(ListMap("name" -> "Ada", "score" -> 99), marshaller.mapNode(Seq("name" -> "Ada", "score" -> 99)))
+    assertEquals("ListMap(name -> Ada, score -> 99)", marshaller.renderCompact(ListMap("name" -> "Ada", "score" -> 99)))
+    assertEquals("42", marshaller.renderPretty(42))
+    assertEquals(Set.empty[MarshallerCapability], marshaller.capabilities)
+  }
+
+  @Test
+  def coercedScalaMarshallerKeepsRawValuesAndWrapsOptionalMapMembers(): Unit = {
+    val marshaller: CoercedScalaResultMarshaller = CoercedScalaResultMarshaller.default
+    val builder: marshaller.MapBuilder = marshaller.emptyMapNode(Seq("required", "optional", "missing"))
+    val withRequired: marshaller.MapBuilder = marshaller.addMapNodeElem(builder, "required", "raw", optional = false)
+    val withOptional: marshaller.MapBuilder = marshaller.addMapNodeElem(withRequired, "optional", 10, optional = true)
+    val complete: marshaller.MapBuilder = marshaller.addMapNodeElem(withOptional, "missing", None, optional = true)
+
+    assertEquals("raw", marshaller.rawScalarNode("raw"))
+    assertEquals(Vector("a", 2), marshaller.arrayNode(Vector("a", 2)))
+    assertEquals(Some("element"), marshaller.optionalArrayNodeValue(Some("element")))
+    assertEquals(None, marshaller.optionalArrayNodeValue(None))
+    assertEquals(None, marshaller.nullNode)
+    assertEquals(ListMap("required" -> "raw", "optional" -> Some(10), "missing" -> None), marshaller.mapNode(complete))
+    assertEquals(ListMap("direct" -> true), marshaller.mapNode(Seq("direct" -> true)))
+    assertEquals("Some(value)", marshaller.renderPretty(Some("value")))
+
+    val scalarException: IllegalArgumentException = assertThrows(
+      classOf[IllegalArgumentException],
+      () => marshaller.scalarNode("not-raw", "String", Set.empty)
+    )
+    assertEquals("Only raw values expected in `RawResultMarshaller`!", scalarException.getMessage)
+    assertThrows(classOf[IllegalArgumentException], () => marshaller.enumNode("ADMIN", "Role"))
+  }
+
+  @Test
+  def scalaInputUnmarshallerClassifiesMapsListsScalarsNullsAndUnsupportedVariables(): Unit = {
+    val unmarshaller: InputUnmarshaller[Any @@ ScalaInput] = InputUnmarshaller.scalaInputUnmarshaller[Any]
+    val node: Any @@ ScalaInput = ScalaInput.scalaInput(ListMap(
+      "profile" -> ListMap("name" -> "Ada", "age" -> 37),
+      "roles" -> Vector("ADMIN", "USER"),
+      "active" -> true,
+      "empty" -> null
+    ))
+
+    assertTrue(unmarshaller.isMapNode(node))
+    assertEquals(List("profile", "roles", "active", "empty"), unmarshaller.getMapKeys(node).toList)
+    assertEquals(unmarshaller.getMapValue(node, "profile"), unmarshaller.getRootMapValue(node, "profile"))
+    assertEquals(None, unmarshaller.getMapValue(node, "missing"))
+
+    val profile: Any @@ ScalaInput = unmarshaller.getMapValue(node, "profile").get
+    assertTrue(unmarshaller.isMapNode(profile))
+    assertEquals(Some("Ada"), unmarshaller.getMapValue(profile, "name"))
+
+    val roles: Any @@ ScalaInput = unmarshaller.getMapValue(node, "roles").get
+    assertTrue(unmarshaller.isListNode(roles))
+    assertEquals(Vector("ADMIN", "USER"), unmarshaller.getListValue(roles).toVector)
+
+    val active: Any @@ ScalaInput = unmarshaller.getMapValue(node, "active").get
+    assertTrue(unmarshaller.isScalarNode(active))
+    assertTrue(unmarshaller.isEnumNode(active))
+    assertEquals(true, unmarshaller.getScalarValue(active))
+    assertEquals(true, unmarshaller.getScalaScalarValue(active))
+    assertEquals("true", unmarshaller.render(active))
+
+    val empty: Any @@ ScalaInput = unmarshaller.getMapValue(node, "empty").getOrElse(null)
+    assertFalse(unmarshaller.isDefined(empty))
+    assertEquals("null", unmarshaller.render(empty))
+    assertFalse(unmarshaller.isVariableNode(active))
+    assertThrows(classOf[IllegalArgumentException], () => unmarshaller.getVariableName(active))
+  }
+
+  @Test
+  def toInputInstancesExposeScalarsThroughScalaInputUnmarshaller(): Unit = {
+    assertScalarToInput(ToInput.intInput, 42)
+    assertScalarToInput(ToInput.longInput, 42L)
+    assertScalarToInput(ToInput.floatInput, 2.5d)
+    assertScalarToInput(ToInput.booleanInput, true)
+    assertScalarToInput(ToInput.stringInput, "native")
+    assertScalarToInput(ToInput.bigIntInput, BigInt("12345678901234567890"))
+    assertScalarToInput(ToInput.bigDecimalInput, BigDecimal("12345.6789"))
+
+    val taggedList: List[Int] @@ ScalaInput = ScalaInput.scalaInput(List(1, 2, 3))
+    val (rawList, listUnmarshaller) = ToInput.normalScalaInput[List[Int]].toInput(taggedList)
+    assertEquals(List(1, 2, 3), listUnmarshaller.getListValue(rawList).toList)
+  }
+
+  @Test
+  def fromInputInstancesReadCoercedScalarOptionalSequenceAndMapResults(): Unit = {
+    val scalarInput: FromInput[String @@ FromInput.CoercedScalaResult] = FromInput.coercedScalaInput[String]
+    assertEquals("scalar", scalarInput.fromResult("scalar".asInstanceOf[scalarInput.marshaller.Node]))
+    assertSame(CoercedScalaResultMarshaller.default, scalarInput.marshaller)
+
+    val mapInput: FromInput[Map[String, Any]] = FromInput.defaultInput[Any]
+    val mapResult: mapInput.marshaller.Node = Map("id" -> 1, "name" -> "Ada").asInstanceOf[mapInput.marshaller.Node]
+    assertEquals(Map("id" -> 1, "name" -> "Ada"), mapInput.fromResult(mapResult))
+
+    val optionInput: FromInput[Option[String @@ FromInput.CoercedScalaResult]] =
+      FromInput.optionInput[String @@ FromInput.CoercedScalaResult](using scalarInput)
+    assertEquals(Some("configured"), optionInput.fromResult(Some("configured").asInstanceOf[optionInput.marshaller.Node]))
+    assertEquals(None, optionInput.fromResult(None.asInstanceOf[optionInput.marshaller.Node]))
+
+    val seqInput: FromInput.SeqFromInput[String @@ FromInput.CoercedScalaResult] =
+      FromInput.seqInput[String @@ FromInput.CoercedScalaResult](using scalarInput)
+    val seqResult: seqInput.marshaller.Node = Vector("first", Some("second"), None).asInstanceOf[seqInput.marshaller.Node]
+    assertEquals(Vector("first", Some("second"), None), seqInput.fromResult(seqResult).toVector)
+
+    val inputObjectInput: FromInput[(String @@ FromInput.CoercedScalaResult) @@ FromInput.InputObjectResult] =
+      FromInput.inputObjectResultInput[String @@ FromInput.CoercedScalaResult](using scalarInput)
+    assertEquals("object-field", inputObjectInput.fromResult("object-field".asInstanceOf[inputObjectInput.marshaller.Node]))
+  }
+
+  @Test
+  def marshallingUtilConvertsNestedScalaInputAndProvidesMarshallerConvenienceOps(): Unit = {
+    val marshaller: ScalaResultMarshaller = new ScalaResultMarshaller
+    val builtNode: marshaller.Node = marshaller.map(
+      "id" -> marshaller.fromInt(7),
+      "name" -> marshaller.fromString("Ada"),
+      "flags" -> marshaller.list(marshaller.fromBoolean(true), marshaller.fromEnumString("ADMIN")),
+      "amount" -> marshaller.fromBigInt(BigDecimal("10.50"))
+    )
+    assertEquals(ListMap("id" -> 7, "name" -> "Ada", "flags" -> Vector(true, "ADMIN"), "amount" -> BigDecimal("10.50")), builtNode)
+
+    val input: Any @@ ScalaInput = ScalaInput.scalaInput(ListMap(
+      "profile" -> ListMap("name" -> "Ada", "score" -> BigInt(99)),
+      "tags" -> Vector("graphql", "native-image"),
+      "enabled" -> true,
+      "unset" -> null
+    ))
+    val converted: marshaller.Node = marshaller.fromInput(input)
+    assertEquals(
+      ListMap(
+        "profile" -> ListMap("name" -> "Ada", "score" -> BigInt(99)),
+        "tags" -> Vector("graphql", "native-image"),
+        "enabled" -> true,
+        "unset" -> null
+      ),
+      converted
+    )
+
+    val convertedWithContextBounds: Any @@ ScalaInput = MarshallingUtil.convert[Any @@ ScalaInput, Any @@ ScalaInput](input)(using
+      InputUnmarshaller.scalaInputUnmarshaller[Any],
+      scalaMarshalling.ScalaMarshallerForType
+    )
+    assertEquals(converted, convertedWithContextBounds)
+  }
+
+  @Test
+  def marshallingUtilRejectsVariableNodesDuringConversion(): Unit = {
+    given InputUnmarshaller[VariableInput] = new InputUnmarshaller[VariableInput] {
+      override def getRootMapValue(node: VariableInput, key: String): Option[VariableInput] = None
+      override def isMapNode(node: VariableInput): Boolean = false
+      override def getMapValue(node: VariableInput, key: String): Option[VariableInput] = None
+      override def getMapKeys(node: VariableInput): Iterable[String] = Nil
+      override def isListNode(node: VariableInput): Boolean = false
+      override def getListValue(node: VariableInput): Seq[VariableInput] = Nil
+      override def isDefined(node: VariableInput): Boolean = true
+      override def isScalarNode(node: VariableInput): Boolean = false
+      override def isEnumNode(node: VariableInput): Boolean = false
+      override def isVariableNode(node: VariableInput): Boolean = true
+      override def getScalarValue(node: VariableInput): Any = node.name
+      override def getScalaScalarValue(node: VariableInput): Any = node.name
+      override def getVariableName(node: VariableInput): String = node.name
+      override def render(node: VariableInput): String = s"$$${node.name}"
+    }
+    given ResultMarshallerForType[Any] = SimpleResultMarshallerForType[Any](new ScalaResultMarshaller)
+
+    val exception: IllegalArgumentException = assertThrows(
+      classOf[IllegalArgumentException],
+      () => MarshallingUtil.convert[VariableInput, Any](VariableInput("viewerId"))
+    )
+    assertEquals(
+      "Variable 'viewerId' found in the input, but variables are not supported in conversion!",
+      exception.getMessage
+    )
+  }
+
+  @Test
+  def symmetricMarshallerCapabilitiesParsingErrorsAndParsersUsePublicContracts(): Unit = {
+    val defaultSymmetric: SymmetricMarshaller[Any] = SymmetricMarshaller.defaultInput
+    assertSame(scalaMarshalling.scalaResultMarshaller, defaultSymmetric.marshaller)
+    assertTrue(defaultSymmetric.inputUnmarshaller.isMapNode(Map("key" -> "value")))
+
+    val explicitSymmetric: SymmetricMarshaller[Any @@ ScalaInput] = SymmetricMarshaller.symmetric[Any @@ ScalaInput](using
+      scalaMarshalling.ScalaMarshallerForType,
+      InputUnmarshaller.scalaInputUnmarshaller[Any]
+    )
+    assertSame(scalaMarshalling.scalaResultMarshaller, explicitSymmetric.marshaller)
+    assertTrue(explicitSymmetric.inputUnmarshaller.isListNode(ScalaInput.scalaInput(Vector(1, 2))))
+
+    assertTrue(DateSupport.isInstanceOf[StandardMarshallerCapability])
+    assertTrue(CalendarSupport.isInstanceOf[StandardMarshallerCapability])
+    assertTrue(BlobSupport.isInstanceOf[StandardMarshallerCapability])
+    assertEquals("DateSupport", DateSupport.toString)
+    assertEquals("CalendarSupport", CalendarSupport.productPrefix)
+    assertNotEquals(DateSupport, BlobSupport)
+
+    val parsingError: InputParsingError = InputParsingError(Vector("first error", "second error"))
+    assertEquals(Vector("first error", "second error"), parsingError.errors)
+    assertEquals("first error\nsecond error", parsingError.getMessage)
+    assertEquals(parsingError, parsingError.copy())
+
+    val parser: InputParser[Int] = (str: String) => Try(str.toInt).filter(_ >= 0)
+    assertEquals(123, parser.parse("123").get)
+    assertTrue(parser.parse("not-an-int").isFailure)
+    assertTrue(parser.parse("-1").isFailure)
+  }
+
+  private def assertScalarToInput[T](toInput: ToInput[T, T @@ ScalaInput], value: T): Unit = {
+    val (rawValue, unmarshaller) = toInput.toInput(value)
+    assertTrue(unmarshaller.isScalarNode(rawValue))
+    assertEquals(value, unmarshaller.getScalarValue(rawValue))
+    assertEquals(value, unmarshaller.getScalaScalarValue(rawValue))
+  }
+
+  private final case class VariableInput(name: String)
 }

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/src/test/scala/org_sangria_graphql/sangria_marshalling_api_3/Sangria_marshalling_api_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sangria_graphql.sangria_marshalling_api_3
+
+import org.junit.jupiter.api.Test
+
+class Sangria_marshalling_api_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/user-code-filter.json
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "sangria.marshalling.**"
+    },
+    {
+      "includeClasses": "sangria.util.**"
+    }
+  ]
+}

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/user-code-filter.json
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/user-code-filter.json
@@ -1,13 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "sangria.marshalling.**"
+      "includeClasses" : "sangria.marshalling.**"
     },
     {
-      "includeClasses": "sangria.util.**"
+      "includeClasses" : "sangria.util.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5060

This PR introduces tests and metadata for org.sangria-graphql:sangria-marshalling-api_3:1.0.8, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 259408
- Cached input tokens: 1492480
- Output tokens: 25915
- Metadata entries: 2
- Iterations: 6
- Library coverage percentage: 90.87
- Generated lines of code: 296
- Tested library lines of code: 199

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `83d4ae997db68eee6efa92ecbff71b962ab028e4`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1318/2550 (51.69%)
- Line: 199/219 (90.87%)
- Method: 149/339 (43.95%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
