### PR TITLE
[GenAI] Add support for org.json4s:json4s-native-core_3:4.0.7 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-native-core_3/4.0.7/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-native-core_3/4.0.7/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.json4s.native.JsonParser$"
+      },
+      "type": "org.json4s.native.JsonParser$Parser",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-native-core_3/index.json
+++ b/metadata/org.json4s/json4s-native-core_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native-core_3/$version$/json4s-native-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/native-core/shared/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native-core_3/$version$/json4s-native-core_3-$version$-javadoc.jar",
+    "description" : "Json4s native-core provides the parser, printer, document model, and native JSON methods used by Json4s' native backend. It supports parsing JSON into the Json4s AST, rendering JSON, querying values, diffing and merging documents, and low-level pull parsing.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "4.0.7"
+    ],
+    "allowed-packages" : [
+      "org.json4s.native"
+    ]
+  }
+]

--- a/stats/org.json4s/json4s-native-core_3/4.0.7/execution-metrics.json
+++ b/stats/org.json4s/json4s-native-core_3/4.0.7/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T04:25:44.105496Z",
+    "library": "org.json4s:json4s-native-core_3:4.0.7",
+    "starting_commit": "dbd26a98b4d9136587887769af18b44613aeb2e4",
+    "ending_commit": "0aab4ded7e3498e4a686c30c92060d03afc81490",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.7",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2959,
+          "missed": 2338,
+          "ratio": 0.558618,
+          "total": 5297
+        },
+        "line": {
+          "covered": 277,
+          "missed": 23,
+          "ratio": 0.923333,
+          "total": 300
+        },
+        "method": {
+          "covered": 204,
+          "missed": 310,
+          "ratio": 0.396887,
+          "total": 514
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 227010,
+      "cached_input_tokens_used": 1753600,
+      "output_tokens_used": 22461,
+      "iterations": 4,
+      "cost_usd": 1.5506,
+      "generated_loc": 275,
+      "tested_library_loc": 277,
+      "metadata_entries": 2,
+      "code_coverage_percent": 92.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala",
+      "metadata_file": "metadata/org.json4s/json4s-native-core_3/4.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-native-core_3/4.0.7/stats.json
+++ b/stats/org.json4s/json4s-native-core_3/4.0.7/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.7",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2959,
+        "missed" : 2338,
+        "ratio" : 0.558618,
+        "total" : 5297
+      },
+      "line" : {
+        "covered" : 277,
+        "missed" : 23,
+        "ratio" : 0.923333,
+        "total" : 300
+      },
+      "method" : {
+        "covered" : 204,
+        "missed" : 310,
+        "ratio" : 0.396887,
+        "total" : 514
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/.gitignore
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-native-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/gradle.properties
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-native-core_3:4.0.7
+library.version = 4.0.7
+metadata.dir = org.json4s/json4s-native-core_3/4.0.7/

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/settings.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-native-core_3_tests'

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_native_core_3
+
+import org.junit.jupiter.api.Test
+
+class Json4s_native_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
@@ -6,11 +6,267 @@
  */
 package org_json4s.json4s_native_core_3
 
+import org.json4s.*
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s.ParserUtil.ParseException
+import org.json4s.native.Document
+import org.json4s.native.JsonMethods
+import org.json4s.native.JsonParser
+import org.json4s.native.Printer
+import org.json4s.prefs.EmptyValueStrategy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+
+import java.io.StringReader
+import java.io.StringWriter
 
 class Json4s_native_core_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def parsesJsonFromStringsWithEscapesAndNestedStructures(): Unit = {
+    val source: String =
+      """
+        {
+          "message": "hello\njson4s",
+          "unicode": "\u2603",
+          "active": true,
+          "missing": null,
+          "items": [
+            {"id": 1, "name": "first"},
+            {"id": 2, "name": "second", "flags": [false, true]}
+          ]
+        }
+      """
+
+    val parsed: JValue = JsonParser.parse(source)
+
+    assertEquals(JString("hello\njson4s"), parsed \ "message")
+    assertEquals(JString("☃"), parsed \ "unicode")
+    assertEquals(JBool.True, parsed \ "active")
+    assertEquals(JNull, parsed \ "missing")
+    assertEquals(JInt(1), (parsed \ "items")(0) \ "id")
+    assertEquals(JString("second"), (parsed \ "items")(1) \ "name")
+    assertEquals(JArray(List(JBool.False, JBool.True)), (parsed \ "items")(1) \ "flags")
+  }
+
+  @Test
+  def honorsNumericParsingOptions(): Unit = {
+    val json: String = """{"small":7,"longValue":9223372036854775807,"decimal":1.25,"scientific":6.02e3}"""
+
+    val defaultParsed: JValue = JsonParser.parse(json)
+    assertEquals(JInt(7), defaultParsed \ "small")
+    assertEquals(JInt(BigInt("9223372036854775807")), defaultParsed \ "longValue")
+    assertEquals(JDouble(1.25d), defaultParsed \ "decimal")
+    assertEquals(JDouble(6020.0d), defaultParsed \ "scientific")
+
+    val preciseParsed: JValue = JsonParser.parse(
+      json,
+      useBigDecimalForDouble = true,
+      useBigIntForLong = false
+    )
+    assertEquals(JLong(7L), preciseParsed \ "small")
+    assertEquals(JLong(Long.MaxValue), preciseParsed \ "longValue")
+    assertEquals(JDecimal(BigDecimal("1.25")), preciseParsed \ "decimal")
+    assertEquals(JDecimal(BigDecimal("6.02e3")), preciseParsed \ "scientific")
+  }
+
+  @Test
+  def parsesFromReadersAndControlsAutomaticClosing(): Unit = {
+    val autoClosedReader: TrackingStringReader = new TrackingStringReader("""{"value":1}""")
+    val autoClosed: JValue = JsonParser.parse(autoClosedReader, closeAutomatically = true)
+    assertEquals(JInt(1), autoClosed \ "value")
+    assertTrue(autoClosedReader.closed)
+
+    val callerManagedReader: TrackingStringReader = new TrackingStringReader("""{"value":2.5}""")
+    val callerManaged: JValue = JsonParser.parse(
+      callerManagedReader,
+      closeAutomatically = false,
+      useBigDecimalForDouble = true
+    )
+    assertEquals(JDecimal(BigDecimal("2.5")), callerManaged \ "value")
+    assertFalse(callerManagedReader.closed)
+    callerManagedReader.close()
+    assertTrue(callerManagedReader.closed)
+  }
+
+  @Test
+  def returnsOptionalParseResultsInsteadOfThrowing(): Unit = {
+    assertEquals(Some(JObject(JField("ok", JBool.True))), JsonParser.parseOpt("""{"ok":true}"""))
+    assertEquals(Some(JObject(JField("n", JDecimal(BigDecimal("2.50"))))), JsonParser.parseOpt("""{"n":2.50}""", useBigDecimalForDouble = true))
+    assertEquals(None, JsonParser.parseOpt("""{"unterminated": [1, 2}"""))
+
+    val reader: TrackingStringReader = new TrackingStringReader("""{"reader":false}""")
+    assertEquals(Some(JObject(JField("reader", JBool.False))), JsonParser.parseOpt(reader, closeAutomatically = true))
+    assertTrue(reader.closed)
+  }
+
+  @Test
+  def reportsMalformedJsonWithParseExceptions(): Unit = {
+    val exception: ParseException = assertThrows(classOf[ParseException], () => JsonParser.parse("""{"bad": tru}"""))
+
+    assertTrue(exception.getMessage.contains("expected boolean"))
+    assertTrue(exception.getMessage.contains("Near:"))
+  }
+
+  @Test
+  def exposesLowLevelPullParserTokensFromStringInput(): Unit = {
+    val tokens: List[JsonParser.Token] = JsonParser.parse(
+      """{"name":"Ada","numbers":[1,9223372036854775807,3.5],"ok":false,"none":null}""",
+      parser => collectTokens(parser)
+    )
+
+    assertEquals(
+      List(
+        JsonParser.OpenObj,
+        JsonParser.FieldStart("name"),
+        JsonParser.StringVal("Ada"),
+        JsonParser.FieldStart("numbers"),
+        JsonParser.OpenArr,
+        JsonParser.IntVal(BigInt(1)),
+        JsonParser.IntVal(BigInt("9223372036854775807")),
+        JsonParser.DoubleVal(3.5d),
+        JsonParser.CloseArr,
+        JsonParser.FieldStart("ok"),
+        JsonParser.BoolVal(false),
+        JsonParser.FieldStart("none"),
+        JsonParser.NullVal,
+        JsonParser.CloseObj,
+        JsonParser.End
+      ),
+      tokens
+    )
+  }
+
+  @Test
+  def exposesLowLevelPullParserTokensFromReaderWithNumericOptions(): Unit = {
+    val reader: StringReader = new StringReader("""[1,2.75,true,null]""")
+    val tokens: List[JsonParser.Token] = JsonParser.parse(
+      reader,
+      parser => collectTokens(parser),
+      useBigDecimalForDouble = true,
+      useBigIntForLong = false
+    )
+
+    assertEquals(
+      List(
+        JsonParser.OpenArr,
+        JsonParser.LongVal(1L),
+        JsonParser.BigDecimalVal(BigDecimal("2.75")),
+        JsonParser.BoolVal(true),
+        JsonParser.NullVal,
+        JsonParser.CloseArr,
+        JsonParser.End
+      ),
+      tokens
+    )
+  }
+
+  @Test
+  def rendersCompactsAndPrettyPrintsJsonValues(): Unit = {
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("quote", JString("he said \"hi\"")),
+      JField("numbers", JArray(List(JInt(1), JDecimal(BigDecimal("2.50"))))),
+      JField("nested", JObject(JField("enabled", JBool.True))),
+      JField("skipMe", JNothing)
+    )
+
+    val compact: String = JsonMethods.compact(JsonMethods.render(value, alwaysEscapeUnicode = true))
+    assertEquals(
+      """{"name":"caf\u00E9","quote":"he said \"hi\"","numbers":[1,2.50],"nested":{"enabled":true}}""",
+      compact
+    )
+    assertEquals(value.removeField(_._1 == "skipMe"), JsonMethods.parse(compact, useBigDecimalForDouble = true))
+    assertEquals("1e+500", JsonMethods.compact(JsonMethods.render(JDouble(Double.PositiveInfinity))))
+
+    val pretty: String = JsonMethods.pretty(JsonMethods.render(value))
+    assertTrue(pretty.contains("\n"))
+    assertTrue(pretty.contains("  \"enabled\":true"))
+    assertEquals(value.removeField(_._1 == "skipMe"), JsonMethods.parse(pretty, useBigDecimalForDouble = true))
+  }
+
+  @Test
+  def appliesEmptyValueStrategiesWhenRendering(): Unit = {
+    val source: JObject = JObject(
+      JField("present", JString("value")),
+      JField("missing", JNothing),
+      JField("array", JArray(List(JInt(1), JNothing, JNull)))
+    )
+
+    val skipped: String = JsonMethods.compact(JsonMethods.render(source, emptyValueStrategy = EmptyValueStrategy.skip))
+    assertEquals("""{"present":"value","array":[1,null]}""", skipped)
+
+    val preserved: String = JsonMethods.compact(JsonMethods.render(source, emptyValueStrategy = EmptyValueStrategy.preserve))
+    assertEquals("""{"present":"value","missing":null,"array":[1,null,null]}""", preserved)
+  }
+
+  @Test
+  def rendersPrimitiveAndSetValues(): Unit = {
+    assertEquals("null", JsonMethods.compact(JsonMethods.render(JString(null))))
+    assertEquals("null", JsonMethods.compact(JsonMethods.render(JNull)))
+    assertEquals("false", JsonMethods.compact(JsonMethods.render(JBool.False)))
+    assertEquals("9000000000", JsonMethods.compact(JsonMethods.render(JLong(9000000000L))))
+
+    val renderedSet: String = JsonMethods.compact(JsonMethods.render(JSet(Set(JInt(1), JInt(2)))))
+    assertEquals(Set(JInt(1), JInt(2)), JsonParser.parse(renderedSet).children.toSet)
+  }
+
+  @Test
+  def usesDocumentCombinatorsAndPrinterWriters(): Unit = {
+    val document: Document = Document.group(
+      Document.nest(
+        2,
+        Document.text("alpha") :/: Document.text("beta") :/: Document.text("gamma")
+      )
+    )
+
+    val wideWriter: StringWriter = new StringWriter()
+    document.format(80, wideWriter)
+    assertEquals("alpha beta gamma", wideWriter.toString)
+
+    val narrowWriter: StringWriter = new StringWriter()
+    document.format(5, narrowWriter)
+    assertEquals("alpha\n  beta\n  gamma", narrowWriter.toString)
+
+    val compactWriter: StringWriter = new StringWriter()
+    val returnedCompactWriter: StringWriter = Printer.compact(document, compactWriter)
+    assertSame(compactWriter, returnedCompactWriter)
+    assertEquals("alphabetagamma", compactWriter.toString)
+
+    val prettyWriter: StringWriter = new StringWriter()
+    val returnedPrettyWriter: StringWriter = Printer.pretty(document, prettyWriter)
+    assertSame(prettyWriter, returnedPrettyWriter)
+    assertEquals("alpha\n  beta\n  gamma", prettyWriter.toString)
+  }
+
+  @Test
+  def rendersAndParsesThroughJsonMethodsFacade(): Unit = {
+    val source: String = """{"project":"json4s","versions":[3,4],"meta":{"native":true}}"""
+    val parsed: JValue = JsonMethods.parse(source)
+    val document: Document = JsonMethods.render(parsed)
+
+    assertEquals(source, JsonMethods.compact(document))
+    assertEquals(parsed, JsonMethods.parse(JsonMethods.pretty(document)))
+    assertEquals(Some(parsed), JsonMethods.parseOpt(source))
+    assertEquals(None, JsonMethods.parseOpt("""{"invalid":]"""))
+  }
+
+  private def collectTokens(parser: JsonParser.Parser): List[JsonParser.Token] = {
+    val builder: scala.collection.mutable.ListBuffer[JsonParser.Token] = scala.collection.mutable.ListBuffer.empty[JsonParser.Token]
+    var continue: Boolean = true
+    while (continue) {
+      val token: JsonParser.Token = parser.nextToken
+      builder += token
+      continue = token != JsonParser.End
+    }
+    builder.toList
+  }
+
+  private final class TrackingStringReader(text: String) extends StringReader(text) {
+    var closed: Boolean = false
+
+    override def close(): Unit = {
+      closed = true
+      super.close()
+    }
   }
 }

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
@@ -255,6 +255,16 @@ class Json4s_native_core_3Test {
   }
 
   @Test
+  def parsesCustomInputsThroughJsonInputTypeClass(): Unit = {
+    given AsJsonInput[JsonEnvelope] = AsJsonInput.stringAsJsonInput.contramap(_.payload)
+
+    val parsed: JValue = JsonMethods.parse(new JsonEnvelope("""{"kind":"custom","tags":["public","api"]}"""))
+
+    assertEquals(JString("custom"), parsed \ "kind")
+    assertEquals(JArray(List(JString("public"), JString("api"))), parsed \ "tags")
+  }
+
+  @Test
   def acceptsNonStringInputsThroughJsonMethodsFacade(): Unit = {
     val stream: TrackingByteArrayInputStream = new TrackingByteArrayInputStream(
       """{"text":"héllo","source":"stream"}""".getBytes(StandardCharsets.UTF_8)
@@ -290,6 +300,8 @@ class Json4s_native_core_3Test {
     }
     builder.toList
   }
+
+  private final class JsonEnvelope(val payload: String)
 
   private final class TrackingStringReader(text: String) extends StringReader(text) {
     var closed: Boolean = false

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/src/test/scala/org_json4s/json4s_native_core_3/Json4s_native_core_3Test.scala
@@ -17,8 +17,12 @@ import org.json4s.prefs.EmptyValueStrategy
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
+import java.io.ByteArrayInputStream
 import java.io.StringReader
 import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 class Json4s_native_core_3Test {
   @Test
@@ -250,6 +254,32 @@ class Json4s_native_core_3Test {
     assertEquals(None, JsonMethods.parseOpt("""{"invalid":]"""))
   }
 
+  @Test
+  def acceptsNonStringInputsThroughJsonMethodsFacade(): Unit = {
+    val stream: TrackingByteArrayInputStream = new TrackingByteArrayInputStream(
+      """{"text":"héllo","source":"stream"}""".getBytes(StandardCharsets.UTF_8)
+    )
+
+    val streamParsed: JValue = JsonMethods.parse(stream)
+
+    assertEquals(JString("héllo"), streamParsed \ "text")
+    assertEquals(JString("stream"), streamParsed \ "source")
+    assertTrue(stream.closed)
+
+    val tempFile: Path = Files.createTempFile("json4s-native-core", ".json")
+    try {
+      Files.writeString(tempFile, """{"source":"file","numbers":[10,20]}""", StandardCharsets.UTF_8)
+
+      val fileParsed: JValue = JsonMethods.parse(tempFile.toFile)
+
+      assertEquals(JString("file"), fileParsed \ "source")
+      assertEquals(JArray(List(JInt(10), JInt(20))), fileParsed \ "numbers")
+      assertEquals(Some(fileParsed), JsonMethods.parseOpt(tempFile.toFile))
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
   private def collectTokens(parser: JsonParser.Parser): List[JsonParser.Token] = {
     val builder: scala.collection.mutable.ListBuffer[JsonParser.Token] = scala.collection.mutable.ListBuffer.empty[JsonParser.Token]
     var continue: Boolean = true
@@ -262,6 +292,15 @@ class Json4s_native_core_3Test {
   }
 
   private final class TrackingStringReader(text: String) extends StringReader(text) {
+    var closed: Boolean = false
+
+    override def close(): Unit = {
+      closed = true
+      super.close()
+    }
+  }
+
+  private final class TrackingByteArrayInputStream(bytes: Array[Byte]) extends ByteArrayInputStream(bytes) {
     var closed: Boolean = false
 
     override def close(): Unit = {

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.json4s.native.**"
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.json4s.native.**"
+      "includeClasses" : "org.json4s.native.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_native_core_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5475

This PR introduces tests and metadata for org.json4s:json4s-native-core_3:4.0.7, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 227010
- Cached input tokens: 1753600
- Output tokens: 22461
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 92.33
- Generated lines of code: 275
- Tested library lines of code: 277

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22afeb3c8f336475cd74048ae4b301c3ee40a02d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2959/5297 (55.86%)
- Line: 277/300 (92.33%)
- Method: 204/514 (39.69%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
