### PR TITLE
[GenAI] Add support for io.arrow-kt:arrow-atomic-jvm:2.2.2 using gpt-5.5

### DIFF
--- a/stats/io.arrow-kt/arrow-atomic-jvm/2.2.2/execution-metrics.json
+++ b/stats/io.arrow-kt/arrow-atomic-jvm/2.2.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T02:38:10.335693Z",
+    "timestamp": "2026-05-04T12:06:03.605996Z",
     "library": "io.arrow-kt:arrow-atomic-jvm:2.2.2",
-    "starting_commit": "a4ab73fc51f427e0d096c562a26470f7fdf959f2",
-    "ending_commit": "853af6f0c8d3569454ca234aa968f7a85342ecdf",
+    "starting_commit": "659aac3a351deb620967a69c33b04a58eb8c3306",
+    "ending_commit": "8530cf0f3f25c2d56cd63653b571cf9134d70e72",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 141789,
-      "cached_input_tokens_used": 1004544,
-      "output_tokens_used": 21038,
-      "iterations": 4,
-      "cost_usd": 1.1334,
-      "generated_loc": 288,
+      "input_tokens_used": 185345,
+      "cached_input_tokens_used": 860672,
+      "output_tokens_used": 15757,
+      "iterations": 5,
+      "cost_usd": 0.903,
+      "generated_loc": 376,
       "tested_library_loc": 20,
       "metadata_entries": 0,
       "code_coverage_percent": 27.78

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -118,6 +118,18 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicIntSupportsGetThenArithmeticOperations() {
+        val counter = AtomicInt(10)
+
+        assertThat(counter.getAndIncrement()).isEqualTo(10)
+        assertThat(counter.value).isEqualTo(11)
+        assertThat(counter.getAndDecrement()).isEqualTo(11)
+        assertThat(counter.value).isEqualTo(10)
+        assertThat(counter.getAndAdd(5)).isEqualTo(10)
+        assertThat(counter.value).isEqualTo(15)
+    }
+
+    @Test
     fun atomicIntSupportsPublicUpdateFunctionsAndRetriesOnInterference() {
         val counter = AtomicInt(0)
         val seenValues = mutableListOf<Int>()
@@ -226,6 +238,18 @@ public class Arrow_atomic_jvmTest {
         assertThat(total.compareAndSet(250L, 300L)).isTrue()
         assertThat(total.compareAndSet(250L, 400L)).isFalse()
         assertThat(total.value).isEqualTo(300L)
+    }
+
+    @Test
+    fun atomicLongSupportsGetThenArithmeticOperations() {
+        val total = AtomicLong(10L)
+
+        assertThat(total.getAndIncrement()).isEqualTo(10L)
+        assertThat(total.value).isEqualTo(11L)
+        assertThat(total.getAndDecrement()).isEqualTo(11L)
+        assertThat(total.value).isEqualTo(10L)
+        assertThat(total.getAndAdd(5L)).isEqualTo(10L)
+        assertThat(total.value).isEqualTo(15L)
     }
 
     @Test

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -76,6 +76,26 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicBooleanLoopContinuouslySuppliesLatestValueUntilActionStops() {
+        val flag = AtomicBoolean(false)
+        val observedValues = mutableListOf<Boolean>()
+
+        val failure = assertThrows<IllegalStateException> {
+            flag.loop { current ->
+                observedValues += current
+                if (current) {
+                    throw IllegalStateException("boolean loop stopped")
+                }
+                flag.value = true
+            }
+        }
+
+        assertThat(failure).hasMessage("boolean loop stopped")
+        assertThat(observedValues).containsExactly(false, true)
+        assertThat(flag.value).isTrue()
+    }
+
+    @Test
     fun atomicIntSupportsActualAtomicOperationsAndValueProperty() {
         val counter = AtomicInt(1)
 
@@ -236,6 +256,26 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicLongLoopContinuouslySuppliesLatestValueUntilActionStops() {
+        val total = AtomicLong(1L)
+        val observedValues = mutableListOf<Long>()
+
+        val failure = assertThrows<IllegalStateException> {
+            total.loop { current ->
+                observedValues += current
+                if (current == 3L) {
+                    throw IllegalStateException("long loop stopped")
+                }
+                total.value = current + 1L
+            }
+        }
+
+        assertThat(failure).hasMessage("long loop stopped")
+        assertThat(observedValues).containsExactly(1L, 2L, 3L)
+        assertThat(total.value).isEqualTo(3L)
+    }
+
+    @Test
     fun atomicReferenceSupportsActualAtomicOperationsAndValueProperty() {
         val state = Atomic(State(step = 1, label = "created"))
 
@@ -282,6 +322,30 @@ public class Arrow_atomic_jvmTest {
         val updated = state.updateAndGet { current -> current.copy(label = "finished") }
         assertThat(updated).isEqualTo(State(51, "finished"))
         assertThat(state.value).isEqualTo(State(51, "finished"))
+    }
+
+    @Test
+    fun atomicReferenceLoopContinuouslySuppliesLatestValueUntilActionStops() {
+        val state = Atomic(State(step = 1, label = "looping"))
+        val observedValues = mutableListOf<State>()
+
+        val failure = assertThrows<IllegalStateException> {
+            state.loop { current ->
+                observedValues += current
+                if (current.step == 3) {
+                    throw IllegalStateException("reference loop stopped")
+                }
+                state.value = current.copy(step = current.step + 1)
+            }
+        }
+
+        assertThat(failure).hasMessage("reference loop stopped")
+        assertThat(observedValues).containsExactly(
+            State(step = 1, label = "looping"),
+            State(step = 2, label = "looping"),
+            State(step = 3, label = "looping"),
+        )
+        assertThat(state.value).isEqualTo(State(step = 3, label = "looping"))
     }
 
     @Test

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -298,6 +298,22 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicReferenceCompareAndSetRequiresTheSameExpectedInstance() {
+        val initial = State(step = 1, label = "same value")
+        val equalButDifferentInstance = initial.copy()
+        val replacement = State(step = 2, label = "replacement")
+        val state = Atomic(initial)
+
+        assertThat(equalButDifferentInstance).isEqualTo(initial)
+        assertThat(equalButDifferentInstance).isNotSameAs(initial)
+        assertThat(state.compareAndSet(equalButDifferentInstance, replacement)).isFalse()
+        assertThat(state.value).isSameAs(initial)
+
+        assertThat(state.compareAndSet(initial, replacement)).isTrue()
+        assertThat(state.value).isSameAs(replacement)
+    }
+
+    @Test
     fun atomicReferenceSupportsPublicUpdateFunctionsAndReportsFailedTryUpdate() {
         val state = Atomic(State(step = 1, label = "initial"))
 


### PR DESCRIPTION

## What does this PR do?

Fixes: #5393

This PR introduces tests and metadata for io.arrow-kt:arrow-atomic-jvm:2.2.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 185345
- Cached input tokens: 860672
- Output tokens: 15757
- Metadata entries: 0
- Iterations: 5
- Library coverage percentage: 27.78
- Generated lines of code: 376
- Tested library lines of code: 20

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `659aac3a351deb620967a69c33b04a58eb8c3306`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 81/210 (38.57%)
- Line: 20/72 (27.78%)
- Method: 14/42 (33.33%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
