### PR TITLE
[GenAI] Add support for software.amazon.awssdk:checksums:2.34.0 using gpt-5.5

### DIFF
--- a/metadata/software.amazon.awssdk/checksums/2.34.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/checksums/2.34.0/reachability-metadata.json
@@ -22,6 +22,24 @@
       "condition": {
         "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
       },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcChecksumProvider"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      },
       "type": "software.amazon.awssdk.crt.checksums.CRC64NVME"
     },
     {
@@ -32,6 +50,30 @@
       "methods": [
         {
           "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC64NVME",
+      "methods": [
+        {
+          "name": "clone",
           "parameterTypes": []
         }
       ]

--- a/stats/software.amazon.awssdk/checksums/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/checksums/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T06:52:04.175652Z",
+    "timestamp": "2026-05-04T09:00:01.556247Z",
     "library": "software.amazon.awssdk:checksums:2.34.0",
-    "starting_commit": "cf0e1d06410aa94252564831fc872567cf6dff9e",
-    "ending_commit": "19350203d491130b1d66f7b5df52ed92f6d8838d",
+    "starting_commit": "5ad066b38a12e5a25432ba22fab6aa8da2e9418c",
+    "ending_commit": "82e4981c02d9ca7fdf4b5fd1e81d193dcdfaa3a2",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -13,46 +13,46 @@
       "dynamicAccess": {
         "breakdown": {
           "reflection": {
-            "coverageRatio": 0.833333,
-            "coveredCalls": 5,
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
             "totalCalls": 6
           }
         },
-        "coverageRatio": 0.833333,
-        "coveredCalls": 5,
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
         "totalCalls": 6
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 8878,
-          "missed": 9103,
-          "ratio": 0.493743,
+          "covered": 8907,
+          "missed": 9074,
+          "ratio": 0.495356,
           "total": 17981
         },
         "line": {
-          "covered": 137,
-          "missed": 188,
-          "ratio": 0.421538,
+          "covered": 145,
+          "missed": 180,
+          "ratio": 0.446154,
           "total": 325
         },
         "method": {
-          "covered": 51,
-          "missed": 58,
-          "ratio": 0.46789,
+          "covered": 55,
+          "missed": 54,
+          "ratio": 0.504587,
           "total": 109
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 151886,
-      "cached_input_tokens_used": 1917952,
-      "output_tokens_used": 33800,
-      "iterations": 5,
-      "cost_usd": 1.973,
-      "generated_loc": 76,
-      "tested_library_loc": 137,
-      "metadata_entries": 8,
-      "code_coverage_percent": 42.15
+      "input_tokens_used": 38842,
+      "cached_input_tokens_used": 112640,
+      "output_tokens_used": 2808,
+      "iterations": 1,
+      "cost_usd": 0.1405,
+      "generated_loc": 107,
+      "tested_library_loc": 145,
+      "metadata_entries": 15,
+      "code_coverage_percent": 44.62
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java",

--- a/stats/software.amazon.awssdk/checksums/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/checksums/2.34.0/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.833333,
-          "coveredCalls" : 5,
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
           "totalCalls" : 6
         }
       },
-      "coverageRatio" : 0.833333,
-      "coveredCalls" : 5,
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
       "totalCalls" : 6
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 8878,
-        "missed" : 9103,
-        "ratio" : 0.493743,
+        "covered" : 8907,
+        "missed" : 9074,
+        "ratio" : 0.495356,
         "total" : 17981
       },
       "line" : {
-        "covered" : 137,
-        "missed" : 188,
-        "ratio" : 0.421538,
+        "covered" : 145,
+        "missed" : 180,
+        "ratio" : 0.446154,
         "total" : 325
       },
       "method" : {
-        "covered" : 51,
-        "missed" : 58,
-        "ratio" : 0.46789,
+        "covered" : 55,
+        "missed" : 54,
+        "ratio" : 0.504587,
         "total" : 109
       }
     }

--- a/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
+++ b/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.checksums.internal.CrcChecksumProvider;
 public class CrcChecksumProviderTest {
     private static final byte[] PAYLOAD =
         "The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] EXTRA_PAYLOAD = " on native image".getBytes(StandardCharsets.UTF_8);
     private static final String JAVA_CRC32C_PROVIDER_TYPE = "CrcCombineOnMarkChecksum";
 
     @Test
@@ -47,8 +48,16 @@ public class CrcChecksumProviderTest {
         SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC64NVME);
 
         checksum.update(PAYLOAD);
+        long markedValue = checksum.getValue();
 
-        assertThat(checksum.getValue()).isNotZero();
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(EXTRA_PAYLOAD);
+
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+
+        assertThat(checksum.getValue()).isEqualTo(markedValue);
         assertThat(checksum.getChecksumBytes()).hasSize(Long.BYTES);
     }
 
@@ -66,7 +75,16 @@ public class CrcChecksumProviderTest {
 
         checksum.update(PAYLOAD);
         expected.update(PAYLOAD, 0, PAYLOAD.length);
+        long markedValue = checksum.getValue();
 
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(EXTRA_PAYLOAD);
+
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
         assertThat(checksum.getClass().getSimpleName()).isEqualTo("CrcCloneOnMarkChecksum");
         assertThat(checksum.getValue()).isEqualTo(expected.getValue());
         assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);

--- a/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
+++ b/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
@@ -8,6 +8,9 @@ package software_amazon_awssdk.checksums;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.CRC32C;
 import org.junit.jupiter.api.MethodOrderer;
@@ -47,5 +50,25 @@ public class CrcChecksumProviderTest {
 
         assertThat(checksum.getValue()).isNotZero();
         assertThat(checksum.getChecksumBytes()).hasSize(Long.BYTES);
+    }
+
+    @Test
+    @Order(3)
+    void packagePrivateCrtCrc32cFactoryUsesCrtConstructor() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(CrcChecksumProvider.class, MethodHandles.lookup());
+        MethodHandle createCrtCrc32C = lookup.findStatic(
+            CrcChecksumProvider.class,
+            "createCrtCrc32C",
+            MethodType.methodType(SdkChecksum.class));
+
+        SdkChecksum checksum = (SdkChecksum) createCrtCrc32C.invokeExact();
+        CRC32C expected = new CRC32C();
+
+        checksum.update(PAYLOAD);
+        expected.update(PAYLOAD, 0, PAYLOAD.length);
+
+        assertThat(checksum.getClass().getSimpleName()).isEqualTo("CrcCloneOnMarkChecksum");
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
     }
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4536

This PR introduces tests and metadata for software.amazon.awssdk:checksums:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 38842
- Cached input tokens: 112640
- Output tokens: 2808
- Metadata entries: 15
- Iterations: 1
- Library coverage percentage: 44.62
- Generated lines of code: 107
- Tested library lines of code: 145

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5ad066b38a12e5a25432ba22fab6aa8da2e9418c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 6/6 covered calls (100.00%)
- Reflection: 6/6 covered calls (100.00%)

Library coverage:
- Instruction: 8907/17981 (49.54%)
- Line: 145/325 (44.62%)
- Method: 55/109 (50.46%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
