### PR TITLE
[GenAI] Mark com.squareup:kotlinpoet as not for Native Image

### DIFF
--- a/metadata/com.squareup/kotlinpoet/index.json
+++ b/metadata/com.squareup/kotlinpoet/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to com.squareup:kotlinpoet-jvm:2.3.0.",
+    "replacement": "com.squareup:kotlinpoet-jvm:2.3.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5309

This PR records `com.squareup:kotlinpoet` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to com.squareup:kotlinpoet-jvm:2.3.0.

Replacement guidance:
- com.squareup:kotlinpoet-jvm:2.3.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `411dc735f2446d0db64fa50cf4c0ff9734f9b5df`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
