### PR TITLE
[GenAI] Mark com.github.h0tk3y.betterParse:better-parse as not for Native Image

### DIFF
--- a/metadata/com.github.h0tk3y.betterParse/better-parse/index.json
+++ b/metadata/com.github.h0tk3y.betterParse/better-parse/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata and no JVM class files; Gradle module metadata redirects JVM variants to com.github.h0tk3y.betterParse:better-parse-jvm:0.4.4.",
+    "replacement": "com.github.h0tk3y.betterParse:better-parse-jvm:0.4.4"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5331

This PR records `com.github.h0tk3y.betterParse:better-parse` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata and no JVM class files; Gradle module metadata redirects JVM variants to com.github.h0tk3y.betterParse:better-parse-jvm:0.4.4.

Replacement guidance:
- com.github.h0tk3y.betterParse:better-parse-jvm:0.4.4

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `86c522f618446c77c0e5e1d5bd43cc18385667f6`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
