### PR TITLE
[GenAI] Mark co.touchlab:stately-strict as not for Native Image

### DIFF
--- a/metadata/co.touchlab/stately-strict/index.json
+++ b/metadata/co.touchlab/stately-strict/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to co.touchlab:stately-strict-jvm:2.1.0.",
+    "replacement": "co.touchlab:stately-strict-jvm:2.1.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4735

This PR records `co.touchlab:stately-strict` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to co.touchlab:stately-strict-jvm:2.1.0.

Replacement guidance:
- co.touchlab:stately-strict-jvm:2.1.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7d732d775eb3480e3308c2a370b2335382a4547e`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
