### PR TITLE
[GenAI] Add support for com.lihaoyi:geny_3:1.0.0 using gpt-5.5

### DIFF
--- a/metadata/com.lihaoyi/geny_3/1.0.0/reachability-metadata.json
+++ b/metadata/com.lihaoyi/geny_3/1.0.0/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "geny.ByteData$Chunks"
+      },
+      "type": "geny.ByteData$Chunks",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.lihaoyi/geny_3/index.json
+++ b/metadata/com.lihaoyi/geny_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/lihaoyi/geny_3/$version$/geny_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/com-lihaoyi/geny",
+    "test-code-url" : "https://github.com/com-lihaoyi/geny/tree/$version$/geny/test/src",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/lihaoyi/geny_3/$version$/geny_3-$version$-javadoc.jar",
+    "description" : "Geny is a small Scala library that provides push-based versions of common standard library interfaces, centered on Generator as an inverse of Iterator and Writable and Readable for byte and text IO. It helps model lazy streaming data with deterministic cleanup and lightweight interoperation with standard Scala collections and Java IO types.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.0.0"
+    ],
+    "allowed-packages" : [
+      "geny"
+    ]
+  }
+]

--- a/stats/com.lihaoyi/geny_3/1.0.0/execution-metrics.json
+++ b/stats/com.lihaoyi/geny_3/1.0.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T05:12:48.761774Z",
+    "library": "com.lihaoyi:geny_3:1.0.0",
+    "starting_commit": "912896cb0170e9c3a4b4d26d8581cd16f8c10b9f",
+    "ending_commit": "89a9e23d2496237edd571ac9a7395db61392b5f3",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1517,
+          "missed": 531,
+          "ratio": 0.740723,
+          "total": 2048
+        },
+        "line": {
+          "covered": 242,
+          "missed": 19,
+          "ratio": 0.927203,
+          "total": 261
+        },
+        "method": {
+          "covered": 200,
+          "missed": 63,
+          "ratio": 0.760456,
+          "total": 263
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 159305,
+      "cached_input_tokens_used": 878592,
+      "output_tokens_used": 17208,
+      "iterations": 5,
+      "cost_usd": 0.9555,
+      "generated_loc": 264,
+      "tested_library_loc": 242,
+      "metadata_entries": 2,
+      "code_coverage_percent": 92.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala",
+      "metadata_file": "metadata/com.lihaoyi/geny_3/1.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.lihaoyi/geny_3/1.0.0/stats.json
+++ b/stats/com.lihaoyi/geny_3/1.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1517,
+        "missed" : 531,
+        "ratio" : 0.740723,
+        "total" : 2048
+      },
+      "line" : {
+        "covered" : 242,
+        "missed" : 19,
+        "ratio" : 0.927203,
+        "total" : 261
+      },
+      "method" : {
+        "covered" : 200,
+        "missed" : 63,
+        "ratio" : 0.760456,
+        "total" : 263
+      }
+    }
+  } ]
+}

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/.gitignore
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.lihaoyi:geny_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/gradle.properties
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.lihaoyi:geny_3:1.0.0
+library.version = 1.0.0
+metadata.dir = com.lihaoyi/geny_3/1.0.0/

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/settings.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.lihaoyi.geny_3_tests'

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
@@ -6,11 +6,266 @@
  */
 package com_lihaoyi.geny_3
 
+import geny.ByteData
+import geny.Bytes
+import geny.Generator
+import geny.Readable
+import geny.Writable
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
 
 class Geny_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def generatorEvaluatesCommonCollectionOperationsAndConversions(): Unit = {
+    val generator: Generator[Int] = Generator(3, 1, 4, 1, 5)
+
+    assertEquals(Some(4), generator.find(_ % 2 == 0))
+    assertEquals(None, generator.find(_ > 10))
+    assertTrue(generator.exists(_ == 5))
+    assertTrue(generator.contains(1))
+    assertFalse(generator.contains(9))
+    assertTrue(generator.forall(_ > 0))
+    assertEquals(5, generator.count())
+    assertEquals(4, generator.count(_ % 2 == 1))
+    assertEquals(14, generator.foldLeft(0)(_ + _))
+    assertEquals("start-3-1-4-1-5", generator.fold("start")((accumulator, value) => s"$accumulator-$value"))
+    assertEquals(14, generator.reduce(_ + _))
+    assertEquals(1, generator.min)
+    assertEquals(5, generator.max)
+    assertEquals(5, generator.maxBy(value => value * value))
+    assertEquals(1, generator.minBy(identity))
+
+    assertEquals(3, generator.head)
+    assertEquals(Some(3), generator.headOption)
+    assertEquals(List(3, 1, 4, 1, 5), generator.toList)
+    assertEquals(Vector(3, 1, 4, 1, 5), generator.toVector)
+    assertEquals(Seq(3, 1, 4, 1, 5), generator.toSeq)
+    assertEquals(Set(1, 3, 4, 5), generator.toSet)
+    assertEquals(mutable.Buffer(3, 1, 4, 1, 5), generator.toBuffer)
+    assertArrayEquals(Array(3, 1, 4, 1, 5), generator.toArray)
+    assertEquals("[3, 1, 4, 1, 5]", generator.mkString("[", ", ", "]"))
+    assertEquals("3|1|4|1|5", generator.mkString("|"))
+    assertEquals("31415", generator.mkString)
+    assertEquals(14, generator.sum)
+    assertEquals(60, generator.product)
+
+    val empty: Generator[Int] = Generator()
+    assertEquals(None, empty.headOption)
+    assertThrows(classOf[NoSuchElementException], () => empty.head)
+    assertThrows(classOf[UnsupportedOperationException], () => empty.reduce(_ + _))
+  }
+
+  @Test
+  def generatorTransformationsAreLazyComposableAndShortCircuiting(): Unit = {
+    val evaluations: AtomicInteger = new AtomicInteger(0)
+    val transformed: Generator[String] = Generator(1, 2, 3, 4, 5)
+      .filter(_ % 2 == 1)
+      .map { value =>
+        evaluations.incrementAndGet()
+        s"value-${value * 2}"
+      }
+
+    assertEquals(0, evaluations.get())
+    assertEquals(List("value-2", "value-6", "value-10"), transformed.toList)
+    assertEquals(3, evaluations.get())
+
+    val comprehension: Generator[String] = for {
+      outer <- Generator(1, 2, 3, 4)
+      if outer % 2 == 0
+      inner <- Generator("a", "b")
+    } yield s"$outer-$inner"
+    assertEquals(List("2-a", "2-b", "4-a", "4-b"), comprehension.toList)
+
+    val collected: Generator[String] = Generator("1", "two", "3", "four").collect {
+      case value if value.forall(_.isDigit) => s"number-$value"
+    }
+    assertEquals(List("number-1", "number-3"), collected.toList)
+    assertEquals(Some("first-two"), Generator("one", "two", "three").collectFirst {
+      case value if value.length == 3 && value.startsWith("t") => s"first-$value"
+    })
+
+    val sliced: Generator[Int] = Generator(0, 1, 2, 3, 4, 5, 6)
+      .drop(1)
+      .slice(1, 5)
+      .take(3)
+    assertEquals(List(2, 3, 4), sliced.toList)
+    assertEquals(List(0, 1, 2), Generator(0, 1, 2, 3, 0).takeWhile(_ < 3).toList)
+    assertEquals(List(3, 0), Generator(0, 1, 2, 3, 0).dropWhile(_ < 3).toList)
+    assertEquals(List(("a", 0), ("b", 1), ("c", 2)), Generator("a", "b", "c").zipWithIndex.toList)
+    assertEquals(List(("a", 10), ("b", 20)), Generator("a", "b", "c").zip(List(10, 20)).toList)
+    assertEquals(List(1, 2, 3, 4), (Generator(1, 2) ++ Generator(3, 4)).toList)
+    assertEquals(List(1, 2, 2, 4, 3, 6), Generator(1, 2, 3).flatMap(value => Generator(value, value * 2)).toList)
+
+    val visited: mutable.Buffer[Int] = mutable.Buffer.empty[Int]
+    val action: Generator.Action = Generator(1, 2, 3, 4).generate { value =>
+      visited.append(value)
+      if (value == 2) Generator.End else Generator.Continue
+    }
+    assertSame(Generator.End, action)
+    assertEquals(List(1, 2), visited.toList)
+  }
+
+  @Test
+  def selfClosingGeneratorRunsCleanupAfterFullAndEarlyEvaluation(): Unit = {
+    val closedAfterFullRead: AtomicInteger = new AtomicInteger(0)
+    val fullRead: Generator[Int] = Generator.selfClosing {
+      (Iterator(1, 2, 3), () => {
+        closedAfterFullRead.incrementAndGet()
+        ()
+      })
+    }
+
+    assertEquals(List(1, 2, 3), fullRead.toList)
+    assertEquals(1, closedAfterFullRead.get())
+
+    val closedAfterShortCircuit: AtomicInteger = new AtomicInteger(0)
+    val pulledValues: AtomicInteger = new AtomicInteger(0)
+    val earlyRead: Generator[Int] = Generator.selfClosing {
+      val iterator: Iterator[Int] = Iterator.from(1).map { value =>
+        pulledValues.incrementAndGet()
+        value
+      }
+      (iterator, () => {
+        closedAfterShortCircuit.incrementAndGet()
+        ()
+      })
+    }
+
+    assertEquals(Some(3), earlyRead.find(_ == 3))
+    assertEquals(3, pulledValues.get())
+    assertEquals(1, closedAfterShortCircuit.get())
+  }
+
+  @Test
+  def byteDataChunksExposeCombinedBytesTextTrimLinesAndValueSemantics(): Unit = {
+    val first: Bytes = new Bytes(" hello\n".getBytes(StandardCharsets.UTF_8))
+    val second: Bytes = new Bytes("world\n\u2603 ".getBytes(StandardCharsets.UTF_8))
+    val chunks: ByteData.Chunks = ByteData.Chunks(Seq(first, second))
+
+    assertArrayEquals(" hello\nworld\n\u2603 ".getBytes(StandardCharsets.UTF_8), chunks.bytes)
+    assertEquals(" hello\nworld\n\u2603 ", chunks.text())
+    assertEquals("hello\nworld\n\u2603", chunks.trim())
+    assertEquals(Vector(" hello", "world", "\u2603 "), chunks.lines())
+    assertEquals(Seq(first, second), chunks.chunks)
+    assertEquals(chunks, chunks.copy())
+    assertEquals("Chunks", chunks.productPrefix)
+    assertEquals(1, chunks.productArity)
+    assertEquals(Seq(first, second), chunks.productElement(0))
+
+    val sameBytes: Bytes = new Bytes("abc".getBytes(StandardCharsets.UTF_8))
+    assertEquals(sameBytes, new Bytes("abc".getBytes(StandardCharsets.UTF_8)))
+    assertNotEquals(sameBytes, new Bytes("abcd".getBytes(StandardCharsets.UTF_8)))
+    assertNotEquals(sameBytes, "abc")
+    assertEquals("abc", sameBytes.toString)
+  }
+
+  @Test
+  def writableImplementationsReportMetadataAndWriteWithoutConsumingByteBuffers(): Unit = {
+    val stringWritable: Writable = Writable.StringWritable("a\u2603")
+    assertEquals(Some("text/plain; charset=utf-8"), stringWritable.httpContentType)
+    assertEquals(Some("a\u2603".getBytes(StandardCharsets.UTF_8).length.toLong), stringWritable.contentLength)
+    assertArrayEquals("a\u2603".getBytes(StandardCharsets.UTF_8), writeToBytes(stringWritable))
+
+    val byteArray: Array[Byte] = Array[Byte](1, 2, 3, 4)
+    val byteArrayWritable: Writable = Writable.ByteArrayWritable(byteArray)
+    assertEquals(Some("application/octet-stream"), byteArrayWritable.httpContentType)
+    assertEquals(Some(4L), byteArrayWritable.contentLength)
+    assertArrayEquals(byteArray, writeToBytes(byteArrayWritable))
+
+    val buffer: ByteBuffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
+    buffer.put(Array[Byte](9, 8, 7, 6, 5))
+    buffer.flip()
+    buffer.get()
+    val initialPosition: Int = buffer.position()
+    val byteBufferWritable: Writable = Writable.ByteBufferWritable(buffer)
+
+    assertEquals(Some("application/octet-stream"), byteBufferWritable.httpContentType)
+    assertEquals(Some(4L), byteBufferWritable.contentLength)
+    assertArrayEquals(Array[Byte](8, 7, 6, 5), writeToBytes(byteBufferWritable))
+    assertEquals(initialPosition, buffer.position())
+    assertEquals(ByteOrder.LITTLE_ENDIAN, buffer.order())
+  }
+
+  @Test
+  def readableImplementationsCanReadAndWriteByteSources(): Unit = {
+    val stringReadable: Readable = Readable.StringReadable("hello")
+    assertEquals(Some("text/plain; charset=utf-8"), stringReadable.httpContentType)
+    assertEquals(Some(5L), stringReadable.contentLength)
+    assertEquals("hello", readAllText(stringReadable))
+    assertArrayEquals("hello".getBytes(StandardCharsets.UTF_8), writeToBytes(stringReadable))
+
+    val byteArrayReadable: Readable = Readable.ByteArrayReadable(Array[Byte](10, 11, 12))
+    assertEquals(Some("application/octet-stream"), byteArrayReadable.httpContentType)
+    assertEquals(Some(3L), byteArrayReadable.contentLength)
+    assertArrayEquals(Array[Byte](10, 11, 12), readAllBytes(byteArrayReadable))
+
+    val buffer: ByteBuffer = ByteBuffer.wrap(Array[Byte](0, 1, 2, 3, 4))
+    buffer.position(2)
+    val byteBufferReadable: Readable = Readable.ByteBufferReadable(buffer)
+    assertEquals(Some("application/octet-stream"), byteBufferReadable.httpContentType)
+    assertEquals(Some(3L), byteBufferReadable.contentLength)
+    assertArrayEquals(Array[Byte](2, 3, 4), readAllBytes(byteBufferReadable))
+    assertEquals(2, buffer.position())
+
+    val inputStream: CloseAwareInputStream = new CloseAwareInputStream(Array[Byte](42, 43, 44))
+    val inputStreamReadable: Readable = Readable.InputStreamReadable(inputStream)
+    assertEquals(Some("application/octet-stream"), inputStreamReadable.httpContentType)
+    assertEquals(None, inputStreamReadable.contentLength)
+    assertArrayEquals(Array[Byte](42, 43, 44), writeToBytes(inputStreamReadable))
+    assertTrue(inputStream.closed)
+  }
+
+  private def writeToBytes(writable: Writable): Array[Byte] = {
+    val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    writable.writeBytesTo(outputStream)
+    outputStream.toByteArray
+  }
+
+  private def readAllText(readable: Readable): String = {
+    new String(readAllBytes(readable), StandardCharsets.UTF_8)
+  }
+
+  private def readAllBytes(readable: Readable): Array[Byte] = {
+    readable.readBytesThrough { inputStream =>
+      val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
+      val buffer: Array[Byte] = new Array[Byte](2)
+      var read: Int = inputStream.read(buffer)
+      while (read != -1) {
+        outputStream.write(buffer, 0, read)
+        read = inputStream.read(buffer)
+      }
+      outputStream.toByteArray
+    }
+  }
+
+  private final class CloseAwareInputStream(bytes: Array[Byte]) extends InputStream {
+    private val delegate: ByteArrayInputStream = new ByteArrayInputStream(bytes)
+    var closed: Boolean = false
+
+    override def read(): Int = delegate.read()
+
+    override def read(buffer: Array[Byte], offset: Int, length: Int): Int = delegate.read(buffer, offset, length)
+
+    override def available(): Int = delegate.available()
+
+    override def close(): Unit = {
+      closed = true
+      delegate.close()
+    }
   }
 }

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_lihaoyi.geny_3
+
+import org.junit.jupiter.api.Test
+
+class Geny_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
@@ -71,6 +71,24 @@ class Geny_3Test {
   }
 
   @Test
+  def generatorFromAdaptsArbitraryIterableOnceSourcesLazilyAndRepeatably(): Unit = {
+    final case class Rows[A](entries: Vector[A])
+
+    val conversions: AtomicInteger = new AtomicInteger(0)
+    val source: Rows[String] = Rows(Vector("red", "blue", "green"))
+    val generator: Generator[String] = Generator.from(source) { rows =>
+      conversions.incrementAndGet()
+      rows.entries.iterator
+    }
+
+    assertEquals(0, conversions.get())
+    assertEquals(List("red", "blue", "green"), generator.toList)
+    assertEquals(1, conversions.get())
+    assertEquals(List("red", "blue", "green"), generator.toList)
+    assertEquals(2, conversions.get())
+  }
+
+  @Test
   def generatorTransformationsAreLazyComposableAndShortCircuiting(): Unit = {
     val evaluations: AtomicInteger = new AtomicInteger(0)
     val transformed: Generator[String] = Generator(1, 2, 3, 4, 5)

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/src/test/scala/com_lihaoyi/geny_3/Geny_3Test.scala
@@ -28,6 +28,7 @@ import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
+import scala.io.Codec
 
 class Geny_3Test {
   @Test
@@ -190,6 +191,20 @@ class Geny_3Test {
     assertNotEquals(sameBytes, new Bytes("abcd".getBytes(StandardCharsets.UTF_8)))
     assertNotEquals(sameBytes, "abc")
     assertEquals("abc", sameBytes.toString)
+  }
+
+  @Test
+  def byteDataDecodesTextWithExplicitCodec(): Unit = {
+    val latin1Text: String = " café \nniño\n"
+    val chunks: ByteData.Chunks = ByteData.Chunks(Seq(
+      new Bytes(" café \n".getBytes(StandardCharsets.ISO_8859_1)),
+      new Bytes("niño\n".getBytes(StandardCharsets.ISO_8859_1))
+    ))
+    val latin1: Codec = Codec(StandardCharsets.ISO_8859_1)
+
+    assertEquals(latin1Text, chunks.text(latin1))
+    assertEquals("café \nniño", chunks.trim(latin1))
+    assertEquals(Vector(" café ", "niño"), chunks.lines(latin1))
   }
 
   @Test

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "geny.**"
+    }
+  ]
+}

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "geny.**"
+      "includeClasses" : "geny.**"
+    },
+    {
+      "includeClasses" : "com_lihaoyi.geny_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4977

This PR introduces tests and metadata for com.lihaoyi:geny_3:1.0.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 159305
- Cached input tokens: 878592
- Output tokens: 17208
- Metadata entries: 2
- Iterations: 5
- Library coverage percentage: 92.72
- Generated lines of code: 264
- Tested library lines of code: 242

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b7d6f1a9dbf439dc0f38681fb7b43aea97703e1d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1517/2048 (74.07%)
- Line: 242/261 (92.72%)
- Method: 200/263 (76.05%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
