### PR TITLE
[GenAI] Add support for software.amazon.awssdk:profiles:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/profiles/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/profiles/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T07:12:54.949565Z",
+    "timestamp": "2026-05-04T09:12:51.456306Z",
     "library": "software.amazon.awssdk:profiles:2.34.0",
-    "starting_commit": "a6cc1a14e34205471353fb657c192d0be1e67ad1",
-    "ending_commit": "bc69a39f1fc398ae85b753e1da8b9831f4ea908c",
+    "starting_commit": "2af50df6b3b78b2ccd11961dff1c80140350eef5",
+    "ending_commit": "be66568e1f2bc194acb20ddf493ba6c28a839ca0",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 1978,
-          "missed": 549,
-          "ratio": 0.782746,
+          "covered": 2072,
+          "missed": 455,
+          "ratio": 0.819945,
           "total": 2527
         },
         "line": {
-          "covered": 418,
-          "missed": 101,
-          "ratio": 0.805395,
+          "covered": 436,
+          "missed": 83,
+          "ratio": 0.840077,
           "total": 519
         },
         "method": {
-          "covered": 121,
-          "missed": 40,
-          "ratio": 0.751553,
+          "covered": 127,
+          "missed": 34,
+          "ratio": 0.78882,
           "total": 161
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 172133,
-      "cached_input_tokens_used": 1114112,
-      "output_tokens_used": 17971,
-      "iterations": 4,
-      "cost_usd": 1.0962,
-      "generated_loc": 365,
-      "tested_library_loc": 418,
+      "input_tokens_used": 173147,
+      "cached_input_tokens_used": 1916928,
+      "output_tokens_used": 18308,
+      "iterations": 3,
+      "cost_usd": 1.5077,
+      "generated_loc": 523,
+      "tested_library_loc": 436,
       "metadata_entries": 0,
-      "code_coverage_percent": 80.54
+      "code_coverage_percent": 84.01
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java",

--- a/stats/software.amazon.awssdk/profiles/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/profiles/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 1978,
-        "missed" : 549,
-        "ratio" : 0.782746,
+        "covered" : 2072,
+        "missed" : 455,
+        "ratio" : 0.819945,
         "total" : 2527
       },
       "line" : {
-        "covered" : 418,
-        "missed" : 101,
-        "ratio" : 0.805395,
+        "covered" : 436,
+        "missed" : 83,
+        "ratio" : 0.840077,
         "total" : 519
       },
       "method" : {
-        "covered" : 121,
-        "missed" : 40,
-        "ratio" : 0.751553,
+        "covered" : 127,
+        "missed" : 34,
+        "ratio" : 0.78882,
         "total" : 161
       }
     }

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.profiles.Profile;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileLocation;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.profiles.ProfileProperty;
 
 public class ProfilesTest {
@@ -67,6 +68,8 @@ public class ProfilesTest {
         assertThat(copy).isEqualTo(profile);
         assertThat(copy.hashCode()).isEqualTo(profile.hashCode());
         assertThat(changed).isNotEqualTo(profile);
+        assertThat(profile).isNotEqualTo(null)
+                           .isNotEqualTo("integration");
         assertThat(profile.toString()).contains("integration", ProfileProperty.REGION);
     }
 
@@ -248,6 +251,96 @@ public class ProfilesTest {
     }
 
     @Test
+    void profileFileExposesImmutableProfilesViewAndValueSemantics() {
+        ProfileFile profileFile = configurationFile("""
+                [default]
+                region = us-east-1
+
+                [profile qa]
+                region = eu-west-3
+
+                [sso-session admin]
+                sso_region = eu-west-3
+                """);
+        ProfileFile sameProfileFile = configurationFile("""
+                [default]
+                region = us-east-1
+
+                [profile qa]
+                region = eu-west-3
+
+                [sso-session admin]
+                sso_region = eu-west-3
+                """);
+        ProfileFile differentProfileFile = configurationFile("""
+                [default]
+                region = ap-northeast-1
+                """);
+
+        assertThat(ProfileFile.PROFILES_SECTION_TITLE).isEqualTo("profiles");
+        assertThat(profileFile.profiles().keySet()).containsExactly("default", "qa");
+        assertThat(profileFile.getSection(ProfileFile.PROFILES_SECTION_TITLE, "qa"))
+                .isEqualTo(profileFile.profile("qa"));
+        assertThat(profileFile.getSection("unknown", "qa")).isEmpty();
+        assertThatThrownBy(() -> profileFile.profiles().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThat(profileFile).isEqualTo(sameProfileFile)
+                               .isNotEqualTo(differentProfileFile)
+                               .isNotEqualTo(null)
+                               .isNotEqualTo("profiles");
+        assertThat(profileFile.hashCode()).isEqualTo(sameProfileFile.hashCode());
+        assertThat(profileFile.toString()).contains("ProfileFile", "profiles", "default", "qa", "sso-session");
+    }
+
+    @Test
+    void parserIgnoresInvalidPropertyProfileAndSpecialSectionNames() {
+        ProfileFile profileFile = configurationFile("""
+                [profile valid]
+                region = us-west-2
+                not valid = ignored
+
+                [profile invalid name]
+                region = ignored-profile
+
+                [sso-session invalid name]
+                sso_region = ignored-session
+
+                [sso-session valid-session]
+                sso_region = eu-central-1
+                """);
+
+        Profile validProfile = profileFile.profile("valid").orElseThrow();
+        assertThat(validProfile.properties()).containsEntry(ProfileProperty.REGION, "us-west-2")
+                                             .doesNotContainKey("not valid");
+        assertThat(profileFile.profile("invalid name")).isEmpty();
+        assertThat(profileFile.getSection("sso-session", "invalid name")).isEmpty();
+        assertThat(profileFile.getSection("sso-session", "valid-session").orElseThrow().properties())
+                .containsEntry(ProfileProperty.SSO_REGION, "eu-central-1");
+    }
+
+    @Test
+    void profileFileSystemSettingsExposePropertiesEnvironmentVariablesAndDefaults() {
+        assertThat(ProfileFileSystemSetting.values()).containsExactly(
+                ProfileFileSystemSetting.AWS_CONFIG_FILE,
+                ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE,
+                ProfileFileSystemSetting.AWS_PROFILE);
+        assertThat(ProfileFileSystemSetting.valueOf("AWS_PROFILE")).isSameAs(ProfileFileSystemSetting.AWS_PROFILE);
+
+        assertThat(ProfileFileSystemSetting.AWS_CONFIG_FILE.property()).isEqualTo(AWS_CONFIG_FILE_PROPERTY);
+        assertThat(ProfileFileSystemSetting.AWS_CONFIG_FILE.environmentVariable()).isEqualTo("AWS_CONFIG_FILE");
+        assertThat(ProfileFileSystemSetting.AWS_CONFIG_FILE.defaultValue()).isNull();
+        assertThat(ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.property())
+                .isEqualTo(AWS_SHARED_CREDENTIALS_FILE_PROPERTY);
+        assertThat(ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.environmentVariable())
+                .isEqualTo("AWS_SHARED_CREDENTIALS_FILE");
+        assertThat(ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.defaultValue()).isNull();
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.property()).isEqualTo("aws.profile");
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.environmentVariable()).isEqualTo("AWS_PROFILE");
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.defaultValue()).isEqualTo("default");
+    }
+
+    @Test
     void profileFileSuppliersCanReturnFixedAndAggregatedViews() {
         ProfileFile first = credentialsFile("""
                 [default]
@@ -345,6 +438,32 @@ public class ProfilesTest {
     }
 
     @Test
+    void defaultSupplierLoadsConfiguredLocationsWhenTheyExist() throws IOException {
+        Path credentials = tempDir.resolve("supplier-credentials");
+        Path config = tempDir.resolve("supplier-config");
+        Files.writeString(credentials, """
+                [default]
+                aws_access_key_id = supplier-key
+                region = credentials-region
+                """);
+        Files.writeString(config, """
+                [default]
+                region = config-region
+                retry_mode = adaptive
+                """);
+
+        withSystemProperty(AWS_SHARED_CREDENTIALS_FILE_PROPERTY, credentials.toString(), () ->
+                withSystemProperty(AWS_CONFIG_FILE_PROPERTY, config.toString(), () -> {
+                    ProfileFile supplied = ProfileFileSupplier.defaultSupplier().get();
+
+                    assertThat(supplied.profile("default").orElseThrow().properties())
+                            .containsEntry(ProfileProperty.AWS_ACCESS_KEY_ID, "supplier-key")
+                            .containsEntry(ProfileProperty.REGION, "credentials-region")
+                            .containsEntry(ProfileProperty.RETRY_MODE, "adaptive");
+                }));
+    }
+
+    @Test
     void defaultSupplierReturnsEmptyProfileFileWhenConfiguredLocationsDoNotExist() {
         Path missingCredentials = tempDir.resolve("missing-credentials");
         Path missingConfig = tempDir.resolve("missing-config");
@@ -379,6 +498,13 @@ public class ProfilesTest {
                 """))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Profile definition must end with ']'");
+
+        assertThatThrownBy(() -> credentialsFile("""
+                [default]
+                = value-without-name
+                """))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property did not have a name on line 2");
     }
 
     private static final class CloseRecordingInputStream extends ByteArrayInputStream {

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -150,6 +150,23 @@ public class ProfilesTest {
     }
 
     @Test
+    void configurationProfileFileParsesIndentedContinuationAsMultilinePropertyValue() {
+        ProfileFile profileFile = configurationFile("""
+                [profile command]
+                credential_process = /opt/bin/token-provider
+                  --audience example
+                  output = json
+                region = us-east-2
+                """);
+
+        Profile command = profileFile.profile("command").orElseThrow();
+        assertThat(command.property(ProfileProperty.CREDENTIAL_PROCESS))
+                .contains("/opt/bin/token-provider\n--audience example\noutput = json");
+        assertThat(command.properties()).containsEntry(ProfileProperty.REGION, "us-east-2")
+                                        .doesNotContainKey("credential_process.output");
+    }
+
+    @Test
     void credentialsProfileFileParsesUnprefixedProfilesAndDuplicateProperties() {
         ProfileFile profileFile = credentialsFile("""
                 [default]

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -12,11 +12,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -438,6 +440,22 @@ public class ProfilesTest {
     }
 
     @Test
+    void profileFileLocationExpandsHomeDirectoryShorthandInConfiguredLocations() {
+        String separator = FileSystems.getDefault().getSeparator();
+        String configProperty = "~" + separator + ".aws" + separator + "custom-config";
+        String credentialsProperty = "~" + separator + ".aws" + separator + "custom-credentials";
+        Path userHomeDirectory = sdkUserHomeDirectory();
+
+        withSystemProperty(AWS_CONFIG_FILE_PROPERTY, configProperty, () ->
+                withSystemProperty(AWS_SHARED_CREDENTIALS_FILE_PROPERTY, credentialsProperty, () -> {
+                    assertThat(ProfileFileLocation.configurationFilePath())
+                            .isEqualTo(userHomeDirectory.resolve(".aws").resolve("custom-config"));
+                    assertThat(ProfileFileLocation.credentialsFilePath())
+                            .isEqualTo(userHomeDirectory.resolve(".aws").resolve("custom-credentials"));
+                }));
+    }
+
+    @Test
     void defaultSupplierLoadsConfiguredLocationsWhenTheyExist() throws IOException {
         Path credentials = tempDir.resolve("supplier-credentials");
         Path config = tempDir.resolve("supplier-config");
@@ -537,6 +555,29 @@ public class ProfilesTest {
                           .content(content)
                           .type(ProfileFile.Type.CREDENTIALS)
                           .build();
+    }
+
+    private static Path sdkUserHomeDirectory() {
+        String home = System.getenv("HOME");
+        if (home != null) {
+            return Path.of(home);
+        }
+
+        String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        if (osName.startsWith("windows")) {
+            String userProfile = System.getenv("USERPROFILE");
+            if (userProfile != null) {
+                return Path.of(userProfile);
+            }
+
+            String homeDrive = System.getenv("HOMEDRIVE");
+            String homePath = System.getenv("HOMEPATH");
+            if (homeDrive != null && homePath != null) {
+                return Path.of(homeDrive + homePath);
+            }
+        }
+
+        return Path.of(System.getProperty("user.home"));
     }
 
     private static void withSystemProperty(String name, String value, Runnable action) {


### PR DESCRIPTION

## What does this PR do?

Fixes: #4533

This PR introduces tests and metadata for software.amazon.awssdk:profiles:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 173147
- Cached input tokens: 1916928
- Output tokens: 18308
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 84.01
- Generated lines of code: 523
- Tested library lines of code: 436

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2af50df6b3b78b2ccd11961dff1c80140350eef5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2072/2527 (81.99%)
- Line: 436/519 (84.01%)
- Method: 127/161 (78.88%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
