### PR TITLE
[GenAI] Add support for software.amazon.awssdk:profiles:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/profiles/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/profiles/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T07:12:54.949565Z",
+    "timestamp": "2026-05-04T09:20:21.292120Z",
     "library": "software.amazon.awssdk:profiles:2.34.0",
-    "starting_commit": "a6cc1a14e34205471353fb657c192d0be1e67ad1",
-    "ending_commit": "bc69a39f1fc398ae85b753e1da8b9831f4ea908c",
+    "starting_commit": "5ad066b38a12e5a25432ba22fab6aa8da2e9418c",
+    "ending_commit": "5e9200040b60291eec87a85096d3141e016c9f16",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 1978,
-          "missed": 549,
-          "ratio": 0.782746,
+          "covered": 2065,
+          "missed": 462,
+          "ratio": 0.817175,
           "total": 2527
         },
         "line": {
-          "covered": 418,
-          "missed": 101,
-          "ratio": 0.805395,
+          "covered": 437,
+          "missed": 82,
+          "ratio": 0.842004,
           "total": 519
         },
         "method": {
-          "covered": 121,
-          "missed": 40,
-          "ratio": 0.751553,
+          "covered": 127,
+          "missed": 34,
+          "ratio": 0.78882,
           "total": 161
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 172133,
-      "cached_input_tokens_used": 1114112,
-      "output_tokens_used": 17971,
+      "input_tokens_used": 177760,
+      "cached_input_tokens_used": 1543680,
+      "output_tokens_used": 18768,
       "iterations": 4,
-      "cost_usd": 1.0962,
-      "generated_loc": 365,
-      "tested_library_loc": 418,
+      "cost_usd": 1.3348,
+      "generated_loc": 567,
+      "tested_library_loc": 437,
       "metadata_entries": 0,
-      "code_coverage_percent": 80.54
+      "code_coverage_percent": 84.2
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java",

--- a/stats/software.amazon.awssdk/profiles/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/profiles/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 1978,
-        "missed" : 549,
-        "ratio" : 0.782746,
+        "covered" : 2065,
+        "missed" : 462,
+        "ratio" : 0.817175,
         "total" : 2527
       },
       "line" : {
-        "covered" : 418,
-        "missed" : 101,
-        "ratio" : 0.805395,
+        "covered" : 437,
+        "missed" : 82,
+        "ratio" : 0.842004,
         "total" : 519
       },
       "method" : {
-        "covered" : 121,
-        "missed" : 40,
-        "ratio" : 0.751553,
+        "covered" : 127,
+        "missed" : 34,
+        "ratio" : 0.78882,
         "total" : 161
       }
     }

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -193,7 +193,7 @@ public class ProfilesTest {
         ProfileFile profileFile = credentialsFile("""
                 ; leading semicolon comment
                 [default] ; section comment
-                aws_access_key_id	=	key=value ; stripped comment
+                aws_access_key_id\t=\tkey=value ; stripped comment
                 !invalid = ignored
                   ignored-continuation
                 multiline = first line
@@ -218,10 +218,10 @@ public class ProfilesTest {
     @Test
     void configurationSectionsSupportTabsAndCredentialsFilesIgnoreSections() {
         ProfileFile configuration = configurationFile("""
-                [sso-session	admin]
+                [sso-session\tadmin]
                 sso_region = us-east-2
 
-                [services	local-services]
+                [services\tlocal-services]
                 sqs =
                   endpoint_url = http://localhost:9324
 

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -84,6 +84,24 @@ public class ProfilesTest {
     }
 
     @Test
+    void profileBuilderRequiresNameAndProperties() {
+        assertThatThrownBy(() -> Profile.builder()
+                                        .properties(Map.of(ProfileProperty.REGION, "us-west-2"))
+                                        .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("name");
+        assertThatThrownBy(() -> Profile.builder()
+                                        .name("missing-properties")
+                                        .build())
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("properties");
+        assertThatThrownBy(() -> Profile.builder()
+                                        .name("null-properties")
+                                        .properties(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void configurationProfileFileParsesProfilesSectionsCommentsAndContinuations() {
         ProfileFile profileFile = configurationFile("""
                 # leading comments and blank lines are ignored
@@ -170,6 +188,65 @@ public class ProfilesTest {
     }
 
     @Test
+    void parserHandlesTabsSemicolonCommentsEqualsInValuesAndInvalidProperties() {
+        ProfileFile profileFile = credentialsFile("""
+                ; leading semicolon comment
+                [default] ; section comment
+                aws_access_key_id	=	key=value ; stripped comment
+                !invalid = ignored
+                  ignored-continuation
+                multiline = first line
+                  second line # continuation comments are values
+                subproperties =
+                  endpoint_url = http://localhost:9000/path?a=b # kept
+                  use_arn_region = true
+                """);
+
+        Profile profile = profileFile.profile("default").orElseThrow();
+        assertThat(profile.property(ProfileProperty.AWS_ACCESS_KEY_ID)).contains("key=value");
+        assertThat(profile.property("!invalid")).isEmpty();
+        assertThat(profile.property("multiline"))
+                .contains("first line\nsecond line # continuation comments are values");
+        assertThat(profile.property("subproperties"))
+                .contains("\nendpoint_url = http://localhost:9000/path?a=b # kept\nuse_arn_region = true");
+        assertThat(profile.properties())
+                .containsEntry("subproperties.endpoint_url", "http://localhost:9000/path?a=b # kept")
+                .containsEntry("subproperties.use_arn_region", "true");
+    }
+
+    @Test
+    void configurationSectionsSupportTabsAndCredentialsFilesIgnoreSections() {
+        ProfileFile configuration = configurationFile("""
+                [sso-session	admin]
+                sso_region = us-east-2
+
+                [services	local-services]
+                sqs =
+                  endpoint_url = http://localhost:9324
+
+                [sso-session bad name]
+                sso_region = ignored
+                """);
+        ProfileFile credentials = credentialsFile("""
+                [sso-session admin]
+                sso_region = ignored
+
+                [valid]
+                aws_access_key_id = still-read
+                """);
+
+        assertThat(configuration.getSection("sso-session", "admin").orElseThrow().property(ProfileProperty.SSO_REGION))
+                .contains("us-east-2");
+        assertThat(configuration.getSection("services", "local-services").orElseThrow()
+                                .property("sqs.endpoint_url"))
+                .contains("http://localhost:9324");
+        assertThat(configuration.getSection("sso-session", "bad name")).isEmpty();
+        assertThat(credentials.getSection("sso-session", "admin")).isEmpty();
+        assertThat(credentials.profile("valid").orElseThrow().property(ProfileProperty.AWS_ACCESS_KEY_ID))
+                .contains("still-read");
+    }
+
+    @Test
     void profileFileBuilderReadsAndClosesInputStreamContent() {
         CloseRecordingInputStream content = new CloseRecordingInputStream("""
                 [stream]
@@ -212,6 +289,38 @@ public class ProfilesTest {
                                              .type(ProfileFile.Type.CREDENTIALS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("does not exist");
+        assertThatThrownBy(() -> ProfileFile.builder()
+                                             .content((Path) null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("profileLocation");
+    }
+
+    @Test
+    void profileFilesExposeImmutableViewsEqualityHashCodeAndToString() {
+        ProfileFile profileFile = credentialsFile("""
+                [one]
+                aws_access_key_id = first-key
+                """);
+        ProfileFile same = credentialsFile("""
+                [one]
+                aws_access_key_id = first-key
+                """);
+        ProfileFile different = credentialsFile("""
+                [one]
+                aws_access_key_id = different-key
+                """);
+        ProfileFile empty = ProfileFile.aggregator().build();
+
+        assertThat(empty.profiles()).isEmpty();
+        assertThat(empty.profile("one")).isEmpty();
+        assertThat(profileFile.profiles()).containsOnlyKeys("one");
+        assertThatThrownBy(() -> profileFile.profiles().put("two", profileFile.profile("one").orElseThrow()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(profileFile).isEqualTo(same);
+        assertThat(profileFile.hashCode()).isEqualTo(same.hashCode());
+        assertThat(profileFile).isNotEqualTo(different);
+        assertThat(profileFile).isNotEqualTo("not-a-profile-file");
+        assertThat(profileFile.toString()).contains("ProfileFile", "profiles", "one");
     }
 
     @Test
@@ -361,6 +470,47 @@ public class ProfilesTest {
     }
 
     @Test
+    void defaultSupplierReadsOnlyExistingConfiguredLocation() throws IOException {
+        Path credentials = tempDir.resolve("credentials-only");
+        Path config = tempDir.resolve("config-only");
+        Path missingCredentials = tempDir.resolve("missing-credentials");
+        Path missingConfig = tempDir.resolve("missing-config");
+        Files.writeString(credentials, """
+                [default]
+                aws_access_key_id = credentials-only-key
+                """);
+        Files.writeString(config, """
+                [default]
+                region = ca-central-1
+                """);
+
+        withSystemProperty(AWS_SHARED_CREDENTIALS_FILE_PROPERTY, credentials.toString(), () ->
+                withSystemProperty(AWS_CONFIG_FILE_PROPERTY, missingConfig.toString(), () -> {
+                    Profile profile = ProfileFileSupplier.defaultSupplier().get().profile("default").orElseThrow();
+
+                    assertThat(profile.property(ProfileProperty.AWS_ACCESS_KEY_ID)).contains("credentials-only-key");
+                    assertThat(profile.property(ProfileProperty.REGION)).isEmpty();
+                }));
+        withSystemProperty(AWS_SHARED_CREDENTIALS_FILE_PROPERTY, missingCredentials.toString(), () ->
+                withSystemProperty(AWS_CONFIG_FILE_PROPERTY, config.toString(), () -> {
+                    Profile profile = ProfileFileSupplier.defaultSupplier().get().profile("default").orElseThrow();
+
+                    assertThat(profile.property(ProfileProperty.REGION)).contains("ca-central-1");
+                    assertThat(profile.property(ProfileProperty.AWS_ACCESS_KEY_ID)).isEmpty();
+                }));
+    }
+
+    @Test
+    void profileFileLocationsExpandHomeDirectoryMarkerInConfiguredLocations() {
+        withSystemProperty(AWS_SHARED_CREDENTIALS_FILE_PROPERTY, "~/custom-credentials", () ->
+                assertThat(ProfileFileLocation.credentialsFilePath())
+                        .isEqualTo(Path.of(System.getProperty("user.home"), "custom-credentials")));
+        withSystemProperty(AWS_CONFIG_FILE_PROPERTY, "~/custom-config", () ->
+                assertThat(ProfileFileLocation.configurationFilePath())
+                        .isEqualTo(Path.of(System.getProperty("user.home"), "custom-config")));
+    }
+
+    @Test
     void malformedProfileFilesFailFastWithLineSpecificMessages() {
         assertThatThrownBy(() -> credentialsFile("aws_access_key_id = no-section"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -379,6 +529,28 @@ public class ProfilesTest {
                 """))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Profile definition must end with ']'");
+
+        assertThatThrownBy(() -> credentialsFile("  orphan-continuation"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected a profile or property definition on line 1");
+        assertThatThrownBy(() -> credentialsFile("""
+                [default]
+                  orphan-continuation
+                """))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected a profile or property definition on line 2");
+        assertThatThrownBy(() -> credentialsFile("""
+                [default]
+                = unnamed
+                """))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property did not have a name on line 2");
+        assertThatThrownBy(() -> configurationFile("""
+                [sso-session admin
+                sso_region = us-west-2
+                """))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Section definition must end with ']'");
     }
 
     private static final class CloseRecordingInputStream extends ByteArrayInputStream {

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -357,6 +357,46 @@ public class ProfilesTest {
     }
 
     @Test
+    void aggregatorMergesConfigurationSectionsAndKeepsEarlierFilesHigherPrecedence() {
+        ProfileFile first = configurationFile("""
+                [sso-session admin]
+                sso_region = us-east-1
+
+                [services local]
+                s3 =
+                  endpoint_url = http://localhost:4566
+                """);
+        ProfileFile second = configurationFile("""
+                [sso-session admin]
+                sso_region = eu-west-1
+                sso_registration_scopes = sso:account:access
+
+                [services local]
+                s3 =
+                  endpoint_url = http://secondary.example.test
+                  use_dualstack_endpoint = true
+                dynamodb =
+                  endpoint_url = http://localhost:8000
+                """);
+
+        ProfileFile aggregate = ProfileFile.aggregator()
+                                           .addFile(first)
+                                           .addFile(second)
+                                           .build();
+
+        Profile ssoSession = aggregate.getSection("sso-session", "admin").orElseThrow();
+        assertThat(ssoSession.properties())
+                .containsEntry(ProfileProperty.SSO_REGION, "us-east-1")
+                .containsEntry("sso_registration_scopes", "sso:account:access");
+
+        Profile services = aggregate.getSection("services", "local").orElseThrow();
+        assertThat(services.properties())
+                .containsEntry("s3.endpoint_url", "http://localhost:4566")
+                .containsEntry("s3.use_dualstack_endpoint", "true")
+                .containsEntry("dynamodb.endpoint_url", "http://localhost:8000");
+    }
+
+    @Test
     void profileFileSuppliersCanReturnFixedAndAggregatedViews() {
         ProfileFile first = credentialsFile("""
                 [default]

--- a/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
+++ b/tests/src/software.amazon.awssdk/profiles/2.34.0/src/test/java/software_amazon_awssdk/profiles/ProfilesTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.profiles.Profile;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileLocation;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.profiles.ProfileProperty;
 
 public class ProfilesTest {
@@ -460,6 +461,19 @@ public class ProfilesTest {
                 .containsEntry(ProfileProperty.AWS_ACCESS_KEY_ID, "refreshed-key")
                 .containsEntry(ProfileProperty.AWS_SECRET_ACCESS_KEY, "refreshed-secret");
         assertThat(supplier.get()).isSameAs(refreshed);
+    }
+
+    @Test
+    void profileFileSystemSettingExposesAwsProfileSelection() {
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.property()).isEqualTo("aws.profile");
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.environmentVariable()).isEqualTo("AWS_PROFILE");
+        assertThat(ProfileFileSystemSetting.AWS_PROFILE.defaultValue()).isEqualTo("default");
+
+        withSystemProperty(ProfileFileSystemSetting.AWS_PROFILE.property(), "analytics", () -> {
+            assertThat(ProfileFileSystemSetting.AWS_PROFILE.getStringValue()).contains("analytics");
+            assertThat(ProfileFileSystemSetting.AWS_PROFILE.getNonDefaultStringValue()).contains("analytics");
+            assertThat(ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow()).isEqualTo("analytics");
+        });
     }
 
     @Test


### PR DESCRIPTION

## What does this PR do?

Fixes: #4533

This PR introduces tests and metadata for software.amazon.awssdk:profiles:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 177760
- Cached input tokens: 1543680
- Output tokens: 18768
- Metadata entries: 0
- Iterations: 4
- Library coverage percentage: 84.2
- Generated lines of code: 567
- Tested library lines of code: 437

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5ad066b38a12e5a25432ba22fab6aa8da2e9418c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2065/2527 (81.72%)
- Line: 437/519 (84.20%)
- Method: 127/161 (78.88%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
