### PR TITLE
[GenAI] Test fix for org.jline:jline-terminal-jni:3.30.7 using gpt-5.5

### DIFF
--- a/metadata/org.jline/jline-terminal-jni/3.30.7/reachability-metadata.json
+++ b/metadata/org.jline/jline-terminal-jni/3.30.7/reachability-metadata.json
@@ -1,0 +1,138 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+      },
+      "type": "java.io.FileDescriptor",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "fd"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "TCSADRAIN"
+        },
+        {
+          "name": "TCSAFLUSH"
+        },
+        {
+          "name": "TCSANOW"
+        },
+        {
+          "name": "TIOCGWINSZ"
+        },
+        {
+          "name": "TIOCSWINSZ"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "type": "org.jline.nativ.CLibrary$Termios",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "c_cc"
+        },
+        {
+          "name": "c_cflag"
+        },
+        {
+          "name": "c_iflag"
+        },
+        {
+          "name": "c_ispeed"
+        },
+        {
+          "name": "c_lflag"
+        },
+        {
+          "name": "c_oflag"
+        },
+        {
+          "name": "c_ospeed"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.linux.LinuxNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary$Termios",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "type": "org.jline.nativ.CLibrary$WinSize",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "SIZEOF"
+        },
+        {
+          "name": "ws_col"
+        },
+        {
+          "name": "ws_row"
+        },
+        {
+          "name": "ws_xpixel"
+        },
+        {
+          "name": "ws_ypixel"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "glob": "META-INF/maven/org.jline/jline-native/pom.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniNativePty"
+      },
+      "glob": "org/jline/nativ/Linux/x86_64/libjlinenative.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "glob": "org/jline/utils/capabilities.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jline.terminal.impl.jni.JniTerminalProvider"
+      },
+      "glob": "org/jline/utils/xterm-256color.caps"
+    }
+  ]
+}

--- a/metadata/org.jline/jline-terminal-jni/index.json
+++ b/metadata/org.jline/jline-terminal-jni/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.30.7",
+    "tested-versions" : [
+      "3.30.7"
+    ],
+    "allowed-packages" : [
+      "org.jline.terminal.impl.jni"
+    ]
+  },
+  {
     "metadata-version" : "3.27.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-sources.jar",
     "repository-url" : "https://github.com/jline/jline3",

--- a/metadata/org.jline/jline-terminal-jni/index.json
+++ b/metadata/org.jline/jline-terminal-jni/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.30.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-sources.jar",
+    "repository-url" : "https://github.com/jline/jline3",
+    "test-code-url" : "https://github.com/jline/jline3/tree/jline-$version$/terminal-jni/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jline/jline-terminal-jni/$version$/jline-terminal-jni-$version$-javadoc.jar",
+    "description" : "JLine JNI Terminal provides the JLine terminal provider implementation that uses JLine's JNI native library for low-level terminal and pseudoterminal access. It plugs into the JLine terminal API to support native console operations across supported platforms without relying on JNA or external process execution.",
     "tested-versions" : [
       "3.30.7"
     ],

--- a/stats/org.jline/jline-terminal-jni/3.30.7/execution-metrics.json
+++ b/stats/org.jline/jline-terminal-jni/3.30.7/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "fix_java_run_fail:2026-05-04": {
+    "timestamp": "2026-05-04T03:36:52.326718Z",
+    "library": "org.jline:jline-terminal-jni:3.30.7",
+    "starting_commit": "de4c066cc2fa8b508967ce7c0db9145bbfeb46a1",
+    "ending_commit": "adc9a7da387af59a492885488a7e569d013ca354",
+    "previous_library": "org.jline:jline-terminal-jni:3.27.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.30.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1501,
+          "missed": 6093,
+          "ratio": 0.197656,
+          "total": 7594
+        },
+        "line": {
+          "covered": 243,
+          "missed": 961,
+          "ratio": 0.201827,
+          "total": 1204
+        },
+        "method": {
+          "covered": 39,
+          "missed": 92,
+          "ratio": 0.29771,
+          "total": 131
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.27.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1461,
+          "missed": 5892,
+          "ratio": 0.198694,
+          "total": 7353
+        },
+        "line": {
+          "covered": 231,
+          "missed": 935,
+          "ratio": 0.198113,
+          "total": 1166
+        },
+        "method": {
+          "covered": 37,
+          "missed": 84,
+          "ratio": 0.305785,
+          "total": 121
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 30354,
+      "cached_input_tokens_used": 291328,
+      "output_tokens_used": 2815,
+      "iterations": 1,
+      "cost_usd": 0.2301,
+      "tested_library_loc": 243,
+      "metadata_entries": 34,
+      "previous_library_metadata_entries": 34,
+      "code_coverage_percent": 20.18,
+      "previous_library_coverage_percent": 19.81
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jline/jline-terminal-jni/3.30.7/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java",
+      "metadata_file": "metadata/org.jline/jline-terminal-jni/3.30.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jline/jline-terminal-jni/3.30.7/stats.json
+++ b/stats/org.jline/jline-terminal-jni/3.30.7/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.30.7",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1501,
+        "missed" : 6093,
+        "ratio" : 0.197656,
+        "total" : 7594
+      },
+      "line" : {
+        "covered" : 243,
+        "missed" : 961,
+        "ratio" : 0.201827,
+        "total" : 1204
+      },
+      "method" : {
+        "covered" : 39,
+        "missed" : 92,
+        "ratio" : 0.29771,
+        "total" : 131
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/.gitignore
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jline:jline-terminal-jni:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
@@ -15,6 +15,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--enable-native-access=ALL-UNNAMED"
+    ]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -22,6 +28,13 @@ graalvmNative {
             conditional {
                 userCodeFilterPath = "user-code-filter.json"
             }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.addAll([
+                '--enable-native-access=ALL-UNNAMED'
+            ])
         }
     }
 }

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/gradle.properties
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jline:jline-terminal-jni:3.30.7
+library.version = 3.30.7
+metadata.dir = org.jline/jline-terminal-jni/3.30.7/

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/settings.gradle
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jline.jline-terminal-jni_tests'

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/src/test/java/org_jline/jline_terminal_jni/Jline_terminal_jniTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jline.jline_terminal_jni;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.jline.terminal.Attributes;
+import org.jline.terminal.Size;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.impl.jni.JniNativePty;
+import org.jline.terminal.impl.jni.JniTerminalProvider;
+import org.jline.terminal.spi.Pty;
+import org.jline.terminal.spi.SystemStream;
+import org.jline.terminal.spi.TerminalExt;
+import org.jline.terminal.spi.TerminalProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Jline_terminal_jniTest {
+    private static final Set<String> SUPPORTED_POSIX_OS_PREFIXES = Set.of(
+            "Linux", "Mac", "Darwin", "Solaris", "SunOS", "FreeBSD");
+
+    @Test
+    void loadsJniTerminalProviderThroughPublicServiceApi() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+
+        assertThat(provider).isInstanceOf(JniTerminalProvider.class);
+        assertThat(provider.name()).isEqualTo("jni");
+        assertThat(provider).hasToString("TerminalProvider[jni]");
+
+        for (SystemStream stream : SystemStream.values()) {
+            assertThat(provider.systemStreamWidth(stream)).isGreaterThanOrEqualTo(-1);
+            assertThat(provider.isSystemStream(stream)).isIn(true, false);
+        }
+    }
+
+    @Test
+    void openCreatesConfiguredNativePtyOnSupportedPosixPlatforms() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(81, 27);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                assertThat(pty).isInstanceOf(JniNativePty.class);
+                assertThat(pty.getProvider()).isSameAs(provider);
+                assertThat(pty.getSystemStream()).isNull();
+
+                JniNativePty nativePty = (JniNativePty) pty;
+                assertThat(nativePty.getMaster()).isGreaterThan(0);
+                assertThat(nativePty.getSlave()).isGreaterThan(0);
+                assertThat(nativePty.getSlaveOut()).isEqualTo(nativePty.getSlave());
+                assertThat(nativePty.getMasterFD()).isNotNull();
+                assertThat(nativePty.getSlaveFD()).isNotNull();
+                assertThat(nativePty.getSlaveOutFD()).isSameAs(nativePty.getSlaveFD());
+                assertThat(nativePty.getName()).isNotBlank();
+                assertThat(nativePty).hasToString("NativePty[" + nativePty.getName() + "]");
+
+                assertThat(nativePty.getSize()).isEqualTo(requestedSize);
+                Size resized = new Size(100, 31);
+                nativePty.setSize(resized);
+                assertThat(nativePty.getSize()).isEqualTo(resized);
+
+                Attributes actualAttributes = nativePty.getAttr();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isFalse();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ICANON)).isTrue();
+                assertThat(actualAttributes.getInputFlag(Attributes.InputFlag.ICRNL)).isTrue();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VERASE)).isEqualTo(127);
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void nativePtyExposesConnectedMasterAndSlaveStreams() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(80, 24);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                byte[] payload = "jni-pty-payload".getBytes(StandardCharsets.UTF_8);
+                InputStream masterInput = pty.getMasterInput();
+                OutputStream slaveOutput = pty.getSlaveOutput();
+                ExecutorService executor = newDaemonSingleThreadExecutor("jni-pty-reader");
+                Future<byte[]> readFromMaster = executor.submit(() -> readExactly(masterInput, payload.length));
+
+                try {
+                    slaveOutput.write(payload);
+                    slaveOutput.flush();
+
+                    assertThat(readFromMaster.get(5, TimeUnit.SECONDS)).containsExactly(payload);
+                } finally {
+                    readFromMaster.cancel(true);
+                    executor.shutdownNow();
+                    assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+                }
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void nativePtyAppliesAttributeChangesAfterOpen() throws Exception {
+        TerminalProvider provider = TerminalProvider.load("jni");
+        Attributes attributes = attributesForPty();
+        Size requestedSize = new Size(80, 24);
+
+        if (isSupportedPosixOperatingSystem()) {
+            try (Pty pty = ((JniTerminalProvider) provider).open(attributes, requestedSize)) {
+                Attributes updatedAttributes = new Attributes(pty.getAttr());
+                updatedAttributes.setLocalFlag(Attributes.LocalFlag.ECHO, true);
+                updatedAttributes.setLocalFlag(Attributes.LocalFlag.ICANON, false);
+                updatedAttributes.setInputFlag(Attributes.InputFlag.ICRNL, false);
+                updatedAttributes.setControlChar(Attributes.ControlChar.VMIN, 0);
+                updatedAttributes.setControlChar(Attributes.ControlChar.VTIME, 1);
+
+                pty.setAttr(updatedAttributes);
+
+                Attributes actualAttributes = pty.getAttr();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ECHO)).isTrue();
+                assertThat(actualAttributes.getLocalFlag(Attributes.LocalFlag.ICANON)).isFalse();
+                assertThat(actualAttributes.getInputFlag(Attributes.InputFlag.ICRNL)).isFalse();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VMIN)).isZero();
+                assertThat(actualAttributes.getControlChar(Attributes.ControlChar.VTIME)).isEqualTo(1);
+            }
+        } else {
+            assertThatThrownBy(() -> ((JniTerminalProvider) provider).open(attributes, requestedSize))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void terminalBuilderCreatesJniBackedTerminalForExplicitStreams() throws Exception {
+        if (isSupportedPosixOperatingSystem()) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (Terminal terminal = buildTerminal(output)) {
+                assertThat(terminal.getName()).isEqualTo("jni-test-terminal");
+                assertThat(terminal.getType()).isEqualTo("xterm-256color");
+                assertThat(terminal.encoding()).isEqualTo(StandardCharsets.UTF_8);
+                assertThat(terminal).isInstanceOf(TerminalExt.class);
+
+                TerminalExt terminalExt = (TerminalExt) terminal;
+                assertThat(terminalExt.getProvider().name()).isEqualTo("jni");
+                assertThat(terminalExt.getSystemStream()).isNull();
+
+                assertThat(terminal.getSize()).isEqualTo(new Size(90, 33));
+                terminal.setSize(new Size(91, 34));
+                assertThat(terminal.getWidth()).isEqualTo(91);
+                assertThat(terminal.getHeight()).isEqualTo(34);
+
+                assertThat(terminal.echo()).isFalse();
+                assertThat(terminal.canPauseResume()).isTrue();
+                assertThat(terminal.paused()).isTrue();
+                terminal.pause();
+                assertThat(terminal.paused()).isTrue();
+                assertThat(terminal.reader()).isNotNull();
+                assertThat(terminal.writer()).isNotNull();
+                assertThat(output.size()).isZero();
+            }
+        } else {
+            assertThatThrownBy(() -> buildTerminal(new ByteArrayOutputStream()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    private static ExecutorService newDaemonSingleThreadExecutor(String threadName) {
+        return Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, threadName);
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    private static byte[] readExactly(InputStream input, int length) throws Exception {
+        byte[] buffer = new byte[length];
+        int offset = 0;
+        while (offset < length) {
+            int read = input.read(buffer, offset, length - offset);
+            if (read < 0) {
+                throw new EOFException("Expected " + length + " bytes, read " + offset);
+            }
+            offset += read;
+        }
+        return buffer;
+    }
+
+    private static Terminal buildTerminal(ByteArrayOutputStream output) throws Exception {
+        return TerminalBuilder.builder()
+                .provider("jni")
+                .system(false)
+                .name("jni-test-terminal")
+                .type("xterm-256color")
+                .encoding(StandardCharsets.UTF_8)
+                .streams(new ByteArrayInputStream(new byte[0]), output)
+                .attributes(attributesForPty())
+                .size(new Size(90, 33))
+                .nativeSignals(false)
+                .paused(true)
+                .build();
+    }
+
+    private static Attributes attributesForPty() {
+        Attributes attributes = new Attributes();
+        attributes.setLocalFlag(Attributes.LocalFlag.ECHO, false);
+        attributes.setLocalFlag(Attributes.LocalFlag.ICANON, true);
+        attributes.setInputFlag(Attributes.InputFlag.ICRNL, true);
+        attributes.setOutputFlag(Attributes.OutputFlag.OPOST, true);
+        attributes.setControlFlag(Attributes.ControlFlag.CREAD, true);
+        attributes.setControlChar(Attributes.ControlChar.VERASE, 127);
+        attributes.setControlChar(Attributes.ControlChar.VMIN, 1);
+        return attributes;
+    }
+
+    private static boolean isSupportedPosixOperatingSystem() {
+        String osName = System.getProperty("os.name", "");
+        return SUPPORTED_POSIX_OS_PREFIXES.stream().anyMatch(osName::startsWith);
+    }
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jline.terminal.impl.jni.**"
+    }
+  ]
+}

--- a/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
+++ b/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jline.terminal.impl.jni.**"
+    },
+    {
+      "includeClasses" : "org_jline.jline_terminal_jni.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #5602

This PR provides test fixes and new metadata for org.jline:jline-terminal-jni:3.30.7, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 30354
- Cached input tokens: 291328
- Output tokens: 2815
- Metadata entries: 34
- Iterations: 1
- Library coverage percentage: 20.18
- Previous library version metadata entries: 34
- Previous library version coverage percentage: 19.81

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `411dc735f2446d0db64fa50cf4c0ff9734f9b5df`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jline:jline-terminal-jni:3.27.1: 0/0 covered calls (100.00%)
- org.jline:jline-terminal-jni:3.30.7: 3/3 covered calls (100.00%)

**Reflection:**
- org.jline:jline-terminal-jni:3.27.1: N/A
- org.jline:jline-terminal-jni:3.30.7: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jline:jline-terminal-jni:3.27.1: 1461/7353 (19.87%)
- org.jline:jline-terminal-jni:3.30.7: 1501/7594 (19.77%)

**Line:**
- org.jline:jline-terminal-jni:3.27.1: 231/1166 (19.81%)
- org.jline:jline-terminal-jni:3.30.7: 243/1204 (20.18%)

**Method:**
- org.jline:jline-terminal-jni:3.27.1: 37/121 (30.58%)
- org.jline:jline-terminal-jni:3.30.7: 39/131 (29.77%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jline/jline-terminal-jni/3.27.1/build.gradle 2/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
index 4147375498..66a95a1745 100644
--- 1/tests/src/org.jline/jline-terminal-jni/3.27.1/build.gradle
+++ 2/tests/src/org.jline/jline-terminal-jni/3.30.7/build.gradle
@@ -15,6 +15,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--enable-native-access=ALL-UNNAMED"
+    ]
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
@@ -24,4 +30,11 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        all {
+            buildArgs.addAll([
+                '--enable-native-access=ALL-UNNAMED'
+            ])
+        }
+    }
 }
diff --git 1/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json 2/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
index f8ba5a989b..f7279b3b76 100644
--- 1/tests/src/org.jline/jline-terminal-jni/3.27.1/user-code-filter.json
+++ 2/tests/src/org.jline/jline-terminal-jni/3.30.7/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jline.terminal.impl.jni.**"
+    },
+    {
+      "includeClasses" : "org_jline.jline_terminal_jni.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
