### PR TITLE
[GenAI] Add support for software.amazon.awssdk:metrics-spi:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/metrics-spi/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/metrics-spi/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T09:51:18.216074Z",
+    "timestamp": "2026-05-04T12:11:13.775345Z",
     "library": "software.amazon.awssdk:metrics-spi:2.34.0",
-    "starting_commit": "06bd65c494a2a71d89b29dba1b0dc007bda32e2f",
-    "ending_commit": "14492cdb60d439bd856e08e555713d6cbe7ab829",
+    "starting_commit": "1d01dcd700f9deea15a129b7580c040035abe30b",
+    "ending_commit": "be0e26d7943b25015108d383dc7699358102e6cd",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 623,
-          "missed": 284,
-          "ratio": 0.68688,
+          "covered": 878,
+          "missed": 29,
+          "ratio": 0.968026,
           "total": 907
         },
         "line": {
-          "covered": 137,
-          "missed": 38,
-          "ratio": 0.782857,
+          "covered": 171,
+          "missed": 4,
+          "ratio": 0.977143,
           "total": 175
         },
         "method": {
-          "covered": 61,
-          "missed": 16,
-          "ratio": 0.792208,
+          "covered": 74,
+          "missed": 3,
+          "ratio": 0.961039,
           "total": 77
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 197809,
-      "cached_input_tokens_used": 1235456,
-      "output_tokens_used": 16306,
-      "iterations": 5,
-      "cost_usd": 1.1069,
-      "generated_loc": 282,
-      "tested_library_loc": 137,
+      "input_tokens_used": 158974,
+      "cached_input_tokens_used": 1527808,
+      "output_tokens_used": 17805,
+      "iterations": 3,
+      "cost_usd": 1.2981,
+      "generated_loc": 373,
+      "tested_library_loc": 171,
       "metadata_entries": 0,
-      "code_coverage_percent": 78.29
+      "code_coverage_percent": 97.71
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java",

--- a/stats/software.amazon.awssdk/metrics-spi/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/metrics-spi/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 623,
-        "missed" : 284,
-        "ratio" : 0.68688,
+        "covered" : 878,
+        "missed" : 29,
+        "ratio" : 0.968026,
         "total" : 907
       },
       "line" : {
-        "covered" : 137,
-        "missed" : 38,
-        "ratio" : 0.782857,
+        "covered" : 171,
+        "missed" : 4,
+        "ratio" : 0.977143,
         "total" : 175
       },
       "method" : {
-        "covered" : 61,
-        "missed" : 16,
-        "ratio" : 0.792208,
+        "covered" : 74,
+        "missed" : 3,
+        "ratio" : 0.961039,
         "total" : 77
       }
     }

--- a/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/build.gradle
+++ b/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "software.amazon.awssdk:metrics-spi:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 graalvmNative {

--- a/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
+++ b/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
@@ -218,6 +218,32 @@ public class Metrics_spiTest {
     }
 
     @Test
+    void metricCollectionReturnsAllDirectChildrenWithMatchingName() {
+        SdkMetric<String> outcome = SdkMetric.create(
+                uniqueMetricName("attempt-outcome"), String.class, MetricLevel.INFO, MetricCategory.CORE);
+        MetricCollector root = MetricCollector.create("duplicate-child-root");
+        MetricCollector firstAttempt = root.createChild("attempt");
+        MetricCollector secondAttempt = root.createChild("attempt");
+        MetricCollector operation = root.createChild("operation");
+
+        firstAttempt.reportMetric(outcome, "throttled");
+        secondAttempt.reportMetric(outcome, "success");
+        operation.reportMetric(outcome, "complete");
+        firstAttempt.createChild("attempt").reportMetric(outcome, "nested");
+        MetricCollection collection = root.collect();
+
+        List<MetricCollection> matchingAttempts = collection.childrenWithName("attempt")
+                .collect(Collectors.toList());
+
+        assertThat(matchingAttempts).hasSize(2);
+        assertThat(matchingAttempts).extracting(MetricCollection::name).containsExactly("attempt", "attempt");
+        assertThat(matchingAttempts).extracting(child -> child.metricValues(outcome))
+                .containsExactly(List.of("throttled"), List.of("success"));
+        assertThat(matchingAttempts.get(0).childrenWithName("attempt")).singleElement()
+                .satisfies(child -> assertThat(child.metricValues(outcome)).containsExactly("nested"));
+    }
+
+    @Test
     void metricCollectionStreamsAndIteratesOverCollectedMetricRecords() {
         SdkMetric<Integer> bytes = SdkMetric.create(
                 uniqueMetricName("bytes"), Integer.class, MetricLevel.TRACE, MetricCategory.HTTP_CLIENT);

--- a/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
+++ b/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
@@ -68,6 +68,33 @@ public class Metrics_spiTest {
     }
 
     @Test
+    void sdkMetricCreatedWithNullAdditionalVarargsUsesOnlyPrimaryCategory() {
+        SdkMetric<Long> metric = SdkMetric.create(
+                uniqueMetricName("single-category"),
+                Long.class,
+                MetricLevel.ERROR,
+                MetricCategory.CUSTOM,
+                (MetricCategory[]) null);
+
+        assertThat(metric.categories()).containsExactly(MetricCategory.CUSTOM);
+    }
+
+    @Test
+    void sdkMetricEqualityHashCodeAndStringAreBasedOnPublicMetricIdentity() {
+        SdkMetric<Integer> first = SdkMetric.create(
+                uniqueMetricName("identity-one"), Integer.class, MetricLevel.INFO, MetricCategory.CORE);
+        SdkMetric<Integer> second = SdkMetric.create(
+                uniqueMetricName("identity-two"), Integer.class, MetricLevel.INFO, MetricCategory.CORE);
+
+        assertThat(first).isEqualTo(first);
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first).isNotEqualTo(null);
+        assertThat(first).isNotEqualTo("not-a-metric");
+        assertThat(first.hashCode()).isEqualTo(first.name().hashCode());
+        assertThat(first.toString()).contains("DefaultMetric", first.name(), "categories");
+    }
+
+    @Test
     void sdkMetricRejectsInvalidDefinitionsAndDuplicateNames() {
         String duplicateName = uniqueMetricName("duplicate");
         SdkMetric.create(duplicateName, Integer.class, MetricLevel.INFO, MetricCategory.CUSTOM);
@@ -109,6 +136,9 @@ public class Metrics_spiTest {
         assertThatThrownBy(() -> MetricCategory.fromString("transport"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("transport");
+        assertThatThrownBy(() -> MetricCategory.fromString(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null");
     }
 
     @Test
@@ -144,6 +174,10 @@ public class Metrics_spiTest {
         MetricCollection collection = collector.collect();
         Instant afterCollecting = Instant.now();
 
+        assertThat(collector.name()).isEqualTo("client-call");
+        assertThat(collector.toString()).contains("DefaultMetricCollector", attemptCount.name());
+        assertThat(retryChild.name()).isEqualTo("retry");
+        assertThat(httpChild.name()).isEqualTo("http");
         assertThat(collection.name()).isEqualTo("client-call");
         assertThat(collection.creationTime()).isBetween(beforeCollecting, afterCollecting);
         assertThat(collection.metricValues(attemptCount)).containsExactly(1, 2);
@@ -229,10 +263,27 @@ public class Metrics_spiTest {
         for (MetricRecord<?> record : collection) {
             iteratedMetrics.add(record.metric());
             iteratedValues.add(record.value());
+            assertThat(record.toString()).contains(record.metric().name(), String.valueOf(record.value()));
         }
 
         assertThat(iteratedMetrics).containsExactlyInAnyOrder(responseSize, serviceId);
         assertThat(iteratedValues).containsExactlyInAnyOrder(512, "s3");
+    }
+
+    @Test
+    void metricCollectionPreservesNullMetricValues() {
+        SdkMetric<String> nullableMetric = SdkMetric.create(
+                uniqueMetricName("nullable"), String.class, MetricLevel.TRACE, MetricCategory.CUSTOM);
+        MetricCollector collector = MetricCollector.create("nullable-collection");
+
+        collector.reportMetric(nullableMetric, null);
+        MetricCollection collection = collector.collect();
+
+        assertThat(collection.metricValues(nullableMetric)).containsExactly((String) null);
+        assertThat(collection.stream()).singleElement().satisfies(record -> {
+            assertThat(record.metric()).isEqualTo(nullableMetric);
+            assertThat(record.value()).isNull();
+        });
     }
 
     @Test
@@ -282,15 +333,30 @@ public class Metrics_spiTest {
         MetricCollection collection = collector.collect();
 
         MetricPublisher defaultPublisher = LoggingMetricPublisher.create();
-        MetricPublisher plainPublisher = LoggingMetricPublisher.create(Level.INFO, LoggingMetricPublisher.Format.PLAIN);
+        MetricPublisher plainPublisher = LoggingMetricPublisher.create(
+                Level.INFO, LoggingMetricPublisher.Format.PLAIN);
         MetricPublisher prettyPublisher = LoggingMetricPublisher.create(
                 Level.INFO, LoggingMetricPublisher.Format.PRETTY);
+        MetricPublisher disabledTracePublisher = LoggingMetricPublisher.create(
+                Level.TRACE, LoggingMetricPublisher.Format.PLAIN);
 
         defaultPublisher.publish(collection);
         plainPublisher.publish(collection);
         prettyPublisher.publish(collection);
+        disabledTracePublisher.publish(collection);
         defaultPublisher.close();
         plainPublisher.close();
+        prettyPublisher.close();
+        disabledTracePublisher.close();
+    }
+
+    @Test
+    void loggingMetricPublisherPrettyPrintsEmptyCollections() {
+        MetricCollection collection = MetricCollector.create("empty-publisher-root").collect();
+        MetricPublisher prettyPublisher = LoggingMetricPublisher.create(
+                Level.INFO, LoggingMetricPublisher.Format.PRETTY);
+
+        prettyPublisher.publish(collection);
         prettyPublisher.close();
     }
 
@@ -308,6 +374,9 @@ public class Metrics_spiTest {
     void metricCollectorRejectsBlankRootName() {
         assertThatThrownBy(() -> MetricCollector.create(""))
                 .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("name");
+        assertThatThrownBy(() -> MetricCollector.create(null))
+                .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("name");
     }
 

--- a/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
+++ b/tests/src/software.amazon.awssdk/metrics-spi/2.34.0/src/test/java/software_amazon_awssdk/metrics_spi/Metrics_spiTest.java
@@ -330,6 +330,18 @@ public class Metrics_spiTest {
     }
 
     @Test
+    void collectedMetricCollectionKeepsChildSnapshotIndependentFromCollector() {
+        MetricCollector collector = MetricCollector.create("snapshot-collector");
+        collector.createChild("collected-child");
+        MetricCollection collection = collector.collect();
+
+        collector.createChild("late-child");
+
+        assertThat(collection.children()).extracting(MetricCollection::name).containsExactly("collected-child");
+        assertThat(collection.childrenWithName("late-child")).isEmpty();
+    }
+
+    @Test
     void noOpMetricCollectorIgnoresMetricsAndReturnsEmptyCollection() {
         SdkMetric<Integer> metric = SdkMetric.create(
                 uniqueMetricName("ignored"), Integer.class, MetricLevel.INFO, MetricCategory.CUSTOM);


### PR DESCRIPTION

## What does this PR do?

Fixes: #4584

This PR introduces tests and metadata for software.amazon.awssdk:metrics-spi:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 158974
- Cached input tokens: 1527808
- Output tokens: 17805
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 97.71
- Generated lines of code: 373
- Tested library lines of code: 171

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1d01dcd700f9deea15a129b7580c040035abe30b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 878/907 (96.80%)
- Line: 171/175 (97.71%)
- Method: 74/77 (96.10%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
