### PR TITLE
Improve native test verification fallback

### DIFF
--- a/forge/docs/dynamic-access-workflow.md
+++ b/forge/docs/dynamic-access-workflow.md
@@ -204,19 +204,31 @@ output_dir = tests/src/<group>/<artifact>/<version>/build/natively-collected/<cl
 ```
 
 where `<class-key>` is a sanitized form of the class name the per-class
-iteration just resolved or advanced. The gate iteratively runs the trace
-loop, executes
-`./gradlew nativeTest -PmetadataConfigDirs=<output_dir>`, and falls
-through codex / Pi recovery until `nativeTest` passes or its
-`max-native-test-verification-iterations` budget (default 100) is
-exhausted.
+iteration just resolved or advanced. The gate always starts with the
+normal JVM-agent metadata path:
+
+```text
+./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar
+./gradlew test -Pcoordinates=<g:a:v>
+```
+
+If the coordinate passes, the gate returns `PASSED` without native tracing.
+If the test fails before `nativeTest`, the gate routes directly to Codex
+because tracing cannot repair compilation or JVM-mode test failures. Native
+tracing is used only as a fallback when `nativeTest` still fails after
+JVM-agent metadata was generated. The fallback runs bounded
+`runNativeTraceImage` cycles, feeds accepted trace dirs back through
+`metadataConfigDirs`, and routes stalled, exhausted, timed-out, or otherwise
+failed tracing to Codex. Pi is not part of this gate.
 
 Effects within this workflow:
 
-1. The contents of the gate's `output_dir` are added to the agent's
-   read-only context for subsequent class iterations.
+1. The contents of the gate's `output_dir`, if any trace-backed metadata
+   was merged there, are added to the agent's read-only context for
+   subsequent class iterations. The directory may remain empty when
+   JVM-agent metadata alone made the native tests pass.
 2. The dynamic-access coverage report is regenerated **after** the gate so
-   that any call sites covered by traced or codex/Pi-supplied metadata are
+   that any call sites covered by JVM-agent, traced, or Codex-supplied metadata are
    reflected in the next class's prompt delta.
 3. **A `FAILED` gate result aborts the workflow with `RUN_STATUS_FAILURE`.**
    Native Image must always work; partial dynamic-access coverage with a
@@ -297,8 +309,8 @@ useful.
 | `ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py` | The control loop described in section 6. |
 | `utility_scripts/source_context.py` | `populate_artifact_urls`, `normalize_source_context_types`, `prepare_source_contexts`, `resolve_test_source_layout`. |
 | `utility_scripts/dynamic_access_report.py` | `load_dynamic_access_coverage_report`, `compute_class_delta`, `format_call_sites`. |
-| `utility_scripts/native_metadata_exploration.py` | `run_native_metadata_exploration` — the trace loop invoked by the verification gate and as a precondition to codex fixup at finalization. See [native-metadata-exploration.md](native-metadata-exploration.md). |
-| `utility_scripts/native_test_verification.py` | `verify_native_test_passes` — the per-class gate invoked after every class with coverage gain. See [native-test-verification.md](native-test-verification.md). |
+| `utility_scripts/native_metadata_exploration.py` | `run_native_metadata_exploration` — the standalone trace loop used as a precondition to codex fixup at finalization, and the Gradle task contract reused by the verification gate's fallback. See [native-metadata-exploration.md](native-metadata-exploration.md). |
+| `utility_scripts/native_test_verification.py` | `verify_native_test_passes` — the per-class gate invoked after every class with coverage gain; it runs JVM-agent metadata first, native tracing only as fallback, and Codex last. See [native-test-verification.md](native-test-verification.md). |
 | `prompt_templates/dynamic_access/dynamic-access-iteration.md` | Per-class prompt template. |
 | Reachability-repo Gradle tasks | `scaffold`, `populateArtifactURLs`, `generateDynamicAccessCoverageReport`, `test`, `nativeTest`, `generateMetadata`, `generateLibraryStats`. |
 

--- a/forge/docs/fix-java-run-fail.md
+++ b/forge/docs/fix-java-run-fail.md
@@ -239,15 +239,18 @@ Rules:
 
 ### Terminal native-test verification gate
 
-After the agent (or the codex/Pi cascade) produces its final edit, the
-runtime fix workflow invokes the
+After the agent (or the configured post-generation intervention) produces
+its final edit, the runtime fix workflow invokes the
 [native test verification gate](../docs/native-test-verification.md) once
 with `output_dir = tests/src/<group>/<artifact>/<version>/build/natively-collected/_global_/`
-as the workflow's terminal success criterion. The gate iteratively re-runs
-the trace loop and `./gradlew nativeTest` until the test passes or the
-`max-native-test-verification-iterations` budget is exhausted. A `FAILED`
-gate result aborts the workflow with `RUN_STATUS_FAILURE`; partial
-recovery is not an acceptable terminal state. This is the same component
-used by the [dynamic-access workflow](../docs/dynamic-access-workflow.md)
-per-class gate, configured with a single global output directory instead
-of a per-class one.
+as the workflow's terminal success criterion. The gate first runs
+`./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`,
+then runs `./gradlew test -Pcoordinates=<g:a:v>`. If native testing still
+fails, it uses native tracing as a fallback; if tracing stalls, exhausts its
+budget, times out, or fails for a non-metadata reason, Codex is the final
+recovery step. A `FAILED` gate result aborts the workflow with
+`RUN_STATUS_FAILURE`; partial recovery is not an acceptable terminal state.
+This is the same component used by the
+[dynamic-access workflow](../docs/dynamic-access-workflow.md) per-class
+gate, configured with a single global output directory instead of a
+per-class one.

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -226,9 +226,10 @@ labels after publishing the part PR.
   `native_trace_collect` intervention.
 - [Native test verification gate](native-test-verification.md) —
   reusable component that asserts `./gradlew nativeTest` passes for a
-  coordinate by composing the trace loop with codex/Pi recovery. Used as
-  the per-class gate in the dynamic-access workflow and the terminal
-  gate in the fix-native-run workflow.
+  coordinate by running JVM-agent metadata collection first, using native
+  tracing only as fallback, and routing final recovery to Codex. Used as the
+  per-class gate in the dynamic-access workflow and the terminal gate in the
+  fix-native-run workflow.
 - [Java compilation / runtime failure fix workflow](fix-java-run-fail.md)
   — version-bump fix workflow shared by `fix_javac_fail` and
   `fix_java_run_fail`. Strategies in this family route through the

--- a/forge/docs/native-metadata-exploration.md
+++ b/forge/docs/native-metadata-exploration.md
@@ -43,9 +43,10 @@ At a glance:
 >
 > The deterministic loop specified here is also composed into the
 > [native test verification gate](native-test-verification.md), which
-> wraps it with `nativeTest` execution and codex/Pi recovery so callers
-> can assert "Native Image tests pass" rather than just "metadata was
-> collected".
+> runs JVM-agent metadata collection first, uses this trace contract only as
+> a fallback when `nativeTest` still fails, and routes terminal recovery to
+> Codex so callers can assert "Native Image tests pass" rather than just
+> "metadata was collected".
 
 ## 1. Purpose
 
@@ -282,9 +283,10 @@ whenever earlier iterations produced accepted traces; callers must inspect
 both `failure` and `output_dir`.
 
 The module must not depend on any workflow strategy or intervention.
-Sequencing with `generateMetadata`, codex fixup, agent hand-off, etc. is
-the responsibility of the `native_trace_collect` intervention that wraps
-it (see §8 and §9).
+Sequencing with `generateMetadata`, native-test verification, codex fixup,
+agent hand-off, etc. is the responsibility of the caller that wraps it
+(see §8 and §9). In the native-test verification gate, that caller runs
+JVM-agent metadata first and reaches this trace loop only as fallback.
 
 ## 7. Required Gradle Support
 

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -1,7 +1,7 @@
 # Native Test Verification — Specification
 
-> Built on top of the [Native metadata exploration](native-metadata-exploration.md)
-> trace loop introduced in
+> Uses the Gradle native-tracing task contract from
+> [Native metadata exploration](native-metadata-exploration.md), introduced in
 > [oracle/graalvm-reachability-metadata#3379](https://github.com/oracle/graalvm-reachability-metadata/pull/3379).
 >
 > **See also:** [Dynamic-access workflow](dynamic-access-workflow.md) ·
@@ -11,26 +11,22 @@
 ## 1. Purpose
 
 The verification gate ensures that the test binary passes on Native Image
-for a given coordinate. Each outer cycle invokes a single Gradle command
-— `./gradlew runNativeTraceImage` — whose binary is built with
-`-H:+MetadataTracingSupport` (collects metadata) plus
-`--exact-reachability-metadata` and
-`-H:MissingRegistrationReportingMode=Exit` (causes
-`ExitStatus.MISSING_METADATA` 172 on missing metadata instead of throwing).
-A single binary execution therefore produces both signals: a per-cycle
-trace dir and the binary's own exit code. The gate routes on that exit
-code:
+for a given coordinate. The ordered recovery contract is:
 
-- `0`              -> `PASSED` (or `PASSED_WITH_INTERVENTION` if codex ran
-  earlier in this gate invocation).
-- `172`            -> metadata gap; append the cycle's trace dir to the
-  running `metadataConfigDirs` so the next cycle's build sees it, then
-  continue. If later `172` cycles stop producing new trace metadata
-  entries, retry once and then route to codex with the native failure log.
-- any other non-0  -> code/test failure; route to codex (the coding
-  agent). Codex finishes it: on codex success return
-  `PASSED_WITH_INTERVENTION`; on codex failure return `FAILED`. The gate
-  does **not** re-verify after codex.
+1. Run the normal JVM `native-image-agent` path first via
+   `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
+   This is the primary metadata source and must not be skipped.
+2. Run the regular coordinate validation (`./gradlew test -Pcoordinates=<g:a:v>`).
+   If the native tests pass, return `PASSED`.
+3. If native testing still fails after JVM-agent metadata was generated, use
+   native tracing as a fallback. Each fallback cycle invokes
+   `./gradlew runNativeTraceImage`; the trace binary is built with
+   `-H:+MetadataTracingSupport`, `--exact-reachability-metadata`, and
+   `-H:MissingRegistrationReportingMode=Exit`.
+4. If native tracing converges, merge the accepted trace dirs into
+   `output_dir` and return `PASSED`. If tracing stalls, exhausts its budget,
+   or fails for a non-metadata reason, route the accumulated diagnostics to
+   codex. Codex is the final recovery step.
 
 Pi is **not** invoked. Removing failing tests would mask exactly the code
 issues that must surface to the coding agent.
@@ -50,10 +46,10 @@ branch to its checkpoint.
 | --- | --- | --- |
 | Coordinate `group:artifact:version` | Caller | Identifies the test module. |
 | Reachability repo path | Caller | Working directory for Gradle. |
-| Output directory | Caller | Absolute path. The caller picks a path namespaced per (library, class) for the dynamic-access caller, or per coordinate for non-class-scoped callers — same convention as [native-metadata-exploration.md §4](native-metadata-exploration.md#4-output). On `PASSED`, the gate merges all accepted per-cycle trace dirs into this directory (one `mergeNativeTraceMetadata` invocation). |
+| Output directory | Caller | Absolute path for fallback native-trace metadata. The caller picks a path namespaced per (library, class) for the dynamic-access caller, or per coordinate for non-class-scoped callers — same convention as [native-metadata-exploration.md §4](native-metadata-exploration.md#4-output). On a trace-backed `PASSED`, the gate merges all accepted per-cycle trace dirs into this directory (one `mergeNativeTraceMetadata` invocation). If the JVM-agent metadata path alone passes, this directory may remain empty. |
 | Condition packages | `condition_packages` argument to `verify_native_test_passes` | Default `[group]`. Passed to the binary at run time as `-XX:TraceMetadataConditionPackages=...`. |
 | Outer budget | Strategy parameter `max-native-test-verification-iterations` | Default **100**. In practice convergence is expected within a handful of cycles; the high default is a soft cap, not a target. Each cycle rebuilds `nativeTestCompile`, so the wall-clock cost is dominated by native-image build time. |
-| Per-cycle timeout | `cycle_timeout_seconds` argument | Default 30 minutes. Caps a single `runNativeTraceImage` invocation; on timeout the cycle is treated as a non-zero binary exit and routed to codex. |
+| Per-cycle timeout | `cycle_timeout_seconds` argument | Default 30 minutes. Caps the preflight `./gradlew test` invocation and each `runNativeTraceImage` invocation; on timeout the step is treated as a non-zero exit and routed to codex. |
 
 ## 3. Outputs
 
@@ -61,12 +57,16 @@ branch to its checkpoint.
 
 - `status` — `PASSED`, `PASSED_WITH_INTERVENTION`, or `FAILED`.
 - `output_dir` — echoes the caller's input. Populated with merged trace
-  metadata when status is `PASSED` / `PASSED_WITH_INTERVENTION` (one
-  `mergeNativeTraceMetadata` invocation at the end). Empty on `FAILED`.
+  metadata only when a fallback trace cycle reaches binary exit `0` (one
+  `mergeNativeTraceMetadata` invocation at the end). It may remain empty
+  when JVM-agent metadata alone made the native tests pass, when Codex is
+  invoked before tracing, or when Codex is invoked after a stalled trace
+  fallback. Empty on `FAILED`.
 - `iterations_used` — number of outer cycles consumed.
-- `last_native_test_log_path` — absolute path to the last
-  `runNativeTraceImage` Gradle log. Required when status is `FAILED`;
-  callers surface it in run metrics and the PR description.
+- `last_native_test_log_path` — absolute path to the last relevant
+  Gradle log (`generateMetadata`, `test`, or `runNativeTraceImage`).
+  Required when status is `FAILED`; callers surface it in run metrics and
+  the PR description.
 - `last_native_test_exit_code` — the verification binary's own exit code
   parsed from the Gradle log (e.g. `172`), or `None` when no exit-value
   line was captured.
@@ -81,25 +81,42 @@ branch to its checkpoint.
 ```mermaid
 flowchart TD
     Start([invoke gate]) --> Init[reset output_dir + runs_dir<br/>config_dirs = []<br/>i = 0]
-    Init --> Outer{i &lt; max-native-test-verification-iterations?}
-    Outer -- no --> FailExhausted([return FAILED<br/>metadata-gap-exhausted])
+    Init --> Agent[gradlew generateMetadata<br/>--agentAllowedPackages=fromJar]
+    Agent -- fail --> Codex[run_codex_metadata_fix]
+    Agent -- pass --> Test[gradlew test<br/>-Pcoordinates=&lt;g:a:v&gt;]
+    Test -- pass --> PassAgent([return PASSED])
+    Test -- fails before nativeTest --> Codex
+    Test -- nativeTest fails --> Outer{i &lt; max-native-test-verification-iterations?}
+    Outer -- no --> Codex
     Outer -- yes --> Run[gradlew runNativeTraceImage<br/>-PtraceMetadataPath=runs/cycle-i<br/>-PtraceMetadataConditionPackages=&lt;packages&gt;<br/>-PmetadataConfigDirs=&lt;config_dirs&gt;]
     Run --> Route{binary exit code}
     Route -- 0 --> Merge[mergeNativeTraceMetadata<br/>config_dirs &rarr; output_dir]
-    Merge --> Pass([return PASSED<br/>or PASSED_WITH_INTERVENTION])
-    Route -- 172 + new metadata --> Append[config_dirs += runs/cycle-i]
+    Merge --> Pass([return PASSED])
+    Route -- 172 --> Append[config_dirs += runs/cycle-i]
     Append --> Bump[i = i + 1]
     Bump --> Outer
-    Route -- 172 + repeated no-progress --> Codex
-    Route -- other --> Codex[run_codex_metadata_fix]
+    Route -- 172 without new metadata --> Codex
+    Route -- other --> Codex
     Codex --> CodexOK{codex rc == 0?}
     CodexOK -- yes --> PassI([return PASSED_WITH_INTERVENTION])
     CodexOK -- no --> FailCode([return FAILED<br/>code-failure])
 ```
 
-Per-cycle semantics:
+Gate semantics:
 
-- **One Gradle invocation per cycle.** The cycle runs only
+- **JVM agent first.** The first metadata action is always
+  `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
+  The JVM agent observes the test suite on HotSpot and writes the normal
+  repository metadata. Native tracing must not run before this step. If
+  metadata generation fails, the gate routes to codex with the generation
+  log and does not attempt native tracing.
+- **Native test run second.** After JVM-agent metadata is generated, the
+  gate runs `./gradlew test -Pcoordinates=<g:a:v>`. A pass returns
+  `PASSED` without invoking native tracing. A failure before `nativeTest`
+  is treated as a code/test problem and is routed to codex.
+- **Native tracing is fallback.** The trace loop starts only after
+  JVM-agent metadata exists and native testing still fails.
+- **One Gradle invocation per trace cycle.** The cycle runs only
   `./gradlew runNativeTraceImage -Pcoordinates=<g:a:v>
   -PtraceMetadataPath=<runs_dir>/cycle-<i>
   -PtraceMetadataConditionPackages=<packages>
@@ -120,9 +137,8 @@ Per-cycle semantics:
     least one missing access; appending it to `config_dirs` makes the
     next cycle's build see that metadata. If the current `172` cycle
     produces no new canonical metadata entries compared with accepted
-    trace dirs, the gate prints the accumulated progress and retries
-    once. A second consecutive no-progress `172` prints the failure-log
-    tail and routes to codex.
+    trace dirs, tracing has stalled; the gate prints the accumulated
+    progress, prints the failure-log tail, and routes to codex.
   - any other non-zero → the test or library code is broken in a way
     that more metadata cannot fix. Codex finishes it: codex is invoked
     once, and the gate returns based on codex's exit code. The gate does
@@ -135,17 +151,18 @@ Per-cycle semantics:
 - **Pi is not used.** Pi's role in `codex_then_pi` is to remove failing
   tests when codex cannot recover — exactly the wrong move when the
   failure is a real code/test bug we want surfaced.
-- **Two failure reasons, one status.** `FAILED` is returned on
-  `metadata-gap-exhausted` (172 every cycle until the budget runs out) or
-  `code-failure` (codex did not converge after a routed failure). The
-  diagnostic is recorded in the result's `intervention_records`,
-  `accepted_run_dirs`, and `last_native_test_log_path`.
+- **Codex after trace failure.** `metadata-gap-exhausted`, stalled
+  metadata progress, trace timeouts, and non-172 trace failures all route
+  to codex with a reproduction command that includes the accepted trace
+  dirs as `metadataConfigDirs`. `FAILED` is returned only when codex does
+  not converge.
 - **Codex keeps prior config_dirs.** Codex's fixes are additive; the gate
   does not discard `config_dirs` before codex runs. (Codex returns
   terminally so the question of carrying state across codex is moot for
   the current design, but the contract preserves the dirs in the result
   for diagnostics.)
-- **Hard fail.** Either failure reason aborts the calling workflow; see §6.
+- **Hard fail.** If codex does not converge, the gate returns `FAILED` and
+  the calling workflow aborts; see §6.
 
 ## 5. Reusable Implementation Surface
 
@@ -168,15 +185,19 @@ def verify_native_test_passes(
 
 The module composes existing helpers and owns no domain logic of its own:
 
+- `./gradlew generateMetadata -Pcoordinates=...
+  --agentAllowedPackages=fromJar` — primary JVM-agent metadata collection.
+- `./gradlew test -Pcoordinates=...` — normal coordinate validation after
+  JVM-agent metadata is available.
 - `./gradlew runNativeTraceImage -Pcoordinates=...
   -PtraceMetadataPath=<runs_dir>/cycle-<i>
   -PtraceMetadataConditionPackages=<packages>
-  -PmetadataConfigDirs=<accepted dirs>` — the per-cycle execution.
+  -PmetadataConfigDirs=<accepted dirs>` — fallback trace-cycle execution.
 - `./gradlew mergeNativeTraceMetadata -PinputDirs=...
-  -PoutputDir=<output_dir>` — single final merge on `PASSED`.
-- `run_codex_metadata_fix` — codex acts as the coding agent on non-172
-  failures and repeated no-progress 172 failures. It is the terminal step.
-  Pi is **not** invoked.
+  -PoutputDir=<output_dir>` — single final merge on trace-backed `PASSED`.
+- `run_codex_metadata_fix` — codex acts as the coding agent after JVM-agent
+  metadata plus native tracing fail to produce passing native tests. Pi is
+  **not** invoked.
 
 The standalone trace-loop driver in
 [`utility_scripts/native_metadata_exploration.py`](native-metadata-exploration.md)
@@ -205,37 +226,41 @@ A `verify_native_test_passes(...)` invocation is correct iff:
 1. The output directory and the sibling `runs/` directory are reset (or
    recreated empty) at the start of the call so no stale entries leak
    across runs.
-2. Each outer cycle invokes `./gradlew runNativeTraceImage
+2. Before any native-trace cycle starts, the gate invokes
+   `./gradlew generateMetadata -Pcoordinates=...
+   --agentAllowedPackages=fromJar`.
+3. If JVM-agent metadata generation fails, the gate invokes codex with
+   the generation log and does not start native tracing.
+4. After successful JVM-agent metadata generation, the gate invokes
+   `./gradlew test -Pcoordinates=...`. If the coordinate passes, return
+   `PASSED` without native tracing.
+5. Each fallback outer cycle invokes `./gradlew runNativeTraceImage
    -Pcoordinates=... -PtraceMetadataPath=<runs_dir>/cycle-<i>
    -PtraceMetadataConditionPackages=<packages>` exactly once, with
    `-PmetadataConfigDirs=<accepted dirs>` appended whenever any prior
    cycle was accepted.
-3. The verification binary's exit code is recovered from Gradle's
+6. The verification binary's exit code is recovered from Gradle's
    "exit value N" log line and routed:
    - `0` → run `mergeNativeTraceMetadata` once with all accepted run
      dirs as `-PinputDirs=` and the caller's `output_dir` as
-     `-PoutputDir=`, then return `PASSED` (or
-     `PASSED_WITH_INTERVENTION` if codex ran in an earlier cycle).
+     `-PoutputDir=`, then return `PASSED`.
    - `172` with new trace metadata entries → append
      `runs_dir/cycle-<i>` to the running config dirs and continue to the
      next outer cycle. Codex is **not** invoked.
-   - first consecutive `172` with no new trace metadata entries → print
-     the accumulated progress and retry once without changing config dirs.
-   - second consecutive `172` with no new trace metadata entries → print
-     the accumulated progress and failure-log tail, invoke
-     `run_codex_metadata_fix` once, and return based on its exit code.
+   - `172` with no new trace metadata entries → print the accumulated
+     progress and failure-log tail, then invoke codex.
    - any other non-zero → invoke `run_codex_metadata_fix` once and
      return based on its exit code: `PASSED_WITH_INTERVENTION` on codex
      success, `FAILED` on codex failure. The gate does not re-run
      `runNativeTraceImage` after codex.
-4. The gate never invokes `run_pi_post_generation_fix`.
-5. The function honors `max-native-test-verification-iterations` and never
+7. The gate never invokes `run_pi_post_generation_fix`.
+8. The function honors `max-native-test-verification-iterations` and never
    exceeds the configured outer budget. Reaching the budget without a
-   passing exit returns `FAILED` with reason "metadata-gap-exhausted".
-6. On `FAILED`, the result includes a non-empty
+   passing exit invokes codex with reason "metadata-gap-exhausted".
+9. On `FAILED`, the result includes a non-empty
    `last_native_test_log_path`, a populated
    `last_native_test_exit_code` (when the binary actually ran), the
    ordered `accepted_run_dirs` list, and at most one entry in
    `intervention_records`.
-7. Callers that observe `FAILED` propagate `RUN_STATUS_FAILURE` and reset
+10. Callers that observe `FAILED` propagate `RUN_STATUS_FAILURE` and reset
    the feature branch to their checkpoint.

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -235,13 +235,16 @@ class GateRoutingTests(unittest.TestCase):
             metadata_exit_codes: set[int] | None = None,
             log_text: str = "BUILD SUCCESSFUL\n",
             repeated_metadata: bool = False,
+            generate_metadata_rc: int = 0,
+            test_rc: int = 1,
+            test_failed_task: str | None = "nativeTest",
     ):
         """Build a subprocess.run replacement that consumes ``scripted_exits``.
 
-        Each call corresponds to one ``./gradlew`` invocation. When the
-        invocation contains ``runNativeTraceImage``, the script writes the
-        next scripted exit code to the sentinel file referenced by the
-        ``-PtraceBinaryExitFile=`` argument so the gate's reader returns
+        The gate runs generateMetadata and test before any trace fallback.
+        When the invocation contains ``runNativeTraceImage``, the script
+        writes the next scripted exit code to the sentinel file referenced by
+        the ``-PtraceBinaryExitFile=`` argument so the gate's reader returns
         that value. By default, 172 runs also write synthetic trace metadata
         so tests that exercise the correction loop represent real progress.
         """
@@ -255,6 +258,12 @@ class GateRoutingTests(unittest.TestCase):
             # Write a synthetic Gradle log if the caller asked us to.
             if hasattr(stdout, "write"):
                 stdout.write(log_text)
+            if "generateMetadata" in cmd:
+                return subprocess.CompletedProcess(cmd, generate_metadata_rc)
+            if "test" in cmd:
+                if hasattr(stdout, "write") and test_failed_task is not None:
+                    stdout.write(f"> Task :{test_failed_task} FAILED\n")
+                return subprocess.CompletedProcess(cmd, test_rc)
             if "runNativeTraceImage" in cmd:
                 exit_file = next(
                     (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceBinaryExitFile=")),
@@ -284,8 +293,8 @@ class GateRoutingTests(unittest.TestCase):
 
         return _fake, calls
 
-    def test_passes_immediately_when_binary_exits_zero(self) -> None:
-        fake, calls = self._fake_run_factory([0])
+    def test_passes_after_jvm_agent_metadata_when_coordinate_test_passes(self) -> None:
+        fake, calls = self._fake_run_factory([], test_rc=0, test_failed_task=None)
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -294,12 +303,33 @@ class GateRoutingTests(unittest.TestCase):
                 max_iterations=5,
             )
         self.assertEqual(result.status, ntv.STATUS_PASSED)
-        self.assertEqual(result.iterations_used, 1)
-        self.assertEqual(result.last_native_test_exit_code, 0)
-        self.assertTrue(any("runNativeTraceImage" in c for c in calls))
+        self.assertEqual(result.iterations_used, 0)
+        self.assertIsNone(result.last_native_test_exit_code)
+        self.assertTrue(any("generateMetadata" in c for c in calls))
+        self.assertTrue(any("test" in c for c in calls))
+        self.assertFalse(any("runNativeTraceImage" in c for c in calls))
+
+    def test_preflight_coordinate_test_uses_gate_timeout(self) -> None:
+        observed_test_timeouts: list[int | None] = []
+
+        def _fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if "test" in cmd:
+                observed_test_timeouts.append(kwargs.get("timeout"))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=_fake_run):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+                cycle_timeout_seconds=17,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        self.assertEqual(observed_test_timeouts, [17])
 
     def test_continues_on_172_until_pass(self) -> None:
-        fake, _calls = self._fake_run_factory([172, 172, 0])
+        fake, calls = self._fake_run_factory([172, 172, 0])
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -310,13 +340,19 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.status, ntv.STATUS_PASSED)
         self.assertEqual(result.iterations_used, 3)
         self.assertEqual(len(result.accepted_run_dirs), 2)
+        trace_calls = [call for call in calls if "runNativeTraceImage" in call]
+        self.assertTrue(trace_calls)
+        self.assertIn("-PtraceMetadataConditionPackages=g", trace_calls[0])
 
-    def test_fails_fast_when_172_repeats_same_metadata(self) -> None:
+    def test_routes_to_codex_when_172_repeats_same_metadata(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172], repeated_metadata=True)
         output = io.StringIO()
         with patch(
                 "utility_scripts.native_test_verification.subprocess.run",
                 side_effect=fake,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -325,7 +361,7 @@ class GateRoutingTests(unittest.TestCase):
                 max_iterations=5,
             )
 
-        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         self.assertEqual(result.iterations_used, 2)
         self.assertEqual(len(result.accepted_run_dirs), 1)
         printed = output.getvalue()
@@ -333,7 +369,7 @@ class GateRoutingTests(unittest.TestCase):
         self.assertIn("accepted_runs=1", printed)
         self.assertIn("accepted_unique_entries=1", printed)
         self.assertIn("current_cycle_entries=1", printed)
-        self.assertIn("produced no new trace metadata; failing fast", printed)
+        self.assertIn("binary exited 172 without new trace metadata", printed)
 
     def test_prints_aggregated_metadata_path_after_merge(self) -> None:
         fake, _calls = self._fake_run_factory([172, 0])
@@ -369,7 +405,7 @@ class GateRoutingTests(unittest.TestCase):
         input_dirs = next(arg for arg in merge_calls[0] if arg.startswith("-PinputDirs="))
         self.assertIn("cycle-0", input_dirs)
 
-    def test_fails_fast_and_prints_stacktrace_when_172_produces_no_metadata(self) -> None:
+    def test_routes_to_codex_and_prints_stacktrace_when_172_produces_no_metadata(self) -> None:
         fake, _calls = self._fake_run_factory(
             [172],
             metadata_exit_codes=set(),
@@ -383,6 +419,9 @@ class GateRoutingTests(unittest.TestCase):
         with patch(
             "utility_scripts.native_test_verification.subprocess.run",
             side_effect=fake,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -390,13 +429,13 @@ class GateRoutingTests(unittest.TestCase):
                 output_dir=self.output_dir,
                 max_iterations=5,
             )
-        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         self.assertEqual(result.iterations_used, 1)
         printed = output.getvalue()
-        self.assertIn("produced no usable trace metadata; failing fast", printed)
+        self.assertIn("produced no usable trace metadata", printed)
         self.assertIn("com.example.MissingThingException: boom", printed)
 
-    def test_fails_fast_when_172_produces_empty_metadata_json(self) -> None:
+    def test_routes_to_codex_when_172_produces_empty_metadata_json(self) -> None:
         def _fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
             stdout = kwargs.get("stdout")
             if hasattr(stdout, "write"):
@@ -404,6 +443,12 @@ class GateRoutingTests(unittest.TestCase):
                     "\n".join(f"native log line {index}" for index in range(305)) +
                     "\ncom.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: missing resource\n"
                 )
+            if "generateMetadata" in cmd:
+                return subprocess.CompletedProcess(cmd, 0)
+            if "test" in cmd:
+                if hasattr(stdout, "write"):
+                    stdout.write("> Task :nativeTest FAILED\n")
+                return subprocess.CompletedProcess(cmd, 1)
             if "runNativeTraceImage" in cmd:
                 exit_file = next(
                     (a.split("=", 1)[1] for a in cmd if a.startswith("-PtraceBinaryExitFile=")),
@@ -426,6 +471,9 @@ class GateRoutingTests(unittest.TestCase):
         with patch(
             "utility_scripts.native_test_verification.subprocess.run",
             side_effect=_fake_run,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -433,30 +481,70 @@ class GateRoutingTests(unittest.TestCase):
                 output_dir=self.output_dir,
                 max_iterations=5,
             )
-        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         self.assertEqual(result.iterations_used, 1)
         printed = output.getvalue()
         self.assertIn("reachability-metadata.json:", printed)
         self.assertIn("{}", printed)
-        self.assertIn("produced no usable trace metadata; failing fast", printed)
+        self.assertIn("produced no usable trace metadata", printed)
         self.assertIn("failure log tail (last 300 lines)", printed)
         self.assertNotIn("native log line 5\n", printed)
         self.assertIn("native log line 6\n", printed)
         self.assertIn("MissingResourceRegistrationError: missing resource", printed)
 
-    def test_failed_when_budget_exhausted_with_only_172(self) -> None:
+    def test_routes_to_codex_when_budget_exhausted_with_only_172(self) -> None:
         fake, _calls = self._fake_run_factory([172, 172])
-        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
                 coordinate="g:a:1.0",
                 output_dir=self.output_dir,
                 max_iterations=2,
             )
-        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         self.assertEqual(result.iterations_used, 2)
         self.assertEqual(result.last_native_test_exit_code, ntv.MISSING_METADATA_EXIT_CODE)
-        self.assertEqual(result.intervention_records, [])
+        self.assertEqual(len(result.intervention_records), 1)
+        reproduction_command = codex_mock.call_args.kwargs["reproduction_command"]
+        trace_path = _command_property(reproduction_command, "-PtraceMetadataPath")
+        config_dirs = _command_property(reproduction_command, "-PmetadataConfigDirs").split(",")
+        self.assertIn("codex-repro-metadata-gap-exhausted", trace_path)
+        self.assertNotIn(trace_path, config_dirs)
+
+    def test_routes_to_codex_when_generate_metadata_fails(self) -> None:
+        fake, calls = self._fake_run_factory([], generate_metadata_rc=1)
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
+        codex_mock.assert_called_once()
+        self.assertFalse(any("runNativeTraceImage" in c for c in calls))
+
+    def test_routes_to_codex_when_test_fails_before_native_test(self) -> None:
+        fake, calls = self._fake_run_factory([], test_rc=1, test_failed_task="compileTestJava")
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
+        codex_mock.assert_called_once()
+        self.assertFalse(any("runNativeTraceImage" in c for c in calls))
 
     def test_routes_to_codex_on_non_172_failure(self) -> None:
         fake, _calls = self._fake_run_factory([1])
@@ -494,6 +582,14 @@ class GateRoutingTests(unittest.TestCase):
                 max_iterations=5,
             )
         self.assertEqual(result.status, ntv.STATUS_FAILED)
+
+
+def _command_property(command: str, property_name: str) -> str:
+    prefix = f"{property_name}="
+    for part in command.split():
+        if part.startswith(prefix):
+            return part.split("=", 1)[1]
+    raise AssertionError(f"{property_name} missing from command: {command}")
 
 
 def _rmtree(path: str) -> None:

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -5,26 +5,13 @@
 
 """Native test verification gate.
 
-Drives ``./gradlew runNativeTraceImage`` per outer cycle. The trace binary is
-built with ``-H:+MetadataTracingSupport`` (collects metadata) plus
-``--exact-reachability-metadata`` and ``-H:MissingRegistrationReportingMode=Exit``
-(causes ``ExitStatus.MISSING_METADATA`` 172 on missing metadata instead of
-throwing). One run produces both signals: a trace dir and the binary's exit
-code. The gate routes on that exit code:
+The gate first runs the normal JVM ``native-image-agent`` metadata collection
+(``generateMetadata``), then validates the coordinate with ``./gradlew test``.
+Native tracing is only a fallback when native testing still fails after that
+metadata exists. Codex is the terminal repair path when the fallback cannot
+converge. Pi is not invoked.
 
-- ``0``     → ``PASSED`` (or ``PASSED_WITH_INTERVENTION`` if codex ran in an
-  earlier cycle).
-- ``172``   → metadata gap; append the cycle's trace dir to the running
-  ``metadataConfigDirs`` so the next cycle's build sees it, then continue.
-  If later ``172`` runs stop producing new trace entries, retry once and then
-  route to Codex with the native failure log.
-- any other → run ``run_codex_metadata_fix`` once. Codex finishes it: on
-  codex success return ``PASSED_WITH_INTERVENTION``; on codex failure return
-  ``FAILED``. The gate does not re-verify after codex.
-
-Pi is not invoked. Removing failing tests would mask code/test issues that
-must surface to the coding agent. See
-``forge/docs/native-test-verification.md`` for the full contract.
+See ``forge/docs/native-test-verification.md`` for the full contract.
 """
 
 from __future__ import annotations
@@ -67,7 +54,7 @@ _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 _AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
 _FAILURE_LOG_TAIL_LINE_LIMIT = 300
-_NO_PROGRESS_CODEX_THRESHOLD = 2
+_FAILED_TASK_PATTERN = re.compile(r"> Task :(\S+) FAILED")
 
 
 @dataclass
@@ -99,10 +86,11 @@ def verify_native_test_passes(
         reachability_repo_path: str,
         coordinate: str,
         output_dir: str,
+        condition_packages: list[str] | None = None,
         max_iterations: int = 100,
         cycle_timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
 ) -> NativeTestVerificationResult:
-    """Iteratively run runNativeTraceImage until the binary passes or fails.
+    """Run JVM-agent metadata first, then trace only as native-test fallback.
 
     See ``forge/docs/native-test-verification.md`` for the full contract.
     """
@@ -115,6 +103,7 @@ def verify_native_test_passes(
     runs_dir = os.path.normpath(os.path.join(output_dir, "..", "runs"))
     _reset_directory(output_dir)
     _reset_directory(runs_dir)
+    condition_packages = condition_packages or _default_condition_packages(coordinate)
 
     log_stage(
         _GATE_STAGE,
@@ -124,10 +113,8 @@ def verify_native_test_passes(
     accepted_run_dirs: list[str] = []
     accepted_metadata_entries: set[str] = set()
     intervention_records: list[InterventionRecord] = []
-    intervention_used = False
     last_log_path: str | None = None
     last_binary_rc: int | None = None
-    consecutive_no_progress_cycles = 0
 
     def _make_result(status: str, iterations_used: int) -> NativeTestVerificationResult:
         return NativeTestVerificationResult(
@@ -140,23 +127,24 @@ def verify_native_test_passes(
             intervention_records=intervention_records,
         )
 
-    def _route_to_codex(cycle: int, run_dir: str, reason: str) -> NativeTestVerificationResult:
+    def _route_to_codex(
+            stage: str,
+            reason: str,
+            reproduction_command: str,
+            iterations_used: int,
+    ) -> NativeTestVerificationResult:
         log_stage(
             _GATE_STAGE,
-            f"cycle {cycle + 1}: {reason}; routing to codex (terminal)",
+            f"{stage}: {reason}; routing to codex (terminal)",
         )
         codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
             reachability_repo_path,
             coordinate,
-            reproduction_command=_run_native_trace_image_command(
-                coordinate=coordinate,
-                run_dir=run_dir,
-                metadata_config_dirs=accepted_run_dirs,
-            ),
+            reproduction_command=reproduction_command,
         )
         intervention_records.append(
             InterventionRecord(
-                stage=f"cycle-{cycle + 1}-codex",
+                stage=f"{stage}-codex",
                 kind="codex",
                 log_path=codex_log_path,
             )
@@ -166,9 +154,46 @@ def verify_native_test_passes(
                 _GATE_STAGE,
                 f"codex did not converge (timed_out={codex_timed_out}, rc={codex_rc}); FAILED",
             )
-            return _make_result(STATUS_FAILED, cycle + 1)
+            return _make_result(STATUS_FAILED, iterations_used)
         log_stage(_GATE_STAGE, "codex finished; trusting codex's outcome")
-        return _make_result(STATUS_PASSED_WITH_INTERVENTION, cycle + 1)
+        return _make_result(STATUS_PASSED_WITH_INTERVENTION, iterations_used)
+
+    generate_metadata_log_path = _gate_log_path(coordinate, 0, "generateMetadata")
+    generate_metadata_rc = _run_generate_metadata(
+        reachability_repo_path=reachability_repo_path,
+        coordinate=coordinate,
+        log_path=generate_metadata_log_path,
+    )
+    last_log_path = generate_metadata_log_path
+    if generate_metadata_rc != 0:
+        return _route_to_codex(
+            stage="generateMetadata",
+            reason=f"generateMetadata failed (exit={generate_metadata_rc})",
+            reproduction_command=_generate_metadata_command(coordinate),
+            iterations_used=0,
+        )
+
+    test_log_path = _gate_log_path(coordinate, 0, "test")
+    test_rc, failed_task = _run_coordinate_test(
+        reachability_repo_path=reachability_repo_path,
+        coordinate=coordinate,
+        log_path=test_log_path,
+        timeout_seconds=cycle_timeout_seconds,
+    )
+    last_log_path = test_log_path
+    if test_rc == 0:
+        log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
+        return _make_result(STATUS_PASSED, 0)
+    if failed_task != "nativeTest":
+        failed_task_display = failed_task or "unknown"
+        return _route_to_codex(
+            stage="test",
+            reason=f"test failed before native trace fallback (failed_task={failed_task_display}, exit={test_rc})",
+            reproduction_command=_coordinate_test_command(coordinate),
+            iterations_used=0,
+        )
+
+    log_stage(_GATE_STAGE, "nativeTest still fails after JVM-agent metadata; starting native trace fallback")
 
     for cycle in range(max_iterations):
         log_stage(_GATE_STAGE, f"cycle {cycle + 1}/{max_iterations}")
@@ -180,6 +205,7 @@ def verify_native_test_passes(
             reachability_repo_path=reachability_repo_path,
             coordinate=coordinate,
             run_dir=run_dir,
+            condition_packages=condition_packages,
             metadata_config_dirs=accepted_run_dirs,
             log_path=log_path,
             timeout_seconds=cycle_timeout_seconds,
@@ -204,44 +230,46 @@ def verify_native_test_passes(
                 output_dir=output_dir,
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
-            status = STATUS_PASSED_WITH_INTERVENTION if intervention_used else STATUS_PASSED
-            return _make_result(status, cycle + 1)
+            return _make_result(STATUS_PASSED, cycle + 1)
 
         if binary_rc == MISSING_METADATA_EXIT_CODE:
             if not usable_metadata_files:
                 log_stage(
                     _GATE_STAGE,
-                    f"cycle {cycle + 1}: binary exited 172 but produced no usable trace metadata; failing fast",
+                    f"cycle {cycle + 1}: binary exited 172 but produced no usable trace metadata",
                 )
                 _print_failure_log_tail(log_path, cycle + 1)
-                return _make_result(STATUS_FAILED, cycle + 1)
+                return _route_to_codex(
+                    stage=f"cycle-{cycle + 1}",
+                    reason="binary exited 172 but produced no usable trace metadata",
+                    reproduction_command=_run_native_trace_image_command(
+                        coordinate=coordinate,
+                        run_dir=run_dir,
+                        condition_packages=condition_packages,
+                        metadata_config_dirs=accepted_run_dirs,
+                    ),
+                    iterations_used=cycle + 1,
+                )
             metadata_entries = _metadata_entries(run_dir)
             added_entries = metadata_entries - accepted_metadata_entries
             if not added_entries:
-                consecutive_no_progress_cycles += 1
                 _print_metadata_progress(
                     accepted_run_dirs=accepted_run_dirs,
                     accepted_entry_count=len(accepted_metadata_entries),
                     current_entry_count=len(metadata_entries),
-                    reason=(
-                        "no new trace metadata entries; "
-                        f"stall {consecutive_no_progress_cycles}/{_NO_PROGRESS_CODEX_THRESHOLD}"
-                    ),
+                    reason="no new trace metadata entries",
                 )
-                if consecutive_no_progress_cycles < _NO_PROGRESS_CODEX_THRESHOLD:
-                    log_stage(
-                        _GATE_STAGE,
-                        (
-                            f"cycle {cycle + 1}: binary exited 172 but produced no new "
-                            "trace metadata; retrying once before codex fallback"
-                        ),
-                    )
-                    continue
                 _print_failure_log_tail(log_path, cycle + 1)
                 return _route_to_codex(
-                    cycle,
-                    run_dir,
-                    "binary exited 172 twice without new trace metadata",
+                    stage=f"cycle-{cycle + 1}",
+                    reason="binary exited 172 without new trace metadata",
+                    reproduction_command=_run_native_trace_image_command(
+                        coordinate=coordinate,
+                        run_dir=run_dir,
+                        condition_packages=condition_packages,
+                        metadata_config_dirs=accepted_run_dirs,
+                    ),
+                    iterations_used=cycle + 1,
                 )
             log_stage(
                 _GATE_STAGE,
@@ -249,7 +277,6 @@ def verify_native_test_passes(
                 f"adding {os.path.basename(run_dir)} to config_dirs "
                 f"({len(added_entries)} new entr{'y' if len(added_entries) == 1 else 'ies'})",
             )
-            consecutive_no_progress_cycles = 0
             accepted_metadata_entries.update(added_entries)
             accepted_run_dirs.append(run_dir)
             continue
@@ -257,9 +284,15 @@ def verify_native_test_passes(
         if not collected_metadata_files:
             _print_failure_log_tail(log_path, cycle + 1)
         return _route_to_codex(
-            cycle,
-            run_dir,
-            f"binary failed (gradle_exit={gradle_rc}, binary_exit={binary_rc})",
+            stage=f"cycle-{cycle + 1}",
+            reason=f"binary failed (gradle_exit={gradle_rc}, binary_exit={binary_rc})",
+            reproduction_command=_run_native_trace_image_command(
+                coordinate=coordinate,
+                run_dir=run_dir,
+                condition_packages=condition_packages,
+                metadata_config_dirs=accepted_run_dirs,
+            ),
+            iterations_used=cycle + 1,
         )
 
     log_stage(
@@ -267,18 +300,116 @@ def verify_native_test_passes(
         f"FAILED after {max_iterations} cycles "
         f"(metadata-gap-exhausted; last binary_exit={last_binary_rc})",
     )
-    return _make_result(STATUS_FAILED, max_iterations)
+    return _route_to_codex(
+        stage="metadata-gap-exhausted",
+        reason=f"metadata gap exhausted after {max_iterations} cycles",
+        reproduction_command=_run_native_trace_image_command(
+            coordinate=coordinate,
+            run_dir=os.path.join(runs_dir, "codex-repro-metadata-gap-exhausted"),
+            condition_packages=condition_packages,
+            metadata_config_dirs=accepted_run_dirs,
+        ),
+        iterations_used=max_iterations,
+    )
+
+
+def _generate_metadata_command(coordinate: str) -> str:
+    return f"./gradlew generateMetadata -Pcoordinates={coordinate} --agentAllowedPackages=fromJar"
+
+
+def _coordinate_test_command(coordinate: str) -> str:
+    return f"./gradlew test -Pcoordinates={coordinate}"
+
+
+def _default_condition_packages(coordinate: str) -> list[str]:
+    return [coordinate.split(":", 1)[0]]
+
+
+def _run_generate_metadata(
+        reachability_repo_path: str,
+        coordinate: str,
+        log_path: str,
+) -> int:
+    """Run JVM-agent metadata generation for the coordinate."""
+    cmd = [
+        "./gradlew",
+        "generateMetadata",
+        f"-Pcoordinates={coordinate}",
+        "--agentAllowedPackages=fromJar",
+    ]
+    return _run_logged_gradle_command(
+        reachability_repo_path=reachability_repo_path,
+        cmd=cmd,
+        log_path=log_path,
+    ).returncode
+
+
+def _run_coordinate_test(
+        reachability_repo_path: str,
+        coordinate: str,
+        log_path: str,
+        timeout_seconds: int,
+) -> tuple[int, str | None]:
+    """Run normal coordinate tests and return the first failed Gradle task."""
+    cmd = ["./gradlew", "test", f"-Pcoordinates={coordinate}"]
+    result = _run_logged_gradle_command(
+        reachability_repo_path=reachability_repo_path,
+        cmd=cmd,
+        log_path=log_path,
+        timeout_seconds=timeout_seconds,
+    )
+    return result.returncode, _parse_first_failed_task(log_path)
+
+
+def _run_logged_gradle_command(
+        reachability_repo_path: str,
+        cmd: list[str],
+        log_path: str,
+        timeout_seconds: int | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a Gradle command and write stdout/stderr to ``log_path``."""
+    log_stage(
+        _GATE_STAGE,
+        f"$ {' '.join(cmd)}  (log: {display_log_path(log_path)})",
+        indent_level=1,
+    )
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        try:
+            return subprocess.run(
+                cmd,
+                cwd=reachability_repo_path,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                check=False,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            log_file.write(f"\nCommand exceeded {timeout_seconds}s timeout\n")
+            return subprocess.CompletedProcess(cmd, 1)
+
+
+def _parse_first_failed_task(log_path: str) -> str | None:
+    """Extract the first Gradle task name that failed from a log file."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+            content = handle.read()
+    except OSError:
+        return None
+    match = _FAILED_TASK_PATTERN.search(content)
+    return match.group(1) if match else None
 
 
 def _run_native_trace_image_command(
         coordinate: str,
         run_dir: str,
+        condition_packages: list[str],
         metadata_config_dirs: list[str],
 ) -> str:
     parts = [
         "./gradlew runNativeTraceImage",
         f"-Pcoordinates={coordinate}",
         f"-PtraceMetadataPath={run_dir}",
+        f"-PtraceMetadataConditionPackages={','.join(condition_packages)}",
     ]
     if metadata_config_dirs:
         parts.append(f"-PmetadataConfigDirs={','.join(metadata_config_dirs)}")
@@ -289,6 +420,7 @@ def _run_native_trace_image(
         reachability_repo_path: str,
         coordinate: str,
         run_dir: str,
+        condition_packages: list[str],
         metadata_config_dirs: list[str],
         log_path: str,
         timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
@@ -309,6 +441,7 @@ def _run_native_trace_image(
         "runNativeTraceImage",
         f"-Pcoordinates={coordinate}",
         f"-PtraceMetadataPath={run_dir}",
+        f"-PtraceMetadataConditionPackages={','.join(condition_packages)}",
         f"-PtraceBinaryExitFile={exit_file}",
     ]
     if metadata_config_dirs:

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -186,7 +186,7 @@ tasks.register("nativeTraceImage", NativeTraceImageInvocationTask.class) { task 
     }
 }
 
-// gradle runNativeTraceImage -Pcoordinates=<maven-coordinates> -PtraceMetadataPath=<path>
+// gradle runNativeTraceImage -Pcoordinates=<maven-coordinates> -PtraceMetadataPath=<path> [-PtraceMetadataConditionPackages=<pkg1,pkg2,...>]
 tasks.register("runNativeTraceImage", RunNativeTraceImageInvocationTask.class) { task ->
     task.setDescription("Runs trace-enabled native tests once for matching coordinates")
     task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
@@ -23,6 +23,7 @@ public abstract class RunNativeTraceImageInvocationTask extends AllCoordinatesEx
         ));
         appendProperty(command, "metadataConfigDirs");
         appendProperty(command, "traceMetadataPath");
+        appendProperty(command, "traceMetadataConditionPackages");
         appendProperty(command, "traceBinaryExitFile");
         return command;
     }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTaskTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.graalvm.internal.tck.harness.TckExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RunNativeTraceImageInvocationTaskTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void commandForForwardsTraceMetadataConditionPackages() throws IOException {
+        Project project = createProject();
+        project.getExtensions().getExtraProperties().set("metadataConfigDirs", "/tmp/config-0,/tmp/config-1");
+        project.getExtensions().getExtraProperties().set("traceMetadataPath", "/tmp/trace-output");
+        project.getExtensions().getExtraProperties().set("traceMetadataConditionPackages", "com.example,org.example");
+        project.getExtensions().getExtraProperties().set("traceBinaryExitFile", "/tmp/trace-exit-code");
+
+        RunNativeTraceImageInvocationTask task = project.getTasks().create(
+                "runNativeTraceImage",
+                RunNativeTraceImageInvocationTask.class
+        );
+
+        List<String> command = task.commandFor("com.example:demo:1.0.0");
+
+        assertThat(command)
+                .contains("runNativeTraceImage")
+                .contains("-PmetadataConfigDirs=/tmp/config-0,/tmp/config-1")
+                .contains("-PtraceMetadataPath=/tmp/trace-output")
+                .contains("-PtraceMetadataConditionPackages=com.example,org.example")
+                .contains("-PtraceBinaryExitFile=/tmp/trace-exit-code");
+    }
+
+    private Project createProject() throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata"));
+        Files.createDirectories(tempDir.resolve("tests/src"));
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        project.getExtensions().create("tck", TckExtension.class, project);
+        return project;
+    }
+}


### PR DESCRIPTION
## Summary

- Run JVM-agent `generateMetadata` before native verification and skip trace fallback when coordinate tests pass.
- Route metadata generation failures, pre-native test failures, stalled traces, and exhausted trace budgets to codex.
- Forward `traceMetadataConditionPackages` through `runNativeTraceImage` and update the native verification docs/tests.

## Testing

- `python3 -m unittest forge.tests.test_native_test_verification`
- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.harness.tasks.RunNativeTraceImageInvocationTaskTests --stacktrace`

Fixes #5519