### PR TITLE
[GenAI] Add support for org.json4s:json4s-native_3:4.0.7 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-native_3/4.0.7/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-native_3/4.0.7/reachability-metadata.json
@@ -1,0 +1,25 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.json4s.native.JsonParser$Parser"
+      },
+      "type": "org.json4s.native.JsonParser$Parser",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.Extraction$"
+      },
+      "type": "org.json4s.Extraction$",
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.json4s.reflect.ScalaType"
+      },
+      "type": "org.json4s.reflect.ScalaType",
+      "allDeclaredFields": true
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-native_3/index.json
+++ b/metadata/org.json4s/json4s-native_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/native/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-javadoc.jar",
+    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, transformation, extraction, and serialization APIs. The json4s-native artifact supplies the native parser and serialization implementation, avoiding the Jackson backend while targeting Scala 3 on the JVM.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "4.0.7"
+    ],
+    "allowed-packages" : [
+      "org.json4s.native"
+    ]
+  }
+]

--- a/metadata/org.json4s/json4s-native_3/index.json
+++ b/metadata/org.json4s/json4s-native_3/index.json
@@ -1,21 +1,23 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.7",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-sources.jar",
-    "repository-url" : "https://github.com/json4s/json4s",
-    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/native/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-javadoc.jar",
-    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, transformation, extraction, and serialization APIs. The json4s-native artifact supplies the native parser and serialization implementation, avoiding the Jackson backend while targeting Scala 3 on the JVM.",
-    "language" : {
-      "name" : "scala",
-      "version" : "3"
+    "latest": true,
+    "metadata-version": "4.0.7",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-sources.jar",
+    "repository-url": "https://github.com/json4s/json4s",
+    "test-code-url": "https://github.com/json4s/json4s/tree/v$version$/native/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/json4s/json4s-native_3/$version$/json4s-native_3-$version$-javadoc.jar",
+    "description": "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, transformation, extraction, and serialization APIs. The json4s-native artifact supplies the native parser and serialization implementation, avoiding the Jackson backend while targeting Scala 3 on the JVM.",
+    "language": {
+      "name": "scala",
+      "version": "3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "4.0.7"
     ],
-    "allowed-packages" : [
-      "org.json4s.native"
+    "allowed-packages": [
+      "org.json4s.native",
+      "org.json4s",
+      "org.json4s.reflect"
     ]
   }
 ]

--- a/stats/org.json4s/json4s-native_3/4.0.7/execution-metrics.json
+++ b/stats/org.json4s/json4s-native_3/4.0.7/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T09:49:14.442278Z",
+    "library": "org.json4s:json4s-native_3:4.0.7",
+    "starting_commit": "14710ba4738653dc6db25e9de94a55a1aefc0287",
+    "ending_commit": "26269edc339927f0a40754a2922c78c86d38fd6b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.7",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 173,
+          "missed": 151,
+          "ratio": 0.533951,
+          "total": 324
+        },
+        "line": {
+          "covered": 30,
+          "missed": 6,
+          "ratio": 0.833333,
+          "total": 36
+        },
+        "method": {
+          "covered": 23,
+          "missed": 27,
+          "ratio": 0.46,
+          "total": 50
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 196968,
+      "cached_input_tokens_used": 1715200,
+      "output_tokens_used": 27027,
+      "iterations": 7,
+      "cost_usd": 1.6684,
+      "generated_loc": 230,
+      "tested_library_loc": 30,
+      "metadata_entries": 6,
+      "code_coverage_percent": 83.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala",
+      "metadata_file": "metadata/org.json4s/json4s-native_3/4.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-native_3/4.0.7/stats.json
+++ b/stats/org.json4s/json4s-native_3/4.0.7/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.7",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 173,
+        "missed" : 151,
+        "ratio" : 0.533951,
+        "total" : 324
+      },
+      "line" : {
+        "covered" : 30,
+        "missed" : 6,
+        "ratio" : 0.833333,
+        "total" : 36
+      },
+      "method" : {
+        "covered" : 23,
+        "missed" : 27,
+        "ratio" : 0.46,
+        "total" : 50
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/.gitignore
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-native_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/gradle.properties
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-native_3:4.0.7
+library.version = 4.0.7
+metadata.dir = org.json4s/json4s-native_3/4.0.7/

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/settings.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-native_3_tests'

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_native_3
+
+import org.junit.jupiter.api.Test
+
+class Json4s_native_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
@@ -6,11 +6,198 @@
  */
 package org_json4s.json4s_native_3
 
+import org.json4s.*
+import org.json4s.`native`.{Json as NativeJson, JsonParser, Serialization as NativeSerialization}
+import org.json4s.`native`.{compactJson, parseJson, parseJsonOpt, prettyJson, renderJValue}
+import org.json4s.`native`.JsonMethods.*
+import org.json4s.prefs.EmptyValueStrategy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+
+import java.io.{StringReader, StringWriter}
+import scala.collection.mutable.ListBuffer
 
 class Json4s_native_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def parsesStrictJsonFromStringsAndReaders(): Unit = {
+    val jsonText: String =
+      """
+        |{
+        |  "message": "hello\nworld",
+        |  "unicode": "caf\u00e9",
+        |  "flags": [true, false, null],
+        |  "price": 12.50,
+        |  "maxLong": 9223372036854775807,
+        |  "largeInteger": 922337203685477580812345
+        |}
+        |""".stripMargin
+
+    val parsedWithBigNumbers: JValue = parse(jsonText, true, true)
+    assertEquals(JString("hello\nworld"), parsedWithBigNumbers \ "message")
+    assertEquals(JString("café"), parsedWithBigNumbers \ "unicode")
+    assertEquals(JArray(List(JBool.True, JBool.False, JNull)), parsedWithBigNumbers \ "flags")
+    assertEquals(JDecimal(BigDecimal("12.50")), parsedWithBigNumbers \ "price")
+    assertEquals(JInt(BigInt("9223372036854775807")), parsedWithBigNumbers \ "maxLong")
+    assertEquals(JInt(BigInt("922337203685477580812345")), parsedWithBigNumbers \ "largeInteger")
+
+    val parsedWithJvmNumbers: JValue = parse(new StringReader("""{"price":12.5,"maxLong":9223372036854775807}"""), false, false)
+    assertEquals(JDouble(12.5d), parsedWithJvmNumbers \ "price")
+    assertEquals(JLong(9223372036854775807L), parsedWithJvmNumbers \ "maxLong")
+
+    assertEquals(Some(JArray(List(JInt(1), JInt(2), JInt(3)))), parseOpt("[1,2,3]"))
+    assertEquals(None, parseOpt("""{"broken": ]}"""))
+    assertThrows(classOf[ParserUtil.ParseException], () => parse("""{"broken": ]}"""))
+  }
+
+  @Test
+  def parsesTokenStreamsWithTheNativeParser(): Unit = {
+    val tokens: List[String] = JsonParser.parse(
+      new StringReader("""{"name":"Ada","scores":[1,2.5,true,null]}"""),
+      parser => {
+        val seen: ListBuffer[String] = ListBuffer.empty[String]
+        var token = parser.nextToken
+        while token != JsonParser.End do
+          token.productPrefix match
+            case "OpenObj" => seen += "open-object"
+            case "CloseObj" => seen += "close-object"
+            case "OpenArr" => seen += "open-array"
+            case "CloseArr" => seen += "close-array"
+            case "FieldStart" => seen += s"field:${token.productElement(0)}"
+            case "StringVal" => seen += s"string:${token.productElement(0)}"
+            case "IntVal" => seen += s"int:${token.productElement(0)}"
+            case "BigDecimalVal" => seen += s"decimal:${token.productElement(0)}"
+            case "BoolVal" => seen += s"bool:${token.productElement(0)}"
+            case "NullVal" => seen += "null"
+            case _ => seen += token.toString
+          token = parser.nextToken
+        seen.toList
+      },
+      true,
+      true
+    )
+
+    assertEquals(
+      List(
+        "open-object",
+        "field:name",
+        "string:Ada",
+        "field:scores",
+        "open-array",
+        "int:1",
+        "decimal:2.5",
+        "bool:true",
+        "null",
+        "close-array",
+        "close-object"
+      ),
+      tokens
+    )
+  }
+
+  @Test
+  def rendersAstToCompactAndPrettyNativeDocuments(): Unit = {
+    val document: JObject = JObject(
+      JField("name", JString("café")),
+      JField("line", JString("one\ntwo")),
+      JField("missing", JNothing),
+      JField("items", JArray(List(JInt(1), JNothing, JNull))),
+      JField("nested", JObject(JField("enabled", JBool.True)))
+    )
+
+    val renderedWithNulls = render(document, true, EmptyValueStrategy.preserve)
+    assertEquals(
+      """{"name":"caf\u00E9","line":"one\ntwo","missing":null,"items":[1,null,null],"nested":{"enabled":true}}""",
+      compact(renderedWithNulls)
+    )
+
+    val renderedSkippingEmptyValues = render(
+      JObject(
+        JField("name", JString("café")),
+        JField("line", JString("one\ntwo")),
+        JField("missing", JNothing),
+        JField("items", JArray(List(JInt(1), JNull))),
+        JField("nested", JObject(JField("enabled", JBool.True)))
+      ),
+      false,
+      EmptyValueStrategy.skip
+    )
+    assertEquals(
+      """{"name":"café","line":"one\ntwo","items":[1,null],"nested":{"enabled":true}}""",
+      compact(renderedSkippingEmptyValues)
+    )
+
+    val prettyText: String = pretty(renderedWithNulls)
+    assertTrue(prettyText.contains("\n"))
+    assertTrue(prettyText.contains("\\u00E9"))
+    assertTrue(prettyText.contains("  \"nested\""))
+  }
+
+  @Test
+  def exposesPackageLevelParseAndRenderHelpers(): Unit = {
+    val parsed: JValue = parseJson("""{"ok":true,"values":[1,2,3]}""")
+    assertEquals(JBool.True, parsed \ "ok")
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "values")
+    assertEquals(Some(parsed), parseJsonOpt("""{"ok":true,"values":[1,2,3]}"""))
+    assertEquals(None, parseJsonOpt("""{"ok":]}"""))
+
+    val rendered = renderJValue(parsed)
+    assertEquals("""{"ok":true,"values":[1,2,3]}""", compactJson(rendered))
+    assertTrue(prettyJson(rendered).contains("\n"))
+  }
+
+  @Test
+  def serializesAndReadsCollectionsWithNativeSerialization(): Unit = {
+    implicit val formats: Formats = NativeSerialization.formats(NoTypeHints)
+
+    val source: Map[String, Any] = Map(
+      "title" -> "Quarterly",
+      "active" -> true,
+      "ids" -> List(1, 2, 3),
+      "amounts" -> List(BigDecimal("12.50"), BigDecimal("19.99")),
+      "metadata" -> Map("region" -> "EMEA", "priority" -> 2)
+    )
+
+    val jsonText: String = NativeSerialization.write(source)
+    val parsed: JValue = parse(jsonText, true, true)
+    assertEquals(JString("Quarterly"), parsed \ "title")
+    assertEquals(JBool.True, parsed \ "active")
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "ids")
+    assertEquals(JArray(List(JDecimal(BigDecimal("12.50")), JDecimal(BigDecimal("19.99")))), parsed \ "amounts")
+    assertEquals(JString("EMEA"), parsed \ "metadata" \ "region")
+    assertEquals(JInt(2), parsed \ "metadata" \ "priority")
+
+    val readIds: Map[String, List[Int]] = NativeSerialization.read[Map[String, List[Int]]]("""{"ids":[1,2,3]}""")
+    assertEquals(Map("ids" -> List(1, 2, 3)), readIds)
+
+    val readFlags: Map[String, Boolean] = NativeSerialization.read[Map[String, Boolean]](new StringReader("""{"enabled":true}"""))
+    assertEquals(Map("enabled" -> true), readFlags)
+
+    val prettyWriter: StringWriter = new StringWriter()
+    assertSame(prettyWriter, NativeSerialization.writePretty(source, prettyWriter))
+    assertTrue(prettyWriter.toString.contains("\n"))
+    assertEquals(parsed, parse(prettyWriter.toString, true, true))
+  }
+
+  @Test
+  def usesNativeJsonFacadeWithExplicitFormats(): Unit = {
+    implicit val formats: Formats = DefaultFormats
+    val json: NativeJson = NativeJson(formats)
+
+    val writer: StringWriter = new StringWriter()
+    val writtenWriter: StringWriter = json.write(List(Map("letter" -> "a"), Map("letter" -> "b")), writer)
+    assertSame(writer, writtenWriter)
+    assertEquals(
+      JArray(List(JObject(JField("letter", JString("a"))), JObject(JField("letter", JString("b"))))),
+      json.parse(writer.toString)
+    )
+
+    assertEquals(Some(JObject(JField("safe", JInt(1)))), json.parseOpt("""{"safe":1}"""))
+    assertEquals(None, json.parseOpt("""{"safe":]}"""))
+
+    val prettyText: String = json.writePretty(Map("message" -> "hello", "count" -> 2))
+    val prettyAst: JValue = json.parse(prettyText)
+    assertEquals(JString("hello"), prettyAst \ "message")
+    assertEquals(JInt(2), prettyAst \ "count")
+    assertTrue(prettyText.contains("\n"))
   }
 }

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
@@ -7,7 +7,7 @@
 package org_json4s.json4s_native_3
 
 import org.json4s.*
-import org.json4s.`native`.{Json as NativeJson, JsonParser, Serialization as NativeSerialization}
+import org.json4s.`native`.{Document, Json as NativeJson, JsonParser, Printer, Serialization as NativeSerialization}
 import org.json4s.`native`.{compactJson, parseJson, parseJsonOpt, prettyJson, renderJValue}
 import org.json4s.`native`.JsonMethods.*
 import org.json4s.prefs.EmptyValueStrategy
@@ -130,6 +130,34 @@ class Json4s_native_3Test {
     assertTrue(prettyText.contains("\n"))
     assertTrue(prettyText.contains("\\u00E9"))
     assertTrue(prettyText.contains("  \"nested\""))
+  }
+
+  @Test
+  def formatsCustomDocumentsWithNativePrinterCombinators(): Unit = {
+    def append(left: Document, right: Document): Document = right.`::`(left)
+    def line(left: Document, right: Document): Document = right.`:/:`(left)
+
+    val fields: Document = line(
+      Document.text("name = Ada,"),
+      line(Document.text("score = 42"), Document.text(")"))
+    )
+    val document: Document = Document.group(
+      append(
+        Document.text("record("),
+        Document.nest(2, line(Document.empty, fields))
+      )
+    )
+
+    val compactWriter: StringWriter = new StringWriter()
+    assertSame(compactWriter, Printer.compact(document, compactWriter))
+    assertEquals("record(name = Ada,score = 42)", compactWriter.toString)
+
+    val prettyWriter: StringWriter = new StringWriter()
+    assertSame(prettyWriter, Printer.pretty(document, prettyWriter))
+    assertEquals(
+      "record(\n  name = Ada,\n  score = 42\n  )",
+      prettyWriter.toString
+    )
   }
 
   @Test

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/src/test/scala/org_json4s/json4s_native_3/Json4s_native_3Test.scala
@@ -161,6 +161,37 @@ class Json4s_native_3Test {
   }
 
   @Test
+  def buildsJsonIncrementallyWithStreamingWriter(): Unit = {
+    val stringWriter: StringWriter = new StringWriter()
+    val writer: JsonWriter[StringWriter] = JsonWriter.streamingPretty(stringWriter, true)
+
+    val completedWriter: JsonWriter[StringWriter] = writer
+      .startObject()
+      .startField("name")
+      .string("café")
+      .startField("scores")
+      .startArray()
+      .int(10)
+      .bigDecimal(BigDecimal("20.50"))
+      .boolean(true)
+      .addJValue(JObject(JField("bonus", JInt(3))))
+      .endArray()
+      .endObject()
+
+    assertSame(stringWriter, completedWriter.result)
+    val jsonText: String = stringWriter.toString
+    assertTrue(jsonText.contains("\n"))
+    assertTrue(jsonText.contains("caf\\u00E9"))
+
+    val parsed: JValue = parse(jsonText, true, true)
+    assertEquals(JString("café"), parsed \ "name")
+    assertEquals(
+      JArray(List(JInt(10), JDecimal(BigDecimal("20.50")), JBool.True, JObject(JField("bonus", JInt(3))))),
+      parsed \ "scores"
+    )
+  }
+
+  @Test
   def exposesPackageLevelParseAndRenderHelpers(): Unit = {
     val parsed: JValue = parseJson("""{"ok":true,"values":[1,2,3]}""")
     assertEquals(JBool.True, parsed \ "ok")

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.json4s.native.**"
+      "includeClasses" : "org.json4s.native.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_native_3.**"
     }
   ]
 }

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.json4s.native.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5431

This PR introduces tests and metadata for org.json4s:json4s-native_3:4.0.7, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 196968
- Cached input tokens: 1715200
- Output tokens: 27027
- Metadata entries: 6
- Iterations: 7
- Library coverage percentage: 83.33
- Generated lines of code: 230
- Tested library lines of code: 30

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `329888eef5a1f611788cd339f0cb542caab94cee`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 173/324 (53.40%)
- Line: 30/36 (83.33%)
- Method: 23/50 (46.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
