### PR TITLE
[GenAI] Add support for io.arrow-kt:arrow-annotations-jvm:2.2.2 using gpt-5.5

### DIFF
--- a/stats/io.arrow-kt/arrow-annotations-jvm/2.2.2/execution-metrics.json
+++ b/stats/io.arrow-kt/arrow-annotations-jvm/2.2.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T02:54:29.025998Z",
+    "timestamp": "2026-05-04T12:09:50.050200Z",
     "library": "io.arrow-kt:arrow-annotations-jvm:2.2.2",
-    "starting_commit": "43838ac261fcf3a6bd9f3572a50acc7be50b015e",
-    "ending_commit": "6b59f21ea7935221c6e293d0816bd3a904f54006",
+    "starting_commit": "659aac3a351deb620967a69c33b04a58eb8c3306",
+    "ending_commit": "68fb263c3a5989b430d48214feef3e180fcd24a0",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 91069,
-      "cached_input_tokens_used": 468480,
-      "output_tokens_used": 10884,
-      "iterations": 3,
-      "cost_usd": 0.5607,
-      "generated_loc": 122,
+      "input_tokens_used": 110791,
+      "cached_input_tokens_used": 438784,
+      "output_tokens_used": 13101,
+      "iterations": 4,
+      "cost_usd": 0.6124,
+      "generated_loc": 247,
       "tested_library_loc": 1,
       "metadata_entries": 0,
       "code_coverage_percent": 100.0

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -4,13 +4,18 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+@file:arrow.synthetic
+
 package io_arrow_kt.arrow_annotations_jvm
 
 import arrow.optics.OpticsTarget
 import arrow.optics.optics
 import arrow.synthetic
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.util.EnumMap
+import java.util.EnumSet
 
 public class ArrowAnnotationsJvmTest {
     @Test
@@ -28,6 +33,30 @@ public class ArrowAnnotationsJvmTest {
         assertThat(OpticsTarget.valueOf("LENS")).isSameAs(OpticsTarget.LENS)
         assertThat(OpticsTarget.values().map(OpticsTarget::name))
             .containsExactly("ISO", "LENS", "PRISM", "OPTIONAL", "DSL")
+        assertThatThrownBy { OpticsTarget.valueOf("TRAVERSAL") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun opticsTargetEnumSupportsStableJdkEnumCollectionsAndOrdering() {
+        val structuralTargets: EnumSet<OpticsTarget> = EnumSet.of(OpticsTarget.ISO, OpticsTarget.LENS)
+        val descriptions: EnumMap<OpticsTarget, String> = EnumMap(OpticsTarget::class.java)
+
+        OpticsTarget.entries.forEach { target: OpticsTarget ->
+            descriptions[target] = target.description()
+        }
+
+        assertThat(structuralTargets).containsExactly(OpticsTarget.ISO, OpticsTarget.LENS)
+        assertThat(descriptions.values)
+            .containsExactly("isomorphism", "lens", "prism", "optional", "dsl")
+        assertThat(OpticsTarget.entries.sortedDescending())
+            .containsExactly(
+                OpticsTarget.DSL,
+                OpticsTarget.OPTIONAL,
+                OpticsTarget.PRISM,
+                OpticsTarget.LENS,
+                OpticsTarget.ISO,
+            )
     }
 
     @Test
@@ -42,6 +71,16 @@ public class ArrowAnnotationsJvmTest {
         assertThat(movedOrder.id).isEqualTo("order-1")
         assertThat(movedOrder.shippingAddress.city).isEqualTo("Belgrade")
         assertThat(movedOrder.shippingAddress.street).isEqualTo("Main Street")
+    }
+
+    @Test
+    fun opticsAnnotationCanRequestIsoTargetsOnInlineAndDataTypes() {
+        val accountId: IsoAnnotatedAccountId = IsoAnnotatedAccountId("account-42")
+        val coordinates: IsoAnnotatedCoordinates = IsoAnnotatedCoordinates(x = 3, y = 5)
+
+        assertThat(accountId.normalized()).isEqualTo("ACCOUNT-42")
+        assertThat(coordinates.copy(y = coordinates.x + coordinates.y))
+            .isEqualTo(IsoAnnotatedCoordinates(x = 3, y = 8))
     }
 
     @Test
@@ -84,6 +123,25 @@ public class ArrowAnnotationsJvmTest {
         assertThat(numbers.value).containsExactly(1, 2, 3)
         assertThat(doubled.value).isEqualTo("doubled=2, 4, 6")
     }
+
+    @Test
+    fun syntheticAnnotationCanMarkObjectsEnumsOperatorsAndSetterParameters() {
+        SyntheticRegistry.clear()
+
+        SyntheticRegistry += SyntheticRegistry.Entry(name = "alpha", weight = 2)
+        SyntheticRegistry += SyntheticRegistry.Entry(name = "beta", weight = 3)
+
+        assertThat(SyntheticRegistry.names()).containsExactly("alpha", "beta")
+        assertThat(SyntheticMode.ENABLED.render()).isEqualTo("enabled")
+    }
+}
+
+private fun OpticsTarget.description(): String = when (this) {
+    OpticsTarget.ISO -> "isomorphism"
+    OpticsTarget.LENS -> "lens"
+    OpticsTarget.PRISM -> "prism"
+    OpticsTarget.OPTIONAL -> "optional"
+    OpticsTarget.DSL -> "dsl"
 }
 
 @optics(targets = [OpticsTarget.LENS, OpticsTarget.PRISM, OpticsTarget.OPTIONAL, OpticsTarget.DSL])
@@ -96,6 +154,20 @@ private data class OpticsAnnotatedOrder(
 private data class ShippingAddress(
     val street: String,
     val city: String,
+)
+
+@optics(targets = [OpticsTarget.ISO])
+@JvmInline
+private value class IsoAnnotatedAccountId(
+    val value: String,
+) {
+    fun normalized(): String = value.uppercase()
+}
+
+@optics(targets = [OpticsTarget.ISO])
+private data class IsoAnnotatedCoordinates(
+    val x: Int,
+    val y: Int,
 )
 
 @optics.copy
@@ -124,6 +196,7 @@ private class SyntheticAnnotatedSample @synthetic constructor(
     @field:synthetic
     @get:synthetic
     @set:synthetic
+    @setparam:synthetic
     var mutableValue: @synthetic SyntheticString = constructorValue
 
     @synthetic
@@ -146,4 +219,41 @@ private data class SyntheticTypedBox<@synthetic T : Any>(
     fun <@synthetic R : Any> map(
         transform: (T) -> R,
     ): SyntheticTypedBox<R> = SyntheticTypedBox(transform(value))
+}
+
+@synthetic
+private object SyntheticRegistry {
+    private val entries: MutableList<Entry> = mutableListOf()
+
+    @synthetic
+    operator fun plusAssign(@synthetic entry: Entry) {
+        entries += entry
+    }
+
+    @synthetic
+    fun names(): List<@synthetic SyntheticString> = entries.map(Entry::name)
+
+    @synthetic
+    fun clear() {
+        entries.clear()
+    }
+
+    @SyntheticDomainAnnotation("entry")
+    data class Entry(
+        @property:synthetic
+        @field:synthetic
+        val name: @synthetic SyntheticString,
+        @property:synthetic
+        val weight: Int,
+    )
+}
+
+@synthetic
+private enum class SyntheticMode {
+    ENABLED,
+    DISABLED,
+    ;
+
+    @synthetic
+    fun render(): @synthetic SyntheticString = name.lowercase()
 }

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -60,6 +60,31 @@ public class ArrowAnnotationsJvmTest {
     }
 
     @Test
+    fun opticsAnnotationInstancesAreUsableAsConfigurationValues() {
+        val defaultConfiguration: optics = optics()
+        val prismDslConfiguration: optics = optics(arrayOf(OpticsTarget.PRISM, OpticsTarget.DSL))
+        val equivalentConfiguration: optics = optics(arrayOf(OpticsTarget.PRISM, OpticsTarget.DSL))
+        val lensConfiguration: optics = optics(arrayOf(OpticsTarget.LENS))
+
+        assertThat(defaultConfiguration.targets).isEmpty()
+        assertThat(prismDslConfiguration.targets)
+            .containsExactly(OpticsTarget.PRISM, OpticsTarget.DSL)
+        assertThat(prismDslConfiguration).isEqualTo(equivalentConfiguration)
+        assertThat(prismDslConfiguration).isNotEqualTo(lensConfiguration)
+    }
+
+    @Test
+    fun markerAnnotationInstancesHaveStableValueSemantics() {
+        val syntheticMarker: synthetic = synthetic()
+        val anotherSyntheticMarker: synthetic = synthetic()
+        val copyMarker: optics.copy = optics.copy()
+
+        assertThat(syntheticMarker).isEqualTo(anotherSyntheticMarker)
+        assertThat(copyMarker).isEqualTo(optics.copy())
+        assertThat(syntheticMarker).isNotEqualTo(copyMarker)
+    }
+
+    @Test
     fun opticsAnnotationCanRequestSpecificTargetsOnDomainTypes() {
         val shippingAddress: ShippingAddress = ShippingAddress(street = "Main Street", city = "Zagreb")
         val order: OpticsAnnotatedOrder = OpticsAnnotatedOrder(id = "order-1", shippingAddress = shippingAddress)

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -74,6 +74,21 @@ public class ArrowAnnotationsJvmTest {
     }
 
     @Test
+    fun annotationInstancesCanBeUsedAsHashBasedLookupKeys() {
+        val generatedDeclarationKinds: Map<Any, String> = mapOf(
+            synthetic() to "synthetic declaration",
+            optics.copy() to "copy optics declaration",
+            optics(arrayOf(OpticsTarget.LENS, OpticsTarget.OPTIONAL)) to "focused optics declaration",
+        )
+
+        assertThat(generatedDeclarationKinds[synthetic()]).isEqualTo("synthetic declaration")
+        assertThat(generatedDeclarationKinds[optics.copy()]).isEqualTo("copy optics declaration")
+        assertThat(generatedDeclarationKinds[optics(arrayOf(OpticsTarget.LENS, OpticsTarget.OPTIONAL))])
+            .isEqualTo("focused optics declaration")
+        assertThat(generatedDeclarationKinds[optics(arrayOf(OpticsTarget.LENS))]).isNull()
+    }
+
+    @Test
     fun markerAnnotationInstancesHaveStableValueSemantics() {
         val syntheticMarker: synthetic = synthetic()
         val anotherSyntheticMarker: synthetic = synthetic()


### PR DESCRIPTION

## What does this PR do?

Fixes: #5391

This PR introduces tests and metadata for io.arrow-kt:arrow-annotations-jvm:2.2.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 110791
- Cached input tokens: 438784
- Output tokens: 13101
- Metadata entries: 0
- Iterations: 4
- Library coverage percentage: 100.0
- Generated lines of code: 247
- Tested library lines of code: 1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `659aac3a351deb620967a69c33b04a58eb8c3306`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 37/37 (100.00%)
- Line: 1/1 (100.00%)
- Method: 1/1 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
