### PR TITLE
[GenAI] Add support for software.amazon.awssdk:retries-spi:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/retries-spi/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/retries-spi/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T08:36:56.528435Z",
+    "timestamp": "2026-05-04T10:08:31.258064Z",
     "library": "software.amazon.awssdk:retries-spi:2.34.0",
-    "starting_commit": "3093f75a960a4b3c1cb75ac0a1dfd5b8351e2aa9",
-    "ending_commit": "5bc66660e67d4d33f1ef5286b9ea8101f8da7883",
+    "starting_commit": "2af50df6b3b78b2ccd11961dff1c80140350eef5",
+    "ending_commit": "34fde6e5a5588200b97f38f7dc0609baccf20888",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 621,
-          "missed": 70,
-          "ratio": 0.898698,
+          "covered": 691,
+          "missed": 0,
+          "ratio": 1.0,
           "total": 691
         },
         "line": {
-          "covered": 154,
-          "missed": 25,
-          "ratio": 0.860335,
+          "covered": 179,
+          "missed": 0,
+          "ratio": 1.0,
           "total": 179
         },
         "method": {
-          "covered": 73,
-          "missed": 6,
-          "ratio": 0.924051,
+          "covered": 79,
+          "missed": 0,
+          "ratio": 1.0,
           "total": 79
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 163760,
-      "cached_input_tokens_used": 1589760,
-      "output_tokens_used": 22972,
-      "iterations": 4,
-      "cost_usd": 1.4841,
-      "generated_loc": 403,
-      "tested_library_loc": 154,
+      "input_tokens_used": 184126,
+      "cached_input_tokens_used": 1285120,
+      "output_tokens_used": 13944,
+      "iterations": 3,
+      "cost_usd": 1.0609,
+      "generated_loc": 456,
+      "tested_library_loc": 179,
       "metadata_entries": 0,
-      "code_coverage_percent": 86.03
+      "code_coverage_percent": 100.0
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java",

--- a/stats/software.amazon.awssdk/retries-spi/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/retries-spi/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 621,
-        "missed" : 70,
-        "ratio" : 0.898698,
+        "covered" : 691,
+        "missed" : 0,
+        "ratio" : 1.0,
         "total" : 691
       },
       "line" : {
-        "covered" : 154,
-        "missed" : 25,
-        "ratio" : 0.860335,
+        "covered" : 179,
+        "missed" : 0,
+        "ratio" : 1.0,
         "total" : 179
       },
       "method" : {
-        "covered" : 73,
-        "missed" : 6,
-        "ratio" : 0.924051,
+        "covered" : 79,
+        "missed" : 0,
+        "ratio" : 1.0,
         "total" : 79
       }
     }

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -223,6 +223,29 @@ public class Retries_spiTest {
     }
 
     @Test
+    void backoffStrategiesCapVeryLargeDelaysToSupportedJitterRange() {
+        Duration veryLargeDelay = Duration.ofDays(365);
+        Duration ceiling = Duration.ofMillis(Integer.MAX_VALUE);
+        BackoffStrategy fixedWithJitter = BackoffStrategy.fixedDelay(veryLargeDelay);
+        BackoffStrategy exponentialWithoutJitter = BackoffStrategy.exponentialDelayWithoutJitter(
+                veryLargeDelay, veryLargeDelay);
+        BackoffStrategy exponentialWithJitter = BackoffStrategy.exponentialDelay(veryLargeDelay, veryLargeDelay);
+        BackoffStrategy exponentialWithHalfJitter = BackoffStrategy.exponentialDelayHalfJitter(
+                veryLargeDelay, veryLargeDelay);
+
+        assertThat(fixedWithJitter.computeDelay(1))
+                .isGreaterThanOrEqualTo(Duration.ZERO)
+                .isLessThan(ceiling);
+        assertThat(exponentialWithoutJitter.computeDelay(2)).isEqualTo(ceiling);
+        assertThat(exponentialWithJitter.computeDelay(2))
+                .isGreaterThanOrEqualTo(Duration.ZERO)
+                .isLessThan(ceiling);
+        assertThat(exponentialWithHalfJitter.computeDelay(2))
+                .isGreaterThanOrEqualTo(Duration.ofMillis(Integer.MAX_VALUE / 2))
+                .isLessThanOrEqualTo(ceiling);
+    }
+
+    @Test
     void backoffStrategiesValidatePositiveAttemptsAndPositiveDurations() {
         BackoffStrategy immediate = BackoffStrategy.retryImmediately();
         BackoffStrategy fixed = BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS);

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -231,6 +231,21 @@ public class Retries_spiTest {
     }
 
     @Test
+    void backoffStrategiesExposeReadableDescriptions() {
+        assertThat(BackoffStrategy.retryImmediately().toString()).isEqualTo("(Immediately)");
+        assertThat(BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS).toString())
+                .contains("FixedDelayWithoutJitter", "delay", "PT0.1S");
+        assertThat(BackoffStrategy.fixedDelay(HUNDRED_MILLIS).toString())
+                .contains("FixedDelayWithJitter", "delay", "PT0.1S");
+        assertThat(BackoffStrategy.exponentialDelayWithoutJitter(HUNDRED_MILLIS, ONE_SECOND).toString())
+                .contains("ExponentialDelayWithoutJitter", "baseDelay", "PT0.1S", "maxDelay", "PT1S");
+        assertThat(BackoffStrategy.exponentialDelay(HUNDRED_MILLIS, ONE_SECOND).toString())
+                .contains("ExponentialDelayWithJitter", "baseDelay", "PT0.1S", "maxDelay", "PT1S");
+        assertThat(BackoffStrategy.exponentialDelayHalfJitter(HUNDRED_MILLIS, ONE_SECOND).toString())
+                .contains("ExponentialDelayWithHalfJitter", "baseDelay", "PT0.1S", "maxDelay", "PT1S");
+    }
+
+    @Test
     void retryStrategyCanCoordinateTokenLifecycleThroughTheSpiRequests() {
         TestRetryStrategy strategy = new TestRetryStrategyBuilder()
                 .maxAttempts(4)
@@ -277,12 +292,19 @@ public class Retries_spiTest {
         IllegalStateException outer = new IllegalStateException("outer", middle);
 
         builder.retryOnExceptionOrCause(IllegalArgumentException.class);
+        assertThat(builder.shouldRetry(new IllegalArgumentException("direct"))).isTrue();
         assertThat(builder.shouldRetry(outer)).isFalse();
         assertThat(builder.shouldRetry(new RuntimeException(
                 "outer", new IllegalArgumentException("direct cause")))).isTrue();
+        assertThat(builder.shouldRetry(new RuntimeException(
+                "outer", new NumberFormatException("different direct cause")))).isFalse();
 
-        builder.retryOnExceptionOrCauseInstanceOf(RuntimeException.class);
-        assertThat(builder.shouldRetry(outer)).isTrue();
+        builder.retryOnExceptionOrCauseInstanceOf(IllegalArgumentException.class);
+        assertThat(builder.shouldRetry(new NumberFormatException("direct subclass"))).isTrue();
+        assertThat(builder.shouldRetry(new RuntimeException(
+                "outer", new NumberFormatException("subclass direct cause")))).isTrue();
+        assertThat(builder.shouldRetry(new RuntimeException(
+                "outer", new IllegalStateException("different direct cause")))).isFalse();
 
         builder.retryOnRootCause(IllegalArgumentException.class);
         assertThat(builder.shouldRetry(outer)).isTrue();

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -210,6 +210,19 @@ public class Retries_spiTest {
     }
 
     @Test
+    void jitteredExponentialBackoffUsesMaximumDelayAsTheCappedRange() {
+        BackoffStrategy fullJitter = BackoffStrategy.exponentialDelay(HUNDRED_MILLIS, TWO_HUNDRED_MILLIS);
+        BackoffStrategy halfJitter = BackoffStrategy.exponentialDelayHalfJitter(HUNDRED_MILLIS, TWO_HUNDRED_MILLIS);
+
+        assertThat(fullJitter.computeDelay(10))
+                .isGreaterThanOrEqualTo(Duration.ZERO)
+                .isLessThan(TWO_HUNDRED_MILLIS);
+        assertThat(halfJitter.computeDelay(10))
+                .isGreaterThanOrEqualTo(HUNDRED_MILLIS)
+                .isLessThanOrEqualTo(TWO_HUNDRED_MILLIS);
+    }
+
+    @Test
     void backoffStrategiesValidatePositiveAttemptsAndPositiveDurations() {
         BackoffStrategy immediate = BackoffStrategy.retryImmediately();
         BackoffStrategy fixed = BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS);


### PR DESCRIPTION

## What does this PR do?

Fixes: #4575

This PR introduces tests and metadata for software.amazon.awssdk:retries-spi:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 184126
- Cached input tokens: 1285120
- Output tokens: 13944
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 456
- Tested library lines of code: 179

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2af50df6b3b78b2ccd11961dff1c80140350eef5`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 691/691 (100.00%)
- Line: 179/179 (100.00%)
- Method: 79/79 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
