### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/reachability-metadata.json
@@ -1,0 +1,500 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.TableFieldSchema$Mode",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.TableFieldSchema$Type",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.TableProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ArrowSerializationOptions$Format",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.StorageError$StorageErrorCode",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.WriteStream"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.WriteStream$Type",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ArrowSchema",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.AvroSchema",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.DataFormat",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableModifiers",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadSession$TableReadOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta2.ReadStream",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.ReadSession"
+      },
+      "type": "com.google.protobuf.Timestamp",
+      "methods": [
+        {
+          "name": "getNanos",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSeconds",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StorageProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta2.StreamProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.186.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta2/$version$/proto-google-cloud-bigquerystorage-v1beta2-$version$-javadoc.jar",
+    "description" : "This artifact provides the Java Protocol Buffer message classes and descriptors for the BigQuery Storage API v1beta2. JVM and gRPC clients use it to serialize requests and responses for reading from and writing to BigQuery table storage.",
+    "tested-versions" : [
+      "0.186.1"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1beta2"
+    ]
+  }
+]

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T11:29:21.432531Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1",
+    "starting_commit": "4236b83eafc36a28a5c7fd009d5a4a4132ff653e",
+    "ending_commit": "13a21b3cc2a2c437ea20b4e773f98a067118bc5e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.186.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15203,
+          "missed": 24969,
+          "ratio": 0.378448,
+          "total": 40172
+        },
+        "line": {
+          "covered": 4217,
+          "missed": 6652,
+          "ratio": 0.387984,
+          "total": 10869
+        },
+        "method": {
+          "covered": 1009,
+          "missed": 1972,
+          "ratio": 0.338477,
+          "total": 2981
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 200751,
+      "cached_input_tokens_used": 1745920,
+      "output_tokens_used": 21192,
+      "iterations": 3,
+      "cost_usd": 1.5088,
+      "generated_loc": 491,
+      "tested_library_loc": 4217,
+      "metadata_entries": 120,
+      "code_coverage_percent": 38.8
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.186.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15203,
+        "missed" : 24969,
+        "ratio" : 0.378448,
+        "total" : 40172
+      },
+      "line" : {
+        "covered" : 4217,
+        "missed" : 6652,
+        "ratio" : 0.387984,
+        "total" : 10869
+      },
+      "method" : {
+        "covered" : 1009,
+        "missed" : 1972,
+        "ratio" : 0.338477,
+        "total" : 2981
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1
+library.version = 0.186.1
+metadata.dir = com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-cloud-bigquerystorage-v1beta2_tests'

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
@@ -197,6 +197,36 @@ public class Proto_google_cloud_bigquerystorage_v1beta2Test {
     }
 
     @Test
+    void avroReadSessionCarriesAvroSchemaAndStreamMetadata() {
+        String avroSchemaJson = """
+                {"type":"record","name":"Event","fields":[{"name":"user_id","type":"long"}]}
+                """;
+        ReadSession readSession = ReadSession.newBuilder()
+                .setName("projects/sample-project/locations/us/sessions/session-1")
+                .setDataFormat(DataFormat.AVRO)
+                .setAvroSchema(AvroSchema.newBuilder().setSchema(avroSchemaJson))
+                .setTable(TableName.format(PROJECT, DATASET, TABLE))
+                .addStreams(ReadStream.newBuilder()
+                        .setName(ReadStreamName.format(PROJECT, LOCATION, SESSION, READ_STREAM)))
+                .build();
+        CreateReadSessionRequest request = CreateReadSessionRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setReadSession(readSession)
+                .setMaxStreamCount(1)
+                .build();
+
+        assertEquals(ProjectName.format(PROJECT), request.getParent());
+        assertEquals(1, request.getMaxStreamCount());
+        assertEquals(DataFormat.AVRO, request.getReadSession().getDataFormat());
+        assertEquals(ReadSession.SchemaCase.AVRO_SCHEMA, request.getReadSession().getSchemaCase());
+        assertTrue(request.getReadSession().hasAvroSchema());
+        assertFalse(request.getReadSession().hasArrowSchema());
+        assertEquals(avroSchemaJson, request.getReadSession().getAvroSchema().getSchema());
+        assertEquals(TableName.format(PROJECT, DATASET, TABLE), request.getReadSession().getTable());
+        assertEquals(READ_STREAM, ReadStreamName.parse(request.getReadSession().getStreams(0).getName()).getStream());
+    }
+
+    @Test
     void storageProtoDescriptorExposesServicesStreamingAndHttpBindings() {
         FileDescriptor descriptor = StorageProto.getDescriptor();
         ServiceDescriptor readService = descriptor.findServiceByName("BigQueryRead");

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_bigquerystorage_v1beta2Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
@@ -6,11 +6,442 @@
  */
 package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.api.ClientProto;
+import com.google.api.HttpRule;
+import com.google.cloud.bigquery.storage.v1beta2.AppendRowsRequest;
+import com.google.cloud.bigquery.storage.v1beta2.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1beta2.ArrowRecordBatch;
+import com.google.cloud.bigquery.storage.v1beta2.ArrowSchema;
+import com.google.cloud.bigquery.storage.v1beta2.ArrowSerializationOptions;
+import com.google.cloud.bigquery.storage.v1beta2.AvroRows;
+import com.google.cloud.bigquery.storage.v1beta2.AvroSchema;
+import com.google.cloud.bigquery.storage.v1beta2.BatchCommitWriteStreamsRequest;
+import com.google.cloud.bigquery.storage.v1beta2.BatchCommitWriteStreamsResponse;
+import com.google.cloud.bigquery.storage.v1beta2.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1beta2.CreateWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1beta2.DataFormat;
+import com.google.cloud.bigquery.storage.v1beta2.FinalizeWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1beta2.FinalizeWriteStreamResponse;
+import com.google.cloud.bigquery.storage.v1beta2.FlushRowsRequest;
+import com.google.cloud.bigquery.storage.v1beta2.FlushRowsResponse;
+import com.google.cloud.bigquery.storage.v1beta2.GetWriteStreamRequest;
+import com.google.cloud.bigquery.storage.v1beta2.ProjectName;
+import com.google.cloud.bigquery.storage.v1beta2.ProtoRows;
+import com.google.cloud.bigquery.storage.v1beta2.ProtoSchema;
+import com.google.cloud.bigquery.storage.v1beta2.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1beta2.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1beta2.ReadSession;
+import com.google.cloud.bigquery.storage.v1beta2.ReadStream;
+import com.google.cloud.bigquery.storage.v1beta2.ReadStreamName;
+import com.google.cloud.bigquery.storage.v1beta2.SplitReadStreamRequest;
+import com.google.cloud.bigquery.storage.v1beta2.SplitReadStreamResponse;
+import com.google.cloud.bigquery.storage.v1beta2.StorageError;
+import com.google.cloud.bigquery.storage.v1beta2.StorageProto;
+import com.google.cloud.bigquery.storage.v1beta2.StreamStats;
+import com.google.cloud.bigquery.storage.v1beta2.TableFieldSchema;
+import com.google.cloud.bigquery.storage.v1beta2.TableName;
+import com.google.cloud.bigquery.storage.v1beta2.TableSchema;
+import com.google.cloud.bigquery.storage.v1beta2.ThrottleState;
+import com.google.cloud.bigquery.storage.v1beta2.WriteStream;
+import com.google.cloud.bigquery.storage.v1beta2.WriteStreamName;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import com.google.rpc.Status;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_bigquerystorage_v1beta2Test {
+public class Proto_google_cloud_bigquerystorage_v1beta2Test {
+    private static final String PROJECT = "sample-project";
+    private static final String DATASET = "analytics";
+    private static final String TABLE = "events";
+    private static final String LOCATION = "us";
+    private static final String SESSION = "session-1";
+    private static final String READ_STREAM = "stream-1";
+    private static final String WRITE_STREAM = "committed";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void resourceNamesFormatParseAndExposeFieldValues() {
+        ProjectName projectName = ProjectName.of(PROJECT);
+        assertEquals("projects/sample-project", projectName.toString());
+        assertEquals(PROJECT, ProjectName.parse(projectName.toString()).getProject());
+        assertEquals(Map.of("project", PROJECT), projectName.getFieldValuesMap());
+        assertEquals(PROJECT, projectName.getFieldValue("project"));
+        assertTrue(ProjectName.isParsableFrom(projectName.toString()));
+        assertFalse(ProjectName.isParsableFrom("organizations/sample-project"));
+
+        TableName tableName = TableName.of(PROJECT, DATASET, TABLE);
+        assertEquals("projects/sample-project/datasets/analytics/tables/events", tableName.toString());
+        TableName parsedTableName = TableName.parse(TableName.format(PROJECT, DATASET, TABLE));
+        assertEquals(PROJECT, parsedTableName.getProject());
+        assertEquals(DATASET, parsedTableName.getDataset());
+        assertEquals(TABLE, parsedTableName.getTable());
+        assertEquals("events", parsedTableName.getFieldValue("table"));
+        assertEquals(parsedTableName, parsedTableName.toBuilder().build());
+        assertNotEquals(parsedTableName, TableName.of(PROJECT, DATASET, "sessions"));
+
+        ReadStreamName readStreamName = ReadStreamName.of(PROJECT, LOCATION, SESSION, READ_STREAM);
+        assertEquals("projects/sample-project/locations/us/sessions/session-1/streams/stream-1",
+                readStreamName.toString());
+        assertEquals(readStreamName, ReadStreamName.parse(readStreamName.toString()));
+        assertEquals(READ_STREAM, readStreamName.getFieldValuesMap().get("stream"));
+
+        WriteStreamName writeStreamName = WriteStreamName.of(PROJECT, DATASET, TABLE, WRITE_STREAM);
+        assertEquals("projects/sample-project/datasets/analytics/tables/events/streams/committed",
+                writeStreamName.toString());
+        assertEquals(writeStreamName, WriteStreamName.parse(writeStreamName.toString()));
+        assertEquals(WRITE_STREAM, writeStreamName.getFieldValue("stream"));
+
+        List<TableName> names = List.of(tableName, TableName.of(PROJECT, DATASET, "users"));
+        List<String> formattedNames = TableName.toStringList(names);
+        assertIterableEquals(List.of(tableName.toString(), "projects/sample-project/datasets/analytics/tables/users"),
+                formattedNames);
+        assertIterableEquals(names, TableName.parseList(formattedNames));
+    }
+
+    @Test
+    void tableSchemaPreservesNestedFieldsThroughBinaryRoundTrip() throws Exception {
+        TableFieldSchema structField = TableFieldSchema.newBuilder()
+                .setName("payload")
+                .setType(TableFieldSchema.Type.STRUCT)
+                .setMode(TableFieldSchema.Mode.REPEATED)
+                .setDescription("event payload")
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("id")
+                        .setType(TableFieldSchema.Type.INT64)
+                        .setMode(TableFieldSchema.Mode.REQUIRED)
+                        .setDescription("primary key"))
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("properties")
+                        .setType(TableFieldSchema.Type.STRUCT)
+                        .addFields(TableFieldSchema.newBuilder()
+                                .setName("json_body")
+                                .setType(TableFieldSchema.Type.JSON)
+                                .setMode(TableFieldSchema.Mode.NULLABLE)))
+                .build();
+        TableSchema schema = TableSchema.newBuilder()
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("event_time")
+                        .setType(TableFieldSchema.Type.TIMESTAMP)
+                        .setMode(TableFieldSchema.Mode.NULLABLE))
+                .addFields(structField)
+                .build();
+
+        TableSchema parsed = TableSchema.parseFrom(schema.toByteArray());
+        assertEquals(schema, parsed);
+        assertEquals(2, parsed.getFieldsCount());
+        assertEquals(TableFieldSchema.Type.TIMESTAMP, parsed.getFields(0).getType());
+        assertEquals(TableFieldSchema.Mode.REPEATED, parsed.getFields(1).getMode());
+        assertEquals("properties", parsed.getFields(1).getFields(1).getName());
+        assertEquals(TableFieldSchema.Type.JSON, parsed.getFields(1).getFields(1).getFields(0).getType());
+        assertEquals("TableSchema", TableSchema.getDescriptor().getName());
+    }
+
+    @Test
+    void readSessionRequestCarriesSchemaReadOptionsAndStreamMetadata() throws Exception {
+        Timestamp snapshotTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).setNanos(123_000_000).build();
+        ArrowSerializationOptions arrowOptions = ArrowSerializationOptions.newBuilder()
+                .setFormat(ArrowSerializationOptions.Format.ARROW_0_15)
+                .build();
+        ReadSession.TableReadOptions readOptions = ReadSession.TableReadOptions.newBuilder()
+                .addSelectedFields("user_id")
+                .addSelectedFields("event_time")
+                .setRowRestriction("event_date >= '2024-01-01'")
+                .setArrowSerializationOptions(arrowOptions)
+                .build();
+        ReadSession readSession = ReadSession.newBuilder()
+                .setName("projects/sample-project/locations/us/sessions/session-1")
+                .setExpireTime(Timestamp.newBuilder().setSeconds(1_700_003_600L))
+                .setDataFormat(DataFormat.ARROW)
+                .setArrowSchema(ArrowSchema.newBuilder().setSerializedSchema(ByteString.copyFromUtf8("arrow-schema")))
+                .setTable(TableName.format(PROJECT, DATASET, TABLE))
+                .setTableModifiers(ReadSession.TableModifiers.newBuilder().setSnapshotTime(snapshotTime))
+                .setReadOptions(readOptions)
+                .addStreams(ReadStream.newBuilder()
+                        .setName(ReadStreamName.format(PROJECT, LOCATION, SESSION, READ_STREAM)))
+                .build();
+        CreateReadSessionRequest request = CreateReadSessionRequest.newBuilder()
+                .setParent(ProjectName.format(PROJECT))
+                .setReadSession(readSession)
+                .setMaxStreamCount(3)
+                .build();
+
+        CreateReadSessionRequest parsed = CreateReadSessionRequest.parseFrom(
+                new ByteArrayInputStream(request.toByteArray()));
+        assertEquals(ProjectName.format(PROJECT), parsed.getParent());
+        assertEquals(3, parsed.getMaxStreamCount());
+        assertEquals(DataFormat.ARROW, parsed.getReadSession().getDataFormat());
+        assertEquals(ReadSession.SchemaCase.ARROW_SCHEMA, parsed.getReadSession().getSchemaCase());
+        assertEquals("event_time", parsed.getReadSession().getReadOptions().getSelectedFields(1));
+        assertTrue(parsed.getReadSession().getReadOptions().hasArrowSerializationOptions());
+        assertEquals(ArrowSerializationOptions.Format.ARROW_0_15,
+                parsed.getReadSession().getReadOptions().getArrowSerializationOptions().getFormat());
+        assertEquals(snapshotTime, parsed.getReadSession().getTableModifiers().getSnapshotTime());
+        assertEquals(READ_STREAM, ReadStreamName.parse(parsed.getReadSession().getStreams(0).getName()).getStream());
+    }
+
+    @Test
+    void storageProtoDescriptorExposesServicesStreamingAndHttpBindings() {
+        FileDescriptor descriptor = StorageProto.getDescriptor();
+        ServiceDescriptor readService = descriptor.findServiceByName("BigQueryRead");
+        ServiceDescriptor writeService = descriptor.findServiceByName("BigQueryWrite");
+        assertNotNull(readService);
+        assertNotNull(writeService);
+        assertEquals("bigquerystorage.googleapis.com", readService.getOptions().getExtension(ClientProto.defaultHost));
+        assertEquals("https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/cloud-platform",
+                readService.getOptions().getExtension(ClientProto.oauthScopes));
+        assertEquals("bigquerystorage.googleapis.com", writeService.getOptions().getExtension(ClientProto.defaultHost));
+        assertTrue(writeService.getOptions().getExtension(ClientProto.oauthScopes).contains(
+                "https://www.googleapis.com/auth/bigquery.insertdata"));
+
+        MethodDescriptor createReadSession = readService.findMethodByName("CreateReadSession");
+        assertNotNull(createReadSession);
+        assertEquals(CreateReadSessionRequest.getDescriptor(), createReadSession.getInputType());
+        assertEquals(ReadSession.getDescriptor(), createReadSession.getOutputType());
+        assertFalse(createReadSession.isClientStreaming());
+        assertFalse(createReadSession.isServerStreaming());
+        assertTrue(createReadSession.getOptions().hasExtension(com.google.api.AnnotationsProto.http));
+        HttpRule createReadSessionHttp = createReadSession.getOptions()
+                .getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.POST, createReadSessionHttp.getPatternCase());
+        assertEquals("/v1beta2/{read_session.table=projects/*/datasets/*/tables/*}", createReadSessionHttp.getPost());
+        assertEquals("*", createReadSessionHttp.getBody());
+
+        MethodDescriptor readRows = readService.findMethodByName("ReadRows");
+        assertNotNull(readRows);
+        assertEquals(ReadRowsRequest.getDescriptor(), readRows.getInputType());
+        assertEquals(ReadRowsResponse.getDescriptor(), readRows.getOutputType());
+        assertFalse(readRows.isClientStreaming());
+        assertTrue(readRows.isServerStreaming());
+        HttpRule readRowsHttp = readRows.getOptions().getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.GET, readRowsHttp.getPatternCase());
+        assertEquals("/v1beta2/{read_stream=projects/*/locations/*/sessions/*/streams/*}", readRowsHttp.getGet());
+
+        MethodDescriptor appendRows = writeService.findMethodByName("AppendRows");
+        assertNotNull(appendRows);
+        assertEquals(AppendRowsRequest.getDescriptor(), appendRows.getInputType());
+        assertEquals(AppendRowsResponse.getDescriptor(), appendRows.getOutputType());
+        assertTrue(appendRows.isClientStreaming());
+        assertTrue(appendRows.isServerStreaming());
+        HttpRule appendRowsHttp = appendRows.getOptions().getExtension(com.google.api.AnnotationsProto.http);
+        assertEquals(HttpRule.PatternCase.POST, appendRowsHttp.getPatternCase());
+        assertEquals("/v1beta2/{write_stream=projects/*/datasets/*/tables/*/streams/*}", appendRowsHttp.getPost());
+        assertEquals("*", appendRowsHttp.getBody());
+    }
+
+    @Test
+    void protoSchemaAndAppendRowsRequestPreserveProtoPayloads() throws Exception {
+        DescriptorProtos.DescriptorProto rowDescriptor = DescriptorProtos.DescriptorProto.newBuilder()
+                .setName("EventRow")
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("user_id")
+                        .setNumber(1)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64))
+                .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                        .setName("event_name")
+                        .setNumber(2)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+        ProtoRows rows = ProtoRows.newBuilder()
+                .addSerializedRows(ByteString.copyFrom(new byte[] {8, 7, 18, 5, 108, 111, 103, 105, 110}))
+                .addSerializedRows(ByteString.copyFrom(new byte[] {8, 9, 18, 4, 118, 105, 101, 119}))
+                .build();
+        AppendRowsRequest request = AppendRowsRequest.newBuilder()
+                .setWriteStream(WriteStreamName.format(PROJECT, DATASET, TABLE, WRITE_STREAM))
+                .setOffset(Int64Value.of(42L))
+                .setProtoRows(AppendRowsRequest.ProtoData.newBuilder()
+                        .setWriterSchema(ProtoSchema.newBuilder().setProtoDescriptor(rowDescriptor))
+                        .setRows(rows))
+                .setTraceId("trace-append")
+                .build();
+
+        AppendRowsRequest parsed = AppendRowsRequest.parseFrom(request.toByteString());
+        assertEquals(AppendRowsRequest.RowsCase.PROTO_ROWS, parsed.getRowsCase());
+        assertEquals(42L, parsed.getOffset().getValue());
+        assertEquals("trace-append", parsed.getTraceId());
+        assertEquals("EventRow", parsed.getProtoRows().getWriterSchema().getProtoDescriptor().getName());
+        assertEquals("event_name", parsed.getProtoRows().getWriterSchema().getProtoDescriptor().getField(1).getName());
+        assertEquals(2, parsed.getProtoRows().getRows().getSerializedRowsCount());
+        assertEquals(ByteString.copyFrom(new byte[] {8, 9, 18, 4, 118, 105, 101, 119}),
+                parsed.getProtoRows().getRows().getSerializedRows(1));
+    }
+
+    @Test
+    void appendRowsResponsesRepresentSuccessErrorsAndUpdatedSchemas() throws Exception {
+        TableSchema updatedSchema = TableSchema.newBuilder()
+                .addFields(TableFieldSchema.newBuilder().setName("user_id").setType(TableFieldSchema.Type.INT64))
+                .build();
+        AppendRowsResponse success = AppendRowsResponse.newBuilder()
+                .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().setOffset(Int64Value.of(42L)))
+                .setUpdatedSchema(updatedSchema)
+                .build();
+
+        AppendRowsResponse parsedSuccess = AppendRowsResponse.parseFrom(success.toByteArray());
+        assertEquals(AppendRowsResponse.ResponseCase.APPEND_RESULT, parsedSuccess.getResponseCase());
+        assertEquals(42L, parsedSuccess.getAppendResult().getOffset().getValue());
+        assertTrue(parsedSuccess.hasUpdatedSchema());
+        assertEquals("user_id", parsedSuccess.getUpdatedSchema().getFields(0).getName());
+
+        AppendRowsResponse error = parsedSuccess.toBuilder()
+                .setError(Status.newBuilder().setCode(3).setMessage("invalid argument"))
+                .build();
+        assertEquals(AppendRowsResponse.ResponseCase.ERROR, error.getResponseCase());
+        assertFalse(error.hasAppendResult());
+        assertEquals("invalid argument", error.getError().getMessage());
+        assertTrue(error.hasUpdatedSchema());
+    }
+
+    @Test
+    void readRowsRequestResponseAndSplitOperationsUseStreamPayloads() throws Exception {
+        ReadRowsRequest request = ReadRowsRequest.newBuilder()
+                .setReadStream(ReadStreamName.format(PROJECT, LOCATION, SESSION, READ_STREAM))
+                .setOffset(10L)
+                .build();
+        assertEquals(request, ReadRowsRequest.parseFrom(request.toByteArray()));
+
+        StreamStats stats = StreamStats.newBuilder()
+                .setProgress(StreamStats.Progress.newBuilder().setAtResponseStart(0.25D).setAtResponseEnd(0.5D))
+                .build();
+        ReadRowsResponse avroResponse = ReadRowsResponse.newBuilder()
+                .setAvroRows(AvroRows.newBuilder().setSerializedBinaryRows(ByteString.copyFromUtf8("avro")))
+                .setRowCount(2L)
+                .setStats(stats)
+                .setThrottleState(ThrottleState.newBuilder().setThrottlePercent(15))
+                .setAvroSchema(AvroSchema.newBuilder().setSchema("{\"type\":\"record\",\"name\":\"Row\"}"))
+                .build();
+
+        ReadRowsResponse parsedAvro = ReadRowsResponse.parseFrom(avroResponse.toByteString());
+        assertEquals(ReadRowsResponse.RowsCase.AVRO_ROWS, parsedAvro.getRowsCase());
+        assertEquals(ReadRowsResponse.SchemaCase.AVRO_SCHEMA, parsedAvro.getSchemaCase());
+        assertEquals(2L, parsedAvro.getRowCount());
+        assertEquals(ByteString.copyFromUtf8("avro"), parsedAvro.getAvroRows().getSerializedBinaryRows());
+        assertEquals(0.5D, parsedAvro.getStats().getProgress().getAtResponseEnd(), 0.0001D);
+        assertEquals(15, parsedAvro.getThrottleState().getThrottlePercent());
+
+        ReadRowsResponse arrowResponse = parsedAvro.toBuilder()
+                .setArrowRecordBatch(ArrowRecordBatch.newBuilder()
+                        .setSerializedRecordBatch(ByteString.copyFromUtf8("arrow")))
+                .setArrowSchema(ArrowSchema.newBuilder().setSerializedSchema(ByteString.copyFromUtf8("arrow-schema")))
+                .setRowCount(4L)
+                .build();
+        assertEquals(ReadRowsResponse.RowsCase.ARROW_RECORD_BATCH, arrowResponse.getRowsCase());
+        assertEquals(ReadRowsResponse.SchemaCase.ARROW_SCHEMA, arrowResponse.getSchemaCase());
+        assertEquals(4L, arrowResponse.getRowCount());
+        assertEquals(ByteString.copyFromUtf8("arrow"), arrowResponse.getArrowRecordBatch().getSerializedRecordBatch());
+
+        SplitReadStreamRequest splitRequest = SplitReadStreamRequest.newBuilder()
+                .setName(request.getReadStream())
+                .setFraction(0.33D)
+                .build();
+        SplitReadStreamResponse splitResponse = SplitReadStreamResponse.newBuilder()
+                .setPrimaryStream(ReadStream.newBuilder().setName(request.getReadStream()))
+                .setRemainderStream(ReadStream.newBuilder()
+                        .setName(ReadStreamName.format(PROJECT, LOCATION, SESSION, "stream-2")))
+                .build();
+        assertEquals(0.33D, SplitReadStreamRequest.parseFrom(splitRequest.toByteArray()).getFraction(), 0.0001D);
+        assertEquals("stream-2", ReadStreamName.parse(splitResponse.getRemainderStream().getName()).getStream());
+    }
+
+    @Test
+    void writeStreamLifecycleMessagesRoundTrip() throws Exception {
+        TableSchema tableSchema = TableSchema.newBuilder()
+                .addFields(TableFieldSchema.newBuilder()
+                        .setName("event_name")
+                        .setType(TableFieldSchema.Type.STRING)
+                        .setMode(TableFieldSchema.Mode.NULLABLE))
+                .build();
+        Timestamp createTime = Timestamp.newBuilder().setSeconds(1_700_000_001L).build();
+        Timestamp commitTime = Timestamp.newBuilder().setSeconds(1_700_000_120L).build();
+        WriteStream writeStream = WriteStream.newBuilder()
+                .setName(WriteStreamName.format(PROJECT, DATASET, TABLE, WRITE_STREAM))
+                .setType(WriteStream.Type.COMMITTED)
+                .setCreateTime(createTime)
+                .setCommitTime(commitTime)
+                .setTableSchema(tableSchema)
+                .build();
+
+        CreateWriteStreamRequest createRequest = CreateWriteStreamRequest.newBuilder()
+                .setParent(TableName.format(PROJECT, DATASET, TABLE))
+                .setWriteStream(writeStream)
+                .build();
+        GetWriteStreamRequest getRequest = GetWriteStreamRequest.newBuilder()
+                .setName(writeStream.getName())
+                .build();
+        FinalizeWriteStreamRequest finalizeRequest = FinalizeWriteStreamRequest.newBuilder()
+                .setName(writeStream.getName())
+                .build();
+        FinalizeWriteStreamResponse finalizeResponse = FinalizeWriteStreamResponse.newBuilder()
+                .setRowCount(5L)
+                .build();
+        FlushRowsRequest flushRequest = FlushRowsRequest.newBuilder()
+                .setWriteStream(writeStream.getName())
+                .setOffset(Int64Value.of(5L))
+                .build();
+        FlushRowsResponse flushResponse = FlushRowsResponse.newBuilder()
+                .setOffset(5L)
+                .build();
+        BatchCommitWriteStreamsRequest commitRequest = BatchCommitWriteStreamsRequest.newBuilder()
+                .setParent(TableName.format(PROJECT, DATASET, TABLE))
+                .addWriteStreams(writeStream.getName())
+                .build();
+        BatchCommitWriteStreamsResponse commitResponse = BatchCommitWriteStreamsResponse.newBuilder()
+                .setCommitTime(commitTime)
+                .addStreamErrors(StorageError.newBuilder()
+                        .setCode(StorageError.StorageErrorCode.STREAM_ALREADY_COMMITTED)
+                        .setEntity(writeStream.getName())
+                        .setErrorMessage("already committed"))
+                .build();
+
+        assertEquals(writeStream, WriteStream.parseFrom(writeStream.toByteArray()));
+        assertEquals(WriteStream.Type.COMMITTED, createRequest.getWriteStream().getType());
+        assertEquals(writeStream.getName(), GetWriteStreamRequest.parseFrom(getRequest.toByteArray()).getName());
+        assertEquals(writeStream.getName(),
+                FinalizeWriteStreamRequest.parseFrom(finalizeRequest.toByteArray()).getName());
+        assertEquals(5L, FinalizeWriteStreamResponse.parseFrom(finalizeResponse.toByteArray()).getRowCount());
+        assertEquals(5L, FlushRowsRequest.parseFrom(flushRequest.toByteArray()).getOffset().getValue());
+        assertEquals(5L, FlushRowsResponse.parseFrom(flushResponse.toByteArray()).getOffset());
+        assertEquals(writeStream.getName(),
+                BatchCommitWriteStreamsRequest.parseFrom(commitRequest.toByteArray()).getWriteStreams(0));
+        assertEquals(StorageError.StorageErrorCode.STREAM_ALREADY_COMMITTED,
+                BatchCommitWriteStreamsResponse.parseFrom(commitResponse.toByteArray()).getStreamErrors(0).getCode());
+        assertEquals(commitTime, commitResponse.getCommitTime());
+    }
+
+    @Test
+    void serializationOptionsEnumsAndParsersExposeExpectedValues() throws Exception {
+        ArrowSerializationOptions arrowOptions = ArrowSerializationOptions.newBuilder()
+                .setFormat(ArrowSerializationOptions.Format.ARROW_0_14)
+                .build();
+        assertEquals(ArrowSerializationOptions.Format.ARROW_0_14,
+                ArrowSerializationOptions.parseFrom(arrowOptions.toByteArray()).getFormat());
+        assertSame(DataFormat.ARROW, DataFormat.forNumber(DataFormat.ARROW_VALUE));
+        assertSame(TableFieldSchema.Type.JSON,
+                TableFieldSchema.Type.valueOf(TableFieldSchema.Type.JSON.getValueDescriptor()));
+        assertSame(ArrowSerializationOptions.Format.ARROW_0_15,
+                ArrowSerializationOptions.Format.forNumber(ArrowSerializationOptions.Format.ARROW_0_15_VALUE));
+        assertSame(StorageError.StorageErrorCode.STREAM_FINALIZED,
+                StorageError.StorageErrorCode.internalGetValueMap().findValueByNumber(
+                        StorageError.StorageErrorCode.STREAM_FINALIZED_VALUE));
+
+        assertThrows(InvalidProtocolBufferException.class,
+                () -> ReadSession.parser().parseFrom(ByteString.copyFrom(new byte[] {-1, 0, 1})));
+        assertEquals(ReadSession.getDefaultInstance(), ReadSession.parseFrom(ByteString.EMPTY));
+        assertEquals("ReadSession", ReadSession.getDefaultInstance().getDescriptorForType().getName());
     }
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta2/Proto_google_cloud_bigquerystorage_v1beta2Test.java
@@ -16,7 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.ClientProto;
+import com.google.api.FieldBehavior;
+import com.google.api.FieldBehaviorProto;
 import com.google.api.HttpRule;
+import com.google.api.ResourceDescriptor;
+import com.google.api.ResourceProto;
+import com.google.api.ResourceReference;
 import com.google.cloud.bigquery.storage.v1beta2.AppendRowsRequest;
 import com.google.cloud.bigquery.storage.v1beta2.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1beta2.ArrowRecordBatch;
@@ -46,6 +51,7 @@ import com.google.cloud.bigquery.storage.v1beta2.SplitReadStreamRequest;
 import com.google.cloud.bigquery.storage.v1beta2.SplitReadStreamResponse;
 import com.google.cloud.bigquery.storage.v1beta2.StorageError;
 import com.google.cloud.bigquery.storage.v1beta2.StorageProto;
+import com.google.cloud.bigquery.storage.v1beta2.StreamProto;
 import com.google.cloud.bigquery.storage.v1beta2.StreamStats;
 import com.google.cloud.bigquery.storage.v1beta2.TableFieldSchema;
 import com.google.cloud.bigquery.storage.v1beta2.TableName;
@@ -55,6 +61,8 @@ import com.google.cloud.bigquery.storage.v1beta2.WriteStream;
 import com.google.cloud.bigquery.storage.v1beta2.WriteStreamName;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
@@ -273,6 +281,52 @@ public class Proto_google_cloud_bigquerystorage_v1beta2Test {
         assertEquals(HttpRule.PatternCase.POST, appendRowsHttp.getPatternCase());
         assertEquals("/v1beta2/{write_stream=projects/*/datasets/*/tables/*/streams/*}", appendRowsHttp.getPost());
         assertEquals("*", appendRowsHttp.getBody());
+    }
+
+    @Test
+    void descriptorsExposeResourceReferencesFieldBehaviorsAndResourcePatterns() {
+        FileDescriptor streamDescriptor = StreamProto.getDescriptor();
+        List<ResourceDescriptor> resourceDefinitions = streamDescriptor.getOptions()
+                .getExtension(ResourceProto.resourceDefinition);
+        assertEquals(1, resourceDefinitions.size());
+        assertEquals("bigquery.googleapis.com/Table", resourceDefinitions.get(0).getType());
+        assertIterableEquals(List.of("projects/{project}/datasets/{dataset}/tables/{table}"),
+                resourceDefinitions.get(0).getPatternList());
+
+        ResourceDescriptor readSessionResource = ReadSession.getDescriptor().getOptions()
+                .getExtension(ResourceProto.resource);
+        assertEquals("bigquerystorage.googleapis.com/ReadSession", readSessionResource.getType());
+        assertIterableEquals(List.of("projects/{project}/locations/{location}/sessions/{session}"),
+                readSessionResource.getPatternList());
+
+        ResourceDescriptor readStreamResource = ReadStream.getDescriptor().getOptions()
+                .getExtension(ResourceProto.resource);
+        assertEquals("bigquerystorage.googleapis.com/ReadStream", readStreamResource.getType());
+        assertIterableEquals(List.of("projects/{project}/locations/{location}/sessions/{session}/streams/{stream}"),
+                readStreamResource.getPatternList());
+
+        ResourceDescriptor writeStreamResource = WriteStream.getDescriptor().getOptions()
+                .getExtension(ResourceProto.resource);
+        assertEquals("bigquerystorage.googleapis.com/WriteStream", writeStreamResource.getType());
+        assertIterableEquals(List.of("projects/{project}/datasets/{dataset}/tables/{table}/streams/{stream}"),
+                writeStreamResource.getPatternList());
+
+        Descriptor createReadSessionRequest = CreateReadSessionRequest.getDescriptor();
+        FieldDescriptor parentField = createReadSessionRequest.findFieldByName("parent");
+        assertIterableEquals(List.of(FieldBehavior.REQUIRED), parentField.getOptions()
+                .getExtension(FieldBehaviorProto.fieldBehavior));
+        ResourceReference parentReference = parentField.getOptions().getExtension(ResourceProto.resourceReference);
+        assertEquals("cloudresourcemanager.googleapis.com/Project", parentReference.getType());
+
+        FieldDescriptor readSessionField = createReadSessionRequest.findFieldByName("read_session");
+        assertIterableEquals(List.of(FieldBehavior.REQUIRED), readSessionField.getOptions()
+                .getExtension(FieldBehaviorProto.fieldBehavior));
+
+        FieldDescriptor tableField = ReadSession.getDescriptor().findFieldByName("table");
+        assertIterableEquals(List.of(FieldBehavior.IMMUTABLE), tableField.getOptions()
+                .getExtension(FieldBehaviorProto.fieldBehavior));
+        assertEquals("bigquery.googleapis.com/Table", tableField.getOptions()
+                .getExtension(ResourceProto.resourceReference).getType());
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.bigquery.storage.v1beta2.**"
+    }
+  ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta2/0.186.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.bigquery.storage.v1beta2.**"
+      "includeClasses" : "com.google.cloud.bigquery.storage.v1beta2.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta2.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4719

This PR introduces tests and metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2:0.186.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 200751
- Cached input tokens: 1745920
- Output tokens: 21192
- Metadata entries: 120
- Iterations: 3
- Library coverage percentage: 38.8
- Generated lines of code: 491
- Tested library lines of code: 4217

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `51d785b38deb78144c77966290fd6f46f1d67a05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 15203/40172 (37.84%)
- Line: 4217/10869 (38.80%)
- Method: 1009/2981 (33.85%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
