### PR TITLE
[GenAI] Test fix for org.asynchttpclient:async-http-client:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.asynchttpclient/async-http-client/3.0.0/reachability-metadata.json
+++ b/metadata/org.asynchttpclient/async-http-client/3.0.0/reachability-metadata.json
@@ -1,0 +1,36 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.asynchttpclient.netty.channel.ChannelManager"
+      },
+      "type" : "org.asynchttpclient.netty.channel.EpollTransportFactory",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.asynchttpclient.netty.channel.ChannelManager"
+      },
+      "type" : "org.asynchttpclient.netty.channel.KQueueTransportFactory",
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.asynchttpclient.filter.ReleasePermitOnComplete"
+      },
+      "type" : {
+        "proxy" : [
+          "org.asynchttpclient.AsyncHandler"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.asynchttpclient.config.AsyncHttpClientConfigHelper$Config"
+      },
+      "glob" : "org/asynchttpclient/config/ahc-default.properties"
+    }
+  ]
+}

--- a/metadata/org.asynchttpclient/async-http-client/index.json
+++ b/metadata/org.asynchttpclient/async-http-client/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/asynchttpclient/async-http-client/$version$/async-http-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/AsyncHttpClient/async-http-client",
+    "test-code-url" : "https://github.com/AsyncHttpClient/async-http-client/tree/async-http-client-project-$version$/client/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/asynchttpclient/async-http-client/$version$/async-http-client-$version$-javadoc.jar",
+    "description" : "Async Http Client is a Java library for executing HTTP requests asynchronously and processing HTTP responses without blocking caller threads. It provides a Netty-based client API with support for common HTTP features such as WebSocket, redirects, authentication, proxies, and reactive streams integration.",
     "tested-versions" : [
       "3.0.0"
     ],

--- a/metadata/org.asynchttpclient/async-http-client/index.json
+++ b/metadata/org.asynchttpclient/async-http-client/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "org.asynchttpclient"
+    ]
+  },
+  {
     "metadata-version" : "2.12.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/asynchttpclient/async-http-client/$version$/async-http-client-$version$-sources.jar",
     "repository-url" : "https://github.com/AsyncHttpClient/async-http-client",

--- a/stats/org.asynchttpclient/async-http-client/3.0.0/execution-metrics.json
+++ b/stats/org.asynchttpclient/async-http-client/3.0.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-04": {
+    "timestamp": "2026-05-04T03:26:10.824362Z",
+    "library": "org.asynchttpclient:async-http-client:3.0.0",
+    "starting_commit": "3332806c07ab6046965f24b2f742ab88dd02bbea",
+    "ending_commit": "b57c4ec20dd391e501a6c1c695b7f8841068d23d",
+    "previous_library": "org.asynchttpclient:async-http-client:2.12.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1561,
+          "missed": 27281,
+          "ratio": 0.054122,
+          "total": 28842
+        },
+        "line": {
+          "covered": 385,
+          "missed": 6342,
+          "ratio": 0.057232,
+          "total": 6727
+        },
+        "method": {
+          "covered": 122,
+          "missed": 1581,
+          "ratio": 0.071638,
+          "total": 1703
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.12.3",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 7,
+        "totalCalls": 7
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1662,
+          "missed": 29606,
+          "ratio": 0.053153,
+          "total": 31268
+        },
+        "line": {
+          "covered": 407,
+          "missed": 6704,
+          "ratio": 0.057235,
+          "total": 7111
+        },
+        "method": {
+          "covered": 137,
+          "missed": 1675,
+          "ratio": 0.075607,
+          "total": 1812
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 88376,
+      "cached_input_tokens_used": 771072,
+      "output_tokens_used": 10714,
+      "iterations": 3,
+      "cost_usd": 0.7069,
+      "tested_library_loc": 385,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 2,
+      "previous_library_metadata_entries": 6,
+      "previous_library_test_only_metadata_entries": 2,
+      "code_coverage_percent": 5.72,
+      "previous_library_coverage_percent": 5.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ReleasePermitOnCompleteTest.java",
+      "metadata_file": "metadata/org.asynchttpclient/async-http-client/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.asynchttpclient/async-http-client/3.0.0/stats.json
+++ b/stats/org.asynchttpclient/async-http-client/3.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1561,
+        "missed" : 27281,
+        "ratio" : 0.054122,
+        "total" : 28842
+      },
+      "line" : {
+        "covered" : 385,
+        "missed" : 6342,
+        "ratio" : 0.057232,
+        "total" : 6727
+      },
+      "method" : {
+        "covered" : 122,
+        "missed" : 1581,
+        "ratio" : 0.071638,
+        "total" : 1703
+      }
+    }
+  } ]
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/.gitignore
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.asynchttpclient:async-http-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.asynchttpclient:async-http-client:$libraryVersion"
+    testImplementation 'io.netty:netty-transport-classes-epoll:4.1.112.Final'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/gradle.properties
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.asynchttpclient:async-http-client:3.0.0
+library.version = 3.0.0
+metadata.dir = org.asynchttpclient/async-http-client/3.0.0/

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/settings.gradle
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.asynchttpclient.async-http-client_tests'

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_asynchttpclient.async_http_client;
+
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.netty.channel.ChannelManager;
+import org.junit.jupiter.api.Test;
+
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChannelManagerTest {
+    @Test
+    void nativeTransportSelectionInstantiatesConfiguredTransportFactory() throws Exception {
+        AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+                .setUseNativeTransport(true)
+                .setKeepAlive(false)
+                .setIoThreadsCount(1)
+                .setThreadFactory(new DefaultThreadFactory("ahc-native-transport-test", true))
+                .setShutdownQuietPeriod(0)
+                .setShutdownTimeout(1_000)
+                .build();
+        Timer timer = new HashedWheelTimer(
+                new DefaultThreadFactory("ahc-native-transport-test-timer", true),
+                10,
+                TimeUnit.MILLISECONDS,
+                32);
+        ChannelManager channelManager = null;
+
+        try {
+            channelManager = new ChannelManager(config, timer);
+
+            assertThat(channelManager.getEventLoopGroup().getClass().getName())
+                    .containsAnyOf("epoll", "kqueue");
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("No suitable native transport");
+        } finally {
+            if (channelManager != null) {
+                channelManager.close();
+                boolean terminated = channelManager.getEventLoopGroup()
+                        .terminationFuture()
+                        .await(5, TimeUnit.SECONDS);
+                assertThat(terminated).isTrue();
+            }
+            timer.stop();
+        }
+    }
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
@@ -11,15 +11,49 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.netty.channel.ChannelManager;
 import org.junit.jupiter.api.Test;
 
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ChannelManagerTest {
+    @Test
+    void externalUnknownEventLoopGroupChecksNativeTransportTypes() throws Exception {
+        DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(
+                1,
+                new DefaultThreadFactory("ahc-external-event-loop-test", true));
+        AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+                .setEventLoopGroup(eventLoopGroup)
+                .setKeepAlive(false)
+                .setThreadFactory(new DefaultThreadFactory("ahc-external-event-loop-config-test", true))
+                .setShutdownQuietPeriod(Duration.ZERO)
+                .setShutdownTimeout(Duration.ofSeconds(1))
+                .build();
+        Timer timer = new HashedWheelTimer(
+                new DefaultThreadFactory("ahc-external-event-loop-test-timer", true),
+                10,
+                TimeUnit.MILLISECONDS,
+                32);
+
+        assertThat(EpollEventLoopGroup.class.getName()).contains("EpollEventLoopGroup");
+
+        try {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> new ChannelManager(config, timer))
+                    .withMessageContaining("Unknown event loop group DefaultEventLoopGroup");
+        } finally {
+            eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).await(5, TimeUnit.SECONDS);
+            timer.stop();
+        }
+    }
+
     @Test
     void nativeTransportSelectionInstantiatesConfiguredTransportFactory() throws Exception {
         AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
@@ -27,8 +61,8 @@ public class ChannelManagerTest {
                 .setKeepAlive(false)
                 .setIoThreadsCount(1)
                 .setThreadFactory(new DefaultThreadFactory("ahc-native-transport-test", true))
-                .setShutdownQuietPeriod(0)
-                .setShutdownTimeout(1_000)
+                .setShutdownQuietPeriod(Duration.ZERO)
+                .setShutdownTimeout(Duration.ofSeconds(1))
                 .build();
         Timer timer = new HashedWheelTimer(
                 new DefaultThreadFactory("ahc-native-transport-test-timer", true),

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/NamePasswordCallbackHandlerTest.java
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/NamePasswordCallbackHandlerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_asynchttpclient.async_http_client;
+
+import org.asynchttpclient.spnego.NamePasswordCallbackHandler;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NamePasswordCallbackHandlerTest {
+    @Test
+    void invokesGenericPasswordCallbackMethod() throws Exception {
+        NamePasswordCallbackHandler handler = new NamePasswordCallbackHandler("alice", "secret");
+        NameCallback nameCallback = new NameCallback("User");
+        RecordingPasswordCallback passwordCallback = new RecordingPasswordCallback();
+
+        handler.handle(new Callback[] {nameCallback, passwordCallback});
+
+        assertThat(nameCallback.getName()).isEqualTo("alice");
+        assertThat(passwordCallback.password).containsExactly('s', 'e', 'c', 'r', 'e', 't');
+    }
+
+    public static final class RecordingPasswordCallback implements Callback {
+        private char[] password;
+
+        public void setObject(Object value) {
+            password = (char[]) value;
+        }
+    }
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ReleasePermitOnCompleteTest.java
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ReleasePermitOnCompleteTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_asynchttpclient.async_http_client;
+
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.filter.ReleasePermitOnComplete;
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.util.concurrent.Semaphore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReleasePermitOnCompleteTest {
+    @Test
+    void releasesPermitAfterSuccessfulCompletion() throws Exception {
+        Semaphore available = new Semaphore(0);
+        RecordingAsyncHandler handler = new RecordingAsyncHandler();
+
+        AsyncHandler<String> wrapped = ReleasePermitOnComplete.wrap(handler, available);
+
+        assertThat(wrapped.onStatusReceived(null)).isEqualTo(AsyncHandler.State.CONTINUE);
+        assertThat(handler.statusCallbacks).isEqualTo(1);
+        assertThat(available.availablePermits()).isZero();
+
+        assertThat(wrapped.onCompleted()).isEqualTo("completed");
+
+        assertThat(handler.completions).isEqualTo(1);
+        assertThat(available.tryAcquire()).isTrue();
+        assertThat(available.availablePermits()).isZero();
+    }
+
+    @Test
+    void releasesPermitAfterThrowableNotification() {
+        Semaphore available = new Semaphore(0);
+        RecordingAsyncHandler handler = new RecordingAsyncHandler();
+        RuntimeException failure = new RuntimeException("request failed");
+
+        AsyncHandler<String> wrapped = ReleasePermitOnComplete.wrap(handler, available);
+        wrapped.onThrowable(failure);
+
+        assertThat(handler.throwables).isEqualTo(1);
+        assertThat(handler.lastThrowable).isSameAs(failure);
+        assertThat(available.tryAcquire()).isTrue();
+        assertThat(available.availablePermits()).isZero();
+    }
+
+    private static final class RecordingAsyncHandler implements AsyncHandler<String> {
+        private int statusCallbacks;
+        private int completions;
+        private int throwables;
+        private Throwable lastThrowable;
+
+        @Override
+        public State onStatusReceived(HttpResponseStatus responseStatus) {
+            statusCallbacks++;
+            return State.CONTINUE;
+        }
+
+        @Override
+        public State onHeadersReceived(HttpHeaders headers) {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public State onBodyPartReceived(HttpResponseBodyPart bodyPart) {
+            return State.CONTINUE;
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+            throwables++;
+            lastThrowable = t;
+        }
+
+        @Override
+        public String onCompleted() {
+            completions++;
+            return "completed";
+        }
+    }
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.asynchttpclient.spnego.NamePasswordCallbackHandler"
+      },
+      "type" : "org_asynchttpclient.async_http_client.NamePasswordCallbackHandlerTest$RecordingPasswordCallback",
+      "methods" : [
+        {
+          "name" : "setObject",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.asynchttpclient/async-http-client/3.0.0/user-code-filter.json
+++ b/tests/src/org.asynchttpclient/async-http-client/3.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.asynchttpclient.**"
+    },
+    {
+      "includeClasses" : "org_asynchttpclient.async_http_client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5600

This PR provides test fixes and new metadata for org.asynchttpclient:async-http-client:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 88376
- Cached input tokens: 771072
- Output tokens: 10714
- Metadata entries: 6
- Test-only metadata entries: 2
- Iterations: 3
- Library coverage percentage: 5.72
- Previous library version metadata entries: 6
- Previous library version test-only metadata entries: 2
- Previous library version coverage percentage: 5.72

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22afeb3c8f336475cd74048ae4b301c3ee40a02d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.asynchttpclient:async-http-client:2.12.3: 7/7 covered calls (100.00%)
- org.asynchttpclient:async-http-client:3.0.0: 6/6 covered calls (100.00%)

**Reflection:**
- org.asynchttpclient:async-http-client:2.12.3: 6/6 covered calls (100.00%)
- org.asynchttpclient:async-http-client:3.0.0: 5/5 covered calls (100.00%)

**Resources:**
- org.asynchttpclient:async-http-client:2.12.3: 1/1 covered calls (100.00%)
- org.asynchttpclient:async-http-client:3.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.asynchttpclient:async-http-client:2.12.3: 1662/31268 (5.32%)
- org.asynchttpclient:async-http-client:3.0.0: 1561/28842 (5.41%)

**Line:**
- org.asynchttpclient:async-http-client:2.12.3: 407/7111 (5.72%)
- org.asynchttpclient:async-http-client:3.0.0: 385/6727 (5.72%)

**Method:**
- org.asynchttpclient:async-http-client:2.12.3: 137/1812 (7.56%)
- org.asynchttpclient:async-http-client:3.0.0: 122/1703 (7.16%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.asynchttpclient/async-http-client/2.12.3/build.gradle 2/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
index f7146818b9..ae177e635e 100644
--- 1/tests/src/org.asynchttpclient/async-http-client/2.12.3/build.gradle
+++ 2/tests/src/org.asynchttpclient/async-http-client/3.0.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.asynchttpclient:async-http-client:$libraryVersion"
+    testImplementation 'io.netty:netty-transport-classes-epoll:4.1.112.Final'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.asynchttpclient/async-http-client/2.12.3/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java 2/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
index 061cd39a50..c45fa35ae7 100644
--- 1/tests/src/org.asynchttpclient/async-http-client/2.12.3/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
+++ 2/tests/src/org.asynchttpclient/async-http-client/3.0.0/src/test/java/org_asynchttpclient/async_http_client/ChannelManagerTest.java
@@ -11,15 +11,49 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.netty.channel.ChannelManager;
 import org.junit.jupiter.api.Test;
 
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ChannelManagerTest {
+    @Test
+    void externalUnknownEventLoopGroupChecksNativeTransportTypes() throws Exception {
+        DefaultEventLoopGroup eventLoopGroup = new DefaultEventLoopGroup(
+                1,
+                new DefaultThreadFactory("ahc-external-event-loop-test", true));
+        AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+                .setEventLoopGroup(eventLoopGroup)
+                .setKeepAlive(false)
+                .setThreadFactory(new DefaultThreadFactory("ahc-external-event-loop-config-test", true))
+                .setShutdownQuietPeriod(Duration.ZERO)
+                .setShutdownTimeout(Duration.ofSeconds(1))
+                .build();
+        Timer timer = new HashedWheelTimer(
+                new DefaultThreadFactory("ahc-external-event-loop-test-timer", true),
+                10,
+                TimeUnit.MILLISECONDS,
+                32);
+
+        assertThat(EpollEventLoopGroup.class.getName()).contains("EpollEventLoopGroup");
+
+        try {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> new ChannelManager(config, timer))
+                    .withMessageContaining("Unknown event loop group DefaultEventLoopGroup");
+        } finally {
+            eventLoopGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).await(5, TimeUnit.SECONDS);
+            timer.stop();
+        }
+    }
+
     @Test
     void nativeTransportSelectionInstantiatesConfiguredTransportFactory() throws Exception {
         AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
@@ -27,8 +61,8 @@ public class ChannelManagerTest {
                 .setKeepAlive(false)
                 .setIoThreadsCount(1)
                 .setThreadFactory(new DefaultThreadFactory("ahc-native-transport-test", true))
-                .setShutdownQuietPeriod(0)
-                .setShutdownTimeout(1_000)
+                .setShutdownQuietPeriod(Duration.ZERO)
+                .setShutdownTimeout(Duration.ofSeconds(1))
                 .build();
         Timer timer = new HashedWheelTimer(
                 new DefaultThreadFactory("ahc-native-transport-test-timer", true),

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
