### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.paranamer.shaded.AdaptiveParanamer"
+      },
+      "type" : "com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.paranamer.shaded.AdaptiveParanamer"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    }
+  ]
+}

--- a/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "2.19.0"
     ],
+    "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/$version$/jackson-module-paranamer-$version$-sources.jar",
+    "repository-url" : "https://github.com/FasterXML/jackson-modules-base",
+    "test-code-url" : "https://github.com/FasterXML/jackson-modules-base/tree/jackson-modules-base-$version$/paranamer/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/$version$/jackson-module-paranamer-$version$-javadoc.jar",
+    "description" : "Jackson Module Paranamer adds annotation introspection support that lets Jackson discover constructor and factory method parameter names through the Paranamer library. It helps Jackson databind deserialize types whose creators rely on parameter names when explicit Jackson annotations are not present.",
     "allowed-packages" : [
       "com.fasterxml.jackson.module.paranamer"
     ]

--- a/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-paranamer/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.19.0",
+    "tested-versions" : [
+      "2.19.0"
+    ],
+    "allowed-packages" : [
+      "com.fasterxml.jackson.module.paranamer"
+    ]
+  },
+  {
     "metadata-version" : "2.11.4",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-paranamer/$version$/jackson-module-paranamer-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-modules-base",

--- a/stats/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-05-04": {
+    "timestamp": "2026-05-04T11:36:01.508818Z",
+    "library": "com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0",
+    "starting_commit": "55f69c79175c935d0d3af8eac274cf4f235efa9e",
+    "ending_commit": "89a5b5f38547c4d07807b088c6e54a73199dc4c3",
+    "previous_library": "com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1415,
+          "missed": 1459,
+          "ratio": 0.492345,
+          "total": 2874
+        },
+        "line": {
+          "covered": 331,
+          "missed": 359,
+          "ratio": 0.47971,
+          "total": 690
+        },
+        "method": {
+          "covered": 45,
+          "missed": 71,
+          "ratio": 0.387931,
+          "total": 116
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.11.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1318,
+          "missed": 1541,
+          "ratio": 0.461,
+          "total": 2859
+        },
+        "line": {
+          "covered": 320,
+          "missed": 386,
+          "ratio": 0.453258,
+          "total": 706
+        },
+        "method": {
+          "covered": 38,
+          "missed": 75,
+          "ratio": 0.336283,
+          "total": 113
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 80494,
+      "cached_input_tokens_used": 928768,
+      "output_tokens_used": 11703,
+      "iterations": 3,
+      "cost_usd": 0.8155,
+      "tested_library_loc": 331,
+      "metadata_entries": 3,
+      "test_only_metadata_entries": 13,
+      "previous_library_metadata_entries": 0,
+      "previous_library_test_only_metadata_entries": 10,
+      "code_coverage_percent": 47.97,
+      "previous_library_coverage_percent": 45.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/stats.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.19.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1415,
+        "missed" : 1459,
+        "ratio" : 0.492345,
+        "total" : 2874
+      },
+      "line" : {
+        "covered" : 331,
+        "missed" : 359,
+        "ratio" : 0.47971,
+        "total" : 690
+      },
+      "method" : {
+        "covered" : 45,
+        "missed" : 71,
+        "ratio" : 0.387931,
+        "total" : 116
+      }
+    }
+  } ]
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/.gitignore
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.fasterxml.jackson.module:jackson-module-paranamer:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/gradle.properties
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0
+library.version = 2.19.0
+metadata.dir = com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/settings.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.fasterxml.jackson.module.jackson-module-paranamer_tests'

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/AdaptiveParanamerTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/AdaptiveParanamerTest.java
@@ -8,18 +8,18 @@ package com_fasterxml_jackson_module.jackson_module_paranamer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer;
+import com.fasterxml.jackson.module.paranamer.shaded.AdaptiveParanamer;
 import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.Test;
 
-public class DefaultParanamerTest {
+public class AdaptiveParanamerTest {
     @Test
-    void readsParameterNamesFromReflectionMetadata() throws Exception {
-        DefaultParanamer paranamer = new DefaultParanamer();
+    void defaultConstructorIncludesReflectionBasedParameterNameLookup() throws Exception {
+        AdaptiveParanamer paranamer = new AdaptiveParanamer();
         Constructor<ConstructorParameterFixture> constructor = ConstructorParameterFixture.class.getDeclaredConstructor(
                 String.class, int.class);
 
-        String[] parameterNames = paranamer.lookupParameterNames(constructor);
+        String[] parameterNames = paranamer.lookupParameterNames(constructor, false);
 
         assertThat(parameterNames).containsExactly("text", "repeatCount");
     }

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.module.paranamer.shaded.BytecodeReadingParanamer;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class BytecodeReadingParanamerTest {
+    @Test
+    void readsParameterNamesFromAvailableClassResource() throws Exception {
+        BytecodeReadingParanamer paranamer = new BytecodeReadingParanamer();
+        Method method = ParameterNameFixture.class.getDeclaredMethod("format", String.class, int.class);
+        assertThatClassResourceIsAvailable(method.getDeclaringClass());
+
+        String[] parameterNames = paranamer.lookupParameterNames(method, false);
+
+        assertThat(parameterNames).containsExactly("message", "repeatCount");
+    }
+
+    @Test
+    void returnsEmptyNamesWhenGeneratedClassHasNoBytecodeResource() throws Exception {
+        BytecodeReadingParanamer paranamer = new BytecodeReadingParanamer();
+        ParameterizedOperation operation = value -> value.length();
+        Method method = operation.getClass().getDeclaredMethod("apply", String.class);
+        assertThat(method.getDeclaringClass()).isSameAs(operation.getClass());
+
+        String[] parameterNames = paranamer.lookupParameterNames(method, false);
+
+        assertThat(parameterNames).isEmpty();
+    }
+
+    private interface ParameterizedOperation {
+        int apply(String value);
+    }
+
+    private static void assertThatClassResourceIsAvailable(Class<?> type) throws Exception {
+        try (InputStream resource = type.getClassLoader().getResourceAsStream(classResourceName(type))) {
+            assertThat(resource).isNotNull();
+        }
+    }
+
+    private static String classResourceName(Class<?> type) {
+        return type.getName().replace('.', '/') + ".class";
+    }
+
+    private static final class ParameterNameFixture {
+        String format(String message, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(message);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class DefaultParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        DefaultParanamer paranamer = new DefaultParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/LegacyParanamerTest.java
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/LegacyParanamerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.module.paranamer.shaded.LegacyParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class LegacyParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        LegacyParanamer paranamer = new LegacyParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,72 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$MethodParameterFixture",
+      "fields" : [
+        {
+          "name" : "__PARANAMER_DATA"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest$ParameterNameFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$MethodParameterFixture"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest",
+          "interfaces" : [
+            "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest$ParameterizedOperation"
+          ]
+        }
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "glob" : "com/fasterxml/jackson/module/paranamer/shaded/com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest$$Lambda/0x00000000141ae470.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest$$Lambda/0x00000000141ae470.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
+      },
+      "glob" : "com_fasterxml_jackson_module/jackson_module_paranamer/BytecodeReadingParanamerTest$ParameterNameFixture.class"
+    }
+  ]
+}

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -4,10 +4,14 @@
       "condition" : {
         "typeReached" : "com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer"
       },
-      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$MethodParameterFixture",
-      "fields" : [
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$ConstructorParameterFixture",
+      "methods" : [
         {
-          "name" : "__PARANAMER_DATA"
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
         }
       ]
     },
@@ -21,7 +25,7 @@
       "condition" : {
         "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest"
       },
-      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$MethodParameterFixture"
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.DefaultParanamerTest$ConstructorParameterFixture"
     },
     {
       "condition" : {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -29,6 +29,26 @@
     },
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.module.paranamer.shaded.LegacyParanamer"
+      },
+      "type" : "com_fasterxml_jackson_module.jackson_module_paranamer.LegacyParanamerTest$MethodParameterFixture",
+      "fields" : [
+        {
+          "name" : "__PARANAMER_DATA"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "combine",
+          "parameterTypes" : [
+            "java.lang.String",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "com_fasterxml_jackson_module.jackson_module_paranamer.BytecodeReadingParanamerTest"
       },
       "type" : {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.fasterxml.jackson.module.paranamer.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_module.jackson_module_paranamer.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5700

This PR provides test fixes and new metadata for com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 80494
- Cached input tokens: 928768
- Output tokens: 11703
- Metadata entries: 3
- Test-only metadata entries: 13
- Iterations: 3
- Library coverage percentage: 47.97
- Previous library version metadata entries: 0
- Previous library version test-only metadata entries: 10
- Previous library version coverage percentage: 45.33

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `edd46542830b15efe88fd17f592460c29da7f399`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 4/4 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 6/6 covered calls (100.00%)

**Reflection:**
- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 4/4 covered calls (100.00%)

**Resources:**
- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 2/2 covered calls (100.00%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 1318/2859 (46.10%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 1415/2874 (49.23%)

**Line:**
- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 320/706 (45.33%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 331/690 (47.97%)

**Method:**
- com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4: 38/113 (33.63%)
- com.fasterxml.jackson.module:jackson-module-paranamer:2.19.0: 45/116 (38.79%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/AdaptiveParanamerTest.java 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/AdaptiveParanamerTest.java
new file mode 100644
index 0000000000..7016e0ea34
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/AdaptiveParanamerTest.java
@@ -0,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.module.paranamer.shaded.AdaptiveParanamer;
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.Test;
+
+public class AdaptiveParanamerTest {
+    @Test
+    void defaultConstructorIncludesReflectionBasedParameterNameLookup() throws Exception {
+        AdaptiveParanamer paranamer = new AdaptiveParanamer();
+        Constructor<ConstructorParameterFixture> constructor = ConstructorParameterFixture.class.getDeclaredConstructor(
+                String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(constructor, false);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public record ConstructorParameterFixture(String text, int repeatCount) {
+    }
+}
diff --git 1/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.11.4/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java
index da9fb3b76e..21becbc99c 100644
--- 1/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.11.4/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java
+++ 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/DefaultParanamerTest.java
@@ -9,32 +9,21 @@ package com_fasterxml_jackson_module.jackson_module_paranamer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.module.paranamer.shaded.DefaultParanamer;
-import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.Test;
 
 public class DefaultParanamerTest {
     @Test
-    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+    void readsParameterNamesFromReflectionMetadata() throws Exception {
         DefaultParanamer paranamer = new DefaultParanamer();
-        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+        Constructor<ConstructorParameterFixture> constructor = ConstructorParameterFixture.class.getDeclaredConstructor(
+                String.class, int.class);
 
-        String[] parameterNames = paranamer.lookupParameterNames(method);
+        String[] parameterNames = paranamer.lookupParameterNames(constructor);
 
         assertThat(parameterNames).containsExactly("text", "repeatCount");
     }
 
-    public static final class MethodParameterFixture {
-        public static final String __PARANAMER_DATA = """
-                v1.0
-                combine java.lang.String,int text,repeatCount
-                """;
-
-        public String combine(String text, int repeatCount) {
-            StringBuilder result = new StringBuilder();
-            for (int index = 0; index < repeatCount; index++) {
-                result.append(text);
-            }
-            return result.toString();
-        }
+    public record ConstructorParameterFixture(String text, int repeatCount) {
     }
 }
diff --git 1/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/LegacyParanamerTest.java 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/LegacyParanamerTest.java
new file mode 100644
index 0000000000..ab24bbd008
--- /dev/null
+++ 2/tests/src/com.fasterxml.jackson.module/jackson-module-paranamer/2.19.0/src/test/java/com_fasterxml_jackson_module/jackson_module_paranamer/LegacyParanamerTest.java
@@ -0,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_fasterxml_jackson_module.jackson_module_paranamer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.module.paranamer.shaded.LegacyParanamer;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+public class LegacyParanamerTest {
+    @Test
+    void readsParameterNamesFromEmbeddedParanamerDataField() throws Exception {
+        LegacyParanamer paranamer = new LegacyParanamer();
+        Method method = MethodParameterFixture.class.getDeclaredMethod("combine", String.class, int.class);
+
+        String[] parameterNames = paranamer.lookupParameterNames(method);
+
+        assertThat(parameterNames).containsExactly("text", "repeatCount");
+    }
+
+    public static final class MethodParameterFixture {
+        public static final String __PARANAMER_DATA = """
+                v1.0
+                combine java.lang.String,int text,repeatCount
+                """;
+
+        public String combine(String text, int repeatCount) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < repeatCount; index++) {
+                result.append(text);
+            }
+            return result.toString();
+        }
+    }
+}

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
