### PR TITLE
Guard new-library coverage before Forge PR publication

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -179,6 +179,7 @@ ADD_NEW_LIBRARY_METRICS_FILE = "add_new_library_support.json"
 FIX_JAVAC_METRICS_FILE = "fix_javac_fail.json"
 FIX_JAVA_RUN_METRICS_FILE = "fix_java_run_fail.json"
 LOW_DYNAMIC_ACCESS_COVERAGE_RATIO = 0.10
+NEW_LIBRARY_DYNAMIC_ACCESS_COVERAGE_RATIO = 0.50
 HUMAN_INTERVENTION_LABEL_COLOR = "B60205"
 HUMAN_INTERVENTION_LABEL_DESCRIPTION = (
     "Requires manual follow-up because automated processing needs human attention"
@@ -1893,6 +1894,18 @@ def _load_dynamic_access_snapshot_from_report(claimed_issue: ClaimedIssue) -> Dy
     )
 
 
+def has_reviewable_dynamic_access_coverage(
+        claimed_issue: ClaimedIssue,
+        coverage_snapshot: DynamicAccessCoverageSnapshot,
+) -> bool:
+    """Return True when dynamic-access coverage is high enough to publish normally."""
+    if coverage_snapshot.covered_calls <= 0:
+        return False
+    if claimed_issue.label == LABEL_LIBRARY_NEW:
+        return coverage_snapshot.coverage_ratio >= NEW_LIBRARY_DYNAMIC_ACCESS_COVERAGE_RATIO
+    return coverage_snapshot.coverage_ratio > LOW_DYNAMIC_ACCESS_COVERAGE_RATIO
+
+
 def resolve_human_intervention_candidate(
         claimed_issue: ClaimedIssue,
         workflow_success: bool = True,
@@ -1945,10 +1958,7 @@ def resolve_human_intervention_candidate(
     if coverage_snapshot is None:
         return None
 
-    if (
-            coverage_snapshot.covered_calls > 0
-            and coverage_snapshot.coverage_ratio > LOW_DYNAMIC_ACCESS_COVERAGE_RATIO
-    ):
+    if has_reviewable_dynamic_access_coverage(claimed_issue, coverage_snapshot):
         return None
 
     return HumanInterventionCandidate(
@@ -3715,6 +3725,46 @@ def handle_failed_claimed_issue(
     revert_claimed_issue(claimed_issue, reason)
 
 
+def handle_successful_human_intervention_claimed_issue(
+        claimed_issue: ClaimedIssue,
+        candidate: HumanInterventionCandidate,
+        started_at: float | None = None,
+) -> None:
+    """Preserve a successful but unpublishable run for human follow-up before PR creation."""
+    if is_user_interrupt_requested():
+        raise KeyboardInterrupt
+    preservation_result = preserve_failed_work_for_follow_up(claimed_issue)
+    if is_user_interrupt_requested():
+        raise KeyboardInterrupt
+    try:
+        comment_body = run_human_intervention_analysis(
+            claimed_issue,
+            candidate,
+            started_at,
+            preservation_result,
+        )
+        comment_body = ensure_preserved_branch_link_in_comment(comment_body, preservation_result)
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to apply human-intervention follow-up to issue #{claimed_issue.issue['number']}: {exc!r}",
+            file=sys.stderr,
+        )
+        traceback.print_exc()
+        comment_body = None
+    if is_user_interrupt_requested():
+        raise KeyboardInterrupt
+    post_human_intervention_comment_and_label(claimed_issue.issue["number"], comment_body)
+    try:
+        refresh_preserved_branch_logs(claimed_issue, preservation_result)
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to refresh preserved logs for issue #{claimed_issue.issue['number']}: {exc!r}",
+            file=sys.stderr,
+        )
+        traceback.print_exc()
+    revert_claimed_issue(claimed_issue, candidate.reason)
+
+
 def handle_completed_run(run_result: WorkflowRunResult) -> bool:
     """Finalize a completed workflow run and return the final handled result."""
     claimed_issue = run_result.claimed_issue
@@ -3728,6 +3778,15 @@ def handle_completed_run(run_result: WorkflowRunResult) -> bool:
                 started_at=run_result.started_at,
             )
             return False
+        if claimed_issue.label == LABEL_LIBRARY_NEW:
+            candidate = resolve_human_intervention_candidate(claimed_issue, workflow_success=True)
+            if candidate is not None:
+                handle_successful_human_intervention_claimed_issue(
+                    claimed_issue,
+                    candidate,
+                    started_at=run_result.started_at,
+                )
+                return True
         try:
             finalize_successful_issue(claimed_issue)
         except Exception as exc:
@@ -3784,7 +3843,7 @@ def process_claimed_issue_lifecycle(
             log_success_banner(
                 format_issue_result_message(
                     claimed_issue,
-                    "Workflow finished, follow-up completed, and the issue was finalized.",
+                    "Workflow finished and follow-up completed.",
                 )
             )
         else:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -129,6 +129,169 @@ class FinalizeSuccessfulIssueTests(unittest.TestCase):
         ])
 
 
+class HumanInterventionCandidateTests(unittest.TestCase):
+    @staticmethod
+    def _dynamic_access_metrics(covered_calls: int, total_calls: int) -> dict:
+        return {
+            "strategy_name": "dynamic-access",
+            "status": "success",
+            "stats": {
+                "dynamicAccess": {
+                    "coveredCalls": covered_calls,
+                    "totalCalls": total_calls,
+                    "coverageRatio": covered_calls / total_calls,
+                },
+            },
+        }
+
+    def test_new_library_coverage_below_review_gate_routes_to_human_intervention(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW)
+
+        with patch.object(
+                forge_metadata,
+                "_load_pending_run_metrics",
+                return_value=self._dynamic_access_metrics(2, 16),
+        ), \
+                patch.object(
+                    forge_metadata,
+                    "load_strategy_by_name",
+                    return_value={"workflow": "dynamic_access_iterative"},
+                ):
+            candidate = forge_metadata.resolve_human_intervention_candidate(claimed_issue)
+
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.reason, "low_dynamic_access_coverage")
+        self.assertEqual(candidate.coverage.covered_calls, 2)
+        self.assertEqual(candidate.coverage.total_calls, 16)
+
+    def test_new_library_coverage_at_review_gate_continues_without_intervention(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW)
+
+        with patch.object(
+                forge_metadata,
+                "_load_pending_run_metrics",
+                return_value=self._dynamic_access_metrics(8, 16),
+        ), \
+                patch.object(
+                    forge_metadata,
+                    "load_strategy_by_name",
+                    return_value={"workflow": "dynamic_access_iterative"},
+                ):
+            candidate = forge_metadata.resolve_human_intervention_candidate(claimed_issue)
+
+        self.assertIsNone(candidate)
+
+    def test_library_update_keeps_existing_low_coverage_threshold(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_LIBRARY_UPDATE)
+
+        with patch.object(
+                forge_metadata,
+                "_load_pending_run_metrics",
+                return_value=self._dynamic_access_metrics(2, 16),
+        ), \
+                patch.object(
+                    forge_metadata,
+                    "load_strategy_by_name",
+                    return_value={"workflow": "dynamic_access_iterative"},
+                ):
+            candidate = forge_metadata.resolve_human_intervention_candidate(claimed_issue)
+
+        self.assertIsNone(candidate)
+
+    def test_successful_low_coverage_new_library_routes_before_pr_publication(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW)
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name="dynamic-access",
+            workflow_status="success",
+            coverage=forge_metadata.DynamicAccessCoverageSnapshot(
+                covered_calls=2,
+                total_calls=16,
+                coverage_ratio=0.125,
+                source="stats",
+            ),
+        )
+        run_result = forge_metadata.WorkflowRunResult(
+            claimed_issue=claimed_issue,
+            success=True,
+            started_at=123.0,
+        )
+
+        with patch.object(
+                forge_metadata,
+                "resolve_human_intervention_candidate",
+                return_value=candidate,
+        ) as resolve_candidate, \
+                patch.object(
+                    forge_metadata,
+                    "handle_successful_human_intervention_claimed_issue",
+                ) as handle_human_intervention, \
+                patch.object(forge_metadata, "finalize_successful_issue") as finalize_successful_issue, \
+                patch.object(forge_metadata, "apply_large_library_completion_follow_up") as large_library_follow_up:
+            self.assertTrue(forge_metadata.handle_completed_run(run_result))
+
+        resolve_candidate.assert_called_once_with(claimed_issue, workflow_success=True)
+        handle_human_intervention.assert_called_once_with(
+            claimed_issue,
+            candidate,
+            started_at=123.0,
+        )
+        finalize_successful_issue.assert_not_called()
+        large_library_follow_up.assert_not_called()
+
+    def test_successful_human_intervention_follow_up_preserves_branch_and_reverts_claim(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW)
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name="dynamic-access",
+            workflow_status="success",
+            coverage=forge_metadata.DynamicAccessCoverageSnapshot(
+                covered_calls=0,
+                total_calls=57,
+                coverage_ratio=0.0,
+                source="stats",
+            ),
+        )
+        preservation_result = forge_metadata.FailurePreservationResult(
+            branch_name="ai/automation/human-intervention/1412",
+            branch_url="https://github.com/example/repo/tree/ai/automation/human-intervention/1412",
+            committed_changes=True,
+        )
+
+        with patch.object(
+                forge_metadata,
+                "preserve_failed_work_for_follow_up",
+                return_value=preservation_result,
+        ) as preserve_failed_work, \
+                patch.object(
+                    forge_metadata,
+                    "run_human_intervention_analysis",
+                    return_value="Human intervention needed\n\nCoverage is too low.",
+                ) as run_human_intervention_analysis, \
+                patch.object(
+                    forge_metadata,
+                    "post_human_intervention_comment_and_label",
+                ) as post_human_intervention, \
+                patch.object(forge_metadata, "refresh_preserved_branch_logs") as refresh_logs, \
+                patch.object(forge_metadata, "revert_claimed_issue") as revert_claimed_issue:
+            forge_metadata.handle_successful_human_intervention_claimed_issue(
+                claimed_issue,
+                candidate,
+                started_at=123.0,
+            )
+
+        preserve_failed_work.assert_called_once_with(claimed_issue)
+        run_human_intervention_analysis.assert_called_once_with(
+            claimed_issue,
+            candidate,
+            123.0,
+            preservation_result,
+        )
+        post_human_intervention.assert_called_once()
+        self.assertEqual(post_human_intervention.call_args.args[0], 1412)
+        self.assertIn(preservation_result.branch_url, post_human_intervention.call_args.args[1])
+        refresh_logs.assert_called_once_with(claimed_issue, preservation_result)
+        revert_claimed_issue.assert_called_once_with(claimed_issue, candidate.reason)
+
+
 class IssueClaimPreflightTests(unittest.TestCase):
     def test_forge_gh_does_not_log_github_query_by_default(self) -> None:
         completed_process = subprocess.CompletedProcess(


### PR DESCRIPTION
### Summary
- add a separate `50%` dynamic-access review gate for successful `library-new-request` runs before Forge publishes a PR
- preserve successful but unpublishable new-library work on a human-intervention branch, post the follow-up evidence, refresh preserved logs, and revert the issue claim instead of finalizing the PR
- keep the existing low-coverage threshold behavior for `library-update-request`

### Root cause
Forge used the same low dynamic-access coverage threshold for successful new-library work as it used for low-coverage update routing. That allowed new-library PR branches with non-zero but clearly unreviewable dynamic-access coverage, such as #5528 at `2/16` and #5222 at `0/57`, to reach publication with empty shipped metadata and then require human intervention after review.

### GitHub items addressed
- Addresses the Forge publication guardrail failure discovered while handling #5528.
- Addresses the same Forge publication guardrail failure discovered while handling #5222.
- #5528 and #5222 are intentionally not marked fixed by this infrastructure PR; both still need library-specific coverage repair before their `human-intervention` labels can be removed.
- Durable handoff comments were already posted on #5528 and #5222 with their current branch heads, unchanged low coverage, validation reruns, and next-owner coverage targets.

### Validation
- `python3 -m unittest tests.test_forge_metadata.HumanInterventionCandidateTests tests.test_forge_metadata.FinalizeSuccessfulIssueTests`
- `python3 -m py_compile forge_metadata.py tests/test_forge_metadata.py`
- `git diff --check`
- Review confirmed PR-specific Gradle reruns passed for `io.undertow:undertow-servlet:2.3.18.Final`, with dynamic-access coverage still `2/16`.
- Review confirmed PR-specific Gradle reruns passed for `org.jboss.modules:jboss-modules:2.1.6.Final`, with dynamic-access coverage still `0/57`.

### Notes
Configured reviewers were `[]`, so this PR uses repository-default review routing. No Forge-specific label exists in the repository label set, matching existing Forge infrastructure PR practice.
