### PR TITLE
[GenAI] Add support for com.lihaoyi:fansi_3:0.3.0 using gpt-5.5

### DIFF
--- a/metadata/com.lihaoyi/fansi_3/0.3.0/reachability-metadata.json
+++ b/metadata/com.lihaoyi/fansi_3/0.3.0/reachability-metadata.json
@@ -1,0 +1,26 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "fansi.Category"
+      },
+      "type": "fansi.Category",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "fansi.Str"
+      },
+      "type": "fansi.Str",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.lihaoyi/fansi_3/index.json
+++ b/metadata/com.lihaoyi/fansi_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.3.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/lihaoyi/fansi_3/$version$/fansi_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/com-lihaoyi/fansi",
+    "test-code-url" : "https://github.com/com-lihaoyi/fansi/tree/$version$/fansi/test/src",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/lihaoyi/fansi_3/$version$/fansi_3-$version$-javadoc.jar",
+    "description" : "Fansi is a Scala library for representing, parsing, and rendering strings with ANSI terminal styling such as colors, backgrounds, bold, underline, and reverse video. It provides immutable fansi.Str values and formatting attributes so command-line applications can measure, concatenate, split, overlay, and safely render colored text without manually managing escape sequences.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "0.3.0"
+    ],
+    "allowed-packages" : [
+      "fansi"
+    ]
+  }
+]

--- a/stats/com.lihaoyi/fansi_3/0.3.0/execution-metrics.json
+++ b/stats/com.lihaoyi/fansi_3/0.3.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T08:14:12.566510Z",
+    "library": "com.lihaoyi:fansi_3:0.3.0",
+    "starting_commit": "4e3c765cff3b52b0e9bed16a4b54f9112f21084c",
+    "ending_commit": "b640a7de13d01bb05877385cb784a592bfea3e65",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.3.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2923,
+          "missed": 1211,
+          "ratio": 0.707063,
+          "total": 4134
+        },
+        "line": {
+          "covered": 333,
+          "missed": 14,
+          "ratio": 0.959654,
+          "total": 347
+        },
+        "method": {
+          "covered": 171,
+          "missed": 189,
+          "ratio": 0.475,
+          "total": 360
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 177732,
+      "cached_input_tokens_used": 1486336,
+      "output_tokens_used": 21587,
+      "iterations": 5,
+      "cost_usd": 1.3908,
+      "generated_loc": 258,
+      "tested_library_loc": 333,
+      "metadata_entries": 4,
+      "code_coverage_percent": 95.97
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala",
+      "metadata_file": "metadata/com.lihaoyi/fansi_3/0.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.lihaoyi/fansi_3/0.3.0/stats.json
+++ b/stats/com.lihaoyi/fansi_3/0.3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2923,
+        "missed" : 1211,
+        "ratio" : 0.707063,
+        "total" : 4134
+      },
+      "line" : {
+        "covered" : 333,
+        "missed" : 14,
+        "ratio" : 0.959654,
+        "total" : 347
+      },
+      "method" : {
+        "covered" : 171,
+        "missed" : 189,
+        "ratio" : 0.475,
+        "total" : 360
+      }
+    }
+  } ]
+}

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/.gitignore
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.lihaoyi:fansi_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/gradle.properties
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.lihaoyi:fansi_3:0.3.0
+library.version = 0.3.0
+metadata.dir = com.lihaoyi/fansi_3/0.3.0/

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/settings.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.lihaoyi.fansi_3_tests'

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
@@ -6,11 +6,249 @@
  */
 package com_lihaoyi.fansi_3
 
+import fansi.Attr
+import fansi.Attrs
+import fansi.Back
+import fansi.Bold
+import fansi.Color
+import fansi.ErrorMode
+import fansi.Reversed
+import fansi.Str
+import fansi.Underlined
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class Fansi_3Test {
+  private val ResetAll: String = "\u001b[0m"
+  private val Red: String = "\u001b[31m"
+  private val Green: String = "\u001b[32m"
+  private val Blue: String = "\u001b[34m"
+  private val BlueBackground: String = "\u001b[44m"
+  private val BoldOn: String = "\u001b[1m"
+  private val UnderlinedOn: String = "\u001b[4m"
+  private val ReversedOn: String = "\u001b[7m"
+  private val ForegroundReset: String = "\u001b[39m"
+  private val BackgroundReset: String = "\u001b[49m"
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def plainStringsExposePlainTextCharactersAndDefensiveCopies(): Unit = {
+    val text: Str = Str("plain")
+
+    assertEquals(5, text.length)
+    assertEquals("plain", text.plainText)
+    assertEquals("plain", text.render)
+    assertEquals("plain", text.toString)
+    assertEquals('p', text.getChar(0))
+    assertEquals(0L, text.getColor(0))
+
+    val chars: Array[Char] = text.getChars
+    val colors: Array[Long] = text.getColors
+    chars(0) = 'X'
+    colors(0) = Color.Red.applyMask
+
+    assertEquals('p', text.getChar(0))
+    assertEquals(0L, text.getColor(0))
+    assertTrue(text.getChars.sameElements(Array('p', 'l', 'a', 'i', 'n')))
+    assertTrue(text.getColors.sameElements(Array.fill[Long](5)(0L)))
+  }
+
+  @Test
+  def fromArraysCopiesInputArraysAndParticipatesInEquality(): Unit = {
+    val chars: Array[Char] = Array('o', 'k')
+    val colors: Array[Long] = Array(Color.Green.transform(0L), Bold.On.transform(0L))
+    val fromArrays: Str = Str.fromArrays(chars, colors)
+
+    chars(0) = 'x'
+    colors(0) = 0L
+
+    val rebuilt: Str = Str.fromArrays(Array('o', 'k'), Array(Color.Green.transform(0L), Bold.On.transform(0L)))
+    assertEquals("ok", fromArrays.plainText)
+    assertEquals(Color.Green.transform(0L), fromArrays.getColor(0))
+    assertEquals(Bold.On.transform(0L), fromArrays.getColor(1))
+    assertEquals(rebuilt, fromArrays)
+    assertEquals(rebuilt.hashCode(), fromArrays.hashCode())
+    assertNotEquals(fromArrays, Str("ok"))
+    assertNotEquals(fromArrays, "ok")
+  }
+
+  @Test
+  def individualAndCombinedAttributesRenderAnsiSequences(): Unit = {
+    val red: Str = Color.Red(Str("red"))
+    val combinedAttributes: Attrs = Color.Green ++ Back.Blue ++ Bold.On ++ Underlined.On ++ Reversed.On
+    val combined: Str = combinedAttributes(Str("go"))
+
+    assertEquals(s"${Red}red$ForegroundReset", red.render)
+    assertEquals(Color.Red.transform(0L), red.getColor(0))
+    assertEquals(
+      s"$Green$BlueBackground$BoldOn$UnderlinedOn${ReversedOn}go$ResetAll",
+      combined.render
+    )
+    assertEquals("go", combined.plainText)
+    assertEquals(combinedAttributes.transform(0L), combined.getColor(0))
+    assertEquals(combinedAttributes.transform(0L), combined.getColor(1))
+  }
+
+  @Test
+  def colorPalettesAndTrueColorAttributesRoundTripThroughRenderingAndParsing(): Unit = {
+    val indexedForeground: Str = Color.Full(196)(Str("hot"))
+    val indexedBackground: Str = Back.Full(22)(Str("forest"))
+    val trueForeground: Str = Color.True(12, 34, 56)(Str("rgb"))
+    val trueBackground: Str = Back.True(0x010203)(Str("back"))
+
+    assertEquals(s"\u001b[38;5;196mhot$ForegroundReset", indexedForeground.render)
+    assertEquals(s"\u001b[48;5;22mforest$BackgroundReset", indexedBackground.render)
+    assertEquals(s"\u001b[38;2;12;34;56mrgb$ForegroundReset", trueForeground.render)
+    assertEquals(s"\u001b[48;2;1;2;3mback$BackgroundReset", trueBackground.render)
+
+    val parsed: Str = Str.Throw("A\u001b[38;2;12;34;56mB\u001b[48;2;1;2;3mC\u001b[0mD")
+    assertEquals("ABCD", parsed.plainText)
+    assertEquals(0L, parsed.getColor(0))
+    assertEquals(Color.True(12, 34, 56).transform(0L), parsed.getColor(1))
+    assertEquals(Color.True(12, 34, 56).transform(0L), parsed.getColor(2) & Color.mask)
+    assertNotEquals(parsed.getColor(1), parsed.getColor(2))
+    assertEquals(0L, parsed.getColor(3))
+
+    assertEquals(0x0c2238, Color.trueIndex(12, 34, 56))
+    assertEquals("\u001b[38;2;12;34;56m", Color.trueRgbEscape(12, 34, 56))
+    assertEquals("\u001b[48;2;1;2;3m", Back.trueRgbEscape(1, 2, 3))
+  }
+
+  @Test
+  def ansiParsingSupportsKnownEscapesResetAndErrorModes(): Unit = {
+    val raw: String = s"${Red}red$ForegroundReset plain \u001b[48;5;42mbg$ResetAll"
+    val parsed: Str = Str.Throw(raw)
+
+    assertEquals("red plain bg", parsed.plainText)
+    assertEquals(Color.Red.transform(0L), parsed.getColor(0))
+    assertEquals(Color.Red.transform(0L), parsed.getColor(2))
+    assertEquals(0L, parsed.getColor(3))
+    assertEquals(Back.Full(42).transform(0L), parsed.getColor(parsed.length - 1))
+
+    val unknown: String = "a\u001b[999mb"
+    val thrown: IllegalArgumentException = assertThrows(classOf[IllegalArgumentException], () => Str.Throw(unknown))
+    assertTrue(thrown.getMessage.contains("Unknown ansi-escape [999m at index 1"))
+    assertEquals("a[999mb", Str.Sanitize(unknown).plainText)
+    assertEquals("ab", Str.Strip(unknown).plainText)
+    assertSame(ErrorMode.Throw, ErrorMode.Throw)
+    assertSame(ErrorMode.Sanitize, ErrorMode.Sanitize)
+    assertSame(ErrorMode.Strip, ErrorMode.Strip)
+    assertTrue(Str.ansiRegex.matcher("before\u001b[999mafter").find())
+  }
+
+  @Test
+  def concatenationJoiningSplittingAndSubstringsPreserveStyles(): Unit = {
+    val red: Str = Color.Red(Str("ab"))
+    val blue: Str = Color.Blue(Str("cd"))
+    val joined: Str = Str.join(Seq(red, blue), Underlined.On(Str("|")))
+    val concatenated: Str = red ++ blue
+    val (left, right): (Str, Str) = concatenated.splitAt(2)
+    val middle: Str = concatenated.substring(1, 3)
+
+    assertEquals("ab|cd", joined.plainText)
+    assertEquals(Color.Red.transform(0L), joined.getColor(0))
+    assertEquals(Underlined.On.transform(0L), joined.getColor(2))
+    assertEquals(Color.Blue.transform(0L), joined.getColor(3))
+
+    assertEquals("abcd", concatenated.plainText)
+    assertEquals(s"${Red}ab$ForegroundReset", left.render)
+    assertEquals(s"${Blue}cd$ForegroundReset", right.render)
+    assertEquals("bc", middle.plainText)
+    assertEquals(Color.Red.transform(0L), middle.getColor(0))
+    assertEquals(Color.Blue.transform(0L), middle.getColor(1))
+    assertEquals(concatenated, Str(red, blue))
+  }
+
+  @Test
+  def overlayAndOverlayAllApplyStylesToBoundedRanges(): Unit = {
+    val base: Str = Str("abcdef")
+    val redMiddle: Str = base.overlay(Color.Red, 1, 4)
+    val layered: Str = base.overlayAll(
+      Seq(
+        (Color.Green, 0, 6),
+        (Bold.On, 0, 2),
+        (Back.Yellow, 2, 5),
+        (Color.Blue, 3, 6),
+        (Underlined.On, 5, 6)
+      )
+    )
+
+    assertEquals(s"a${Red}bcd${ForegroundReset}ef", redMiddle.render)
+    assertEquals(0L, redMiddle.getColor(0))
+    assertEquals(Color.Red.transform(0L), redMiddle.getColor(1))
+    assertEquals(Color.Red.transform(0L), redMiddle.getColor(3))
+    assertEquals(0L, redMiddle.getColor(4))
+
+    assertEquals((Color.Green ++ Bold.On).transform(0L), layered.getColor(0))
+    assertEquals((Color.Green ++ Back.Yellow).transform(0L), layered.getColor(2))
+    assertEquals((Color.Blue ++ Back.Yellow).transform(0L), layered.getColor(3))
+    assertEquals((Color.Blue ++ Underlined.On).transform(0L), layered.getColor(5))
+    assertEquals("abcdef", layered.plainText)
+
+    assertThrows(classOf[IllegalArgumentException], () => base.overlay(Color.Red, -1, 2))
+    assertThrows(classOf[IllegalArgumentException], () => base.overlay(Color.Red, 3, 2))
+    assertThrows(classOf[IllegalArgumentException], () => base.overlay(Color.Red, 0, 7))
+  }
+
+  @Test
+  def attrsUtilitiesExposeCompositionCategoryLookupAndStateTransitions(): Unit = {
+    val attrs: Attrs = Attrs(Color.Red, Back.Blue, Bold.On, Color.Green)
+    val state: Long = attrs.transform(0L)
+
+    val attrsAsSeq: Seq[Attr] = Attrs.toSeq(attrs)
+    assertEquals(3, attrsAsSeq.length)
+    assertTrue(attrsAsSeq.contains(Color.Green))
+    assertTrue(attrsAsSeq.contains(Back.Blue))
+    assertTrue(attrsAsSeq.contains(Bold.On))
+    assertFalse(attrsAsSeq.contains(Color.Red))
+    assertEquals(state, (Color.Green ++ Back.Blue ++ Bold.On).transform(0L))
+    assertEquals(state, Attrs.Empty.transform(state))
+    assertFalse(Attrs.Empty == Color.Red)
+    assertEquals("Attrs()", Attrs.Empty.toString)
+    assertEquals(0L, Attrs.Empty.resetMask)
+    assertEquals(0L, Attrs.Empty.applyMask)
+
+    assertEquals(s"$Green$BlueBackground$BoldOn", Attrs.emitAnsiCodes(0L, state))
+    assertEquals(s"$ResetAll$Green$BlueBackground", Attrs.emitAnsiCodes(state, (Color.Green ++ Back.Blue).transform(0L)))
+    assertEquals(ResetAll, Attrs.emitAnsiCodes(state, 0L))
+    assertSame(Color.Green, Color.lookupAttr(Color.Green.applyMask))
+    assertSame(Back.Blue, Back.lookupAttr(Back.Blue.applyMask))
+    assertEquals(Green, Color.lookupEscape(Color.Green.applyMask))
+    assertEquals(BlueBackground, Back.lookupEscape(Back.Blue.applyMask))
+    assertEquals("", Bold.lookupEscape(Bold.Off.applyMask))
+    assertTrue(Attr.categories.contains(Color))
+    assertTrue(Attr.categories.contains(Back))
+    assertTrue(Attr.categories.contains(Bold))
+    assertTrue(Attr.categories.contains(Underlined))
+    assertTrue(Attr.categories.contains(Reversed))
+  }
+
+  @Test
+  def publicAttributeMetadataAndValidationAreAvailable(): Unit = {
+    assertEquals("Color.Red", Color.Red.name)
+    assertEquals(Some(Red), Color.Red.escapeOpt)
+    assertEquals("Bold.Off", Bold.Off.name)
+    assertEquals(None, Bold.Off.escapeOpt)
+    assertTrue(Color.all.contains(Color.LightMagenta))
+    assertTrue(Back.all.contains(Back.LightCyan))
+    assertTrue(Bold.all.contains(Bold.On))
+    assertTrue(Underlined.all.contains(Underlined.Off))
+    assertTrue(Reversed.all.contains(Reversed.Off))
+
+    val trueByIndex: fansi.Attr = Color.True(0x0a0b0c)
+    assertEquals("Color.True(10,11,12)", trueByIndex.name)
+    assertEquals(Some("\u001b[38;2;10;11;12m"), trueByIndex.escapeOpt)
+    assertNotSame(Color.True(0x0a0b0c), trueByIndex)
+
+    assertThrows(classOf[IllegalArgumentException], () => Color.True(-1))
+    assertThrows(classOf[IllegalArgumentException], () => Color.True(1 << 24 + 1))
+    assertThrows(classOf[IllegalArgumentException], () => Color.True(-1, 0, 0))
+    assertThrows(classOf[IllegalArgumentException], () => Color.True(0, 256, 0))
+    assertThrows(classOf[IllegalArgumentException], () => Back.True(0, 0, 256))
   }
 }

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
@@ -229,6 +229,24 @@ class Fansi_3Test {
   }
 
   @Test
+  def selectiveResetAttributesClearOnlyMatchingStyleCategories(): Unit = {
+    val allStyles: Attrs = Color.Red ++ Back.Blue ++ Bold.On ++ Underlined.On ++ Reversed.On
+    val styled: Str = allStyles(Str("x"))
+    val withoutForeground: Str = Color.Reset(styled)
+    val foregroundOnly: Str = (Back.Reset ++ Bold.Off ++ Underlined.Off ++ Reversed.Off)(styled)
+    val plainAgain: Str = Attr.Reset(styled)
+
+    assertEquals((Back.Blue ++ Bold.On ++ Underlined.On ++ Reversed.On).transform(0L), withoutForeground.getColor(0))
+    assertEquals(s"$BlueBackground$BoldOn$UnderlinedOn${ReversedOn}x$ResetAll", withoutForeground.render)
+    assertEquals(Color.Red.transform(0L), foregroundOnly.getColor(0))
+    assertEquals(s"${Red}x$ForegroundReset", foregroundOnly.render)
+    assertEquals(0L, plainAgain.getColor(0))
+    assertEquals("x", plainAgain.render)
+    assertEquals("x", withoutForeground.plainText)
+    assertEquals("x", foregroundOnly.plainText)
+  }
+
+  @Test
   def publicAttributeMetadataAndValidationAreAvailable(): Unit = {
     assertEquals("Color.Red", Color.Red.name)
     assertEquals(Some(Red), Color.Red.escapeOpt)

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_lihaoyi.fansi_3
+
+import org.junit.jupiter.api.Test
+
+class Fansi_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/src/test/scala/com_lihaoyi/fansi_3/Fansi_3Test.scala
@@ -247,6 +247,27 @@ class Fansi_3Test {
   }
 
   @Test
+  def renderEmitsAnsiTransitionsForAdjacentPerCharacterStyleChanges(): Unit = {
+    val redState: Long = Color.Red.transform(0L)
+    val blueState: Long = Color.Blue.transform(0L)
+    val blueBackgroundState: Long = (Color.Blue ++ Back.Blue).transform(0L)
+    val styled: Str = Str.fromArrays(
+      Array('a', 'b', 'c', 'd', 'e'),
+      Array(0L, redState, blueState, blueBackgroundState, 0L)
+    )
+
+    assertEquals("abcde", styled.plainText)
+    assertEquals(
+      s"a${Red}b${Blue}c${BlueBackground}d$ForegroundReset${BackgroundReset}e",
+      styled.render
+    )
+    assertEquals(redState, styled.getColor(1))
+    assertEquals(blueState, styled.getColor(2))
+    assertEquals(blueBackgroundState, styled.getColor(3))
+    assertEquals(0L, styled.getColor(4))
+  }
+
+  @Test
   def publicAttributeMetadataAndValidationAreAvailable(): Unit = {
     assertEquals("Color.Red", Color.Red.name)
     assertEquals(Some(Red), Color.Red.escapeOpt)

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "fansi.**"
+      "includeClasses" : "fansi.**"
+    },
+    {
+      "includeClasses" : "com_lihaoyi.fansi_3.**"
     }
   ]
 }

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "fansi.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5033

This PR introduces tests and metadata for com.lihaoyi:fansi_3:0.3.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 177732
- Cached input tokens: 1486336
- Output tokens: 21587
- Metadata entries: 4
- Iterations: 5
- Library coverage percentage: 95.97
- Generated lines of code: 258
- Tested library lines of code: 333

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fc6bbfa9f09b1f962728ba4d8db1be8daaf0b3d1`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2923/4134 (70.71%)
- Line: 333/347 (95.97%)
- Method: 171/360 (47.50%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
