### PR TITLE
[GenAI] Mark com.squareup.wire:wire-runtime as not for Native Image

### DIFF
--- a/metadata/com.squareup.wire/wire-runtime/index.json
+++ b/metadata/com.squareup.wire/wire-runtime/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to com.squareup.wire:wire-runtime-jvm:5.3.3.",
+    "replacement": "com.squareup.wire:wire-runtime-jvm:5.3.3"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4492

This PR records `com.squareup.wire:wire-runtime` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to com.squareup.wire:wire-runtime-jvm:5.3.3.

Replacement guidance:
- com.squareup.wire:wire-runtime-jvm:5.3.3

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c086f996186313347cc1798aedd219e2c3e60773`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
