### PR TITLE
[GenAI] Mark io.netty:netty-transport-native-io_uring as not for Native Image

### DIFF
--- a/metadata/io.netty/netty-transport-native-io_uring/index.json
+++ b/metadata/io.netty/netty-transport-native-io_uring/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The main JAR contains only module metadata, and platform classifier JARs carry native libraries; the JVM io_uring transport classes are published separately.",
+    "replacement": "io.netty:netty-transport-classes-io_uring:4.2.1.Final"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4982

This PR records `io.netty:netty-transport-native-io_uring` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The main JAR contains only module metadata, and platform classifier JARs carry native libraries; the JVM io_uring transport classes are published separately.

Replacement guidance:
- io.netty:netty-transport-classes-io_uring:4.2.1.Final

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3da08fddbd440a7ace700c13403139445390fa52`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
