### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/reachability-metadata.json
@@ -1,0 +1,312 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1alpha/$version$/proto-google-cloud-bigquerystorage-v1alpha-$version$-javadoc.jar",
+    "description" : "This artifact provides generated Java Protocol Buffer classes and descriptors for the Google Cloud BigQuery Storage v1alpha API. It defines messages, resource names, and service-related types used by JVM clients and gRPC stubs to serialize BigQuery Storage requests and responses.",
+    "tested-versions" : [
+      "3.14.1"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1alpha"
+    ]
+  }
+]

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T12:02:34.834183Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1",
+    "starting_commit": "9fa147b9fe7bb38d96fd2525be3b4676c5d7f5f5",
+    "ending_commit": "c8489f352340d453f4b6e10f95af0eb59517ac4d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.14.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9091,
+          "missed": 15237,
+          "ratio": 0.373685,
+          "total": 24328
+        },
+        "line": {
+          "covered": 2509,
+          "missed": 4080,
+          "ratio": 0.380786,
+          "total": 6589
+        },
+        "method": {
+          "covered": 543,
+          "missed": 1191,
+          "ratio": 0.313149,
+          "total": 1734
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 202077,
+      "cached_input_tokens_used": 2839552,
+      "output_tokens_used": 22800,
+      "iterations": 3,
+      "cost_usd": 2.1038,
+      "generated_loc": 381,
+      "tested_library_loc": 2509,
+      "metadata_entries": 86,
+      "code_coverage_percent": 38.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.14.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9091,
+        "missed" : 15237,
+        "ratio" : 0.373685,
+        "total" : 24328
+      },
+      "line" : {
+        "covered" : 2509,
+        "missed" : 4080,
+        "ratio" : 0.380786,
+        "total" : 6589
+      },
+      "method" : {
+        "covered" : 543,
+        "missed" : 1191,
+        "ratio" : 0.313149,
+        "total" : 1734
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1
+library.version = 3.14.1
+metadata.dir = com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-cloud-bigquerystorage-v1alpha_tests'

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
@@ -6,6 +6,11 @@
  */
 package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha;
 
+import com.google.api.AnnotationsProto;
+import com.google.api.ClientProto;
+import com.google.api.HttpRule;
+import com.google.api.ResourceDescriptor;
+import com.google.api.ResourceProto;
 import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsRequest;
 import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsResponse;
 import com.google.cloud.bigquery.storage.v1alpha.BatchDeleteMetastorePartitionsRequest;
@@ -227,6 +232,62 @@ public class Proto_google_cloud_bigquerystorage_v1alphaTest {
         assertThat(error.getMaxBatchSize()).isEqualTo(900L);
         assertThat(error.getErrorMessage()).isEqualTo("too many metastore partitions");
         assertThat(BatchSizeTooLargeError.parseFrom(error.toByteString())).isEqualTo(error);
+    }
+
+    @Test
+    void exposesServiceHttpAndResourceAnnotations() {
+        Descriptors.FileDescriptor serviceDescriptor = MetastorePartitionServiceProto.getDescriptor();
+        Descriptors.ServiceDescriptor service = serviceDescriptor.findServiceByName("MetastorePartitionService");
+
+        assertThat(service.getOptions().getExtension(ClientProto.defaultHost))
+                        .isEqualTo("bigquerystorage.googleapis.com");
+        assertThat(service.getOptions().getExtension(ClientProto.oauthScopes))
+                        .contains("https://www.googleapis.com/auth/bigquery")
+                        .contains("https://www.googleapis.com/auth/cloud-platform");
+
+        HttpRule createRule = service.findMethodByName("BatchCreateMetastorePartitions")
+                        .getOptions()
+                        .getExtension(AnnotationsProto.http);
+        HttpRule deleteRule = service.findMethodByName("BatchDeleteMetastorePartitions")
+                        .getOptions()
+                        .getExtension(AnnotationsProto.http);
+        HttpRule updateRule = service.findMethodByName("BatchUpdateMetastorePartitions")
+                        .getOptions()
+                        .getExtension(AnnotationsProto.http);
+        HttpRule listRule = service.findMethodByName("ListMetastorePartitions")
+                        .getOptions()
+                        .getExtension(AnnotationsProto.http);
+
+        assertThat(createRule.getPost())
+                        .isEqualTo("/v1alpha/{parent=projects/*/datasets/*/tables/*}/partitions:batchCreate");
+        assertThat(createRule.getBody()).isEqualTo("*");
+        assertThat(deleteRule.getPost())
+                        .isEqualTo("/v1alpha/{parent=projects/*/datasets/*/tables/*}/partitions:batchDelete");
+        assertThat(deleteRule.getBody()).isEqualTo("*");
+        assertThat(updateRule.getPost())
+                        .isEqualTo("/v1alpha/{parent=projects/*/datasets/*/tables/*}/partitions:batchUpdate");
+        assertThat(updateRule.getBody()).isEqualTo("*");
+        assertThat(listRule.getGet())
+                        .isEqualTo("/v1alpha/{parent=projects/*/locations/*/datasets/*/tables/*}/partitions:list");
+        assertThat(service.findMethodByName("ListMetastorePartitions").getOptions()
+                        .getExtension(ClientProto.methodSignature))
+                        .containsExactly("parent");
+        assertThat(service.findMethodByName("StreamMetastorePartitions").getOptions()
+                        .hasExtension(AnnotationsProto.http))
+                        .isFalse();
+
+        List<ResourceDescriptor> resourceDefinitions = serviceDescriptor.getOptions()
+                        .getExtension(ResourceProto.resourceDefinition);
+        ResourceDescriptor readStreamResource = ReadStream.getDescriptor().getOptions()
+                        .getExtension(ResourceProto.resource);
+
+        assertThat(resourceDefinitions).extracting(ResourceDescriptor::getType)
+                        .contains("bigquery.googleapis.com/Table");
+        assertThat(resourceDefinitions.get(0).getPatternList())
+                        .contains("projects/{project}/datasets/{dataset}/tables/{table}");
+        assertThat(readStreamResource.getType()).isEqualTo("bigquerystorage.googleapis.com/ReadStream");
+        assertThat(readStreamResource.getPatternList())
+                        .contains("projects/{project}/locations/{location}/sessions/{session}/streams/{stream}");
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_bigquerystorage_v1alphaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
@@ -8,9 +8,12 @@ package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha;
 
 import com.google.api.AnnotationsProto;
 import com.google.api.ClientProto;
+import com.google.api.FieldBehavior;
+import com.google.api.FieldBehaviorProto;
 import com.google.api.HttpRule;
 import com.google.api.ResourceDescriptor;
 import com.google.api.ResourceProto;
+import com.google.api.ResourceReference;
 import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsRequest;
 import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsResponse;
 import com.google.cloud.bigquery.storage.v1alpha.BatchDeleteMetastorePartitionsRequest;
@@ -291,6 +294,50 @@ public class Proto_google_cloud_bigquerystorage_v1alphaTest {
     }
 
     @Test
+    void exposesFieldBehaviorAndResourceReferenceAnnotations() {
+        Descriptors.FileDescriptor partitionDescriptor = MetastorePartitionProto.getDescriptor();
+        Descriptors.Descriptor partition = partitionDescriptor.findMessageTypeByName("MetastorePartition");
+        Descriptors.Descriptor storageDescriptor = partitionDescriptor.findMessageTypeByName("StorageDescriptor");
+        Descriptors.Descriptor serdeInfo = partitionDescriptor.findMessageTypeByName("SerDeInfo");
+        Descriptors.Descriptor readStream = partitionDescriptor.findMessageTypeByName("ReadStream");
+        Descriptors.FileDescriptor serviceDescriptor = MetastorePartitionServiceProto.getDescriptor();
+        Descriptors.Descriptor createRequest = serviceDescriptor.findMessageTypeByName("CreateMetastorePartitionRequest");
+        Descriptors.Descriptor batchCreateRequest =
+                        serviceDescriptor.findMessageTypeByName("BatchCreateMetastorePartitionsRequest");
+        Descriptors.Descriptor listRequest = serviceDescriptor.findMessageTypeByName("ListMetastorePartitionsRequest");
+
+        assertThat(fieldBehaviors(partition, "values")).containsExactly(FieldBehavior.REQUIRED);
+        assertThat(fieldBehaviors(partition, "create_time")).containsExactly(FieldBehavior.OUTPUT_ONLY);
+        assertThat(fieldBehaviors(partition, "storage_descriptor")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(fieldBehaviors(partition, "parameters")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(fieldBehaviors(partition, "fields")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(fieldBehaviors(storageDescriptor, "serde_info")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(fieldBehaviors(serdeInfo, "serialization_library")).containsExactly(FieldBehavior.REQUIRED);
+        assertThat(fieldBehaviors(readStream, "name"))
+                        .containsExactly(FieldBehavior.OUTPUT_ONLY, FieldBehavior.IDENTIFIER);
+
+        Descriptors.FieldDescriptor createParent = createRequest.findFieldByName("parent");
+        Descriptors.FieldDescriptor batchCreateParent = batchCreateRequest.findFieldByName("parent");
+        Descriptors.FieldDescriptor listParent = listRequest.findFieldByName("parent");
+        ResourceReference createParentReference = createParent.getOptions().getExtension(ResourceProto.resourceReference);
+        ResourceReference batchCreateParentReference =
+                        batchCreateParent.getOptions().getExtension(ResourceProto.resourceReference);
+        ResourceReference listParentReference = listParent.getOptions().getExtension(ResourceProto.resourceReference);
+
+        assertThat(createParent.getOptions().getExtension(FieldBehaviorProto.fieldBehavior))
+                        .containsExactly(FieldBehavior.REQUIRED);
+        assertThat(batchCreateParent.getOptions().getExtension(FieldBehaviorProto.fieldBehavior))
+                        .containsExactly(FieldBehavior.REQUIRED);
+        assertThat(listParent.getOptions().getExtension(FieldBehaviorProto.fieldBehavior))
+                        .containsExactly(FieldBehavior.REQUIRED);
+        assertThat(fieldBehaviors(listRequest, "filter")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(fieldBehaviors(listRequest, "trace_id")).containsExactly(FieldBehavior.OPTIONAL);
+        assertThat(createParentReference.getType()).isEqualTo("bigquery.googleapis.com/Table");
+        assertThat(batchCreateParentReference.getType()).isEqualTo("bigquery.googleapis.com/Table");
+        assertThat(listParentReference.getType()).isEqualTo("bigquery.googleapis.com/Table");
+    }
+
+    @Test
     void exposesResourceNameHelpersAndProtoDescriptors() {
         TableName tableName = TableName.of("project-one", "dataset_one", "table_one");
         String formatted = TableName.format("project-one", "dataset_one", "table_one");
@@ -336,6 +383,10 @@ public class Proto_google_cloud_bigquerystorage_v1alphaTest {
         MetastorePartitionProto.registerAllExtensions(registry);
         MetastorePartitionServiceProto.registerAllExtensions(registry);
         assertThat(registry.getUnmodifiable()).isNotNull();
+    }
+
+    private static List<FieldBehavior> fieldBehaviors(Descriptors.Descriptor descriptor, String fieldName) {
+        return descriptor.findFieldByName(fieldName).getOptions().getExtension(FieldBehaviorProto.fieldBehavior);
     }
 
     private static MetastorePartition samplePartition(String year, String month) {

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1alpha/Proto_google_cloud_bigquerystorage_v1alphaTest.java
@@ -6,11 +6,304 @@
  */
 package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha;
 
+import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1alpha.BatchCreateMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1alpha.BatchDeleteMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1alpha.BatchSizeTooLargeError;
+import com.google.cloud.bigquery.storage.v1alpha.BatchUpdateMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1alpha.BatchUpdateMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1alpha.CreateMetastorePartitionRequest;
+import com.google.cloud.bigquery.storage.v1alpha.FieldSchema;
+import com.google.cloud.bigquery.storage.v1alpha.ListMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1alpha.ListMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1alpha.MetastorePartition;
+import com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionList;
+import com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionProto;
+import com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionServiceProto;
+import com.google.cloud.bigquery.storage.v1alpha.MetastorePartitionValues;
+import com.google.cloud.bigquery.storage.v1alpha.ReadStream;
+import com.google.cloud.bigquery.storage.v1alpha.SerDeInfo;
+import com.google.cloud.bigquery.storage.v1alpha.StorageDescriptor;
+import com.google.cloud.bigquery.storage.v1alpha.StreamList;
+import com.google.cloud.bigquery.storage.v1alpha.StreamMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1alpha.StreamMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1alpha.TableName;
+import com.google.cloud.bigquery.storage.v1alpha.UpdateMetastorePartitionRequest;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.Timestamp;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_bigquerystorage_v1alphaTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Proto_google_cloud_bigquerystorage_v1alphaTest {
+    private static final String TABLE = "projects/project-one/datasets/dataset_one/tables/table_one";
+    private static final String TABLE_WITH_LOCATION =
+                    "projects/project-one/locations/us/datasets/dataset_one/tables/table_one";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void buildsNestedMetastorePartitionAndPreservesAllFields() throws Exception {
+        MetastorePartition partition = samplePartition("2025", "05");
+
+        assertThat(partition.getValuesList()).containsExactly("2025", "05");
+        assertThat(partition.hasCreateTime()).isTrue();
+        assertThat(partition.getCreateTime().getSeconds()).isEqualTo(1_746_057_600L);
+        assertThat(partition.hasStorageDescriptor()).isTrue();
+        assertThat(partition.getStorageDescriptor().getLocationUri())
+                        .isEqualTo("gs://example-bucket/table/dt=2025/month=05");
+        assertThat(partition.getStorageDescriptor().getInputFormat()).contains("OrcInputFormat");
+        assertThat(partition.getStorageDescriptor().getOutputFormat()).contains("OrcOutputFormat");
+        assertThat(partition.getStorageDescriptor().getSerdeInfo().getSerializationLibrary())
+                        .contains("OrcSerde");
+        assertThat(partition.getStorageDescriptor().getSerdeInfo().getParametersMap())
+                        .containsEntry("serialization.format", "1")
+                        .containsEntry("field.delim", "|");
+        assertThat(partition.getParametersMap()).containsEntry("source", "unit-test");
+        assertThat(partition.getParametersOrDefault("missing", "fallback")).isEqualTo("fallback");
+        assertThat(partition.getFieldsList())
+                        .extracting(FieldSchema::getName)
+                        .containsExactly("customer_id", "amount");
+        assertThat(partition.getFieldsList())
+                        .extracting(FieldSchema::getType)
+                        .containsExactly("string", "decimal(10,2)");
+
+        MetastorePartition parsed = MetastorePartition.parseFrom(partition.toByteArray());
+        assertThat(parsed).isEqualTo(partition);
+        assertThat(MetastorePartition.parser().parseFrom(partition.toByteString())).isEqualTo(partition);
+
+        MetastorePartition updated = parsed.toBuilder()
+                        .setValues(1, "06")
+                        .putParameters("quality", "validated")
+                        .addFields(FieldSchema.newBuilder().setName("region").setType("string"))
+                        .build();
+
+        assertThat(updated.getValuesList()).containsExactly("2025", "06");
+        assertThat(updated.getParametersMap()).containsEntry("quality", "validated");
+        assertThat(updated.getFieldsCount()).isEqualTo(3);
     }
+
+    @Test
+    void constructsBatchRequestsResponsesAndMasks() throws Exception {
+        MetastorePartition firstPartition = samplePartition("2025", "05");
+        MetastorePartition secondPartition = samplePartition("2025", "06");
+        CreateMetastorePartitionRequest createRequest = CreateMetastorePartitionRequest.newBuilder()
+                        .setParent(TABLE)
+                        .setMetastorePartition(firstPartition)
+                        .build();
+        FieldMask updateMask = FieldMask.newBuilder()
+                        .addPaths("storage_descriptor.location_uri")
+                        .addPaths("parameters")
+                        .build();
+        UpdateMetastorePartitionRequest updateRequest = UpdateMetastorePartitionRequest.newBuilder()
+                        .setMetastorePartition(secondPartition)
+                        .setUpdateMask(updateMask)
+                        .build();
+
+        BatchCreateMetastorePartitionsRequest batchCreateRequest = BatchCreateMetastorePartitionsRequest.newBuilder()
+                        .setParent(TABLE_WITH_LOCATION)
+                        .addRequests(createRequest)
+                        .setSkipExistingPartitions(true)
+                        .setTraceId("trace-create")
+                        .build();
+        BatchUpdateMetastorePartitionsRequest batchUpdateRequest = BatchUpdateMetastorePartitionsRequest.newBuilder()
+                        .setParent(TABLE_WITH_LOCATION)
+                        .addRequests(updateRequest)
+                        .setTraceId("trace-update")
+                        .build();
+        BatchDeleteMetastorePartitionsRequest batchDeleteRequest = BatchDeleteMetastorePartitionsRequest.newBuilder()
+                        .setParent(TABLE_WITH_LOCATION)
+                        .addPartitionValues(MetastorePartitionValues.newBuilder().addValues("2025").addValues("05"))
+                        .setTraceId("trace-delete")
+                        .build();
+
+        assertThat(batchCreateRequest.getParent()).isEqualTo(TABLE_WITH_LOCATION);
+        assertThat(batchCreateRequest.getRequests(0).getMetastorePartition()).isEqualTo(firstPartition);
+        assertThat(batchCreateRequest.getSkipExistingPartitions()).isTrue();
+        assertThat(BatchCreateMetastorePartitionsRequest.parseFrom(batchCreateRequest.toByteString()))
+                        .isEqualTo(batchCreateRequest);
+        assertThat(batchUpdateRequest.getRequests(0).getUpdateMask().getPathsList())
+                        .containsExactly("storage_descriptor.location_uri", "parameters");
+        assertThat(BatchUpdateMetastorePartitionsRequest.parseFrom(batchUpdateRequest.toByteArray()))
+                        .isEqualTo(batchUpdateRequest);
+        assertThat(batchDeleteRequest.getPartitionValues(0).getValuesList()).containsExactly("2025", "05");
+        assertThat(BatchDeleteMetastorePartitionsRequest.parseFrom(batchDeleteRequest.toByteArray()))
+                        .isEqualTo(batchDeleteRequest);
+
+        BatchCreateMetastorePartitionsResponse createResponse = BatchCreateMetastorePartitionsResponse.newBuilder()
+                        .addAllPartitions(Arrays.asList(firstPartition, secondPartition))
+                        .build();
+        BatchUpdateMetastorePartitionsResponse updateResponse = BatchUpdateMetastorePartitionsResponse.newBuilder()
+                        .addPartitions(secondPartition)
+                        .build();
+
+        assertThat(createResponse.getPartitionsList()).containsExactly(firstPartition, secondPartition);
+        assertThat(updateResponse.getPartitionsList()).containsExactly(secondPartition);
+        assertThat(BatchCreateMetastorePartitionsResponse.parseFrom(createResponse.toByteString()))
+                        .isEqualTo(createResponse);
+        assertThat(BatchUpdateMetastorePartitionsResponse.parseFrom(updateResponse.toByteString()))
+                        .isEqualTo(updateResponse);
+    }
+
+    @Test
+    void switchesListResponseBetweenPartitionAndStreamOneofVariants() throws Exception {
+        MetastorePartition partition = samplePartition("2025", "07");
+        MetastorePartitionList partitionList = MetastorePartitionList.newBuilder()
+                        .addPartitions(partition)
+                        .build();
+        ListMetastorePartitionsResponse partitionsResponse = ListMetastorePartitionsResponse.newBuilder()
+                        .setPartitions(partitionList)
+                        .build();
+
+        assertThat(partitionsResponse.getResponseCase())
+                        .isEqualTo(ListMetastorePartitionsResponse.ResponseCase.PARTITIONS);
+        assertThat(partitionsResponse.hasPartitions()).isTrue();
+        assertThat(partitionsResponse.hasStreams()).isFalse();
+        assertThat(partitionsResponse.getPartitions().getPartitionsList()).containsExactly(partition);
+
+        ReadStream firstStream = ReadStream.newBuilder()
+                        .setName("projects/project-one/locations/us/sessions/session-one/streams/stream-one")
+                        .build();
+        ReadStream secondStream = firstStream.toBuilder()
+                        .setName("projects/project-one/locations/us/sessions/session-one/streams/stream-two")
+                        .build();
+        StreamList streamList = StreamList.newBuilder()
+                        .addStreams(firstStream)
+                        .addStreams(secondStream)
+                        .build();
+        ListMetastorePartitionsResponse streamsResponse = partitionsResponse.toBuilder()
+                        .setStreams(streamList)
+                        .build();
+
+        assertThat(streamsResponse.getResponseCase()).isEqualTo(ListMetastorePartitionsResponse.ResponseCase.STREAMS);
+        assertThat(streamsResponse.hasPartitions()).isFalse();
+        assertThat(streamsResponse.hasStreams()).isTrue();
+        assertThat(streamsResponse.getStreams().getStreamsList()).containsExactly(firstStream, secondStream);
+        assertThat(ListMetastorePartitionsResponse.parseFrom(streamsResponse.toByteArray())).isEqualTo(streamsResponse);
+
+        ListMetastorePartitionsRequest listRequest = ListMetastorePartitionsRequest.newBuilder()
+                        .setParent(TABLE_WITH_LOCATION)
+                        .setFilter("amount BETWEEN 1.0 AND 5.0")
+                        .setTraceId("trace-list")
+                        .build();
+
+        assertThat(listRequest.getParent()).isEqualTo(TABLE_WITH_LOCATION);
+        assertThat(listRequest.getFilter()).isEqualTo("amount BETWEEN 1.0 AND 5.0");
+        assertThat(ListMetastorePartitionsRequest.parseFrom(listRequest.toByteString())).isEqualTo(listRequest);
+    }
+
+    @Test
+    void handlesStreamingMessagesAndStructuredBatchSizeError() throws Exception {
+        MetastorePartition firstPartition = samplePartition("2025", "08");
+        MetastorePartition secondPartition = samplePartition("2025", "09");
+        StreamMetastorePartitionsRequest streamRequest = StreamMetastorePartitionsRequest.newBuilder()
+                        .setParent(TABLE_WITH_LOCATION)
+                        .addMetastorePartitions(firstPartition)
+                        .addMetastorePartitions(secondPartition)
+                        .setSkipExistingPartitions(true)
+                        .build();
+        StreamMetastorePartitionsResponse streamResponse = StreamMetastorePartitionsResponse.newBuilder()
+                        .setTotalPartitionsStreamedCount(2L)
+                        .setTotalPartitionsInsertedCount(1L)
+                        .build();
+        BatchSizeTooLargeError error = BatchSizeTooLargeError.newBuilder()
+                        .setMaxBatchSize(900L)
+                        .setErrorMessage("too many metastore partitions")
+                        .build();
+
+        assertThat(streamRequest.getParent()).isEqualTo(TABLE_WITH_LOCATION);
+        assertThat(streamRequest.getMetastorePartitionsList()).containsExactly(firstPartition, secondPartition);
+        assertThat(streamRequest.getSkipExistingPartitions()).isTrue();
+        assertThat(StreamMetastorePartitionsRequest.parseFrom(streamRequest.toByteArray())).isEqualTo(streamRequest);
+        assertThat(streamResponse.getTotalPartitionsStreamedCount()).isEqualTo(2L);
+        assertThat(streamResponse.getTotalPartitionsInsertedCount()).isEqualTo(1L);
+        assertThat(StreamMetastorePartitionsResponse.parseFrom(streamResponse.toByteString()))
+                        .isEqualTo(streamResponse);
+        assertThat(error.getMaxBatchSize()).isEqualTo(900L);
+        assertThat(error.getErrorMessage()).isEqualTo("too many metastore partitions");
+        assertThat(BatchSizeTooLargeError.parseFrom(error.toByteString())).isEqualTo(error);
+    }
+
+    @Test
+    void exposesResourceNameHelpersAndProtoDescriptors() {
+        TableName tableName = TableName.of("project-one", "dataset_one", "table_one");
+        String formatted = TableName.format("project-one", "dataset_one", "table_one");
+        List<TableName> parsedTables = TableName.parseList(Arrays.asList(formatted, TABLE));
+
+        assertThat(formatted).isEqualTo(TABLE);
+        assertThat(TableName.isParsableFrom(TABLE)).isTrue();
+        assertThat(TableName.parse(TABLE)).isEqualTo(tableName);
+        assertThat(tableName.getProject()).isEqualTo("project-one");
+        assertThat(tableName.getDataset()).isEqualTo("dataset_one");
+        assertThat(tableName.getTable()).isEqualTo("table_one");
+        assertThat(tableName.getFieldValuesMap())
+                        .containsEntry("project", "project-one")
+                        .containsEntry("dataset", "dataset_one")
+                        .containsEntry("table", "table_one");
+        assertThat(TableName.toStringList(parsedTables)).containsExactly(TABLE, TABLE);
+        assertThat(TableName.newBuilder().setProject("p").setDataset("d").setTable("t").build().toString())
+                        .isEqualTo("projects/p/datasets/d/tables/t");
+        assertThatThrownBy(() -> TableName.parse("projects/project-one/tables/table_one"))
+                        .isInstanceOf(IllegalArgumentException.class);
+
+        Descriptors.FileDescriptor partitionDescriptor = MetastorePartitionProto.getDescriptor();
+        Descriptors.FileDescriptor serviceDescriptor = MetastorePartitionServiceProto.getDescriptor();
+        Descriptors.ServiceDescriptor service = serviceDescriptor.findServiceByName("MetastorePartitionService");
+
+        Descriptors.Descriptor metastorePartitionDescriptor =
+                        partitionDescriptor.findMessageTypeByName("MetastorePartition");
+        assertThat(metastorePartitionDescriptor.findFieldByName("values").isRepeated()).isTrue();
+        assertThat(partitionDescriptor.findMessageTypeByName("SerDeInfo").findFieldByName("parameters").isMapField())
+                        .isTrue();
+        assertThat(service.getMethods()).extracting(Descriptors.MethodDescriptor::getName)
+                        .containsExactly(
+                                        "BatchCreateMetastorePartitions",
+                                        "BatchDeleteMetastorePartitions",
+                                        "BatchUpdateMetastorePartitions",
+                                        "ListMetastorePartitions",
+                                        "StreamMetastorePartitions");
+        assertThat(service.findMethodByName("StreamMetastorePartitions").isClientStreaming()).isTrue();
+        assertThat(service.findMethodByName("StreamMetastorePartitions").isServerStreaming()).isTrue();
+        assertThat(service.findMethodByName("ListMetastorePartitions").isServerStreaming()).isFalse();
+
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        MetastorePartitionProto.registerAllExtensions(registry);
+        MetastorePartitionServiceProto.registerAllExtensions(registry);
+        assertThat(registry.getUnmodifiable()).isNotNull();
+    }
+
+    private static MetastorePartition samplePartition(String year, String month) {
+        SerDeInfo serDeInfo = SerDeInfo.newBuilder()
+                        .setName("orc-serde")
+                        .setSerializationLibrary("org.apache.hadoop.hive.ql.io.orc.OrcSerde")
+                        .putParameters("serialization.format", "1")
+                        .putAllParameters(Map.of("field.delim", "|"))
+                        .build();
+        StorageDescriptor storageDescriptor = StorageDescriptor.newBuilder()
+                        .setLocationUri("gs://example-bucket/table/dt=" + year + "/month=" + month)
+                        .setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
+                        .setOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat")
+                        .setSerdeInfo(serDeInfo)
+                        .build();
+        Timestamp createTime = Timestamp.newBuilder()
+                        .setSeconds(1_746_057_600L)
+                        .setNanos(123_000_000)
+                        .build();
+
+        return MetastorePartition.newBuilder()
+                        .addValues(year)
+                        .addValuesBytes(ByteString.copyFromUtf8(month))
+                        .setCreateTime(createTime)
+                        .setStorageDescriptor(storageDescriptor)
+                        .putParameters("source", "unit-test")
+                        .addFields(FieldSchema.newBuilder().setName("customer_id").setType("string"))
+                        .addFields(FieldSchema.newBuilder().setName("amount").setType("decimal(10,2)"))
+                        .build();
+    }
+
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.bigquery.storage.v1alpha.**"
+      "includeClasses" : "com.google.cloud.bigquery.storage.v1alpha.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1alpha.**"
     }
   ]
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1alpha/3.14.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.bigquery.storage.v1alpha.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4713

This PR introduces tests and metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1alpha:3.14.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 202077
- Cached input tokens: 2839552
- Output tokens: 22800
- Metadata entries: 86
- Iterations: 3
- Library coverage percentage: 38.08
- Generated lines of code: 381
- Tested library lines of code: 2509

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a564ba6d3f486ae12c419bb1189c2f5fa9fc5aaf`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 9091/24328 (37.37%)
- Line: 2509/6589 (38.08%)
- Method: 543/1734 (31.31%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
