### PR TITLE
[GenAI] Mark io.insert-koin:koin-ktor as not for Native Image

### DIFF
--- a/metadata/io.insert-koin/koin-ktor/index.json
+++ b/metadata/io.insert-koin/koin-ktor/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.insert-koin:koin-ktor-jvm:4.2.1.",
+    "replacement": "io.insert-koin:koin-ktor-jvm:4.2.1"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5313

This PR records `io.insert-koin:koin-ktor` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.insert-koin:koin-ktor-jvm:4.2.1.

Replacement guidance:
- io.insert-koin:koin-ktor-jvm:4.2.1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `411dc735f2446d0db64fa50cf4c0ff9734f9b5df`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
