### PR TITLE
[GenAI] Test fix for org.openjfx:javafx-base:13-ea using gpt-5.5

### DIFF
--- a/metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json
+++ b/metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json
@@ -2,7 +2,7 @@
   "reflection" : [
     {
       "condition" : {
-        "typeReached" : "javafx.beans.property.adapter.JavaBeanIntegerProperty"
+        "typeReached" : "com.sun.javafx.reflect.MethodUtil"
       },
       "type" : "com.sun.javafx.reflect.Trampoline",
       "methods" : [

--- a/metadata/org.openjfx/javafx-base/index.json
+++ b/metadata/org.openjfx/javafx-base/index.json
@@ -12,7 +12,8 @@
     ],
     "allowed-packages": [
       "org.openjfx",
-      "javafx.beans.property.adapter"
+      "javafx.beans.property.adapter",
+      "com.sun.javafx.reflect"
     ]
   },
   {

--- a/stats/org.openjfx/javafx-base/13-ea/execution-metrics.json
+++ b/stats/org.openjfx/javafx-base/13-ea/execution-metrics.json
@@ -105,5 +105,112 @@
       "test_file": "tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyDescriptorTest.java",
       "metadata_file": "metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json"
     }
+  },
+  "fix_javac_fail:2026-05-04": {
+    "timestamp": "2026-05-04T03:22:27.470209Z",
+    "library": "org.openjfx:javafx-base:13-ea",
+    "starting_commit": "b7d6f1a9dbf439dc0f38681fb7b43aea97703e1d",
+    "ending_commit": "afdd4a61759e662e55c6e7cf4cc1fb3d376f5968",
+    "previous_library": "org.openjfx:javafx-base:13-ea",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "13-ea",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.701754,
+            "coveredCalls": 40,
+            "totalCalls": 57
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.706897,
+        "coveredCalls": 41,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6721,
+          "missed": 56770,
+          "ratio": 0.105858,
+          "total": 63491
+        },
+        "line": {
+          "covered": 1769,
+          "missed": 12591,
+          "ratio": 0.123189,
+          "total": 14360
+        },
+        "method": {
+          "covered": 510,
+          "missed": 4069,
+          "ratio": 0.111378,
+          "total": 4579
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "13-ea",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.701754,
+            "coveredCalls": 40,
+            "totalCalls": 57
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.706897,
+        "coveredCalls": 41,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6721,
+          "missed": 56770,
+          "ratio": 0.105858,
+          "total": 63491
+        },
+        "line": {
+          "covered": 1769,
+          "missed": 12591,
+          "ratio": 0.123189,
+          "total": 14360
+        },
+        "method": {
+          "covered": 510,
+          "missed": 4069,
+          "ratio": 0.111378,
+          "total": 4579
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 231169,
+      "cached_input_tokens_used": 2229760,
+      "output_tokens_used": 23564,
+      "iterations": 5,
+      "cost_usd": 1.8218,
+      "tested_library_loc": 1769,
+      "metadata_entries": 2,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 12.32,
+      "previous_library_coverage_percent": 12.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/FXCollectionsInnerCheckedObservableListTest.java",
+      "metadata_file": "metadata/org.openjfx/javafx-base/13-ea/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.openjfx/javafx-base/13-ea/stats.json
+++ b/stats/org.openjfx/javafx-base/13-ea/stats.json
@@ -4,8 +4,8 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.263158,
-          "coveredCalls" : 15,
+          "coverageRatio" : 0.701754,
+          "coveredCalls" : 40,
           "totalCalls" : 57
         },
         "resources" : {
@@ -14,27 +14,27 @@
           "totalCalls" : 1
         }
       },
-      "coverageRatio" : 0.275862,
-      "coveredCalls" : 16,
+      "coverageRatio" : 0.706897,
+      "coveredCalls" : 41,
       "totalCalls" : 58
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 5799,
-        "missed" : 57692,
-        "ratio" : 0.091336,
+        "covered" : 6721,
+        "missed" : 56770,
+        "ratio" : 0.105858,
         "total" : 63491
       },
       "line" : {
-        "covered" : 1551,
-        "missed" : 12809,
-        "ratio" : 0.108008,
+        "covered" : 1769,
+        "missed" : 12591,
+        "ratio" : 0.123189,
         "total" : 14360
       },
       "method" : {
-        "covered" : 460,
-        "missed" : 4119,
-        "ratio" : 0.100459,
+        "covered" : 510,
+        "missed" : 4069,
+        "ratio" : 0.111378,
         "total" : 4579
       }
     }

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/FXCollectionsInnerCheckedObservableListTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/FXCollectionsInnerCheckedObservableListTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
+
+public class FXCollectionsInnerCheckedObservableListTest {
+
+    @Test
+    void addAllCollectionOverloadsCopyInputThroughTypedArrays() {
+        ObservableList<Integer> checkedValues = FXCollections.checkedObservableList(
+                FXCollections.observableArrayList(10, 40), Integer.class);
+
+        boolean appended = checkedValues.addAll(List.of(50, 60));
+        boolean inserted = checkedValues.addAll(1, List.of(20, 30));
+
+        assertThat(appended).isTrue();
+        assertThat(inserted).isTrue();
+        assertThat(checkedValues).containsExactly(10, 20, 30, 40, 50, 60);
+    }
+
+    @Test
+    void addAllVarargsCopiesInputThroughTypedArray() {
+        ObservableList<Integer> checkedValues = FXCollections.checkedObservableList(
+                FXCollections.observableArrayList(10), Integer.class);
+
+        boolean changed = checkedValues.addAll(20, 30);
+
+        assertThat(changed).isTrue();
+        assertThat(checkedValues).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    void setAllOverloadsCopyInputThroughTypedArrays() {
+        ObservableList<Integer> checkedValues = FXCollections.checkedObservableList(
+                FXCollections.observableArrayList(10, 20), Integer.class);
+
+        boolean changedFromVarargs = checkedValues.setAll(30, 40);
+        boolean changedFromCollection = checkedValues.setAll(List.of(50, 60));
+
+        assertThat(changedFromVarargs).isTrue();
+        assertThat(changedFromCollection).isTrue();
+        assertThat(checkedValues).containsExactly(50, 60);
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/MethodUtilTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/MethodUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.javafx.reflect.MethodUtil;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class MethodUtilTest {
+
+    @Test
+    void publicLookupMethodsReturnInvocableBeanMethods() throws Exception {
+        Method getter = MethodUtil.getMethod(AccessibleBean.class, "getName", new Class<?>[0]);
+        Method setter = MethodUtil.getMethod(AccessibleBean.class, "setName", new Class<?>[] {String.class});
+        AccessibleBean bean = new AccessibleBean("Ada");
+
+        MethodUtil.invoke(setter, bean, new Object[] {"Grace"});
+        Object name = MethodUtil.invoke(getter, bean, null);
+        Method[] methods = MethodUtil.getMethods(AccessibleBean.class);
+
+        assertThat(name).isEqualTo("Grace");
+        assertThat(methods)
+                .extracting(Method::getName)
+                .contains("getName", "setName", "describe");
+    }
+
+    @Test
+    void publicMethodsFastPathEnumeratesAccessibleMethodsWithoutSecurityManager() throws Exception {
+        Method[] methods = invokeGetPublicMethods(AccessibleBean.class);
+
+        assertThat(methods)
+                .extracting(Method::getName)
+                .contains("getName", "setName", "describe");
+    }
+
+    @Test
+    void internalPublicMethodScanCollectsInterfaceAndImplementationMethods() throws Exception {
+        Map<Object, Method> signatures = new HashMap<>();
+        Method getInternalPublicMethods = MethodUtil.class.getDeclaredMethod(
+                "getInternalPublicMethods", Class.class, Map.class);
+        getInternalPublicMethods.setAccessible(true);
+
+        boolean complete = (boolean) getInternalPublicMethods.invoke(null, AccessibleBean.class, signatures);
+
+        assertThat(complete).isTrue();
+        assertThat(signatures.values())
+                .extracting(Method::getName)
+                .contains("getName", "setName", "describe");
+    }
+
+    private static Method[] invokeGetPublicMethods(Class<?> type) throws Exception {
+        Method getPublicMethods = MethodUtil.class.getDeclaredMethod("getPublicMethods", Class.class);
+        getPublicMethods.setAccessible(true);
+        return (Method[]) getPublicMethods.invoke(null, type);
+    }
+
+    public interface Described {
+        String describe();
+    }
+
+    public static final class AccessibleBean implements Described {
+        private String name;
+
+        public AccessibleBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String describe() {
+            return "bean:" + name;
+        }
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyReferenceTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/PropertyReferenceTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.javafx.property.PropertyReference;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.junit.jupiter.api.Test;
+
+public class PropertyReferenceTest {
+
+    @Test
+    void reflectsReadableWritablePropertyAndObservablePropertyGetter() {
+        PropertyReference<String> reference = new PropertyReference<>(StandardBean.class, "name");
+
+        assertThat(reference.isReadable()).isTrue();
+        assertThat(reference.isWritable()).isTrue();
+        assertThat(reference.hasProperty()).isTrue();
+        assertThat(reference.getType()).isEqualTo(String.class);
+    }
+
+    @Test
+    void reflectsBooleanPropertyUsingIsGetter() {
+        PropertyReference<Boolean> reference = new PropertyReference<>(BooleanBean.class, "active");
+
+        assertThat(reference.isReadable()).isTrue();
+        assertThat(reference.isWritable()).isTrue();
+        assertThat(reference.hasProperty()).isFalse();
+        assertThat(reference.getType()).isEqualTo(boolean.class);
+    }
+
+    @Test
+    void reflectsWriteOnlyPropertyByScanningPublicMethods() {
+        PropertyReference<Integer> reference = new PropertyReference<>(WriteOnlyBean.class, "score");
+
+        assertThat(reference.isReadable()).isFalse();
+        assertThat(reference.isWritable()).isTrue();
+        assertThat(reference.hasProperty()).isFalse();
+        assertThat(reference.getType()).isEqualTo(int.class);
+    }
+
+    public static final class StandardBean {
+        private final StringProperty name = new SimpleStringProperty(this, "name", "Ada");
+
+        public String getName() {
+            return name.get();
+        }
+
+        public void setName(String newName) {
+            name.set(newName);
+        }
+
+        public StringProperty nameProperty() {
+            return name;
+        }
+    }
+
+    public static final class BooleanBean {
+        private boolean active = true;
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+    }
+
+    public static final class WriteOnlyBean {
+        private int score;
+
+        public void setScore(int score) {
+            this.score = score;
+        }
+    }
+}

--- a/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/ReadOnlyPropertyDescriptorTest.java
+++ b/tests/src/org.openjfx/javafx-base/13-ea/src/test/java/org_openjfx/javafx_base/ReadOnlyPropertyDescriptorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_openjfx.javafx_base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.beans.property.adapter.ReadOnlyJavaBeanIntegerProperty;
+import javafx.beans.property.adapter.ReadOnlyJavaBeanIntegerPropertyBuilder;
+import org.junit.jupiter.api.Test;
+
+public class ReadOnlyPropertyDescriptorTest {
+
+    @Test
+    void readOnlyPropertyRegistersAndRemovesSpecificPropertyChangeListener() throws NoSuchMethodException {
+        SpecificPropertyChangeBean bean = new SpecificPropertyChangeBean(3);
+
+        ReadOnlyJavaBeanIntegerProperty property = ReadOnlyJavaBeanIntegerPropertyBuilder.create()
+                .bean(bean)
+                .name("score")
+                .build();
+        List<Object> invalidatedObservables = observeInvalidations(property);
+
+        assertThat(bean.getScore()).isEqualTo(3);
+        assertThat(bean.scoreListeners).hasSize(1);
+
+        bean.setScore(5);
+        assertThat(bean.getScore()).isEqualTo(5);
+        assertThat(invalidatedObservables).containsExactly(property);
+
+        property.dispose();
+        assertThat(bean.scoreListeners).isEmpty();
+    }
+
+    @Test
+    void readOnlyPropertyRegistersAndRemovesNamedPropertyChangeListener() throws NoSuchMethodException {
+        NamedPropertyChangeBean bean = new NamedPropertyChangeBean(7);
+
+        ReadOnlyJavaBeanIntegerProperty property = ReadOnlyJavaBeanIntegerPropertyBuilder.create()
+                .bean(bean)
+                .name("score")
+                .build();
+        List<Object> invalidatedObservables = observeInvalidations(property);
+
+        assertThat(bean.getScore()).isEqualTo(7);
+        assertThat(bean.addedPropertyNames).containsExactly("score");
+        assertThat(bean.propertyChangeListeners).hasSize(1);
+
+        bean.setScore(11);
+        assertThat(bean.getScore()).isEqualTo(11);
+        assertThat(invalidatedObservables).containsExactly(property);
+
+        property.dispose();
+        assertThat(bean.removedPropertyNames).containsExactly("score");
+        assertThat(bean.propertyChangeListeners).isEmpty();
+    }
+
+    @Test
+    void readOnlyPropertyRegistersAndRemovesGlobalPropertyChangeListener() throws NoSuchMethodException {
+        GlobalPropertyChangeBean bean = new GlobalPropertyChangeBean(13);
+
+        ReadOnlyJavaBeanIntegerProperty property = ReadOnlyJavaBeanIntegerPropertyBuilder.create()
+                .bean(bean)
+                .name("score")
+                .build();
+        List<Object> invalidatedObservables = observeInvalidations(property);
+
+        assertThat(bean.getScore()).isEqualTo(13);
+        assertThat(bean.propertyChangeListeners).hasSize(1);
+
+        bean.setScore(17);
+        assertThat(bean.getScore()).isEqualTo(17);
+        assertThat(invalidatedObservables).containsExactly(property);
+
+        property.dispose();
+        assertThat(bean.removedListeners).hasSize(1);
+        assertThat(bean.propertyChangeListeners).isEmpty();
+    }
+
+    private static List<Object> observeInvalidations(ReadOnlyJavaBeanIntegerProperty property) {
+        List<Object> invalidatedObservables = new ArrayList<>();
+        property.addListener(invalidatedObservables::add);
+        return invalidatedObservables;
+    }
+
+    public static final class SpecificPropertyChangeBean {
+        private final List<PropertyChangeListener> scoreListeners = new ArrayList<>();
+        private int score;
+
+        public SpecificPropertyChangeBean(int score) {
+            this.score = score;
+        }
+
+        public int getScore() {
+            return score;
+        }
+
+        public void setScore(int score) {
+            int oldScore = this.score;
+            this.score = score;
+            PropertyChangeEvent event = new PropertyChangeEvent(this, "score", oldScore, score);
+            for (PropertyChangeListener listener : List.copyOf(scoreListeners)) {
+                listener.propertyChange(event);
+            }
+        }
+
+        public void addScoreListener(PropertyChangeListener listener) {
+            scoreListeners.add(listener);
+        }
+
+        public void removeScoreListener(PropertyChangeListener listener) {
+            scoreListeners.remove(listener);
+        }
+    }
+
+    public static final class NamedPropertyChangeBean {
+        private final List<String> addedPropertyNames = new ArrayList<>();
+        private final List<String> removedPropertyNames = new ArrayList<>();
+        private final List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
+        private int score;
+
+        public NamedPropertyChangeBean(int score) {
+            this.score = score;
+        }
+
+        public int getScore() {
+            return score;
+        }
+
+        public void setScore(int score) {
+            int oldScore = this.score;
+            this.score = score;
+            PropertyChangeEvent event = new PropertyChangeEvent(this, "score", oldScore, score);
+            for (PropertyChangeListener listener : List.copyOf(propertyChangeListeners)) {
+                listener.propertyChange(event);
+            }
+        }
+
+        public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+            addedPropertyNames.add(propertyName);
+            propertyChangeListeners.add(listener);
+        }
+
+        public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+            removedPropertyNames.add(propertyName);
+            propertyChangeListeners.remove(listener);
+        }
+    }
+
+    public static final class GlobalPropertyChangeBean {
+        private final PropertyChangeSupport changeSupport = new PropertyChangeSupport(this);
+        private final List<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
+        private final List<PropertyChangeListener> removedListeners = new ArrayList<>();
+        private int score;
+
+        public GlobalPropertyChangeBean(int score) {
+            this.score = score;
+        }
+
+        public int getScore() {
+            return score;
+        }
+
+        public void setScore(int score) {
+            int oldScore = this.score;
+            this.score = score;
+            changeSupport.firePropertyChange("score", oldScore, score);
+        }
+
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+            propertyChangeListeners.add(listener);
+            changeSupport.addPropertyChangeListener(listener);
+        }
+
+        public void removePropertyChangeListener(PropertyChangeListener listener) {
+            removedListeners.add(listener);
+            propertyChangeListeners.remove(listener);
+            changeSupport.removePropertyChangeListener(listener);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5605

This PR provides test fixes and new metadata for org.openjfx:javafx-base:13-ea, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 231169
- Cached input tokens: 2229760
- Output tokens: 23564
- Metadata entries: 2
- Iterations: 5
- Library coverage percentage: 12.32
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 12.32

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b7d6f1a9dbf439dc0f38681fb7b43aea97703e1d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.openjfx:javafx-base:13-ea` and `org.openjfx:javafx-base:13-ea`.

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
