### PR TITLE
Rerun failed PR CI jobs after approval

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -129,6 +129,9 @@ REVIEW_PERIOD_SUFFIX_SECONDS = {
     "h": 60 * 60,
     "d": 24 * 60 * 60,
 }
+FAILED_CI_STATES = {"FAILURE", "ERROR"}
+RERUNNABLE_WORKFLOW_RUN_CONCLUSIONS = {"failure"}
+MAX_AUTOMATED_WORKFLOW_RERUN_ATTEMPTS = 3
 
 REPO = "oracle/graalvm-reachability-metadata"
 PROJECT_NUMBER = 30
@@ -1231,6 +1234,76 @@ def has_passing_pull_request_gates(pr: dict) -> bool:
     )
 
 
+def has_failed_pull_request_ci(pr: dict) -> bool:
+    """Return True when the pull request's combined CI status is failed."""
+    status_check_rollup = pr.get("statusCheckRollup")
+    ci_state = status_check_rollup.get("state") if isinstance(status_check_rollup, dict) else None
+    return ci_state in FAILED_CI_STATES
+
+
+def get_pull_request_workflow_runs(head_sha: str) -> list[dict]:
+    """Return GitHub Actions workflow runs for the pull request head commit."""
+    data = gh_json(
+        "api",
+        "--method",
+        "GET",
+        f"/repos/{REPO}/actions/runs",
+        "-F",
+        f"head_sha={head_sha}",
+        "-F",
+        "event=pull_request",
+        "-F",
+        "per_page=100",
+    )
+    workflow_runs = data.get("workflow_runs") if isinstance(data, dict) else None
+    if not isinstance(workflow_runs, list):
+        print(f"ERROR: Missing workflow runs for pull request head {head_sha}.", file=sys.stderr)
+        raise RuntimeError(f"Missing workflow runs for pull request head {head_sha}")
+    return workflow_runs
+
+
+def get_rerunnable_failed_workflow_run_ids(workflow_runs: list[dict]) -> list[int]:
+    """Return failed GitHub Actions run IDs below the automated rerun limit."""
+    run_ids: list[int] = []
+    for workflow_run in workflow_runs:
+        if not isinstance(workflow_run, dict):
+            continue
+        run_id = workflow_run.get("id")
+        run_attempt = workflow_run.get("run_attempt")
+        conclusion = workflow_run.get("conclusion")
+        if (
+                isinstance(run_id, int)
+                and isinstance(run_attempt, int)
+                and run_attempt < MAX_AUTOMATED_WORKFLOW_RERUN_ATTEMPTS
+                and conclusion in RERUNNABLE_WORKFLOW_RUN_CONCLUSIONS
+        ):
+            run_ids.append(run_id)
+    return run_ids
+
+
+def rerun_failed_pull_request_workflow_jobs(pr_number: int, head_sha: str) -> int:
+    """Rerun failed GitHub Actions jobs for the current pull request head SHA."""
+    workflow_runs = get_pull_request_workflow_runs(head_sha)
+    run_ids = get_rerunnable_failed_workflow_run_ids(workflow_runs)
+    if not run_ids:
+        print(
+            f"[No failed GitHub Actions workflow runs eligible for rerun on PR #{pr_number} "
+            f"at head {head_sha}.]"
+        )
+        return 0
+
+    for run_id in run_ids:
+        print(f"[Rerunning failed GitHub Actions jobs for PR #{pr_number}, workflow run {run_id}.]")
+        gh(
+            "api",
+            "--method",
+            "POST",
+            f"/repos/{REPO}/actions/runs/{run_id}/rerun-failed-jobs",
+        )
+
+    return len(run_ids)
+
+
 def resolve_pull_request_merge_flag(pr: dict) -> str:
     """Resolve the merge method flag, preferring squash merges by default."""
     repository = pr.get("repository")
@@ -1299,6 +1372,24 @@ def reconcile_reviewed_pull_request(pr_number: int) -> bool:
 
         if review_decision != "APPROVED":
             print(f"[Skipping merge for PR #{pr_number}: review decision is '{review_decision}'.]")
+            return True
+
+        if has_failed_pull_request_ci(pr):
+            head_sha = pr.get("headRefOid")
+            if not isinstance(head_sha, str) or not head_sha:
+                print(f"ERROR: Missing head SHA for approved PR #{pr_number} with failed CI.", file=sys.stderr)
+                raise RuntimeError(f"Missing head SHA for approved PR #{pr_number} with failed CI")
+            rerun_count = rerun_failed_pull_request_workflow_jobs(pr_number, head_sha)
+            if rerun_count:
+                print(
+                    f"[Reran failed GitHub Actions job(s) in {rerun_count} workflow run(s) "
+                    f"for approved PR #{pr_number}; skipping merge for this pass.]"
+                )
+            else:
+                print(
+                    f"[Skipping merge for approved PR #{pr_number}: CI failed, but no eligible "
+                    "GitHub Actions workflow runs were found to rerun.]"
+                )
             return True
 
         if not has_passing_pull_request_gates(pr):

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1596,6 +1596,85 @@ class InterruptHandlingTests(unittest.TestCase):
 
 
 class PullRequestReviewTests(unittest.TestCase):
+    def test_reconcile_approved_pr_with_failed_ci_reruns_failed_jobs_without_merging(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "reviewDecision": "APPROVED",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "FAILURE"},
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_state", return_value=pr), \
+                patch.object(
+                    forge_metadata,
+                    "rerun_failed_pull_request_workflow_jobs",
+                    return_value=1,
+                ) as rerun_failed_jobs, \
+                patch.object(forge_metadata, "merge_pull_request") as merge_pull_request:
+            self.assertTrue(forge_metadata.reconcile_reviewed_pull_request(3513))
+
+        rerun_failed_jobs.assert_called_once_with(3513, "abc123")
+        merge_pull_request.assert_not_called()
+
+    def test_reconcile_unapproved_pr_with_failed_ci_does_not_rerun_failed_jobs(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": {"state": "FAILURE"},
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_state", return_value=pr), \
+                patch.object(
+                    forge_metadata,
+                    "rerun_failed_pull_request_workflow_jobs",
+                ) as rerun_failed_jobs, \
+                patch.object(forge_metadata, "merge_pull_request") as merge_pull_request:
+            self.assertTrue(forge_metadata.reconcile_reviewed_pull_request(3513))
+
+        rerun_failed_jobs.assert_not_called()
+        merge_pull_request.assert_not_called()
+
+    def test_rerun_failed_pull_request_workflow_jobs_reruns_failures_under_attempt_limit(self) -> None:
+        workflow_runs = [
+            {"id": 101, "conclusion": "failure", "run_attempt": 1},
+            {"id": 102, "conclusion": "failure", "run_attempt": 2},
+            {"id": 103, "conclusion": "failure", "run_attempt": 3},
+            {"id": 104, "conclusion": "success", "run_attempt": 1},
+            {"id": 105, "conclusion": None, "run_attempt": 1},
+        ]
+
+        with patch.object(forge_metadata, "get_pull_request_workflow_runs", return_value=workflow_runs), \
+                patch.object(forge_metadata, "gh") as gh:
+            self.assertEqual(
+                forge_metadata.rerun_failed_pull_request_workflow_jobs(3513, "abc123"),
+                2,
+            )
+
+        self.assertEqual(
+            gh.call_args_list,
+            [
+                call(
+                    "api",
+                    "--method",
+                    "POST",
+                    f"/repos/{forge_metadata.REPO}/actions/runs/101/rerun-failed-jobs",
+                ),
+                call(
+                    "api",
+                    "--method",
+                    "POST",
+                    f"/repos/{forge_metadata.REPO}/actions/runs/102/rerun-failed-jobs",
+                ),
+            ],
+        )
+
     def test_fetch_review_base_ref_updates_origin_master_without_pull(self) -> None:
         completed_process = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
 


### PR DESCRIPTION
### Summary

- Rerun failed GitHub Actions jobs when an approved PR has failed CI.
- Limit reruns to current-head pull request workflow runs and stop after three attempts.
- Add unit coverage for approved failed-CI reruns and non-approved PR skips.

### How it works

After Forge finishes reviewing a PR, it fetches the latest PR state before deciding what to do next. If the review decision is not `APPROVED`, it does not rerun CI. If the PR is approved and the CI rollup is `SUCCESS`, Forge keeps the existing merge path. If the PR is approved and the CI rollup is `FAILURE` or `ERROR`, Forge queries GitHub Actions workflow runs for the PR's current `headRefOid` and `pull_request` event.

For each matching workflow run, Forge reruns failed jobs only when the run conclusion is `failure` and `run_attempt < 3`. In practice, attempt `1` can be rerun, attempt `2` can be rerun, and attempt `3` is the cutoff where Forge stops retrying automatically. This prevents repeated review cycles from rerunning a persistently broken CI failure forever. After triggering reruns, Forge skips merging for the current pass and lets a later review cycle observe the new CI result.

### Testing

- `.venv/bin/python -m unittest tests.test_forge_metadata.PullRequestReviewTests`
- `forge/.venv/bin/python -m py_compile forge/forge_metadata.py forge/tests/test_forge_metadata.py`
- `git diff --check -- forge/forge_metadata.py forge/tests/test_forge_metadata.py`

Closes #5673