### PR TITLE
[GenAI] Add support for com.google.api.grpc:grpc-google-cloud-spanner-executor-v1:6.116.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.protobuf.ExtensionRegistryFactory"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.116.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/google-cloud-java",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-javadoc.jar",
+    "description" : "This artifact provides generated gRPC Java stubs for the Cloud Spanner Executor v1 API. It exposes the SpannerExecutorProxy service bindings used by Java clients and tests to execute Spanner actions asynchronously over gRPC.",
+    "tested-versions" : [
+      "6.116.1"
+    ],
+    "allowed-packages" : [
+      "com.google.spanner.executor.v1"
+    ]
+  }
+]

--- a/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/index.json
+++ b/metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "6.116.1",
-    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-sources.jar",
-    "repository-url" : "https://github.com/googleapis/google-cloud-java",
-    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-tests.jar",
-    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-javadoc.jar",
-    "description" : "This artifact provides generated gRPC Java stubs for the Cloud Spanner Executor v1 API. It exposes the SpannerExecutorProxy service bindings used by Java clients and tests to execute Spanner actions asynchronously over gRPC.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "6.116.1",
+    "source-code-url": "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-sources.jar",
+    "repository-url": "https://github.com/googleapis/google-cloud-java",
+    "test-code-url": "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-tests.jar",
+    "documentation-url": "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-spanner-executor-v1/$version$/grpc-google-cloud-spanner-executor-v1-$version$-javadoc.jar",
+    "description": "This artifact provides generated gRPC Java stubs for the Cloud Spanner Executor v1 API. It exposes the SpannerExecutorProxy service bindings used by Java clients and tests to execute Spanner actions asynchronously over gRPC.",
+    "tested-versions": [
       "6.116.1"
     ],
-    "allowed-packages" : [
-      "com.google.spanner.executor.v1"
+    "allowed-packages": [
+      "com.google.spanner.executor.v1",
+      "com.google.protobuf"
     ]
   }
 ]

--- a/stats/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T05:24:02.896135Z",
+    "library": "com.google.api.grpc:grpc-google-cloud-spanner-executor-v1:6.116.1",
+    "starting_commit": "af062d26c39afe70f44311674004557c6e2e8976",
+    "ending_commit": "d10c0ad5633f48e158149d4235410b54b3b0a643",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.116.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 110,
+          "missed": 53,
+          "ratio": 0.674847,
+          "total": 163
+        },
+        "line": {
+          "covered": 33,
+          "missed": 13,
+          "ratio": 0.717391,
+          "total": 46
+        },
+        "method": {
+          "covered": 21,
+          "missed": 9,
+          "ratio": 0.7,
+          "total": 30
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 212926,
+      "cached_input_tokens_used": 1661440,
+      "output_tokens_used": 19920,
+      "iterations": 4,
+      "cost_usd": 1.4283,
+      "generated_loc": 366,
+      "tested_library_loc": 33,
+      "metadata_entries": 2,
+      "code_coverage_percent": 71.74
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/stats.json
+++ b/stats/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.116.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 110,
+        "missed" : 53,
+        "ratio" : 0.674847,
+        "total" : 163
+      },
+      "line" : {
+        "covered" : 33,
+        "missed" : 13,
+        "ratio" : 0.717391,
+        "total" : 46
+      },
+      "method" : {
+        "covered" : 21,
+        "missed" : 9,
+        "ratio" : 0.7,
+        "total" : 30
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/.gitignore
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/build.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:grpc-google-cloud-spanner-executor-v1:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:grpc-google-cloud-spanner-executor-v1:6.116.1
+library.version = 6.116.1
+metadata.dir = com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.grpc-google-cloud-spanner-executor-v1_tests'

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
@@ -6,11 +6,373 @@
  */
 package com_google_api_grpc.grpc_google_cloud_spanner_executor_v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.spanner.executor.v1.QueryAction;
+import com.google.spanner.executor.v1.QueryResult;
+import com.google.spanner.executor.v1.SpannerAction;
+import com.google.spanner.executor.v1.SpannerActionOutcome;
+import com.google.spanner.executor.v1.SpannerAsyncActionRequest;
+import com.google.spanner.executor.v1.SpannerAsyncActionResponse;
+import com.google.spanner.executor.v1.SpannerExecutorProxyGrpc;
+import com.google.spanner.executor.v1.Value;
+import com.google.spanner.executor.v1.ValueList;
+import com.google.protobuf.ByteString;
+import com.google.rpc.Status;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
+import io.grpc.stub.BlockingClientCall;
+import io.grpc.stub.StreamObserver;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
-class Grpc_google_cloud_spanner_executor_v1Test {
+public class Grpc_google_cloud_spanner_executor_v1Test {
+    private static final int ACTION_ID = 17;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void methodDescriptorDefinesBidiStreamingExecutorContract() {
+        MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> method =
+                SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod();
+        SpannerAsyncActionRequest request = request(ACTION_ID, "SELECT 1");
+        SpannerAsyncActionResponse response = response(ACTION_ID, 0, "OK");
+
+        assertThat(SpannerExecutorProxyGrpc.SERVICE_NAME).isEqualTo("google.spanner.executor.v1.SpannerExecutorProxy");
+        assertThat(method.getType()).isEqualTo(MethodDescriptor.MethodType.BIDI_STREAMING);
+        assertThat(method.getServiceName()).isEqualTo(SpannerExecutorProxyGrpc.SERVICE_NAME);
+        assertThat(method.getBareMethodName()).isEqualTo("ExecuteActionAsync");
+        assertThat(method.getFullMethodName())
+                .isEqualTo("google.spanner.executor.v1.SpannerExecutorProxy/ExecuteActionAsync");
+        assertThat(method.isSampledToLocalTracing()).isTrue();
+
+        assertThat(parseRequest(method, request)).isEqualTo(request);
+        assertThat(parseResponse(method, response)).isEqualTo(response);
+    }
+
+    @Test
+    void serviceDescriptorAndBoundServiceExposeSingleExecutorMethod() {
+        ServiceDescriptor serviceDescriptor = SpannerExecutorProxyGrpc.getServiceDescriptor();
+        SpannerExecutorProxyGrpc.AsyncService service = new SpannerExecutorProxyGrpc.AsyncService() {
+            @Override
+            public StreamObserver<SpannerAsyncActionRequest> executeActionAsync(
+                    StreamObserver<SpannerAsyncActionResponse> responseObserver) {
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(SpannerAsyncActionRequest request) {
+                        responseObserver.onNext(response(request.getActionId(), 0, "dispatched"));
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        responseObserver.onError(throwable);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        responseObserver.onCompleted();
+                    }
+                };
+            }
+        };
+        ServerServiceDefinition serviceDefinition = SpannerExecutorProxyGrpc.bindService(service);
+
+        assertThat(serviceDescriptor.getName()).isEqualTo(SpannerExecutorProxyGrpc.SERVICE_NAME);
+        assertThat(serviceDescriptor.getMethods())
+                .singleElement()
+                .extracting(MethodDescriptor::getFullMethodName)
+                .isEqualTo(SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getFullMethodName());
+        assertThat(serviceDefinition.getServiceDescriptor().getName()).isEqualTo(serviceDescriptor.getName());
+        String fullMethodName = SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getFullMethodName();
+        assertThat(serviceDefinition.getMethod(fullMethodName)).isNotNull();
+    }
+
+    @Test
+    void boundAsyncServiceDispatchesStreamingMessagesThroughGrpcHandler() {
+        SpannerExecutorProxyGrpc.AsyncService service = new SpannerExecutorProxyGrpc.AsyncService() {
+            @Override
+            public StreamObserver<SpannerAsyncActionRequest> executeActionAsync(
+                    StreamObserver<SpannerAsyncActionResponse> responseObserver) {
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(SpannerAsyncActionRequest request) {
+                        SpannerAction action = request.getAction();
+                        responseObserver.onNext(response(
+                                request.getActionId(), 0, "sql=" + action.getQuery().getSql()));
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        responseObserver.onError(throwable);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        responseObserver.onCompleted();
+                    }
+                };
+            }
+        };
+        ServerMethodDefinition<SpannerAsyncActionRequest, SpannerAsyncActionResponse> methodDefinition =
+                getExecuteActionMethodDefinition(SpannerExecutorProxyGrpc.bindService(service));
+        RecordingServerCall serverCall = new RecordingServerCall(methodDefinition.getMethodDescriptor());
+
+        ServerCallHandler<SpannerAsyncActionRequest, SpannerAsyncActionResponse> handler =
+                methodDefinition.getServerCallHandler();
+        ServerCall.Listener<SpannerAsyncActionRequest> listener = handler.startCall(serverCall, new Metadata());
+        listener.onMessage(request(ACTION_ID, "SELECT 'grpc'"));
+        listener.onHalfClose();
+        listener.onComplete();
+
+        assertThat(serverCall.sentHeaders).isTrue();
+        assertThat(serverCall.messages)
+                .singleElement()
+                .satisfies(response -> {
+                    assertThat(response.getActionId()).isEqualTo(ACTION_ID);
+                    assertThat(response.getOutcome().getStatus().getMessage()).isEqualTo("sql=SELECT 'grpc'");
+                });
+        assertThat(serverCall.closedStatus.isOk()).isTrue();
+    }
+
+    @Test
+    void asyncStubSendsRequestWithConfiguredCallOptionsAndReceivesResponse() throws Exception {
+        SpannerAsyncActionResponse expectedResponse = response(ACTION_ID, 0, "async-ok");
+        RecordingChannel channel = new RecordingChannel(request -> expectedResponse);
+        List<SpannerAsyncActionResponse> responses = new ArrayList<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch completed = new CountDownLatch(1);
+        StreamObserver<SpannerAsyncActionResponse> responseObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(SpannerAsyncActionResponse response) {
+                responses.add(response);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                error.set(throwable);
+                completed.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                completed.countDown();
+            }
+        };
+
+        StreamObserver<SpannerAsyncActionRequest> requestObserver = SpannerExecutorProxyGrpc.newStub(channel)
+                .withCompression("gzip")
+                .withDeadlineAfter(5, TimeUnit.SECONDS)
+                .executeActionAsync(responseObserver);
+        SpannerAsyncActionRequest request = request(ACTION_ID, "SELECT @value");
+        requestObserver.onNext(request);
+        requestObserver.onCompleted();
+
+        assertThat(completed.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(error.get()).isNull();
+        assertThat(channel.method.getFullMethodName())
+                .isEqualTo(SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getFullMethodName());
+        assertThat(channel.callOptions.getCompressor()).isEqualTo("gzip");
+        assertThat(channel.callOptions.getDeadline()).isNotNull();
+        assertThat(channel.lastCall.messages).containsExactly(request);
+        assertThat(responses).containsExactly(expectedResponse);
+    }
+
+    @Test
+    void blockingV2StubUsesBidiStreamingCallWithBoundedReadsAndWrites() throws Exception {
+        SpannerAsyncActionResponse expectedResponse = response(ACTION_ID, 0, "blocking-ok");
+        RecordingChannel channel = new RecordingChannel(request -> expectedResponse);
+        BlockingClientCall<SpannerAsyncActionRequest, SpannerAsyncActionResponse> call =
+                SpannerExecutorProxyGrpc.newBlockingV2Stub(channel)
+                        .withWaitForReady()
+                        .executeActionAsync();
+        SpannerAsyncActionRequest request = request(ACTION_ID, "SELECT TRUE");
+
+        assertThat(call.write(request, 1, TimeUnit.SECONDS)).isTrue();
+        SpannerAsyncActionResponse actualResponse = call.read(1, TimeUnit.SECONDS);
+        call.halfClose();
+
+        assertThat(channel.callOptions.isWaitForReady()).isTrue();
+        assertThat(channel.lastCall.messages).containsExactly(request);
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
+
+    private static SpannerAsyncActionRequest parseRequest(
+            MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> method,
+            SpannerAsyncActionRequest request) {
+        try (InputStream stream = method.streamRequest(request)) {
+            return method.parseRequest(stream);
+        } catch (Exception exception) {
+            throw new AssertionError("Failed to parse marshalled request", exception);
+        }
+    }
+
+    private static SpannerAsyncActionResponse parseResponse(
+            MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> method,
+            SpannerAsyncActionResponse response) {
+        try (InputStream stream = method.streamResponse(response)) {
+            return method.parseResponse(stream);
+        } catch (Exception exception) {
+            throw new AssertionError("Failed to parse marshalled response", exception);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ServerMethodDefinition<SpannerAsyncActionRequest, SpannerAsyncActionResponse>
+            getExecuteActionMethodDefinition(ServerServiceDefinition serviceDefinition) {
+        return (ServerMethodDefinition<SpannerAsyncActionRequest, SpannerAsyncActionResponse>) serviceDefinition
+                .getMethod(SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getFullMethodName());
+    }
+
+    private static SpannerAsyncActionRequest request(int actionId, String sql) {
+        Value parameterValue = Value.newBuilder().setStringValue("native-image").build();
+        QueryAction.Parameter parameter = QueryAction.Parameter.newBuilder()
+                .setName("value")
+                .setValue(parameterValue)
+                .build();
+        SpannerAction action = SpannerAction.newBuilder()
+                .setDatabasePath("projects/p/instances/i/databases/d")
+                .setQuery(QueryAction.newBuilder().setSql(sql).addParams(parameter))
+                .build();
+        return SpannerAsyncActionRequest.newBuilder()
+                .setActionId(actionId)
+                .setAction(action)
+                .build();
+    }
+
+    private static SpannerAsyncActionResponse response(int actionId, int code, String message) {
+        ValueList row = ValueList.newBuilder()
+                .addValue(Value.newBuilder().setStringValue(message))
+                .addValue(Value.newBuilder().setBytesValue(ByteString.copyFromUtf8("bytes")))
+                .build();
+        SpannerActionOutcome outcome = SpannerActionOutcome.newBuilder()
+                .setStatus(Status.newBuilder().setCode(code).setMessage(message))
+                .setQueryResult(QueryResult.newBuilder().addRow(row))
+                .build();
+        return SpannerAsyncActionResponse.newBuilder()
+                .setActionId(actionId)
+                .setOutcome(outcome)
+                .build();
+    }
+
+    private static final class RecordingChannel extends Channel {
+        private final Function<SpannerAsyncActionRequest, SpannerAsyncActionResponse> responseFactory;
+        private MethodDescriptor<?, ?> method;
+        private CallOptions callOptions;
+        private RecordingClientCall lastCall;
+
+        private RecordingChannel(Function<SpannerAsyncActionRequest, SpannerAsyncActionResponse> responseFactory) {
+            this.responseFactory = responseFactory;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions options) {
+            method = methodDescriptor;
+            callOptions = options;
+            lastCall = new RecordingClientCall(responseFactory);
+            return (ClientCall<RequestT, ResponseT>) lastCall;
+        }
+
+        @Override
+        public String authority() {
+            return "in-memory-spanner-executor.test";
+        }
+    }
+
+    private static final class RecordingClientCall
+            extends ClientCall<SpannerAsyncActionRequest, SpannerAsyncActionResponse> {
+        private final Function<SpannerAsyncActionRequest, SpannerAsyncActionResponse> responseFactory;
+        private final List<SpannerAsyncActionRequest> messages = new ArrayList<>();
+        private Listener<SpannerAsyncActionResponse> listener;
+
+        private RecordingClientCall(Function<SpannerAsyncActionRequest, SpannerAsyncActionResponse> responseFactory) {
+            this.responseFactory = responseFactory;
+        }
+
+        @Override
+        public void start(Listener<SpannerAsyncActionResponse> responseListener, Metadata headers) {
+            listener = responseListener;
+            listener.onHeaders(new Metadata());
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+            listener.onClose(io.grpc.Status.CANCELLED.withDescription(message).withCause(cause), new Metadata());
+        }
+
+        @Override
+        public void halfClose() {
+            listener.onClose(io.grpc.Status.OK, new Metadata());
+        }
+
+        @Override
+        public void sendMessage(SpannerAsyncActionRequest message) {
+            messages.add(message);
+            listener.onMessage(responseFactory.apply(message));
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+    }
+
+    private static final class RecordingServerCall
+            extends ServerCall<SpannerAsyncActionRequest, SpannerAsyncActionResponse> {
+        private final MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> methodDescriptor;
+        private final List<SpannerAsyncActionResponse> messages = new ArrayList<>();
+        private boolean sentHeaders;
+        private io.grpc.Status closedStatus;
+
+        private RecordingServerCall(
+                MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> methodDescriptor) {
+            this.methodDescriptor = methodDescriptor;
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void sendHeaders(Metadata headers) {
+            sentHeaders = true;
+        }
+
+        @Override
+        public void sendMessage(SpannerAsyncActionResponse message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void close(io.grpc.Status status, Metadata trailers) {
+            closedStatus = status;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public MethodDescriptor<SpannerAsyncActionRequest, SpannerAsyncActionResponse> getMethodDescriptor() {
+            return methodDescriptor;
+        }
     }
 }

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
@@ -174,6 +174,21 @@ public class Grpc_google_cloud_spanner_executor_v1Test {
     }
 
     @Test
+    void implBaseDefaultServiceReportsUnimplementedStreamingMethod() {
+        SpannerExecutorProxyGrpc.SpannerExecutorProxyImplBase service =
+                new SpannerExecutorProxyGrpc.SpannerExecutorProxyImplBase() { };
+        ServerMethodDefinition<SpannerAsyncActionRequest, SpannerAsyncActionResponse> methodDefinition =
+                getExecuteActionMethodDefinition(service.bindService());
+        RecordingServerCall serverCall = new RecordingServerCall(methodDefinition.getMethodDescriptor());
+
+        methodDefinition.getServerCallHandler().startCall(serverCall, new Metadata());
+
+        assertThat(serverCall.closedStatus).isNotNull();
+        assertThat(serverCall.closedStatus.getCode()).isEqualTo(io.grpc.Status.Code.UNIMPLEMENTED);
+        assertThat(serverCall.messages).isEmpty();
+    }
+
+    @Test
     void asyncStubSendsRequestWithConfiguredCallOptionsAndReceivesResponse() throws Exception {
         SpannerAsyncActionResponse expectedResponse = response(ACTION_ID, 0, "async-ok");
         RecordingChannel channel = new RecordingChannel(request -> expectedResponse);

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
@@ -18,6 +18,7 @@ import com.google.spanner.executor.v1.SpannerExecutorProxyGrpc;
 import com.google.spanner.executor.v1.Value;
 import com.google.spanner.executor.v1.ValueList;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
 import com.google.rpc.Status;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -29,6 +30,8 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServiceDescriptor;
+import io.grpc.protobuf.ProtoMethodDescriptorSupplier;
+import io.grpc.protobuf.ProtoServiceDescriptorSupplier;
 import io.grpc.stub.BlockingClientCall;
 import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
@@ -97,6 +100,30 @@ public class Grpc_google_cloud_spanner_executor_v1Test {
         assertThat(serviceDefinition.getServiceDescriptor().getName()).isEqualTo(serviceDescriptor.getName());
         String fullMethodName = SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getFullMethodName();
         assertThat(serviceDefinition.getMethod(fullMethodName)).isNotNull();
+    }
+
+    @Test
+    void protobufSchemaDescriptorsExposeExecutorServiceAndStreamingMethod() {
+        Object serviceSchemaDescriptor = SpannerExecutorProxyGrpc.getServiceDescriptor().getSchemaDescriptor();
+        assertThat(serviceSchemaDescriptor).isInstanceOf(ProtoServiceDescriptorSupplier.class);
+        ProtoServiceDescriptorSupplier serviceSupplier = (ProtoServiceDescriptorSupplier) serviceSchemaDescriptor;
+        Descriptors.FileDescriptor fileDescriptor = serviceSupplier.getFileDescriptor();
+        Descriptors.ServiceDescriptor protoService = serviceSupplier.getServiceDescriptor();
+
+        Object methodSchemaDescriptor = SpannerExecutorProxyGrpc.getExecuteActionAsyncMethod().getSchemaDescriptor();
+        assertThat(methodSchemaDescriptor).isInstanceOf(ProtoMethodDescriptorSupplier.class);
+        ProtoMethodDescriptorSupplier methodSupplier = (ProtoMethodDescriptorSupplier) methodSchemaDescriptor;
+        Descriptors.MethodDescriptor protoMethod = methodSupplier.getMethodDescriptor();
+
+        assertThat(fileDescriptor.getPackage()).isEqualTo("google.spanner.executor.v1");
+        assertThat(fileDescriptor.getServices()).contains(protoService);
+        assertThat(protoService.getFullName()).isEqualTo(SpannerExecutorProxyGrpc.SERVICE_NAME);
+        assertThat(protoMethod.getService()).isEqualTo(protoService);
+        assertThat(protoMethod.getName()).isEqualTo("ExecuteActionAsync");
+        assertThat(protoMethod.isClientStreaming()).isTrue();
+        assertThat(protoMethod.isServerStreaming()).isTrue();
+        assertThat(protoMethod.getInputType()).isEqualTo(SpannerAsyncActionRequest.getDescriptor());
+        assertThat(protoMethod.getOutputType()).isEqualTo(SpannerAsyncActionResponse.getDescriptor());
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/src/test/java/com_google_api_grpc/grpc_google_cloud_spanner_executor_v1/Grpc_google_cloud_spanner_executor_v1Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.grpc_google_cloud_spanner_executor_v1;
+
+import org.junit.jupiter.api.Test;
+
+class Grpc_google_cloud_spanner_executor_v1Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.spanner.executor.v1.**"
+      "includeClasses" : "com.google.spanner.executor.v1.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.grpc_google_cloud_spanner_executor_v1.**"
     }
   ]
 }

--- a/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/grpc-google-cloud-spanner-executor-v1/6.116.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.spanner.executor.v1.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4728

This PR introduces tests and metadata for com.google.api.grpc:grpc-google-cloud-spanner-executor-v1:6.116.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 212926
- Cached input tokens: 1661440
- Output tokens: 19920
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 71.74
- Generated lines of code: 366
- Tested library lines of code: 33

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7d732d775eb3480e3308c2a370b2335382a4547e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 110/163 (67.48%)
- Line: 33/46 (71.74%)
- Method: 21/30 (70.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
