### PR TITLE
Fix Forge metrics test artifact selection

### DIFF
--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 
@@ -58,6 +59,56 @@ def _public_execution_metrics(run_metrics: dict) -> dict:
     run_metrics = dict(run_metrics)
     run_metrics.pop("post_generation_intervention", None)
     return run_metrics
+
+
+def _run_git(repo_path: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+
+
+def _git_commit_all(repo_path: str, message: str) -> str:
+    _run_git(repo_path, "add", "-A")
+    _run_git(
+        repo_path,
+        "-c",
+        "user.name=Forge Tests",
+        "-c",
+        "user.email=forge-tests@example.com",
+        "commit",
+        "-m",
+        message,
+    )
+    return _run_git(repo_path, "rev-parse", "HEAD").stdout.strip()
+
+
+def _write_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(content)
+
+
+def _write_metadata_files(repo_path: str, package: str, artifact: str, library_version: str) -> None:
+    metadata_dir = os.path.join(repo_path, "metadata", package, artifact, library_version)
+    metadata_index_dir = os.path.dirname(metadata_dir)
+    os.makedirs(metadata_dir, exist_ok=True)
+    with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
+        json.dump(
+            [
+                {
+                    "metadata-version": library_version,
+                    "tested-versions": [library_version],
+                }
+            ],
+            file,
+        )
+    with open(os.path.join(metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+        json.dump({"reflection": [{"type": "org.example.Demo"}]}, file)
 
 
 class DummyAgent:
@@ -140,6 +191,140 @@ class MetricsPathTests(unittest.TestCase):
             self.assertEqual(
                 metadata_file,
                 os.path.join("metadata", "org.example", "demo", "1.0.0", "reachability-metadata.json"),
+            )
+
+    def test_resolve_artifact_paths_prefers_changed_generated_test_in_multi_file_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _run_git(temp_dir, "init")
+            package = "org.freemarker"
+            artifact = "freemarker"
+            library_version = "2.3.31"
+            tests_root = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                package,
+                artifact,
+                library_version,
+                "src",
+                "test",
+                "java",
+                "fm",
+            )
+            _write_metadata_files(temp_dir, package, artifact, library_version)
+            _write_file(os.path.join(tests_root, "Product.java"), "package fm;\nclass Product {}\n")
+            _write_file(
+                os.path.join(tests_root, "FreemarkerTest.java"),
+                "package fm;\nimport org.junit.jupiter.api.Test;\nclass FreemarkerTest { @Test void renders() {} }\n",
+            )
+            starting_commit = _git_commit_all(temp_dir, "scaffold")
+            generated_test = os.path.join(
+                tests_root,
+                "ObjectBuilderSettingEvaluatorInnerBuilderCallExpressionTest.java",
+            )
+            _write_file(
+                generated_test,
+                "package fm;\n"
+                "import org.junit.jupiter.api.Test;\n"
+                "class ObjectBuilderSettingEvaluatorInnerBuilderCallExpressionTest { @Test void evaluates() {} }\n",
+            )
+            ending_commit = _git_commit_all(temp_dir, "generated test")
+
+            test_file, _metadata_file = resolve_artifact_paths(
+                temp_dir,
+                package,
+                artifact,
+                library_version,
+                tests_root,
+                starting_commit=starting_commit,
+                ending_commit=ending_commit,
+            )
+
+            self.assertEqual(
+                test_file,
+                os.path.join(
+                    "tests",
+                    "src",
+                    package,
+                    artifact,
+                    library_version,
+                    "src",
+                    "test",
+                    "java",
+                    "fm",
+                    "ObjectBuilderSettingEvaluatorInnerBuilderCallExpressionTest.java",
+                ),
+            )
+
+    def test_resolve_artifact_paths_prefers_changed_semantic_test_over_changed_helper(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _run_git(temp_dir, "init")
+            package = "jline"
+            artifact = "jline"
+            library_version = "3.0.0.M1"
+            tests_root = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                package,
+                artifact,
+                library_version,
+                "src",
+                "test",
+                "java",
+            )
+            helper_file = os.path.join(tests_root, "com", "cloudius", "util", "Stty.java")
+            semantic_test = os.path.join(
+                tests_root,
+                "org",
+                "graalvm",
+                "jline",
+                "CandidateListCompletionHandlerMessagesTest.java",
+            )
+            _write_metadata_files(temp_dir, package, artifact, library_version)
+            _write_file(helper_file, "package com.cloudius.util;\nclass Stty {}\n")
+            _write_file(
+                semantic_test,
+                "package org.graalvm.jline;\n"
+                "import org.junit.jupiter.api.Test;\n"
+                "class CandidateListCompletionHandlerMessagesTest { @Test void printsMessages() {} }\n",
+            )
+            starting_commit = _git_commit_all(temp_dir, "scaffold")
+            _write_file(helper_file, "package com.cloudius.util;\nclass Stty { static final int ROWS = 24; }\n")
+            _write_file(
+                semantic_test,
+                "package org.graalvm.jline;\n"
+                "import org.junit.jupiter.api.Test;\n"
+                "class CandidateListCompletionHandlerMessagesTest { @Test void printsMessages() {} @Test void loadsBundle() {} }\n",
+            )
+            ending_commit = _git_commit_all(temp_dir, "fix javac")
+
+            test_file, _metadata_file = resolve_artifact_paths(
+                temp_dir,
+                package,
+                artifact,
+                library_version,
+                tests_root,
+                starting_commit=starting_commit,
+                ending_commit=ending_commit,
+            )
+
+            self.assertEqual(
+                test_file,
+                os.path.join(
+                    "tests",
+                    "src",
+                    package,
+                    artifact,
+                    library_version,
+                    "src",
+                    "test",
+                    "java",
+                    "org",
+                    "graalvm",
+                    "jline",
+                    "CandidateListCompletionHandlerMessagesTest.java",
+                ),
             )
 
     def test_test_version_resolution_uses_first_tested_versions_entry(self) -> None:

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -442,16 +442,17 @@ def build_run_metrics_dict(
     return run_metrics
 
 
-def resolve_artifact_paths(repo_path, package, artifact, library_version, tests_root):
+def resolve_artifact_paths(
+        repo_path: str,
+        package: str,
+        artifact: str,
+        library_version: str,
+        tests_root: str,
+        starting_commit: str | None = None,
+        ending_commit: str | None = None,
+) -> tuple[str, str]:
     """Resolve test file and metadata file paths for a library version."""
-    test_file_path = None
-    for dirpath, _, filenames in os.walk(tests_root):
-        for fname in filenames:
-            if _is_test_source_file(fname):
-                test_file_path = os.path.relpath(os.path.join(dirpath, fname), repo_path)
-                break
-        if test_file_path:
-            break
+    test_file_path = _resolve_test_artifact_path(repo_path, tests_root, starting_commit, ending_commit)
 
     # Determine metadata_file path (either reachability-metadata.json or the metadata dir)
     metadata_version = resolve_metadata_version(repo_path, package, artifact, library_version)
@@ -469,6 +470,117 @@ def resolve_artifact_paths(repo_path, package, artifact, library_version, tests_
 
 def _is_test_source_file(file_name: str) -> bool:
     return file_name.endswith((".java", ".kt", ".scala", ".groovy"))
+
+
+def _resolve_test_artifact_path(
+        repo_path: str,
+        tests_root: str,
+        starting_commit: str | None = None,
+        ending_commit: str | None = None,
+) -> str | None:
+    source_files = _list_test_source_files(repo_path, tests_root)
+    if not source_files:
+        return None
+
+    changed_source_files = set(_changed_test_source_files(repo_path, tests_root, starting_commit, ending_commit))
+    ranked_files = sorted(
+        source_files,
+        key=lambda path: (
+            _test_artifact_rank(repo_path, path, changed_source_files),
+            path,
+        ),
+    )
+    return ranked_files[0]
+
+
+def _test_artifact_rank(repo_path: str, rel_path: str, changed_source_files: set[str]) -> int:
+    is_semantic_test = _is_semantic_test_file(repo_path, rel_path)
+    if rel_path in changed_source_files and is_semantic_test:
+        return 0
+    if is_semantic_test:
+        return 1
+    if rel_path in changed_source_files:
+        return 2
+    return 3
+
+
+def _list_test_source_files(repo_path: str, tests_root: str) -> list[str]:
+    source_files = []
+    if not tests_root or not os.path.isdir(tests_root):
+        return source_files
+
+    for dirpath, dirnames, filenames in os.walk(tests_root):
+        dirnames.sort()
+        for file_name in sorted(filenames):
+            if _is_test_source_file(file_name):
+                source_files.append(
+                    os.path.normpath(os.path.relpath(os.path.join(dirpath, file_name), repo_path))
+                )
+    return source_files
+
+
+def _changed_test_source_files(
+        repo_path: str,
+        tests_root: str,
+        starting_commit: str | None,
+        ending_commit: str | None,
+) -> list[str]:
+    if not starting_commit or not _is_git_worktree(repo_path):
+        return []
+
+    test_root_rel = os.path.relpath(tests_root, repo_path)
+    revision_range = [starting_commit]
+    if ending_commit:
+        revision_range.append(ending_commit)
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", *revision_range, "--", test_root_rel],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+
+    return sorted(os.path.normpath(path) for path in result.stdout.splitlines() if _is_test_source_file(path))
+
+
+def _is_git_worktree(repo_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _is_semantic_test_file(repo_path: str, rel_path: str) -> bool:
+    file_name = os.path.basename(rel_path)
+    source_name, _ = os.path.splitext(file_name)
+    if source_name.endswith(("Test", "Tests", "IT", "ITCase", "Spec", "Specification")):
+        return True
+
+    absolute_path = os.path.join(repo_path, rel_path)
+    try:
+        with open(absolute_path, "r", encoding="utf-8") as source_file:
+            content = source_file.read()
+    except OSError:
+        return False
+
+    semantic_markers = (
+        "@Test",
+        "@ParameterizedTest",
+        "org.junit",
+        "junit.framework",
+        "spock.lang",
+        "io.kotest",
+    )
+    return any(marker in content for marker in semantic_markers)
 
 
 def collect_base_metrics(repo_path, package, artifact, library_version, agent, model_name, global_iterations):
@@ -504,7 +616,15 @@ def create_run_metrics_output_json(
     Build a run_metrics dict using collected metrics.
     """
     metrics = collect_base_metrics(repo_path, package, artifact, library_version, agent, model_name, global_iterations)
-    test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, library_version, tests_root)
+    test_file, metadata_file = resolve_artifact_paths(
+        repo_path,
+        package,
+        artifact,
+        library_version,
+        tests_root,
+        starting_commit=starting_commit,
+        ending_commit=ending_commit,
+    )
     agent_name = resolve_agent(strategy_name)
     stats = load_library_stats_snapshot(repo_path, package, artifact, library_version)
 
@@ -553,7 +673,15 @@ def create_javac_fix_run_metrics_output_json(
 ):
     """Build run metrics for fix_javac_fail workflow including previous-version metrics."""
     metrics = collect_base_metrics(repo_path, package, artifact, new_library_version, agent, model_name, global_iterations)
-    test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, new_library_version, tests_root)
+    test_file, metadata_file = resolve_artifact_paths(
+        repo_path,
+        package,
+        artifact,
+        new_library_version,
+        tests_root,
+        starting_commit=starting_commit,
+        ending_commit=ending_commit,
+    )
 
     previous_coverage_percent, _ = collect_version_coverage_metrics(
         repo_path=repo_path,


### PR DESCRIPTION
### Summary
- fix Forge metrics artifact selection so `artifacts.test_file` prefers changed/generated semantic tests instead of the first source file returned by `os.walk`
- keep deterministic fallback ordering for semantic tests, changed helper sources, and remaining test sources
- add focused coverage for the Freemarker multi-file test root and JLine helper-source layouts reported by the human-intervention items

### Root cause
Forge recorded the wrong generated-test artifact when a test root contained multiple source files. The old resolver in `forge/utility_scripts/metrics_writer.py` walked `tests_root` and selected the first source file, so #5221 pointed at `Product.java` instead of `ObjectBuilderSettingEvaluatorInnerBuilderCallExpressionTest.java`, and #5189 pointed at `Stty.java` instead of `CandidateListCompletionHandlerMessagesTest.java`.

### GitHub items addressed
- Addresses the Forge metrics-artifact portion of #5221.
- Addresses the Forge metrics-artifact portion of #5189.
- The affected PR branches were refreshed separately so their `execution-metrics.json` files now point at the reviewed generated/semantic test files.

### Validation
- `PYTHONPATH=$PWD/forge python3 -m unittest forge.tests.test_metrics_paths`
- `PYTHONPATH=$PWD/forge python3 -m py_compile forge/utility_scripts/metrics_writer.py forge/tests/test_metrics_paths.py`
- `git diff --check`
- Review verified refreshed remote branch heads: #5221 at `5365bb1728`, #5189 at `d8fae3d9b8`.
- Review verified each refreshed stats commit changes only the relevant `execution-metrics.json` `artifacts.test_file` value.

### Notes
#5189 still has a separate JLine resource dynamic-access follow-up, so this PR does not by itself clear that PR's remaining human-intervention state.
