### PR TITLE
[GenAI] Mark app.cash.sqldelight:runtime as not for Native Image

### DIFF
--- a/metadata/app.cash.sqldelight/runtime/index.json
+++ b/metadata/app.cash.sqldelight/runtime/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to app.cash.sqldelight:runtime-jvm:2.3.2.",
+    "replacement": "app.cash.sqldelight:runtime-jvm:2.3.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5359

This PR records `app.cash.sqldelight:runtime` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to app.cash.sqldelight:runtime-jvm:2.3.2.

Replacement guidance:
- app.cash.sqldelight:runtime-jvm:2.3.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e55493c65d8b1842d06b9d777871e92c765e7411`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
