### PR TITLE
[GenAI] Mark app.cash.sqldelight:primitive-adapters as not for Native Image

### DIFF
--- a/metadata/app.cash.sqldelight/primitive-adapters/index.json
+++ b/metadata/app.cash.sqldelight/primitive-adapters/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to app.cash.sqldelight:primitive-adapters-jvm:2.3.2.",
+    "replacement": "app.cash.sqldelight:primitive-adapters-jvm:2.3.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5303

This PR records `app.cash.sqldelight:primitive-adapters` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to app.cash.sqldelight:primitive-adapters-jvm:2.3.2.

Replacement guidance:
- app.cash.sqldelight:primitive-adapters-jvm:2.3.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b208df6e318d3d991b162f197eadfb657e20f6a0`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
