### PR TITLE
[GenAI] Add support for io.prometheus:simpleclient_caffeine:0.16.0 using gpt-5.5

### DIFF
--- a/metadata/io.prometheus/simpleclient_caffeine/0.16.0/reachability-metadata.json
+++ b/metadata/io.prometheus/simpleclient_caffeine/0.16.0/reachability-metadata.json
@@ -1,0 +1,32 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.benmanes.caffeine.cache.LocalCacheFactory"
+      },
+      "type": "com.github.benmanes.caffeine.cache.SSSMW",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github.benmanes.caffeine.cache.Caffeine",
+            "com.github.benmanes.caffeine.cache.AsyncCacheLoader",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.github.benmanes.caffeine.cache.SSSMW"
+      },
+      "type": "com.github.benmanes.caffeine.cache.PSMW",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.prometheus/simpleclient_caffeine/index.json
+++ b/metadata/io.prometheus/simpleclient_caffeine/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "0.16.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-sources.jar",
-    "repository-url" : "https://github.com/prometheus/client_java",
-    "test-code-url" : "https://github.com/prometheus/client_java/tree/parent-$version$/simpleclient_caffeine/src/test/java",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-javadoc.jar",
-    "description" : "simpleclient_caffeine adds a Prometheus Java client collector for Caffeine caches. It exports cache statistics such as hits, misses, requests, evictions, estimated size, and load timing as Prometheus metrics labeled by cache name.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "0.16.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-sources.jar",
+    "repository-url": "https://github.com/prometheus/client_java",
+    "test-code-url": "https://github.com/prometheus/client_java/tree/parent-$version$/simpleclient_caffeine/src/test/java",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-javadoc.jar",
+    "description": "simpleclient_caffeine adds a Prometheus Java client collector for Caffeine caches. It exports cache statistics such as hits, misses, requests, evictions, estimated size, and load timing as Prometheus metrics labeled by cache name.",
+    "tested-versions": [
       "0.16.0"
     ],
-    "allowed-packages" : [
-      "io.prometheus.client.cache.caffeine"
+    "allowed-packages": [
+      "io.prometheus.client.cache.caffeine",
+      "com.github.benmanes.caffeine.cache"
     ]
   }
 ]

--- a/metadata/io.prometheus/simpleclient_caffeine/index.json
+++ b/metadata/io.prometheus/simpleclient_caffeine/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.16.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-sources.jar",
+    "repository-url" : "https://github.com/prometheus/client_java",
+    "test-code-url" : "https://github.com/prometheus/client_java/tree/parent-$version$/simpleclient_caffeine/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/prometheus/simpleclient_caffeine/$version$/simpleclient_caffeine-$version$-javadoc.jar",
+    "description" : "simpleclient_caffeine adds a Prometheus Java client collector for Caffeine caches. It exports cache statistics such as hits, misses, requests, evictions, estimated size, and load timing as Prometheus metrics labeled by cache name.",
+    "tested-versions" : [
+      "0.16.0"
+    ],
+    "allowed-packages" : [
+      "io.prometheus.client.cache.caffeine"
+    ]
+  }
+]

--- a/stats/io.prometheus/simpleclient_caffeine/0.16.0/execution-metrics.json
+++ b/stats/io.prometheus/simpleclient_caffeine/0.16.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T02:22:08.160023Z",
+    "library": "io.prometheus:simpleclient_caffeine:0.16.0",
+    "starting_commit": "f406e5f5ccdee7b62832de75faaba5dccdbe838e",
+    "ending_commit": "7d66cb01e04d49780b60bec05480be570fd6c637",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.16.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 249,
+          "missed": 1,
+          "ratio": 0.996,
+          "total": 250
+        },
+        "line": {
+          "covered": 45,
+          "missed": 1,
+          "ratio": 0.978261,
+          "total": 46
+        },
+        "method": {
+          "covered": 6,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 6
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 142390,
+      "cached_input_tokens_used": 945152,
+      "output_tokens_used": 18683,
+      "iterations": 4,
+      "cost_usd": 1.0331,
+      "generated_loc": 220,
+      "tested_library_loc": 45,
+      "metadata_entries": 4,
+      "code_coverage_percent": 97.83
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java",
+      "metadata_file": "metadata/io.prometheus/simpleclient_caffeine/0.16.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.prometheus/simpleclient_caffeine/0.16.0/stats.json
+++ b/stats/io.prometheus/simpleclient_caffeine/0.16.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.16.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 249,
+        "missed" : 1,
+        "ratio" : 0.996,
+        "total" : 250
+      },
+      "line" : {
+        "covered" : 45,
+        "missed" : 1,
+        "ratio" : 0.978261,
+        "total" : 46
+      },
+      "method" : {
+        "covered" : 6,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 6
+      }
+    }
+  } ]
+}

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/.gitignore
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/build.gradle
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.prometheus:simpleclient_caffeine:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/gradle.properties
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.prometheus:simpleclient_caffeine:0.16.0
+library.version = 0.16.0
+metadata.dir = io.prometheus/simpleclient_caffeine/0.16.0/

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/settings.gradle
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.prometheus.simpleclient_caffeine_tests'

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_prometheus.simpleclient_caffeine;
+
+import org.junit.jupiter.api.Test;
+
+class Simpleclient_caffeineTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
@@ -6,11 +6,195 @@
  */
 package io_prometheus.simpleclient_caffeine;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.Collector.Type;
+import io.prometheus.client.cache.caffeine.CacheMetricsCollector;
 import org.junit.jupiter.api.Test;
 
-class Simpleclient_caffeineTest {
+public class Simpleclient_caffeineTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void collectReportsRequestAndSizeMetricsForManualCache() {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .build();
+        cache.put("alpha", "one");
+        assertThat(cache.getIfPresent("alpha")).isEqualTo("one");
+        assertThat(cache.getIfPresent("missing")).isNull();
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("manual", cache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertFamily(samples, "caffeine_cache_hit", Type.COUNTER, "Cache hit totals");
+        assertFamily(samples, "caffeine_cache_miss", Type.COUNTER, "Cache miss totals");
+        assertFamily(samples, "caffeine_cache_requests", Type.COUNTER, "Cache request totals, hits + misses");
+        assertFamily(samples, "caffeine_cache_estimated_size", Type.GAUGE, "Estimated cache size");
+
+        assertThat(metricValue(samples, "caffeine_cache_hit", "manual")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "manual")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "manual")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_eviction", "manual")).isEqualTo(0.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "manual")).isEqualTo(1.0);
+        assertThat(family(samples, "caffeine_cache_loads").samples).isEmpty();
+        assertThat(family(samples, "caffeine_cache_load_duration_seconds").samples).isEmpty();
+    }
+
+    @Test
+    void collectReportsLoadingCacheSuccessesFailuresAndDurationSummary() {
+        AtomicInteger loadCount = new AtomicInteger();
+        LoadingCache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .build(key -> {
+                    loadCount.incrementAndGet();
+                    if ("failure".equals(key)) {
+                        throw new IllegalStateException("intentional load failure");
+                    }
+                    return "loaded-" + key;
+                });
+
+        assertThat(cache.get("ok")).isEqualTo("loaded-ok");
+        assertThat(cache.get("ok")).isEqualTo("loaded-ok");
+        assertThatThrownBy(() -> cache.get("failure")).isInstanceOf(RuntimeException.class);
+        assertThat(loadCount.get()).isEqualTo(2);
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("loading", cache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertFamily(samples, "caffeine_cache_load_failure", Type.COUNTER, "Cache load failures");
+        assertFamily(samples, "caffeine_cache_loads", Type.COUNTER, "Cache loads: both success and failures");
+        assertFamily(samples, "caffeine_cache_load_duration_seconds", Type.SUMMARY,
+                "Cache load duration: both success and failures");
+
+        assertThat(metricValue(samples, "caffeine_cache_hit", "loading")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "loading")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "loading")).isEqualTo(3.0);
+        assertThat(metricValue(samples, "caffeine_cache_load_failure", "loading")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_loads", "loading")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "loading")).isEqualTo(1.0);
+        assertThat(summaryValue(samples, "caffeine_cache_load_duration_seconds_count", "loading")).isEqualTo(2.0);
+        assertThat(summaryValue(samples, "caffeine_cache_load_duration_seconds_sum", "loading"))
+                .isGreaterThanOrEqualTo(0.0);
+    }
+
+    @Test
+    void collectReportsMetricsForAsyncCacheAddedThroughAsyncApi() throws Exception {
+        AsyncLoadingCache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .executor(Runnable::run)
+                .buildAsync(key -> "async-" + key);
+
+        assertThat(cache.get("value").get(1, SECONDS)).isEqualTo("async-value");
+        assertThat(cache.get("value").get(1, SECONDS)).isEqualTo("async-value");
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("async", cache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertThat(metricValue(samples, "caffeine_cache_hit", "async")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "async")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "async")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_loads", "async")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_load_failure", "async")).isEqualTo(0.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "async")).isEqualTo(1.0);
+        assertThat(summaryValue(samples, "caffeine_cache_load_duration_seconds_count", "async")).isEqualTo(1.0);
+    }
+
+    @Test
+    void collectReportsEvictionWeightForWeightedCache() {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .maximumWeight(1)
+                .weigher((String key, String value) -> 1)
+                .build();
+        cache.put("first", "one");
+        cache.put("second", "two");
+        cache.cleanUp();
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("weighted", cache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertThat(metricValue(samples, "caffeine_cache_eviction", "weighted")).isGreaterThanOrEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_eviction_weight", "weighted")).isGreaterThanOrEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "weighted")).isLessThanOrEqualTo(1.0);
+    }
+
+    @Test
+    void removeCacheAndClearStopPublishingCacheSamples() {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .build();
+        cache.put("key", "value");
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("removed", cache);
+
+        assertThat(collector.removeCache("removed")).isSameAs(cache);
+        assertThat(collector.removeCache("missing")).isNull();
+        assertAllFamiliesEmpty(collector.collect());
+
+        collector.addCache("cleared", cache);
+        assertThat(metricValue(collector.collect(), "caffeine_cache_estimated_size", "cleared")).isEqualTo(1.0);
+
+        collector.clear();
+        assertAllFamiliesEmpty(collector.collect());
+    }
+
+    private static void assertFamily(List<MetricFamilySamples> samples, String name, Type type, String help) {
+        MetricFamilySamples family = family(samples, name);
+        assertThat(family.type).isEqualTo(type);
+        assertThat(family.help).isEqualTo(help);
+    }
+
+    private static double metricValue(List<MetricFamilySamples> samples, String familyName, String cacheName) {
+        List<Sample> matchingSamples = family(samples, familyName).samples.stream()
+                .filter(sample -> sample.labelNames.equals(List.of("cache")))
+                .filter(sample -> sample.labelValues.equals(List.of(cacheName)))
+                .toList();
+        assertThat(matchingSamples)
+                .describedAs("samples for metric family %s and cache %s", familyName, cacheName)
+                .hasSize(1);
+        return matchingSamples.get(0).value;
+    }
+
+    private static double summaryValue(List<MetricFamilySamples> samples, String sampleName, String cacheName) {
+        List<Sample> matchingSamples = family(samples, "caffeine_cache_load_duration_seconds").samples.stream()
+                .filter(sample -> sample.name.equals(sampleName))
+                .filter(sample -> sample.labelNames.equals(List.of("cache")))
+                .filter(sample -> sample.labelValues.equals(List.of(cacheName)))
+                .toList();
+        assertThat(matchingSamples)
+                .describedAs("summary samples named %s for cache %s", sampleName, cacheName)
+                .hasSize(1);
+        return matchingSamples.get(0).value;
+    }
+
+    private static MetricFamilySamples family(List<MetricFamilySamples> samples, String name) {
+        List<MetricFamilySamples> matchingFamilies = samples.stream()
+                .filter(sample -> sample.name.equals(name))
+                .toList();
+        assertThat(matchingFamilies)
+                .describedAs("metric family %s", name)
+                .hasSize(1);
+        return matchingFamilies.get(0);
+    }
+
+    private static void assertAllFamiliesEmpty(List<MetricFamilySamples> samples) {
+        assertThat(samples)
+                .extracting(sample -> sample.samples)
+                .allSatisfy(familySamples -> assertThat(familySamples).isEmpty());
     }
 }

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
@@ -52,6 +52,37 @@ public class Simpleclient_caffeineTest {
     }
 
     @Test
+    void collectReportsMetricsForMultipleCaches() {
+        Cache<String, String> usersCache = Caffeine.newBuilder()
+                .recordStats()
+                .build();
+        usersCache.put("alice", "admin");
+        assertThat(usersCache.getIfPresent("alice")).isEqualTo("admin");
+
+        Cache<String, String> sessionsCache = Caffeine.newBuilder()
+                .recordStats()
+                .build();
+        sessionsCache.put("session-1", "alice");
+        sessionsCache.put("session-2", "bob");
+        assertThat(sessionsCache.getIfPresent("session-1")).isEqualTo("alice");
+        assertThat(sessionsCache.getIfPresent("expired")).isNull();
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("users", usersCache);
+        collector.addCache("sessions", sessionsCache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertThat(metricValue(samples, "caffeine_cache_hit", "users")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "users")).isEqualTo(0.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "users")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "users")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_hit", "sessions")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "sessions")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "sessions")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "sessions")).isEqualTo(2.0);
+    }
+
+    @Test
     void collectReportsLoadingCacheSuccessesFailuresAndDurationSummary() {
         AtomicInteger loadCount = new AtomicInteger();
         LoadingCache<String, String> cache = Caffeine.newBuilder()

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/src/test/java/io_prometheus/simpleclient_caffeine/Simpleclient_caffeineTest.java
@@ -11,8 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -141,6 +143,30 @@ public class Simpleclient_caffeineTest {
         assertThat(metricValue(samples, "caffeine_cache_load_failure", "async")).isEqualTo(0.0);
         assertThat(metricValue(samples, "caffeine_cache_estimated_size", "async")).isEqualTo(1.0);
         assertThat(summaryValue(samples, "caffeine_cache_load_duration_seconds_count", "async")).isEqualTo(1.0);
+    }
+
+    @Test
+    void collectReportsMetricsForManualAsyncCacheWithoutLoadSamples() throws Exception {
+        AsyncCache<String, String> cache = Caffeine.newBuilder()
+                .recordStats()
+                .executor(Runnable::run)
+                .buildAsync();
+        cache.put("ready", CompletableFuture.completedFuture("async-ready"));
+
+        assertThat(cache.getIfPresent("ready").get(1, SECONDS)).isEqualTo("async-ready");
+        assertThat(cache.getIfPresent("missing")).isNull();
+
+        CacheMetricsCollector collector = new CacheMetricsCollector();
+        collector.addCache("manual-async", cache);
+
+        List<MetricFamilySamples> samples = collector.collect();
+        assertThat(metricValue(samples, "caffeine_cache_hit", "manual-async")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_miss", "manual-async")).isEqualTo(1.0);
+        assertThat(metricValue(samples, "caffeine_cache_requests", "manual-async")).isEqualTo(2.0);
+        assertThat(metricValue(samples, "caffeine_cache_estimated_size", "manual-async")).isEqualTo(1.0);
+        assertThat(family(samples, "caffeine_cache_load_failure").samples).isEmpty();
+        assertThat(family(samples, "caffeine_cache_loads").samples).isEmpty();
+        assertThat(family(samples, "caffeine_cache_load_duration_seconds").samples).isEmpty();
     }
 
     @Test

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/user-code-filter.json
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.prometheus.client.cache.caffeine.**"
+    }
+  ]
+}

--- a/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/user-code-filter.json
+++ b/tests/src/io.prometheus/simpleclient_caffeine/0.16.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.prometheus.client.cache.caffeine.**"
+      "includeClasses" : "io.prometheus.client.cache.caffeine.**"
+    },
+    {
+      "includeClasses" : "io_prometheus.simpleclient_caffeine.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4822

This PR introduces tests and metadata for io.prometheus:simpleclient_caffeine:0.16.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 142390
- Cached input tokens: 945152
- Output tokens: 18683
- Metadata entries: 4
- Iterations: 4
- Library coverage percentage: 97.83
- Generated lines of code: 220
- Tested library lines of code: 45

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `463a3b8f21fb1aea518890cf79d2787ffa087a5c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 249/250 (99.60%)
- Line: 45/46 (97.83%)
- Method: 6/6 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
