### PR TITLE
[GenAI] Add support for io.suzaku:boopickle_3:1.4.0 using gpt-5.5

### DIFF
--- a/metadata/io.suzaku/boopickle_3/1.4.0/reachability-metadata.json
+++ b/metadata/io.suzaku/boopickle_3/1.4.0/reachability-metadata.json
@@ -1,0 +1,26 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "boopickle.Default$"
+      },
+      "type": "boopickle.Default$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "boopickle.ExceptionPickler$"
+      },
+      "type": "boopickle.ExceptionPickler$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.suzaku/boopickle_3/index.json
+++ b/metadata/io.suzaku/boopickle_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.4.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/suzaku/boopickle_3/$version$/boopickle_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/suzaku-io/boopickle",
+    "test-code-url" : "https://github.com/suzaku-io/boopickle/tree/v$version$/boopickle/shared/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/suzaku/boopickle_3/$version$/boopickle_3-$version$-javadoc.jar",
+    "description" : "BooPickle is a Scala binary serialization library for pickling and unpickling values into compact ByteBuffer data. It supports primitives, collections, options, tuples, case classes, custom serializers, references, and deduplication without reflection across JVM, Scala.js, and Scala Native.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.4.0"
+    ],
+    "allowed-packages" : [
+      "boopickle"
+    ]
+  }
+]

--- a/stats/io.suzaku/boopickle_3/1.4.0/execution-metrics.json
+++ b/stats/io.suzaku/boopickle_3/1.4.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T04:14:51.995303Z",
+    "library": "io.suzaku:boopickle_3:1.4.0",
+    "starting_commit": "1c05e05abbccb8f31e7c28ec9ef5a7e2166a4202",
+    "ending_commit": "1d43cf04c0cbd0b60052e6b302b06c7b47417171",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.4.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4622,
+          "missed": 11335,
+          "ratio": 0.289653,
+          "total": 15957
+        },
+        "line": {
+          "covered": 716,
+          "missed": 722,
+          "ratio": 0.497914,
+          "total": 1438
+        },
+        "method": {
+          "covered": 361,
+          "missed": 552,
+          "ratio": 0.3954,
+          "total": 913
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 205448,
+      "cached_input_tokens_used": 1431552,
+      "output_tokens_used": 19925,
+      "iterations": 6,
+      "cost_usd": 1.3136,
+      "generated_loc": 208,
+      "tested_library_loc": 716,
+      "metadata_entries": 4,
+      "code_coverage_percent": 49.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala",
+      "metadata_file": "metadata/io.suzaku/boopickle_3/1.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.suzaku/boopickle_3/1.4.0/stats.json
+++ b/stats/io.suzaku/boopickle_3/1.4.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.4.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4622,
+        "missed" : 11335,
+        "ratio" : 0.289653,
+        "total" : 15957
+      },
+      "line" : {
+        "covered" : 716,
+        "missed" : 722,
+        "ratio" : 0.497914,
+        "total" : 1438
+      },
+      "method" : {
+        "covered" : 361,
+        "missed" : 552,
+        "ratio" : 0.3954,
+        "total" : 913
+      }
+    }
+  } ]
+}

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/.gitignore
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.suzaku:boopickle_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/gradle.properties
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.suzaku:boopickle_3:1.4.0
+library.version = 1.4.0
+metadata.dir = io.suzaku/boopickle_3/1.4.0/

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/settings.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.suzaku.boopickle_3_tests'

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_suzaku.boopickle_3
+
+import org.junit.jupiter.api.Test
+
+class Boopickle_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
@@ -6,11 +6,216 @@
  */
 package io_suzaku.boopickle_3
 
+import boopickle.Default.*
+import boopickle.{PickleState, UnpickleState}
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.UUID
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success}
+
+final case class Address(street: String, postalCode: Int)
+
+final case class CustomerProfile(
+    id: UUID,
+    name: String,
+    primaryAddress: Address,
+    aliases: Vector[String],
+    metadata: Map[String, Either[Int, String]],
+    discount: Option[BigDecimal])
+
+sealed trait InventoryEvent
+final case class StockAdded(sku: String, count: Int, source: Option[String]) extends InventoryEvent
+final case class StockRemoved(sku: String, count: Int, reason: String) extends InventoryEvent
+
+sealed trait WireCommand
+final case class PutValue(key: String, value: Array[Byte]) extends WireCommand
+final case class DeleteValue(key: String) extends WireCommand
+
+final case class Money(cents: Long)
+
+final case class SharedNode(label: String, ordinal: Int)
+
+final class DomainFailure(message: String) extends RuntimeException(message)
 
 class Boopickle_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def roundTripsPrimitiveCollectionAndTupleValues(): Unit = {
+    val value: (
+        Int,
+        Long,
+        Boolean,
+        Char,
+        Float,
+        Double,
+        String,
+        Option[String],
+        Either[String, Int],
+        List[Int],
+        Vector[String],
+        Map[String, Int]) = (
+      42,
+      Long.MaxValue - 7L,
+      true,
+      'λ',
+      12.5f,
+      Math.PI,
+      "BooPickle ✅",
+      Some("present"),
+      Right(2048),
+      List(1, 1, 2, 3, 5, 8),
+      Vector("alpha", "beta", "gamma"),
+      Map("one" -> 1, "two" -> 2)
+    )
+
+    assertEquals(value, roundTrip(value))
+    assertEquals(None, roundTrip(Option.empty[String]))
+    assertEquals(Left("problem"), roundTrip(Left[String, Int]("problem")))
+  }
+
+  @Test
+  def roundTripsSpecialScalarValuesAndDurations(): Unit = {
+    val value: (BigInt, BigDecimal, UUID, FiniteDuration, Duration) = (
+      BigInt("123456789012345678901234567890"),
+      BigDecimal("1234567890.0987654321"),
+      UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+      1500.millis,
+      Duration.Inf
+    )
+
+    assertEquals(value, roundTrip(value))
+    assertEquals(Duration.MinusInf, roundTrip(Duration.MinusInf))
+    assertSame(Duration.Undefined, roundTrip(Duration.Undefined))
+  }
+
+  @Test
+  def roundTripsPrimitiveArraysAndByteBuffers(): Unit = {
+    val intArray: Array[Int] = Array(3, 1, 4, 1, 5, 9)
+    val doubleArray: Array[Double] = Array(2.0d, 2.5d, 3.5d)
+    val byteBuffer: ByteBuffer = ByteBuffer.wrap(Array[Byte](10, 20, 30, 40, 50))
+
+    assertArrayEquals(intArray, roundTrip(intArray))
+    assertArrayEquals(doubleArray, roundTrip(doubleArray), 0.0d)
+    assertArrayEquals(Array[Byte](10, 20, 30, 40, 50), remainingBytes(roundTrip(byteBuffer)))
+  }
+
+  @Test
+  def derivesPicklersForNestedCaseClasses(): Unit = {
+    val profile: CustomerProfile = CustomerProfile(
+      UUID.fromString("7ec99e3c-cbb4-4788-9ec7-8f8fdf377b2f"),
+      "Ada",
+      Address("Compiler Avenue", 1843),
+      Vector("Augusta", "Lovelace"),
+      Map("score" -> Left(99), "tier" -> Right("gold")),
+      Some(BigDecimal("12.50"))
+    )
+
+    assertEquals(profile, roundTrip(profile))
+  }
+
+  @Test
+  def derivesPicklersForSealedTraitHierarchies(): Unit = {
+    val events: Vector[InventoryEvent] = Vector(
+      StockAdded("book-1", 25, Some("warehouse")),
+      StockRemoved("book-1", 3, "shipment"),
+      StockAdded("pen-9", 100, None)
+    )
+
+    assertEquals(events, roundTrip(events))
+  }
+
+  @Test
+  def usesCompositePicklerForExplicitPolymorphicProtocols(): Unit = {
+    given Pickler[PutValue] = generatePickler[PutValue]
+    given Pickler[DeleteValue] = generatePickler[DeleteValue]
+    given Pickler[WireCommand] = compositePickler[WireCommand]
+      .addConcreteType[PutValue]
+      .addConcreteType[DeleteValue]
+
+    val commands: List[WireCommand] = List(
+      PutValue("first", Array[Byte](1, 2, 3)),
+      DeleteValue("obsolete"),
+      PutValue("second", Array[Byte](5, 8, 13))
+    )
+
+    val decoded: List[WireCommand] = roundTrip(commands)
+    assertEquals(commands.map(_.getClass), decoded.map(_.getClass))
+    assertArrayEquals(Array[Byte](1, 2, 3), decoded.head.asInstanceOf[PutValue].value)
+    assertEquals(DeleteValue("obsolete"), decoded(1))
+    assertArrayEquals(Array[Byte](5, 8, 13), decoded(2).asInstanceOf[PutValue].value)
+  }
+
+  @Test
+  def usesTransformPicklersForDomainValueObjects(): Unit = {
+    given Pickler[Money] = transformPickler((cents: Long) => Money(cents))(_.cents)
+
+    val prices: Seq[Money] = Seq(Money(199), Money(2500), Money(123456789L))
+
+    assertEquals(prices, roundTrip(prices))
+  }
+
+  @Test
+  def preservesSharedObjectReferencesWhenDeduplicationIsEnabled(): Unit = {
+    val shared: SharedNode = SharedNode("same instance", 1)
+    val decoded: (SharedNode, SharedNode) = roundTrip((shared, shared))
+
+    assertEquals(shared, decoded._1)
+    assertSame(decoded._1, decoded._2)
+  }
+
+  @Test
+  def supportsManualPickleAndUnpickleStatePipelines(): Unit = {
+    val pickleState: PickleState = Pickle(List("header", "payload"))
+      .pickle(Map("answer" -> 42, "size" -> 2))
+    val unpickleState: UnpickleState = UnpickleState(pickleState.toByteBuffer)
+
+    assertEquals(List("header", "payload"), unpickleState.unpickle[List[String]])
+    assertEquals(Map("answer" -> 42, "size" -> 2), unpickleState.unpickle[Map[String, Int]])
+  }
+
+  @Test
+  def restoresInputByteOrderAndReportsTryFromBytesFailures(): Unit = {
+    val bytes: ByteBuffer = Pickle.intoBytes(Vector("little", "endian"))
+    bytes.order(ByteOrder.BIG_ENDIAN)
+
+    val decoded: Vector[String] = Unpickle[Vector[String]].fromBytes(bytes)
+
+    assertEquals(Vector("little", "endian"), decoded)
+    assertEquals(ByteOrder.BIG_ENDIAN, bytes.order())
+
+    Unpickle[Vector[String]].tryFromBytes(ByteBuffer.wrap(Array[Byte](1))) match {
+      case Failure(_: IllegalArgumentException) => ()
+      case Failure(_: RuntimeException)         => ()
+      case Failure(unexpected)                  => fail(s"Unexpected failure type: ${unexpected.getClass.getName}")
+      case Success(value)                       => fail(s"Expected decoding to fail, but decoded $value")
+    }
+  }
+
+  @Test
+  def picklesBuiltInAndCustomExceptionMessages(): Unit = {
+    val customExceptionPickler: Pickler[Throwable] = exceptionPickler
+      .addException[DomainFailure](message => new DomainFailure(message))
+
+    val builtIn: Throwable = roundTrip[Throwable](new IllegalArgumentException("bad argument"))(using customExceptionPickler)
+    val custom: Throwable = roundTrip[Throwable](new DomainFailure("domain rejected"))(using customExceptionPickler)
+
+    assertTrue(builtIn.isInstanceOf[IllegalArgumentException])
+    assertEquals("bad argument", builtIn.getMessage)
+    assertTrue(custom.isInstanceOf[DomainFailure])
+    assertEquals("domain rejected", custom.getMessage)
+  }
+
+  private def roundTrip[A](value: A)(using pickler: Pickler[A]): A = {
+    val bytes: ByteBuffer = Pickle.intoBytes(value)(using PickleState.pickleStateSpeed, pickler)
+    Unpickle[A].fromBytes(bytes)(using UnpickleState.unpickleStateSpeed)
+  }
+
+  private def remainingBytes(buffer: ByteBuffer): Array[Byte] = {
+    val duplicate: ByteBuffer = buffer.slice()
+    val bytes: Array[Byte] = new Array[Byte](duplicate.remaining())
+    duplicate.get(bytes)
+    bytes
   }
 }

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
@@ -176,6 +176,23 @@ class Boopickle_3Test {
   }
 
   @Test
+  def writesLargePayloadsAsMultipleByteBufferChunks(): Unit = {
+    val value: Vector[Int] = Vector.tabulate(2000)(index => index * 3)
+    val chunks: Vector[ByteBuffer] = Pickle.intoByteBuffers(value).toVector
+
+    assertTrue(chunks.size > 1, "Expected the payload to be split across multiple buffers")
+
+    val totalSize: Int = chunks.map(_.remaining()).sum
+    val combined: ByteBuffer = ByteBuffer.allocate(totalSize)
+    chunks.foreach { chunk =>
+      combined.put(chunk.duplicate())
+    }
+    combined.flip()
+
+    assertEquals(value, Unpickle[Vector[Int]].fromBytes(combined))
+  }
+
+  @Test
   def restoresInputByteOrderAndReportsTryFromBytesFailures(): Unit = {
     val bytes: ByteBuffer = Pickle.intoBytes(Vector("little", "endian"))
     bytes.order(ByteOrder.BIG_ENDIAN)

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/src/test/scala/io_suzaku/boopickle_3/Boopickle_3Test.scala
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.UUID
+import scala.collection.immutable.SeqMap
 import scala.concurrent.duration.*
 import scala.util.{Failure, Success}
 
@@ -222,6 +223,20 @@ class Boopickle_3Test {
     assertEquals("bad argument", builtIn.getMessage)
     assertTrue(custom.isInstanceOf[DomainFailure])
     assertEquals("domain rejected", custom.getMessage)
+  }
+
+  @Test
+  def roundTripsSeqMapWhilePreservingIterationOrder(): Unit = {
+    val routingTable: SeqMap[String, Int] = SeqMap(
+      "first" -> 10,
+      "second" -> 20,
+      "third" -> 30
+    )
+
+    val decoded: SeqMap[String, Int] = roundTrip(routingTable)
+
+    assertEquals(routingTable, decoded)
+    assertEquals(routingTable.keys.toVector, decoded.keys.toVector)
   }
 
   private def roundTrip[A](value: A)(using pickler: Pickler[A]): A = {

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/user-code-filter.json
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "boopickle.**"
+      "includeClasses" : "boopickle.**"
+    },
+    {
+      "includeClasses" : "io_suzaku.boopickle_3.**"
     }
   ]
 }

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/user-code-filter.json
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "boopickle.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5028

This PR introduces tests and metadata for io.suzaku:boopickle_3:1.4.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 205448
- Cached input tokens: 1431552
- Output tokens: 19925
- Metadata entries: 4
- Iterations: 6
- Library coverage percentage: 49.79
- Generated lines of code: 208
- Tested library lines of code: 716

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b7d6f1a9dbf439dc0f38681fb7b43aea97703e1d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 4622/15957 (28.97%)
- Line: 716/1438 (49.79%)
- Method: 361/913 (39.54%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
