### PR TITLE
[GenAI] Add support for io.smallrye.common:smallrye-common-io:2.16.0 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye.common/smallrye-common-io/2.16.0/reachability-metadata.json
+++ b/metadata/io.smallrye.common/smallrye-common-io/2.16.0/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.io.Messages"
+      },
+      "type": "io.smallrye.common.io.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.smallrye.common/smallrye-common-io/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-io/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.16.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-io/$version$/smallrye-common-io-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/smallrye-common",
+    "test-code-url" : "https://github.com/smallrye/smallrye-common/tree/$version$/io/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-io/$version$/smallrye-common-io-$version$-javadoc.jar",
+    "description" : "SmallRye Common IO provides utility classes that extend Java file-system operations, including secure and recursive deletion helpers. It also includes JAR-file helpers for creating and inspecting runtime-aware multi-release JARs.",
+    "tested-versions" : [
+      "2.16.0"
+    ],
+    "allowed-packages" : [
+      "io.smallrye.common.io"
+    ]
+  }
+]

--- a/stats/io.smallrye.common/smallrye-common-io/2.16.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-io/2.16.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-03": {
+    "timestamp": "2026-05-03T21:39:41.836430Z",
+    "library": "io.smallrye.common:smallrye-common-io:2.16.0",
+    "starting_commit": "4c0e4ecea43f422e735bfecd259876ba4f41b7d9",
+    "ending_commit": "b05dd761544ea0f4afc2fff29fc1f4c719733d5b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.16.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 575,
+          "missed": 272,
+          "ratio": 0.678867,
+          "total": 847
+        },
+        "line": {
+          "covered": 144,
+          "missed": 77,
+          "ratio": 0.651584,
+          "total": 221
+        },
+        "method": {
+          "covered": 33,
+          "missed": 10,
+          "ratio": 0.767442,
+          "total": 43
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 98237,
+      "cached_input_tokens_used": 778240,
+      "output_tokens_used": 16337,
+      "iterations": 3,
+      "cost_usd": 0.8792,
+      "generated_loc": 289,
+      "tested_library_loc": 144,
+      "metadata_entries": 2,
+      "code_coverage_percent": 65.16
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java",
+      "metadata_file": "metadata/io.smallrye.common/smallrye-common-io/2.16.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye.common/smallrye-common-io/2.16.0/stats.json
+++ b/stats/io.smallrye.common/smallrye-common-io/2.16.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.16.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 575,
+        "missed" : 272,
+        "ratio" : 0.678867,
+        "total" : 847
+      },
+      "line" : {
+        "covered" : 144,
+        "missed" : 77,
+        "ratio" : 0.651584,
+        "total" : 221
+      },
+      "method" : {
+        "covered" : 33,
+        "missed" : 10,
+        "ratio" : 0.767442,
+        "total" : 43
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/.gitignore
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/build.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye.common:smallrye-common-io:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/gradle.properties
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye.common:smallrye-common-io:2.16.0
+library.version = 2.16.0
+metadata.dir = io.smallrye.common/smallrye-common-io/2.16.0/

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/settings.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.common.smallrye-common-io_tests'

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye_common.smallrye_common_io;
+
+import org.junit.jupiter.api.Test;
+
+class Smallrye_common_ioTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
@@ -126,6 +126,31 @@ public class Smallrye_common_ioTest {
     }
 
     @Test
+    void cleanRecursivelyOnFileTargetsRemovesOnlyTheFile(@TempDir Path tempDir) throws IOException {
+        Path insecureFile = tempDir.resolve("insecure-file.txt");
+        Path insecureSibling = tempDir.resolve("insecure-sibling.txt");
+        Files.writeString(insecureFile, "remove me");
+        Files.writeString(insecureSibling, "keep me");
+
+        Files2.cleanRecursivelyEvenIfInsecure(insecureFile);
+
+        assertThat(insecureFile).doesNotExist();
+        assertThat(insecureSibling).hasContent("keep me");
+
+        if (Files2.hasSecureDirectories()) {
+            Path secureFile = tempDir.resolve("secure-file.txt");
+            Path secureSibling = tempDir.resolve("secure-sibling.txt");
+            Files.writeString(secureFile, "remove me securely");
+            Files.writeString(secureSibling, "keep me securely");
+
+            Files2.cleanRecursively(secureFile);
+
+            assertThat(secureFile).doesNotExist();
+            assertThat(secureSibling).hasContent("keep me securely");
+        }
+    }
+
+    @Test
     void recursiveDeletionRemovesDirectorySymbolicLinksWithoutFollowingThem(@TempDir Path tempDir) throws IOException {
         Path externalTarget = tempDir.resolve("external-target");
         Files.createDirectories(externalTarget);

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
@@ -6,11 +6,282 @@
  */
 package io_smallrye_common.smallrye_common_io;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Smallrye_common_ioTest {
+import io.smallrye.common.io.DeleteStats;
+import io.smallrye.common.io.Files2;
+import io.smallrye.common.io.jar.JarEntries;
+import io.smallrye.common.io.jar.JarFiles;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Smallrye_common_ioTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void deleteStatsExposesRecordValuesAndValidatesBounds() {
+        DeleteStats stats = new DeleteStats(2, 1, 3, 2);
+        DeleteStats sameStats = new DeleteStats(2, 1, 3, 2);
+
+        assertThat(stats.directoriesFound()).isEqualTo(2);
+        assertThat(stats.directoriesRemoved()).isEqualTo(1);
+        assertThat(stats.filesFound()).isEqualTo(3);
+        assertThat(stats.filesRemoved()).isEqualTo(2);
+        assertThat(stats).isEqualTo(sameStats).hasSameHashCodeAs(sameStats);
+        assertThat(stats.toString())
+                .contains("directoriesFound=2", "directoriesRemoved=1", "filesFound=3", "filesRemoved=2");
+
+        assertThatThrownBy(() -> new DeleteStats(-1, 0, 0, 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DeleteStats(1, 2, 0, 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DeleteStats(0, 0, -1, 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new DeleteStats(0, 0, 1, 2)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void pathHelpersExposeStableCurrentDirectoryAndParentResolution() {
+        Path expectedCurrentDirectory = Path.of(System.getProperty("user.dir", ".")).normalize().toAbsolutePath();
+
+        assertThat(Files2.currentDirectory()).isEqualTo(expectedCurrentDirectory);
+        assertThat(Files2.getParent(Path.of("child.txt"))).isEqualTo(expectedCurrentDirectory);
+        assertThat(Files2.getParent(Path.of("nested", "child.txt")))
+                .isEqualTo(expectedCurrentDirectory.resolve("nested"));
+        assertThat(Files2.getParent(expectedCurrentDirectory.resolve("absolute-child.txt")))
+                .isEqualTo(expectedCurrentDirectory);
+        assertThatThrownBy(() -> Files2.getParent(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void insecureDeletionUtilitiesDeleteTreesAndReportQuietStats(@TempDir Path tempDir) throws IOException {
+        Path deleteTarget = createTree(tempDir.resolve("delete-target"));
+        Files2.deleteRecursivelyEvenIfInsecure(deleteTarget);
+        assertThat(deleteTarget).doesNotExist();
+
+        Path quietTarget = createTree(tempDir.resolve("quiet-target"));
+        DeleteStats stats = Files2.deleteRecursivelyQuietlyEvenIfInsecure(quietTarget);
+        assertThat(stats.directoriesFound()).isEqualTo(2);
+        assertThat(stats.directoriesRemoved()).isEqualTo(2);
+        assertThat(stats.filesFound()).isEqualTo(2);
+        assertThat(stats.filesRemoved()).isEqualTo(2);
+        assertThat(quietTarget).doesNotExist();
+
+        DeleteStats missingStats = Files2.deleteRecursivelyQuietlyEvenIfInsecure(tempDir.resolve("missing"));
+        assertThat(missingStats).isEqualTo(new DeleteStats(0, 0, 0, 0));
+    }
+
+    @Test
+    void insecureDirectoryStreamOverloadsCleanAndDeleteContents(@TempDir Path tempDir) throws IOException {
+        Path cleanRoot = createTree(tempDir.resolve("clean-root"));
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(cleanRoot)) {
+            Files2.cleanRecursivelyEvenIfInsecure(stream);
+        }
+        assertThat(cleanRoot).isDirectory();
+        assertThat(cleanRoot.resolve("nested")).isDirectory();
+        assertThat(cleanRoot.resolve("root.txt")).doesNotExist();
+        assertThat(cleanRoot.resolve("nested/child.txt")).doesNotExist();
+
+        Path deleteRoot = createTree(tempDir.resolve("delete-root"));
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(deleteRoot)) {
+            DeleteStats stats = Files2.deleteRecursivelyQuietlyEvenIfInsecure(stream);
+            assertThat(stats.directoriesFound()).isEqualTo(1);
+            assertThat(stats.directoriesRemoved()).isEqualTo(1);
+            assertThat(stats.filesFound()).isEqualTo(2);
+            assertThat(stats.filesRemoved()).isEqualTo(2);
+        }
+        assertThat(deleteRoot).isDirectory();
+        assertThat(fileNames(deleteRoot)).isEmpty();
+
+        Path throwingDeleteRoot = createTree(tempDir.resolve("throwing-delete-root"));
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(throwingDeleteRoot)) {
+            Files2.deleteRecursivelyEvenIfInsecure(stream);
+        }
+        assertThat(throwingDeleteRoot).isDirectory();
+        assertThat(fileNames(throwingDeleteRoot)).isEmpty();
+    }
+
+    @Test
+    void cleanRecursivelyPreservesDirectoriesAndDeletesFiles(@TempDir Path tempDir) throws IOException {
+        Path root = createTree(tempDir.resolve("root"));
+
+        Files2.cleanRecursivelyEvenIfInsecure(root);
+
+        assertThat(root).isDirectory();
+        assertThat(root.resolve("nested")).isDirectory();
+        assertThat(root.resolve("root.txt")).doesNotExist();
+        assertThat(root.resolve("nested/child.txt")).doesNotExist();
+        assertThat(fileNames(root)).containsExactly("nested");
+        assertThat(fileNames(root.resolve("nested"))).isEmpty();
+    }
+
+    @Test
+    void secureDirectoryUtilitiesOperateOnPathAndStreamOverloads(@TempDir Path tempDir) throws IOException {
+        Path secureRoot = tempDir.resolve("secure-root");
+        Files.createDirectories(secureRoot);
+
+        if (Files2.hasSecureDirectories()) {
+            Path pathCleanTarget = createTree(secureRoot.resolve("path-clean"));
+            Files2.cleanRecursively(pathCleanTarget);
+            assertThat(pathCleanTarget).isDirectory();
+            assertThat(pathCleanTarget.resolve("nested")).isDirectory();
+            assertThat(pathCleanTarget.resolve("root.txt")).doesNotExist();
+            assertThat(pathCleanTarget.resolve("nested/child.txt")).doesNotExist();
+
+            Path pathDeleteTarget = createTree(secureRoot.resolve("path-delete"));
+            Files2.deleteRecursively(pathDeleteTarget);
+            assertThat(pathDeleteTarget).doesNotExist();
+
+            Path quietPathDeleteTarget = createTree(secureRoot.resolve("quiet-path-delete"));
+            DeleteStats quietPathStats = Files2.deleteRecursivelyQuietly(quietPathDeleteTarget);
+            assertTreeDeletedWithExpectedStats(quietPathDeleteTarget, quietPathStats, 2, 2);
+
+            createTree(secureRoot.resolve("stream-clean"));
+            createTree(secureRoot.resolve("stream-delete"));
+            createTree(secureRoot.resolve("stream-quiet-delete"));
+            try (SecureDirectoryStream<Path> stream = Files2.newSecureDirectoryStream(
+                    secureRoot, LinkOption.NOFOLLOW_LINKS)) {
+                Files2.cleanRecursively(stream, Path.of("stream-clean"));
+                assertThat(secureRoot.resolve("stream-clean")).isDirectory();
+                assertThat(secureRoot.resolve("stream-clean/nested")).isDirectory();
+                assertThat(secureRoot.resolve("stream-clean/root.txt")).doesNotExist();
+                assertThat(secureRoot.resolve("stream-clean/nested/child.txt")).doesNotExist();
+
+                Files2.deleteRecursively(stream, Path.of("stream-delete"));
+                assertThat(secureRoot.resolve("stream-delete")).doesNotExist();
+
+                DeleteStats quietStreamStats = Files2.deleteRecursivelyQuietly(stream, Path.of("stream-quiet-delete"));
+                assertTreeDeletedWithExpectedStats(secureRoot.resolve("stream-quiet-delete"), quietStreamStats, 2, 2);
+            }
+
+            Path cleanAll = createTree(secureRoot.resolve("clean-all"));
+            try (SecureDirectoryStream<Path> stream = Files2.newSecureDirectoryStream(cleanAll)) {
+                Files2.cleanRecursively(stream);
+            }
+            assertThat(cleanAll).isDirectory();
+            assertThat(cleanAll.resolve("nested")).isDirectory();
+            assertThat(cleanAll.resolve("root.txt")).doesNotExist();
+            assertThat(cleanAll.resolve("nested/child.txt")).doesNotExist();
+
+            Path quietAll = createTree(secureRoot.resolve("quiet-all"));
+            try (SecureDirectoryStream<Path> stream = Files2.newSecureDirectoryStream(quietAll)) {
+                DeleteStats quietAllStats = Files2.deleteRecursivelyQuietly(stream);
+                assertThat(quietAllStats.directoriesFound()).isEqualTo(1);
+                assertThat(quietAllStats.directoriesRemoved()).isEqualTo(1);
+                assertThat(quietAllStats.filesFound()).isEqualTo(2);
+                assertThat(quietAllStats.filesRemoved()).isEqualTo(2);
+            }
+            assertThat(quietAll).isDirectory();
+            assertThat(fileNames(quietAll)).isEmpty();
+
+            Path deleteAll = createTree(secureRoot.resolve("delete-all"));
+            try (SecureDirectoryStream<Path> stream = Files2.newSecureDirectoryStream(deleteAll)) {
+                Files2.deleteRecursively(stream);
+            }
+            assertThat(deleteAll).isDirectory();
+            assertThat(fileNames(deleteAll)).isEmpty();
+        } else {
+            assertThatThrownBy(() -> Files2.newSecureDirectoryStream(secureRoot))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> Files2.cleanRecursively(secureRoot))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> Files2.deleteRecursively(secureRoot))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThatThrownBy(() -> Files2.deleteRecursivelyQuietly(secureRoot))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void jarUtilitiesCreateRuntimeAwareJarFilesAndResolveRealEntryNames(@TempDir Path tempDir) throws IOException {
+        Path multiReleaseJar = tempDir.resolve("multi-release.jar");
+        writeJar(multiReleaseJar, true);
+
+        try (JarFile jarFile = JarFiles.create(multiReleaseJar.toFile())) {
+            assertThat(JarFiles.isMultiRelease(jarFile)).isTrue();
+            JarEntry entry = jarFile.getJarEntry("sample.txt");
+            assertThat(entry).isNotNull();
+            assertThat(entry.getName()).isEqualTo("sample.txt");
+            assertThat(JarEntries.getRealName(entry)).isEqualTo("META-INF/versions/9/sample.txt");
+        }
+
+        try (JarFile jarFile = JarFiles.create(multiReleaseJar.toString(), false)) {
+            assertThat(JarFiles.isMultiRelease(jarFile)).isTrue();
+            assertThat(JarEntries.getRealName(jarFile.getJarEntry("sample.txt")))
+                    .isEqualTo("META-INF/versions/9/sample.txt");
+        }
+    }
+
+    @Test
+    void jarUtilitiesHandleRegularJarsAndVerifyOverloads(@TempDir Path tempDir) throws IOException {
+        Path regularJar = tempDir.resolve("regular.jar");
+        writeJar(regularJar, false);
+
+        try (JarFile jarFile = JarFiles.create(regularJar.toFile(), false)) {
+            assertThat(JarFiles.isMultiRelease(jarFile)).isFalse();
+            JarEntry entry = jarFile.getJarEntry("sample.txt");
+            assertThat(entry).isNotNull();
+            assertThat(JarEntries.getRealName(entry)).isEqualTo("sample.txt");
+        }
+
+        try (JarFile jarFile = JarFiles.create(regularJar.toString())) {
+            assertThat(JarFiles.isMultiRelease(jarFile)).isFalse();
+            assertThat(JarEntries.getRealName(jarFile.getJarEntry("sample.txt"))).isEqualTo("sample.txt");
+        }
+    }
+
+    private static Path createTree(Path root) throws IOException {
+        Files.createDirectories(root.resolve("nested"));
+        Files.writeString(root.resolve("root.txt"), "root");
+        Files.writeString(root.resolve("nested/child.txt"), "child");
+        return root;
+    }
+
+    private static List<String> fileNames(Path directory) throws IOException {
+        try (Stream<Path> stream = Files.list(directory)) {
+            return stream.map(path -> path.getFileName().toString()).sorted().toList();
+        }
+    }
+
+    private static void assertTreeDeletedWithExpectedStats(
+            Path root, DeleteStats stats, long expectedDirectories, long expectedFiles) {
+        assertThat(root).doesNotExist();
+        assertThat(stats.directoriesFound()).isEqualTo(expectedDirectories);
+        assertThat(stats.directoriesRemoved()).isEqualTo(expectedDirectories);
+        assertThat(stats.filesFound()).isEqualTo(expectedFiles);
+        assertThat(stats.filesRemoved()).isEqualTo(expectedFiles);
+    }
+
+    private static void writeJar(Path jarPath, boolean multiRelease) throws IOException {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        if (multiRelease) {
+            attributes.putValue("Multi-Release", "true");
+        }
+
+        try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+            writeJarEntry(jarOutputStream, "sample.txt", "base");
+            if (multiRelease) {
+                writeJarEntry(jarOutputStream, "META-INF/versions/9/sample.txt", "version-nine");
+            }
+        }
+    }
+
+    private static void writeJarEntry(JarOutputStream jarOutputStream, String name, String content) throws IOException {
+        JarEntry entry = new JarEntry(name);
+        jarOutputStream.putNextEntry(entry);
+        jarOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        jarOutputStream.closeEntry();
     }
 }

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/src/test/java/io_smallrye_common/smallrye_common_io/Smallrye_common_ioTest.java
@@ -126,6 +126,31 @@ public class Smallrye_common_ioTest {
     }
 
     @Test
+    void recursiveDeletionRemovesDirectorySymbolicLinksWithoutFollowingThem(@TempDir Path tempDir) throws IOException {
+        Path externalTarget = tempDir.resolve("external-target");
+        Files.createDirectories(externalTarget);
+        Path externalFile = externalTarget.resolve("preserved.txt");
+        Files.writeString(externalFile, "preserved");
+
+        Path root = tempDir.resolve("root");
+        Files.createDirectories(root);
+        Files.writeString(root.resolve("ordinary.txt"), "ordinary");
+        Path symbolicLink = root.resolve("linked-target");
+        Files.createSymbolicLink(symbolicLink, externalTarget);
+
+        DeleteStats stats = Files2.deleteRecursivelyQuietlyEvenIfInsecure(root);
+
+        assertThat(root).doesNotExist();
+        assertThat(Files.exists(symbolicLink, LinkOption.NOFOLLOW_LINKS)).isFalse();
+        assertThat(externalTarget).isDirectory();
+        assertThat(externalFile).hasContent("preserved");
+        assertThat(stats.directoriesFound()).isEqualTo(1);
+        assertThat(stats.directoriesRemoved()).isEqualTo(1);
+        assertThat(stats.filesFound()).isEqualTo(2);
+        assertThat(stats.filesRemoved()).isEqualTo(2);
+    }
+
+    @Test
     void secureDirectoryUtilitiesOperateOnPathAndStreamOverloads(@TempDir Path tempDir) throws IOException {
         Path secureRoot = tempDir.resolve("secure-root");
         Files.createDirectories(secureRoot);

--- a/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-io/2.16.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.smallrye.common.io.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3829

This PR introduces tests and metadata for io.smallrye.common:smallrye-common-io:2.16.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 98237
- Cached input tokens: 778240
- Output tokens: 16337
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 65.16
- Generated lines of code: 289
- Tested library lines of code: 144

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5e6d2d225cf9b3b8289af5d68d468ea37ca6b40a`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 575/847 (67.89%)
- Line: 144/221 (65.16%)
- Method: 33/43 (76.74%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
