### PR TITLE
[GenAI] Mark io.insert-koin:koin-core as not for Native Image

### DIFF
--- a/metadata/io.insert-koin/koin-core/index.json
+++ b/metadata/io.insert-koin/koin-core/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.insert-koin:koin-core-jvm:4.1.0.",
+    "replacement": "io.insert-koin:koin-core-jvm:4.1.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4493

This PR records `io.insert-koin:koin-core` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.insert-koin:koin-core-jvm:4.1.0.

Replacement guidance:
- io.insert-koin:koin-core-jvm:4.1.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `22bd601b2663ac9f7d6de57da10ef9398b90865b`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
