### PR TITLE
[GenAI] Add support for org.threeten:threetenbp:1.7.0 using gpt-5.5

### DIFF
--- a/metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json
+++ b/metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json
@@ -1,0 +1,13 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.threeten.bp.zone.TzdbZoneRulesProvider"
+      },
+      "glob": "org/threeten/bp/TZDB.dat"
+    },
+    {
+      "bundle": "org.threeten.bp.format.ChronologyText"
+    }
+  ]
+}

--- a/metadata/org.threeten/threetenbp/index.json
+++ b/metadata/org.threeten/threetenbp/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.7.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/threeten/threetenbp/$version$/threetenbp-$version$-sources.jar",
+    "repository-url" : "https://github.com/ThreeTen/threetenbp",
+    "test-code-url" : "https://github.com/ThreeTen/threetenbp/tree/v$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/threeten/threetenbp/$version$/threetenbp-$version$-javadoc.jar",
+    "description" : "ThreeTen-Backport provides a backport of the Java SE 8 date and time API to Java SE 6 and 7 in the org.threeten.bp package. It includes date, time, duration, formatting, calendar system, and time-zone support for applications that cannot use java.time directly.",
+    "tested-versions" : [
+      "1.7.0"
+    ],
+    "allowed-packages" : [
+      "org.threeten.bp"
+    ]
+  }
+]

--- a/stats/org.threeten/threetenbp/1.7.0/execution-metrics.json
+++ b/stats/org.threeten/threetenbp/1.7.0/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T19:55:19.072822Z",
+    "library": "org.threeten:threetenbp:1.7.0",
+    "starting_commit": "93e79b2f476a1f41223b034e66a3121548eca8a9",
+    "ending_commit": "9c822aeb6fc840fb00382835bfd199654974289c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.7.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7576,
+          "missed": 48653,
+          "ratio": 0.134735,
+          "total": 56229
+        },
+        "line": {
+          "covered": 1515,
+          "missed": 9038,
+          "ratio": 0.143561,
+          "total": 10553
+        },
+        "method": {
+          "covered": 339,
+          "missed": 1919,
+          "ratio": 0.150133,
+          "total": 2258
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 103477,
+      "cached_input_tokens_used": 937984,
+      "output_tokens_used": 12915,
+      "iterations": 3,
+      "cost_usd": 0.8564,
+      "generated_loc": 101,
+      "tested_library_loc": 1515,
+      "metadata_entries": 2,
+      "code_coverage_percent": 14.36
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java",
+      "metadata_file": "metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.threeten/threetenbp/1.7.0/stats.json
+++ b/stats/org.threeten/threetenbp/1.7.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.7.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7576,
+        "missed" : 48653,
+        "ratio" : 0.134735,
+        "total" : 56229
+      },
+      "line" : {
+        "covered" : 1515,
+        "missed" : 9038,
+        "ratio" : 0.143561,
+        "total" : 10553
+      },
+      "method" : {
+        "covered" : 339,
+        "missed" : 1919,
+        "ratio" : 0.150133,
+        "total" : 2258
+      }
+    }
+  } ]
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/.gitignore
+++ b/tests/src/org.threeten/threetenbp/1.7.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.threeten/threetenbp/1.7.0/build.gradle
+++ b/tests/src/org.threeten/threetenbp/1.7.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.threeten:threetenbp:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/gradle.properties
+++ b/tests/src/org.threeten/threetenbp/1.7.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.threeten:threetenbp:1.7.0
+library.version = 1.7.0
+metadata.dir = org.threeten/threetenbp/1.7.0/

--- a/tests/src/org.threeten/threetenbp/1.7.0/settings.gradle
+++ b/tests/src/org.threeten/threetenbp/1.7.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.threeten.threetenbp_tests'

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_threeten.threetenbp;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.threeten.bp.chrono.Chronology;
+import org.threeten.bp.chrono.IsoChronology;
+import org.threeten.bp.chrono.JapaneseChronology;
+import org.threeten.bp.chrono.MinguoChronology;
+import org.threeten.bp.chrono.ThaiBuddhistChronology;
+
+public class ChronologyTest {
+    @Test
+    void resolvesChronologyFromUnicodeCalendarLocaleExtension() {
+        assertSame(ThaiBuddhistChronology.INSTANCE, Chronology.ofLocale(Locale.forLanguageTag("th-TH-u-ca-buddhist")));
+        assertSame(JapaneseChronology.INSTANCE, Chronology.ofLocale(Locale.forLanguageTag("ja-JP-u-ca-japanese")));
+        assertSame(MinguoChronology.INSTANCE, Chronology.ofLocale(Locale.forLanguageTag("zh-TW-u-ca-roc")));
+    }
+
+    @Test
+    void resolvesIsoChronologyWhenLocaleHasNoCalendarExtension() {
+        assertSame(IsoChronology.INSTANCE, Chronology.ofLocale(Locale.US));
+    }
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/DateTimeFormatterBuilderInnerChronoPrinterParserTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/DateTimeFormatterBuilderInnerChronoPrinterParserTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_threeten.threetenbp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.threeten.bp.chrono.ThaiBuddhistDate;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.format.DateTimeFormatterBuilder;
+import org.threeten.bp.format.TextStyle;
+
+public class DateTimeFormatterBuilderInnerChronoPrinterParserTest {
+    @Test
+    void formatsChronologyTextUsingResourceBundle() {
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendChronologyText(TextStyle.FULL)
+                .toFormatter(Locale.ENGLISH);
+
+        String formatted = formatter.format(ThaiBuddhistDate.of(2567, 1, 1));
+
+        assertEquals("Buddhist Calendar", formatted);
+    }
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ThreetenbpTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ThreetenbpTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_threeten.threetenbp;
+
+import org.junit.jupiter.api.Test;
+
+class ThreetenbpTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ThreetenbpTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ThreetenbpTest.java
@@ -8,7 +8,7 @@ package org_threeten.threetenbp;
 
 import org.junit.jupiter.api.Test;
 
-class ThreetenbpTest {
+public class ThreetenbpTest {
     @Test
     void test() throws Exception {
         System.out.println("This is just a placeholder, implement your test");

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/TzdbZoneRulesProviderTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/TzdbZoneRulesProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_threeten.threetenbp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NavigableMap;
+
+import org.junit.jupiter.api.Test;
+import org.threeten.bp.Instant;
+import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.zone.TzdbZoneRulesProvider;
+import org.threeten.bp.zone.ZoneRules;
+import org.threeten.bp.zone.ZoneRulesProvider;
+
+public class TzdbZoneRulesProviderTest {
+    private static final String SAMPLE_ZONE_ID = "Europe/London";
+
+    @Test
+    void loadsBundledTzdbDataThroughDefaultClassLoader() {
+        TzdbZoneRulesProvider provider = new TzdbZoneRulesProvider();
+        assertEquals("TZDB", provider.toString());
+
+        registerProviderIfServiceLoadingDidNotRegisterIt(provider);
+
+        assertTrue(ZoneRulesProvider.getAvailableZoneIds().contains(SAMPLE_ZONE_ID));
+        NavigableMap<String, ZoneRules> versions = ZoneRulesProvider.getVersions(SAMPLE_ZONE_ID);
+        assertFalse(versions.isEmpty());
+
+        ZoneRules rules = ZoneRulesProvider.getRules(SAMPLE_ZONE_ID, false);
+        assertEquals(ZoneOffset.UTC, rules.getOffset(Instant.parse("2024-01-01T00:00:00Z")));
+    }
+
+    private static void registerProviderIfServiceLoadingDidNotRegisterIt(ZoneRulesProvider provider) {
+        if (!ZoneRulesProvider.getAvailableZoneIds().contains(SAMPLE_ZONE_ID)) {
+            ZoneRulesProvider.registerProvider(provider);
+        }
+    }
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
+++ b/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.threeten.bp.**"
+      "includeClasses" : "org.threeten.bp.**"
     }
   ]
 }

--- a/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
+++ b/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.threeten.bp.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4641

This PR introduces tests and metadata for org.threeten:threetenbp:1.7.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 103477
- Cached input tokens: 937984
- Output tokens: 12915
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 14.36
- Generated lines of code: 101
- Tested library lines of code: 1515

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d1d8ff09661a270e21076ee9fd4112ca62d43d5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 3/3 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)
- Resources: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 7576/56229 (13.47%)
- Line: 1515/10553 (14.36%)
- Method: 339/2258 (15.01%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
