### PR TITLE
[GenAI] Mark org.webjars:jquery as not for Native Image

### DIFF
--- a/metadata/org.webjars/jquery/index.json
+++ b/metadata/org.webjars/jquery/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains jQuery static web assets under META-INF/resources/webjars and Maven metadata, but no JVM class files."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5304

This PR records `org.webjars:jquery` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains jQuery static web assets under META-INF/resources/webjars and Maven metadata, but no JVM class files.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b208df6e318d3d991b162f197eadfb657e20f6a0`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
