### PR TITLE
[GenAI] Add support for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta:3.14.1 using gpt-5.5

### DIFF
--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/reachability-metadata.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/reachability-metadata.json
@@ -1,0 +1,528 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.api.FieldBehavior",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "com.google.protobuf.Descriptors$EnumValueDescriptor"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.Extension"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "com.google.protobuf.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.Extension"
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "add",
+          "parameterTypes": [
+            "com.google.protobuf.Extension"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.google.protobuf.ExtensionRegistry",
+      "methods": [
+        {
+          "name": "getEmptyRegistry",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.protobuf.Timestamp",
+      "methods": [
+        {
+          "name": "getNanos",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSeconds",
+          "parameterTypes": []
+        },
+        {
+          "name": "newBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.StorageDescriptor",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.StorageDescriptor$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.SerDeInfo",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.SerDeInfo$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.FieldSchema",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartition"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.FieldSchema$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MessageOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.BatchSizeTooLargeError",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.cloud.bigquery.storage.v1beta.BatchSizeTooLargeError$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$ServiceOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$MethodOptions$IdempotencyLevel",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FileOptions$OptimizeMode",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$FieldPresence",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$EnumType",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$RepeatedFieldEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$Utf8Validation",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$MessageEncoding",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$FeatureSet$JsonFormat",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto"
+      },
+      "type": "com.google.protobuf.DescriptorProtos$UninterpretedOption$NamePart$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/index.json
+++ b/metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta/$version$/proto-google-cloud-bigquerystorage-v1beta-$version$-sources.jar",
+    "repository-url" : "https://github.com/googleapis/java-bigquerystorage",
+    "test-code-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta/$version$/proto-google-cloud-bigquerystorage-v1beta-$version$-tests.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-bigquerystorage-v1beta/$version$/proto-google-cloud-bigquerystorage-v1beta-$version$-javadoc.jar",
+    "description" : "This artifact provides generated Java Protocol Buffer classes and descriptors for the Google Cloud BigQuery Storage v1beta API. It defines messages, resource names, and service-related types used by JVM clients and gRPC stubs to read from and write to BigQuery Storage.",
+    "tested-versions" : [
+      "3.14.1"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.bigquery.storage.v1beta"
+    ]
+  }
+]

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/execution-metrics.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T12:31:28.027262Z",
+    "library": "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta:3.14.1",
+    "starting_commit": "9a4f30e3c2702a5723b8e27642c6807bb65ee821",
+    "ending_commit": "71aafc5ca09bbb9590ad0aef42fbd2276b986942",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.14.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 9241,
+          "missed": 15087,
+          "ratio": 0.37985,
+          "total": 24328
+        },
+        "line": {
+          "covered": 2546,
+          "missed": 4039,
+          "ratio": 0.386636,
+          "total": 6585
+        },
+        "method": {
+          "covered": 573,
+          "missed": 1161,
+          "ratio": 0.33045,
+          "total": 1734
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 144126,
+      "cached_input_tokens_used": 1832448,
+      "output_tokens_used": 22644,
+      "iterations": 3,
+      "cost_usd": 1.5955,
+      "generated_loc": 498,
+      "tested_library_loc": 2546,
+      "metadata_entries": 140,
+      "code_coverage_percent": 38.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java",
+      "metadata_file": "metadata/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/stats.json
+++ b/stats/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.14.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 9241,
+        "missed" : 15087,
+        "ratio" : 0.37985,
+        "total" : 24328
+      },
+      "line" : {
+        "covered" : 2546,
+        "missed" : 4039,
+        "ratio" : 0.386636,
+        "total" : 6585
+      },
+      "method" : {
+        "covered" : 573,
+        "missed" : 1161,
+        "ratio" : 0.33045,
+        "total" : 1734
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/.gitignore
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/build.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/gradle.properties
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta:3.14.1
+library.version = 3.14.1
+metadata.dir = com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/settings.gradle
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.api.grpc.proto-google-cloud-bigquerystorage-v1beta_tests'

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
@@ -6,11 +6,459 @@
  */
 package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.api.AnnotationsProto;
+import com.google.api.ClientProto;
+import com.google.api.FieldBehavior;
+import com.google.api.FieldBehaviorProto;
+import com.google.api.HttpRule;
+import com.google.api.ResourceDescriptor;
+import com.google.api.ResourceProto;
+import com.google.cloud.bigquery.storage.v1beta.BatchCreateMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1beta.BatchCreateMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1beta.BatchDeleteMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1beta.BatchSizeTooLargeError;
+import com.google.cloud.bigquery.storage.v1beta.BatchUpdateMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1beta.BatchUpdateMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1beta.CreateMetastorePartitionRequest;
+import com.google.cloud.bigquery.storage.v1beta.FieldSchema;
+import com.google.cloud.bigquery.storage.v1beta.ListMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1beta.ListMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1beta.MetastorePartition;
+import com.google.cloud.bigquery.storage.v1beta.MetastorePartitionList;
+import com.google.cloud.bigquery.storage.v1beta.MetastorePartitionProto;
+import com.google.cloud.bigquery.storage.v1beta.MetastorePartitionServiceProto;
+import com.google.cloud.bigquery.storage.v1beta.MetastorePartitionValues;
+import com.google.cloud.bigquery.storage.v1beta.ReadStream;
+import com.google.cloud.bigquery.storage.v1beta.SerDeInfo;
+import com.google.cloud.bigquery.storage.v1beta.StorageDescriptor;
+import com.google.cloud.bigquery.storage.v1beta.StreamList;
+import com.google.cloud.bigquery.storage.v1beta.StreamMetastorePartitionsRequest;
+import com.google.cloud.bigquery.storage.v1beta.StreamMetastorePartitionsResponse;
+import com.google.cloud.bigquery.storage.v1beta.TableName;
+import com.google.cloud.bigquery.storage.v1beta.UpdateMetastorePartitionRequest;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class Proto_google_cloud_bigquerystorage_v1betaTest {
+public class Proto_google_cloud_bigquerystorage_v1betaTest {
+    private static final String PROJECT = "sample-project";
+    private static final String DATASET = "analytics";
+    private static final String TABLE = "events";
+    private static final String PARENT = "projects/" + PROJECT + "/datasets/" + DATASET + "/tables/" + TABLE;
+    private static final String LOCATION_PARENT = "projects/" + PROJECT + "/locations/us/datasets/" + DATASET
+            + "/tables/" + TABLE;
+    private static final String TRACE_ID = "trace-2026-05-04";
+    private static final String STREAM_ONE = "projects/sample-project/locations/us/sessions/session-1/streams/stream-1";
+    private static final String STREAM_TWO = "projects/sample-project/locations/us/sessions/session-1/streams/stream-2";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void tableNameFormatsParsesAndExposesFieldValues() {
+        TableName tableName = TableName.of(PROJECT, DATASET, TABLE);
+
+        assertEquals(PARENT, tableName.toString());
+        assertEquals(PARENT, TableName.format(PROJECT, DATASET, TABLE));
+        assertEquals(PROJECT, TableName.parse(PARENT).getProject());
+        assertEquals(DATASET, TableName.parse(PARENT).getDataset());
+        assertEquals(TABLE, TableName.parse(PARENT).getTable());
+        assertEquals(Map.of("project", PROJECT, "dataset", DATASET, "table", TABLE), tableName.getFieldValuesMap());
+        assertEquals(DATASET, tableName.getFieldValue("dataset"));
+        assertTrue(TableName.isParsableFrom(PARENT));
+        assertFalse(TableName.isParsableFrom(LOCATION_PARENT));
+        assertEquals(tableName, tableName.toBuilder().build());
+        assertNotEquals(tableName, TableName.of(PROJECT, DATASET, "other"));
+
+        TableName rebuilt = TableName.newBuilder()
+                .setProject(PROJECT)
+                .setDataset(DATASET)
+                .setTable(TABLE)
+                .build();
+        assertEquals(tableName, rebuilt);
+
+        List<TableName> names = List.of(tableName, TableName.of("billing-project", "warehouse", "orders"));
+        List<String> formatted = TableName.toStringList(names);
+        assertIterableEquals(List.of(PARENT, "projects/billing-project/datasets/warehouse/tables/orders"), formatted);
+        assertIterableEquals(names, TableName.parseList(formatted));
+    }
+
+    @Test
+    void metastorePartitionRoundTripsNestedStorageDescriptorFieldsAndMaps() throws Exception {
+        Timestamp createTime = Timestamp.newBuilder().setSeconds(1_700_000_000L).setNanos(123_000_000).build();
+        SerDeInfo serdeInfo = SerDeInfo.newBuilder()
+                .setName("orc-serde")
+                .setSerializationLibrary("org.apache.hadoop.hive.ql.io.orc.OrcSerde")
+                .putParameters("serialization.format", "1")
+                .putParameters("field.delim", "|")
+                .build();
+        StorageDescriptor storageDescriptor = StorageDescriptor.newBuilder()
+                .setLocationUri("gs://warehouse/events/dt=2026-05-04/region=emea")
+                .setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
+                .setOutputFormat("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat")
+                .setSerdeInfo(serdeInfo)
+                .build();
+        MetastorePartition partition = MetastorePartition.newBuilder()
+                .addValues("2026-05-04")
+                .addValues("emea")
+                .setCreateTime(createTime)
+                .setStorageDescriptor(storageDescriptor)
+                .putParameters("source", "daily-ingest")
+                .putParameters("quality", "gold")
+                .addFields(FieldSchema.newBuilder().setName("user_id").setType("STRING"))
+                .addFields(FieldSchema.newBuilder().setName("event_count").setType("INT64"))
+                .build();
+
+        MetastorePartition parsed = MetastorePartition.parseFrom(new ByteArrayInputStream(partition.toByteArray()));
+
+        assertIterableEquals(List.of("2026-05-04", "emea"), parsed.getValuesList());
+        assertEquals(ByteString.copyFromUtf8("emea"), parsed.getValuesBytes(1));
+        assertTrue(parsed.hasCreateTime());
+        assertEquals(createTime, parsed.getCreateTime());
+        assertTrue(parsed.hasStorageDescriptor());
+        assertEquals("gs://warehouse/events/dt=2026-05-04/region=emea",
+                parsed.getStorageDescriptor().getLocationUri());
+        assertTrue(parsed.getStorageDescriptor().hasSerdeInfo());
+        assertEquals("org.apache.hadoop.hive.ql.io.orc.OrcSerde",
+                parsed.getStorageDescriptor().getSerdeInfo().getSerializationLibrary());
+        assertEquals("|", parsed.getStorageDescriptor().getSerdeInfo().getParametersOrThrow("field.delim"));
+        assertEquals("fallback", parsed.getStorageDescriptor().getSerdeInfo().getParametersOrDefault(
+                "missing", "fallback"));
+        assertEquals("gold", parsed.getParametersOrThrow("quality"));
+        assertTrue(parsed.containsParameters("source"));
+        assertEquals(2, parsed.getFieldsCount());
+        assertEquals("event_count", parsed.getFields(1).getName());
+        assertEquals("INT64", parsed.getFields(1).getType());
+
+        StorageDescriptor movedStorage = parsed.getStorageDescriptor().toBuilder()
+                .setLocationUri("gs://warehouse/events/dt=2026-05-04/region=apac")
+                .setSerdeInfo(parsed.getStorageDescriptor().getSerdeInfo().toBuilder()
+                        .putParameters("compression", "zstd"))
+                .build();
+        MetastorePartition modified = parsed.toBuilder()
+                .setValues(1, "apac")
+                .removeParameters("quality")
+                .putParameters("quality", "silver")
+                .setStorageDescriptor(movedStorage)
+                .build();
+        assertIterableEquals(List.of("2026-05-04", "apac"), modified.getValuesList());
+        assertEquals("silver", modified.getParametersOrThrow("quality"));
+        assertEquals("gs://warehouse/events/dt=2026-05-04/region=apac",
+                modified.getStorageDescriptor().getLocationUri());
+    }
+
+    @Test
+    void createUpdateDeleteAndBatchMessagesPreserveRequestsMasksAndResponses() throws Exception {
+        MetastorePartition firstPartition = partition("2026-05-04", "emea");
+        MetastorePartition secondPartition = partition("2026-05-05", "apac");
+        CreateMetastorePartitionRequest createRequest = CreateMetastorePartitionRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .setMetastorePartition(firstPartition)
+                .build();
+        BatchCreateMetastorePartitionsRequest batchCreate = BatchCreateMetastorePartitionsRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .addRequests(createRequest)
+                .addRequests(CreateMetastorePartitionRequest.newBuilder()
+                        .setParent(LOCATION_PARENT)
+                        .setMetastorePartition(secondPartition))
+                .setSkipExistingPartitions(true)
+                .setTraceId(TRACE_ID)
+                .build();
+
+        BatchCreateMetastorePartitionsRequest parsedCreate = BatchCreateMetastorePartitionsRequest.parseFrom(
+                ByteBuffer.wrap(batchCreate.toByteArray()));
+        assertEquals(LOCATION_PARENT, parsedCreate.getParent());
+        assertEquals(2, parsedCreate.getRequestsCount());
+        assertTrue(parsedCreate.getSkipExistingPartitions());
+        assertEquals(TRACE_ID, parsedCreate.getTraceId());
+        assertEquals(firstPartition, parsedCreate.getRequests(0).getMetastorePartition());
+
+        FieldMask updateMask = FieldMask.newBuilder()
+                .addPaths("storage_descriptor.location_uri")
+                .addPaths("parameters")
+                .build();
+        UpdateMetastorePartitionRequest updateRequest = UpdateMetastorePartitionRequest.newBuilder()
+                .setMetastorePartition(firstPartition.toBuilder().putParameters("status", "corrected"))
+                .setUpdateMask(updateMask)
+                .build();
+        BatchUpdateMetastorePartitionsRequest batchUpdate = BatchUpdateMetastorePartitionsRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .addRequests(updateRequest)
+                .setTraceId(TRACE_ID)
+                .build();
+
+        BatchUpdateMetastorePartitionsRequest parsedUpdate = BatchUpdateMetastorePartitionsRequest.parseFrom(
+                batchUpdate.toByteString());
+        assertEquals(1, parsedUpdate.getRequestsCount());
+        assertTrue(parsedUpdate.getRequests(0).hasUpdateMask());
+        assertEquals(List.of("storage_descriptor.location_uri", "parameters"),
+                parsedUpdate.getRequests(0).getUpdateMask().getPathsList());
+        assertEquals("corrected", parsedUpdate.getRequests(0).getMetastorePartition().getParametersOrThrow("status"));
+
+        BatchDeleteMetastorePartitionsRequest batchDelete = BatchDeleteMetastorePartitionsRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .addPartitionValues(MetastorePartitionValues.newBuilder().addValues("2026-05-04").addValues("emea"))
+                .addPartitionValues(MetastorePartitionValues.newBuilder().addValues("2026-05-05").addValues("apac"))
+                .setTraceId(TRACE_ID)
+                .build();
+        BatchDeleteMetastorePartitionsRequest parsedDelete = BatchDeleteMetastorePartitionsRequest.parseFrom(
+                new ByteArrayInputStream(batchDelete.toByteArray()));
+        assertEquals(2, parsedDelete.getPartitionValuesCount());
+        assertIterableEquals(List.of("2026-05-05", "apac"), parsedDelete.getPartitionValues(1).getValuesList());
+
+        BatchCreateMetastorePartitionsResponse createResponse = BatchCreateMetastorePartitionsResponse.newBuilder()
+                .addPartitions(firstPartition)
+                .addPartitions(secondPartition)
+                .build();
+        assertEquals("apac", BatchCreateMetastorePartitionsResponse.parseFrom(
+                createResponse.toByteArray()).getPartitions(1).getValues(1));
+
+        BatchUpdateMetastorePartitionsResponse updateResponse = BatchUpdateMetastorePartitionsResponse.newBuilder()
+                .addPartitions(firstPartition)
+                .build();
+        assertEquals(firstPartition, BatchUpdateMetastorePartitionsResponse.parseDelimitedFrom(
+                delimited(updateResponse)).getPartitions(0));
+    }
+
+    @Test
+    void listRequestResponseAndOneofSwitchBetweenPartitionAndStreamLists() throws Exception {
+        ListMetastorePartitionsRequest request = ListMetastorePartitionsRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .setFilter("dt >= DATE '2026-05-01' AND region IS NOT NULL")
+                .setTraceId(TRACE_ID)
+                .build();
+        ListMetastorePartitionsRequest parsedRequest = ListMetastorePartitionsRequest.parseFrom(request.toByteString());
+        assertEquals(LOCATION_PARENT, parsedRequest.getParent());
+        assertEquals("dt >= DATE '2026-05-01' AND region IS NOT NULL", parsedRequest.getFilter());
+        assertEquals(TRACE_ID, parsedRequest.getTraceId());
+
+        MetastorePartitionList partitionList = MetastorePartitionList.newBuilder()
+                .addPartitions(partition("2026-05-04", "emea"))
+                .addPartitions(partition("2026-05-05", "apac"))
+                .build();
+        ListMetastorePartitionsResponse partitionsResponse = ListMetastorePartitionsResponse.newBuilder()
+                .setPartitions(partitionList)
+                .build();
+        ListMetastorePartitionsResponse parsedPartitions = ListMetastorePartitionsResponse.parseFrom(
+                ByteBuffer.wrap(partitionsResponse.toByteArray()));
+        assertSame(ListMetastorePartitionsResponse.ResponseCase.PARTITIONS, parsedPartitions.getResponseCase());
+        assertTrue(parsedPartitions.hasPartitions());
+        assertFalse(parsedPartitions.hasStreams());
+        assertEquals(2, parsedPartitions.getPartitions().getPartitionsCount());
+        assertEquals("apac", parsedPartitions.getPartitions().getPartitions(1).getValues(1));
+
+        StreamList streamList = StreamList.newBuilder()
+                .addStreams(ReadStream.newBuilder().setName(STREAM_ONE))
+                .addStreams(ReadStream.newBuilder().setName(STREAM_TWO))
+                .build();
+        ListMetastorePartitionsResponse streamsResponse = parsedPartitions.toBuilder()
+                .setStreams(streamList)
+                .build();
+        assertSame(ListMetastorePartitionsResponse.ResponseCase.STREAMS, streamsResponse.getResponseCase());
+        assertFalse(streamsResponse.hasPartitions());
+        assertTrue(streamsResponse.hasStreams());
+        assertEquals(STREAM_TWO, streamsResponse.getStreams().getStreams(1).getName());
+
+        ListMetastorePartitionsResponse cleared = streamsResponse.toBuilder().clearResponse().build();
+        assertSame(ListMetastorePartitionsResponse.ResponseCase.RESPONSE_NOT_SET, cleared.getResponseCase());
+    }
+
+    @Test
+    void streamingMessagesAndStructuredErrorsRoundTrip() throws Exception {
+        StreamMetastorePartitionsRequest request = StreamMetastorePartitionsRequest.newBuilder()
+                .setParent(LOCATION_PARENT)
+                .addMetastorePartitions(partition("2026-05-04", "emea"))
+                .addMetastorePartitions(partition("2026-05-05", "apac"))
+                .setSkipExistingPartitions(true)
+                .build();
+        StreamMetastorePartitionsRequest parsedRequest = StreamMetastorePartitionsRequest.parseDelimitedFrom(
+                delimited(request));
+        assertEquals(LOCATION_PARENT, parsedRequest.getParent());
+        assertTrue(parsedRequest.getSkipExistingPartitions());
+        assertEquals(2, parsedRequest.getMetastorePartitionsCount());
+        assertEquals("2026-05-05", parsedRequest.getMetastorePartitions(1).getValues(0));
+
+        StreamMetastorePartitionsResponse response = StreamMetastorePartitionsResponse.newBuilder()
+                .setTotalPartitionsStreamedCount(2L)
+                .setTotalPartitionsInsertedCount(1L)
+                .build();
+        StreamMetastorePartitionsResponse parsedResponse = StreamMetastorePartitionsResponse.parseFrom(
+                response.toByteString());
+        assertEquals(2L, parsedResponse.getTotalPartitionsStreamedCount());
+        assertEquals(1L, parsedResponse.getTotalPartitionsInsertedCount());
+
+        BatchSizeTooLargeError error = BatchSizeTooLargeError.newBuilder()
+                .setMaxBatchSize(900L)
+                .setErrorMessage("batch contains too many partitions")
+                .build();
+        BatchSizeTooLargeError parsedError = BatchSizeTooLargeError.parser().parseFrom(error.toByteArray());
+        assertEquals(900L, parsedError.getMaxBatchSize());
+        assertEquals("batch contains too many partitions", parsedError.getErrorMessage());
+    }
+
+    @Test
+    void generatedDescriptorsExposeProtosMessagesServicesAndStreamingMethods() {
+        FileDescriptor partitionDescriptor = MetastorePartitionProto.getDescriptor();
+        assertEquals("google/cloud/bigquery/storage/v1beta/partition.proto", partitionDescriptor.getName());
+        assertEquals(FieldSchema.getDescriptor(), partitionDescriptor.findMessageTypeByName("FieldSchema"));
+        assertEquals(MetastorePartition.getDescriptor(),
+                partitionDescriptor.findMessageTypeByName("MetastorePartition"));
+        assertEquals(ReadStream.getDescriptor(), partitionDescriptor.findMessageTypeByName("ReadStream"));
+        assertSame(partitionDescriptor, MetastorePartition.getDescriptor().getFile());
+
+        FileDescriptor serviceDescriptor = MetastorePartitionServiceProto.getDescriptor();
+        assertEquals("google/cloud/bigquery/storage/v1beta/metastore_partition.proto", serviceDescriptor.getName());
+        assertEquals(BatchCreateMetastorePartitionsRequest.getDescriptor(),
+                serviceDescriptor.findMessageTypeByName("BatchCreateMetastorePartitionsRequest"));
+        assertEquals(ListMetastorePartitionsResponse.getDescriptor(),
+                serviceDescriptor.findMessageTypeByName("ListMetastorePartitionsResponse"));
+
+        ServiceDescriptor service = serviceDescriptor.findServiceByName("MetastorePartitionService");
+        assertNotNull(service);
+        assertEquals("bigquerystorage.googleapis.com", service.getOptions().getExtension(ClientProto.defaultHost));
+        assertEquals("https://www.googleapis.com/auth/bigquery,https://www.googleapis.com/auth/cloud-platform",
+                service.getOptions().getExtension(ClientProto.oauthScopes));
+
+        MethodDescriptor batchCreate = service.findMethodByName("BatchCreateMetastorePartitions");
+        MethodDescriptor batchDelete = service.findMethodByName("BatchDeleteMetastorePartitions");
+        MethodDescriptor batchUpdate = service.findMethodByName("BatchUpdateMetastorePartitions");
+        MethodDescriptor list = service.findMethodByName("ListMetastorePartitions");
+        MethodDescriptor stream = service.findMethodByName("StreamMetastorePartitions");
+        assertNotNull(batchCreate);
+        assertNotNull(batchDelete);
+        assertNotNull(batchUpdate);
+        assertNotNull(list);
+        assertNotNull(stream);
+        assertEquals(BatchCreateMetastorePartitionsRequest.getDescriptor(), batchCreate.getInputType());
+        assertEquals(BatchCreateMetastorePartitionsResponse.getDescriptor(), batchCreate.getOutputType());
+        assertEquals(BatchDeleteMetastorePartitionsRequest.getDescriptor(), batchDelete.getInputType());
+        assertEquals(BatchUpdateMetastorePartitionsRequest.getDescriptor(), batchUpdate.getInputType());
+        assertEquals(BatchUpdateMetastorePartitionsResponse.getDescriptor(), batchUpdate.getOutputType());
+        assertEquals(ListMetastorePartitionsRequest.getDescriptor(), list.getInputType());
+        assertEquals(ListMetastorePartitionsResponse.getDescriptor(), list.getOutputType());
+        assertEquals(StreamMetastorePartitionsRequest.getDescriptor(), stream.getInputType());
+        assertEquals(StreamMetastorePartitionsResponse.getDescriptor(), stream.getOutputType());
+        assertFalse(batchCreate.isClientStreaming());
+        assertFalse(batchCreate.isServerStreaming());
+        assertFalse(list.isClientStreaming());
+        assertFalse(list.isServerStreaming());
+        assertTrue(stream.isClientStreaming());
+        assertTrue(stream.isServerStreaming());
+    }
+
+    @Test
+    void generatedDescriptorsExposeHttpBindingsMethodSignaturesAndResourceOptions() {
+        ServiceDescriptor service = MetastorePartitionServiceProto.getDescriptor()
+                .findServiceByName("MetastorePartitionService");
+        assertNotNull(service);
+
+        MethodDescriptor batchCreate = service.findMethodByName("BatchCreateMetastorePartitions");
+        HttpRule createHttp = batchCreate.getOptions().getExtension(AnnotationsProto.http);
+        assertEquals("/v1beta/{parent=projects/*/datasets/*/tables/*}/partitions:batchCreate", createHttp.getPost());
+        assertEquals("*", createHttp.getBody());
+
+        MethodDescriptor batchDelete = service.findMethodByName("BatchDeleteMetastorePartitions");
+        HttpRule deleteHttp = batchDelete.getOptions().getExtension(AnnotationsProto.http);
+        assertEquals("/v1beta/{parent=projects/*/datasets/*/tables/*}/partitions:batchDelete", deleteHttp.getPost());
+        assertEquals("*", deleteHttp.getBody());
+
+        MethodDescriptor batchUpdate = service.findMethodByName("BatchUpdateMetastorePartitions");
+        HttpRule updateHttp = batchUpdate.getOptions().getExtension(AnnotationsProto.http);
+        assertEquals("/v1beta/{parent=projects/*/datasets/*/tables/*}/partitions:batchUpdate", updateHttp.getPost());
+        assertEquals("*", updateHttp.getBody());
+
+        MethodDescriptor list = service.findMethodByName("ListMetastorePartitions");
+        HttpRule listHttp = list.getOptions().getExtension(AnnotationsProto.http);
+        assertEquals("/v1beta/{parent=projects/*/locations/*/datasets/*/tables/*}/partitions:list",
+                listHttp.getGet());
+        assertIterableEquals(List.of("parent"), list.getOptions().getExtension(ClientProto.methodSignature));
+
+        List<ResourceDescriptor> resourceDefinitions = MetastorePartitionServiceProto.getDescriptor()
+                .getOptions()
+                .getExtension(ResourceProto.resourceDefinition);
+        assertEquals(1, resourceDefinitions.size());
+        assertEquals("bigquery.googleapis.com/Table", resourceDefinitions.get(0).getType());
+        assertIterableEquals(List.of("projects/{project}/datasets/{dataset}/tables/{table}"),
+                resourceDefinitions.get(0).getPatternList());
+
+        ResourceDescriptor readStreamResource = ReadStream.getDescriptor().getOptions()
+                .getExtension(ResourceProto.resource);
+        assertEquals("bigquerystorage.googleapis.com/ReadStream", readStreamResource.getType());
+        assertIterableEquals(List.of("projects/{project}/locations/{location}/sessions/{session}/streams/{stream}"),
+                readStreamResource.getPatternList());
+    }
+
+    @Test
+    void generatedFieldDescriptorsExposeBehaviorAndParserDefaults() throws Exception {
+        Descriptor partitionDescriptor = MetastorePartition.getDescriptor();
+        FieldDescriptor valuesField = partitionDescriptor.findFieldByName("values");
+        FieldDescriptor createTimeField = partitionDescriptor.findFieldByName("create_time");
+        FieldDescriptor storageDescriptorField = partitionDescriptor.findFieldByName("storage_descriptor");
+        assertNotNull(valuesField);
+        assertNotNull(createTimeField);
+        assertNotNull(storageDescriptorField);
+        assertTrue(valuesField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior)
+                .contains(FieldBehavior.REQUIRED));
+        assertTrue(createTimeField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior)
+                .contains(FieldBehavior.OUTPUT_ONLY));
+        assertTrue(storageDescriptorField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior)
+                .contains(FieldBehavior.OPTIONAL));
+
+        FieldDescriptor parentField = BatchCreateMetastorePartitionsRequest.getDescriptor().findFieldByName("parent");
+        assertNotNull(parentField);
+        assertEquals("bigquery.googleapis.com/Table",
+                parentField.getOptions().getExtension(ResourceProto.resourceReference).getType());
+        assertTrue(parentField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior)
+                .contains(FieldBehavior.REQUIRED));
+
+        FieldDescriptor readStreamNameField = ReadStream.getDescriptor().findFieldByName("name");
+        assertNotNull(readStreamNameField);
+        assertTrue(readStreamNameField.getOptions().getExtension(FieldBehaviorProto.fieldBehavior)
+                .contains(FieldBehavior.IDENTIFIER));
+
+        assertEquals(MetastorePartition.getDefaultInstance(), MetastorePartition.parseFrom(ByteString.EMPTY));
+        assertEquals("MetastorePartition", MetastorePartition.getDefaultInstance().getDescriptorForType().getName());
+        assertThrows(InvalidProtocolBufferException.class,
+                () -> MetastorePartition.parser().parseFrom(ByteString.copyFrom(new byte[] {-1, 0, 1})));
+    }
+
+    private static MetastorePartition partition(String date, String region) {
+        return MetastorePartition.newBuilder()
+                .addValues(date)
+                .addValues(region)
+                .setStorageDescriptor(StorageDescriptor.newBuilder()
+                        .setLocationUri("gs://warehouse/events/dt=" + date + "/region=" + region)
+                        .setSerdeInfo(SerDeInfo.newBuilder()
+                                .setName("parquet-serde")
+                                .setSerializationLibrary(
+                                        "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")))
+                .putParameters("region", region)
+                .addFields(FieldSchema.newBuilder().setName("event_id").setType("STRING"))
+                .build();
+    }
+
+    private static ByteArrayInputStream delimited(com.google.protobuf.MessageLite message) throws Exception {
+        byte[] payload = message.toByteArray();
+        ByteString.Output output = ByteString.newOutput();
+        message.writeDelimitedTo(output);
+        assertTrue(output.size() > payload.length);
+        return new ByteArrayInputStream(output.toByteString().toByteArray());
     }
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
@@ -168,6 +168,60 @@ public class Proto_google_cloud_bigquerystorage_v1betaTest {
     }
 
     @Test
+    void nestedBuildersConstructAndMutateBatchCreateRequestsInPlace() {
+        BatchCreateMetastorePartitionsRequest.Builder batchBuilder = BatchCreateMetastorePartitionsRequest
+                .newBuilder()
+                .setParent(LOCATION_PARENT)
+                .setTraceId(TRACE_ID);
+        CreateMetastorePartitionRequest.Builder createBuilder = batchBuilder.addRequestsBuilder()
+                .setParent(LOCATION_PARENT);
+        MetastorePartition.Builder partitionBuilder = createBuilder.getMetastorePartitionBuilder()
+                .addAllValues(List.of("2026-05-06", "amer"))
+                .putAllParameters(Map.of("owner", "etl", "status", "new"));
+        partitionBuilder.getCreateTimeBuilder().setSeconds(1_700_100_000L);
+        partitionBuilder.getStorageDescriptorBuilder()
+                .setLocationUri("gs://warehouse/events/dt=2026-05-06/region=amer")
+                .setInputFormat("org.apache.hadoop.mapred.TextInputFormat")
+                .getSerdeInfoBuilder()
+                .setName("json-serde")
+                .setSerializationLibrary("org.apache.hive.hcatalog.data.JsonSerDe")
+                .putAllParameters(Map.of(
+                        "ignore.malformed.json", "true",
+                        "timestamp.formats", "yyyy-MM-dd HH:mm:ss"));
+        partitionBuilder.addFieldsBuilder().setName("payload").setType("STRING");
+        partitionBuilder.addFieldsBuilder().setName("ingested_at").setType("TIMESTAMP");
+        partitionBuilder.getFieldsBuilder(0).setType("JSON");
+
+        BatchCreateMetastorePartitionsRequest request = batchBuilder.build();
+
+        assertEquals(1, request.getRequestsCount());
+        MetastorePartition partition = request.getRequests(0).getMetastorePartition();
+        assertTrue(partition.hasCreateTime());
+        assertEquals(1_700_100_000L, partition.getCreateTime().getSeconds());
+        assertIterableEquals(List.of("2026-05-06", "amer"), partition.getValuesList());
+        assertEquals("JSON", partition.getFields(0).getType());
+        assertEquals("TIMESTAMP", partition.getFields(1).getType());
+        assertEquals("etl", partition.getParametersOrThrow("owner"));
+        assertEquals("org.apache.hadoop.mapred.TextInputFormat", partition.getStorageDescriptor().getInputFormat());
+        assertEquals("true", partition.getStorageDescriptor().getSerdeInfo().getParametersOrThrow(
+                "ignore.malformed.json"));
+
+        BatchCreateMetastorePartitionsRequest.Builder amendedBuilder = request.toBuilder();
+        amendedBuilder.getRequestsBuilder(0)
+                .getMetastorePartitionBuilder()
+                .removeParameters("status")
+                .putParameters("status", "queued")
+                .getStorageDescriptorBuilder()
+                .clearInputFormat();
+        BatchCreateMetastorePartitionsRequest amended = amendedBuilder.build();
+
+        MetastorePartition amendedPartition = amended.getRequests(0).getMetastorePartition();
+        assertEquals("queued", amendedPartition.getParametersOrThrow("status"));
+        assertEquals("", amendedPartition.getStorageDescriptor().getInputFormat());
+        assertEquals("org.apache.hadoop.mapred.TextInputFormat", partition.getStorageDescriptor().getInputFormat());
+    }
+
+    @Test
     void createUpdateDeleteAndBatchMessagesPreserveRequestsMasksAndResponses() throws Exception {
         MetastorePartition firstPartition = partition("2026-05-04", "emea");
         MetastorePartition secondPartition = partition("2026-05-05", "apac");

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta;
+
+import org.junit.jupiter.api.Test;
+
+class Proto_google_cloud_bigquerystorage_v1betaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/src/test/java/com_google_api_grpc/proto_google_cloud_bigquerystorage_v1beta/Proto_google_cloud_bigquerystorage_v1betaTest.java
@@ -45,6 +45,7 @@ import com.google.cloud.bigquery.storage.v1beta.StreamMetastorePartitionsRequest
 import com.google.cloud.bigquery.storage.v1beta.StreamMetastorePartitionsResponse;
 import com.google.cloud.bigquery.storage.v1beta.TableName;
 import com.google.cloud.bigquery.storage.v1beta.UpdateMetastorePartitionRequest;
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -54,6 +55,8 @@ import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -311,6 +314,35 @@ public class Proto_google_cloud_bigquerystorage_v1betaTest {
         BatchSizeTooLargeError parsedError = BatchSizeTooLargeError.parser().parseFrom(error.toByteArray());
         assertEquals(900L, parsedError.getMaxBatchSize());
         assertEquals("batch contains too many partitions", parsedError.getErrorMessage());
+    }
+
+    @Test
+    void structuredErrorsCanBeAttachedToRpcStatusDetails() throws Exception {
+        BatchSizeTooLargeError error = BatchSizeTooLargeError.newBuilder()
+                .setMaxBatchSize(900L)
+                .setErrorMessage("batch contains too many partitions")
+                .build();
+
+        Status status = Status.newBuilder()
+                .setCode(Code.INVALID_ARGUMENT_VALUE)
+                .setMessage("cannot commit metastore partitions")
+                .addDetails(Any.pack(error))
+                .build();
+
+        assertEquals(Code.INVALID_ARGUMENT_VALUE, status.getCode());
+        assertEquals(Code.INVALID_ARGUMENT, Code.forNumber(status.getCode()));
+        assertEquals("cannot commit metastore partitions", status.getMessage());
+        assertEquals(1, status.getDetailsCount());
+
+        Any detail = status.getDetails(0);
+        assertEquals("type.googleapis.com/google.cloud.bigquery.storage.v1beta.BatchSizeTooLargeError",
+                detail.getTypeUrl());
+        assertTrue(detail.is(BatchSizeTooLargeError.class));
+        assertFalse(detail.is(MetastorePartition.class));
+
+        BatchSizeTooLargeError unpacked = detail.unpack(BatchSizeTooLargeError.class);
+        assertEquals(900L, unpacked.getMaxBatchSize());
+        assertEquals("batch contains too many partitions", unpacked.getErrorMessage());
     }
 
     @Test

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.bigquery.storage.v1beta.**"
+      "includeClasses" : "com.google.cloud.bigquery.storage.v1beta.**"
+    },
+    {
+      "includeClasses" : "com_google_api_grpc.proto_google_cloud_bigquerystorage_v1beta.**"
     }
   ]
 }

--- a/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/user-code-filter.json
+++ b/tests/src/com.google.api.grpc/proto-google-cloud-bigquerystorage-v1beta/3.14.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.bigquery.storage.v1beta.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4715

This PR introduces tests and metadata for com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta:3.14.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 144126
- Cached input tokens: 1832448
- Output tokens: 22644
- Metadata entries: 140
- Iterations: 3
- Library coverage percentage: 38.66
- Generated lines of code: 498
- Tested library lines of code: 2546

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b208df6e318d3d991b162f197eadfb657e20f6a0`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 9241/24328 (37.98%)
- Line: 2546/6585 (38.66%)
- Method: 573/1734 (33.05%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
