### PR TITLE
[GenAI] Add support for software.amazon.awssdk:retries:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T09:34:00.998970Z",
+    "timestamp": "2026-05-04T11:34:09.949148Z",
     "library": "software.amazon.awssdk:retries:2.34.0",
-    "starting_commit": "652e891d25dfd099c72bc3daf405d977c86e5303",
-    "ending_commit": "dc48289f8f95be2157e05357f85a67b33b320b29",
+    "starting_commit": "d21334aa146de20e69d36ea11c3cd729991a7715",
+    "ending_commit": "ea768223cdad88ac4fe12cda7e432400dfd83f03",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 2165,
-          "missed": 473,
-          "ratio": 0.820697,
+          "covered": 2174,
+          "missed": 464,
+          "ratio": 0.824109,
           "total": 2638
         },
         "line": {
-          "covered": 592,
-          "missed": 105,
-          "ratio": 0.849354,
+          "covered": 596,
+          "missed": 101,
+          "ratio": 0.855093,
           "total": 697
         },
         "method": {
-          "covered": 183,
-          "missed": 44,
-          "ratio": 0.806167,
+          "covered": 186,
+          "missed": 41,
+          "ratio": 0.819383,
           "total": 227
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 185112,
-      "cached_input_tokens_used": 2310144,
-      "output_tokens_used": 21477,
+      "input_tokens_used": 146922,
+      "cached_input_tokens_used": 1445376,
+      "output_tokens_used": 15078,
       "iterations": 3,
-      "cost_usd": 1.7994,
-      "generated_loc": 338,
-      "tested_library_loc": 592,
+      "cost_usd": 1.175,
+      "generated_loc": 456,
+      "tested_library_loc": 596,
       "metadata_entries": 0,
-      "code_coverage_percent": 84.94
+      "code_coverage_percent": 85.51
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java",

--- a/stats/software.amazon.awssdk/retries/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/retries/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 2165,
-        "missed" : 473,
-        "ratio" : 0.820697,
+        "covered" : 2174,
+        "missed" : 464,
+        "ratio" : 0.824109,
         "total" : 2638
       },
       "line" : {
-        "covered" : 592,
-        "missed" : 105,
-        "ratio" : 0.849354,
+        "covered" : 596,
+        "missed" : 101,
+        "ratio" : 0.855093,
         "total" : 697
       },
       "method" : {
-        "covered" : 183,
-        "missed" : 44,
-        "ratio" : 0.806167,
+        "covered" : 186,
+        "missed" : 41,
+        "ratio" : 0.819383,
         "total" : 227
       }
     }

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -258,6 +258,22 @@ public class RetriesTest {
     }
 
     @Test
+    void customRetryPredicatesCanUseFailureStateAndAreAdditive() {
+        RetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnException(failure -> failure instanceof IllegalStateException
+                && failure.getMessage().contains("transient"))
+            .retryOnException(failure -> failure instanceof UnsupportedOperationException)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .circuitBreakerEnabled(false)
+            .build();
+
+        assertRefreshSucceeds(strategy, new IllegalStateException("transient connection reset"));
+        assertRefreshSucceeds(strategy, new UnsupportedOperationException("retryable by second predicate"));
+        assertRefreshFails(strategy, new IllegalStateException("permanent validation failure"));
+    }
+
+    @Test
     void requestFactoriesAndCopyBuilderPreserveValues() {
         RetryToken token = StandardRetryStrategy.builder()
             .maxAttempts(2)

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -57,6 +57,25 @@ public class RetriesTest {
     }
 
     @Test
+    void standardStrategyUsesThrottlingBackoffForFailuresMarkedAsThrottling() {
+        StandardRetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(3)))
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(29)))
+            .circuitBreakerEnabled(false)
+            .build();
+
+        RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("standard-throttled"))
+            .token();
+        RefreshRetryTokenResponse retry = strategy.refreshRetryToken(
+            refreshRequest(token, new ThrottlingFailure()).build());
+
+        assertThat(retry.delay()).isEqualTo(Duration.ofMillis(29));
+    }
+
+    @Test
     void suggestedDelayOverridesComputedBackoffWhenItIsLonger() {
         RetryStrategy strategy = DefaultRetryStrategy.standardStrategyBuilder()
             .maxAttempts(2)

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -356,6 +356,108 @@ public class RetriesTest {
             .hasMessageContaining("RetryToken is of unexpected class");
     }
 
+    @Test
+    void responseFactoriesReturnProvidedTokensAndDelays() {
+        RetryToken token = new ForeignRetryToken();
+
+        AcquireInitialTokenResponse initialResponse = AcquireInitialTokenResponse.create(token, Duration.ofMillis(1));
+        RefreshRetryTokenResponse retryResponse = RefreshRetryTokenResponse.create(token, Duration.ofMillis(2));
+        RecordSuccessResponse successResponse = RecordSuccessResponse.create(token);
+
+        assertThat(initialResponse.token()).isSameAs(token);
+        assertThat(initialResponse.delay()).isEqualTo(Duration.ofMillis(1));
+        assertThat(retryResponse.token()).isSameAs(token);
+        assertThat(retryResponse.delay()).isEqualTo(Duration.ofMillis(2));
+        assertThat(successResponse.token()).isSameAs(token);
+    }
+
+    @Test
+    void tokenAcquisitionFailureConstructorsExposeMessageCauseAndOptionalToken() {
+        RetryToken token = new ForeignRetryToken();
+        RuntimeException cause = new RuntimeException("cause");
+
+        TokenAcquisitionFailedException messageOnly = new TokenAcquisitionFailedException("message only");
+        TokenAcquisitionFailedException messageAndCause = new TokenAcquisitionFailedException(
+            "message and cause", cause);
+        TokenAcquisitionFailedException messageTokenAndCause = new TokenAcquisitionFailedException(
+            "message token and cause", token, cause);
+
+        assertThat(messageOnly).hasMessage("message only").hasNoCause();
+        assertThat(messageOnly.token()).isNull();
+        assertThat(messageAndCause).hasMessage("message and cause").hasCause(cause);
+        assertThat(messageAndCause.token()).isNull();
+        assertThat(messageTokenAndCause).hasMessage("message token and cause").hasCause(cause);
+        assertThat(messageTokenAndCause.token()).isSameAs(token);
+    }
+
+    @Test
+    void retryPredicateInstanceConvenienceMethodsAcceptSubclassesInExceptionChain() {
+        assertRefreshSucceeds(StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(ExactFailure.class)
+            .circuitBreakerEnabled(false)
+            .build(), new ExactFailureSubclass());
+
+        assertRefreshSucceeds(StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionOrCauseInstanceOf(ExactFailure.class)
+            .circuitBreakerEnabled(false)
+            .build(), new RuntimeException(new ExactFailureSubclass()));
+
+        assertRefreshFails(StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnRootCause(ExactFailure.class)
+            .circuitBreakerEnabled(false)
+            .build(), new RuntimeException(new ExactFailureSubclass()));
+    }
+
+    @Test
+    void defaultBuildersCreateUsableLegacyAndAdaptiveStrategies() {
+        LegacyRetryStrategy legacy = DefaultRetryStrategy.legacyStrategyBuilder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(5)))
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(11)))
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+        AdaptiveRetryStrategy adaptive = DefaultRetryStrategy.adaptiveStrategyBuilder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .throttlingBackoffStrategy(BackoffStrategy.retryImmediately())
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .useClientDefaults(false)
+            .build();
+
+        assertThat(legacy.maxAttempts()).isEqualTo(2);
+        assertThat(legacy.refreshRetryToken(refreshRequest(
+            legacy.acquireInitialToken(AcquireInitialTokenRequest.create("default-legacy")).token(),
+            new ThrottlingFailure()).build()).delay()).isEqualTo(Duration.ofMillis(11));
+        assertThat(adaptive.maxAttempts()).isEqualTo(2);
+        assertThat(adaptive.useClientDefaults()).isFalse();
+        assertThat(adaptive.refreshRetryToken(refreshRequest(
+            adaptive.acquireInitialToken(AcquireInitialTokenRequest.create("default-adaptive")).token(),
+            new RuntimeException("retryable")).build()).token()).isNotNull();
+    }
+
+    @Test
+    void recordingSuccessAfterInitialAttemptReturnsANewToken() {
+        StandardRetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .circuitBreakerEnabled(false)
+            .build();
+        RetryToken initialToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("initial-success"))
+            .token();
+
+        RetryToken successToken = strategy.recordSuccess(RecordSuccessRequest.create(initialToken)).token();
+
+        assertThat(successToken).isNotNull();
+        assertThat(successToken).isNotSameAs(initialToken);
+    }
+
     private static RefreshRetryTokenRequest.Builder refreshRequest(RetryToken token, Throwable failure) {
         return RefreshRetryTokenRequest.builder()
             .token(token)


### PR DESCRIPTION

## What does this PR do?

Fixes: #4539

This PR introduces tests and metadata for software.amazon.awssdk:retries:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 146922
- Cached input tokens: 1445376
- Output tokens: 15078
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 85.51
- Generated lines of code: 456
- Tested library lines of code: 596

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d21334aa146de20e69d36ea11c3cd729991a7715`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2174/2638 (82.41%)
- Line: 596/697 (85.51%)
- Method: 186/227 (81.94%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
