### PR TITLE
[GenAI] Add support for com.google.cloud:grpc-gcp:1.10.0 using gpt-5.5

### DIFF
--- a/metadata/com.google.cloud/grpc-gcp/1.10.0/reachability-metadata.json
+++ b/metadata/com.google.cloud/grpc-gcp/1.10.0/reachability-metadata.json
@@ -1,0 +1,67 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ApiConfig$Builder"
+      },
+      "type": "com.google.cloud.grpc.proto.ApiConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ChannelPoolConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.ChannelPoolConfig$Builder"
+      },
+      "type": "com.google.cloud.grpc.proto.ChannelPoolConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.MethodConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.MethodConfig$Builder"
+      },
+      "type": "com.google.cloud.grpc.proto.MethodConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig$Command",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.google.cloud.grpc.proto.AffinityConfig$Builder"
+      },
+      "type": "com.google.cloud.grpc.proto.AffinityConfig$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/com.google.cloud/grpc-gcp/index.json
+++ b/metadata/com.google.cloud/grpc-gcp/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.10.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-sources.jar",
+    "repository-url" : "https://github.com/GoogleCloudPlatform/grpc-gcp-java",
+    "test-code-url" : "https://github.com/GoogleCloudPlatform/grpc-gcp-java/tree/$version$/grpc-gcp/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/google/cloud/grpc-gcp/$version$/grpc-gcp-$version$-javadoc.jar",
+    "description" : "grpc-gcp provides Java extensions for using gRPC with Google Cloud clients. It supplies a GCP managed channel layer with channel pooling, affinity configuration, multi-endpoint support, fallback handling, and metrics-related integration for Cloud API calls.",
+    "tested-versions" : [
+      "1.10.0"
+    ],
+    "allowed-packages" : [
+      "com.google.cloud.grpc"
+    ]
+  }
+]

--- a/stats/com.google.cloud/grpc-gcp/1.10.0/execution-metrics.json
+++ b/stats/com.google.cloud/grpc-gcp/1.10.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T13:07:30.860553Z",
+    "library": "com.google.cloud:grpc-gcp:1.10.0",
+    "starting_commit": "6e6d31bcd539ba6c13faf2d9c30eac3e2f573e4c",
+    "ending_commit": "46729e8c37070fc7f84bcdcd123e856f6866e4cd",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.10.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6554,
+          "missed": 9389,
+          "ratio": 0.41109,
+          "total": 15943
+        },
+        "line": {
+          "covered": 1750,
+          "missed": 2181,
+          "ratio": 0.445179,
+          "total": 3931
+        },
+        "method": {
+          "covered": 414,
+          "missed": 396,
+          "ratio": 0.511111,
+          "total": 810
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 474137,
+      "cached_input_tokens_used": 7459328,
+      "output_tokens_used": 40006,
+      "iterations": 6,
+      "cost_usd": 4.9299,
+      "generated_loc": 618,
+      "tested_library_loc": 1750,
+      "metadata_entries": 18,
+      "code_coverage_percent": 44.52
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java",
+      "metadata_file": "metadata/com.google.cloud/grpc-gcp/1.10.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.google.cloud/grpc-gcp/1.10.0/stats.json
+++ b/stats/com.google.cloud/grpc-gcp/1.10.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.10.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6554,
+        "missed" : 9389,
+        "ratio" : 0.41109,
+        "total" : 15943
+      },
+      "line" : {
+        "covered" : 1750,
+        "missed" : 2181,
+        "ratio" : 0.445179,
+        "total" : 3931
+      },
+      "method" : {
+        "covered" : 414,
+        "missed" : 396,
+        "ratio" : 0.511111,
+        "total" : 810
+      }
+    }
+  } ]
+}

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/.gitignore
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
@@ -12,6 +12,12 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "com.google.cloud:grpc-gcp:$libraryVersion"
+    testImplementation 'com.google.api:api-common:2.1.5'
+    testImplementation 'com.google.protobuf:protobuf-java:3.25.5'
+    testImplementation 'com.google.protobuf:protobuf-java-util:3.25.5'
+    testImplementation 'io.grpc:grpc-api:1.69.0'
+    testImplementation 'io.opencensus:opencensus-api:0.28.3'
+    testImplementation 'io.opentelemetry:opentelemetry-api:1.46.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.google.cloud:grpc-gcp:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/gradle.properties
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.google.cloud:grpc-gcp:1.10.0
+library.version = 1.10.0
+metadata.dir = com.google.cloud/grpc-gcp/1.10.0/

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/settings.gradle
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.google.cloud.grpc-gcp_tests'

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
@@ -17,6 +17,7 @@ import com.google.cloud.grpc.GcpManagedChannelOptions.ChannelPickStrategy;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpChannelPoolOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpResiliencyOptions;
+import com.google.cloud.grpc.GcpMultiEndpointChannel;
 import com.google.cloud.grpc.GcpMultiEndpointOptions;
 import com.google.cloud.grpc.fallback.GcpFallbackChannel;
 import com.google.cloud.grpc.fallback.GcpFallbackChannelOptions;
@@ -33,6 +34,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.ConnectivityState;
+import io.grpc.Context;
 import io.grpc.DecompressorRegistry;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
@@ -53,6 +55,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -274,6 +277,61 @@ public class Grpc_gcpTest {
     }
 
     @Test
+    void multiEndpointChannelRoutesCallsUsingDefaultCallOptionAndContextSelections() throws Exception {
+        AtomicInteger builderIndex = new AtomicInteger();
+        List<CountingManagedChannel> createdChannels = new ArrayList<>();
+        ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> configurator = builder ->
+                new TestManagedChannelBuilder("pool-" + builderIndex.incrementAndGet(), createdChannels);
+        GcpManagedChannelOptions managedOptions = GcpManagedChannelOptions.newBuilder()
+                .withChannelPoolOptions(GcpChannelPoolOptions.newBuilder()
+                        .setMaxSize(1)
+                        .setMinSize(0)
+                        .setInitSize(0)
+                        .build())
+                .build();
+        GcpMultiEndpointOptions defaultEndpoint = GcpMultiEndpointOptions.newBuilder(
+                        List.of("default-primary", "default-backup"))
+                .withName("default")
+                .withChannelConfigurator(configurator)
+                .withRecoveryTimeout(Duration.ZERO)
+                .withSwitchingDelay(Duration.ZERO)
+                .build();
+        GcpMultiEndpointOptions analyticsEndpoint = GcpMultiEndpointOptions.newBuilder(List.of("analytics-primary"))
+                .withName("analytics")
+                .withChannelConfigurator(configurator)
+                .withRecoveryTimeout(Duration.ZERO)
+                .withSwitchingDelay(Duration.ZERO)
+                .build();
+        GcpMultiEndpointChannel channel = new GcpMultiEndpointChannel(
+                List.of(defaultEndpoint, analyticsEndpoint), ApiConfig.getDefaultInstance(), managedOptions);
+        try {
+            assertThat(createdChannels).hasSize(3);
+            assertThat(channel.authority()).isEqualTo("pool-1");
+            assertThat(channel.authorityFor("default")).isEqualTo("pool-1");
+            assertThat(channel.authorityFor("analytics")).isEqualTo("pool-3");
+            assertThat(channel.authorityFor("missing")).isNull();
+
+            channel.newCall(METHOD, CallOptions.DEFAULT);
+            channel.newCall(METHOD, CallOptions.DEFAULT.withOption(GcpMultiEndpointChannel.ME_KEY, "analytics"));
+            Context.current()
+                    .withValue(GcpMultiEndpointChannel.ME_CONTEXT_KEY, "analytics")
+                    .run(() -> channel.newCall(METHOD, CallOptions.DEFAULT));
+            Context.current()
+                    .withValue(GcpMultiEndpointChannel.ME_CONTEXT_KEY, "analytics")
+                    .run(() -> channel.newCall(
+                            METHOD, CallOptions.DEFAULT.withOption(GcpMultiEndpointChannel.ME_KEY, "default")));
+            channel.newCall(METHOD, CallOptions.DEFAULT.withOption(GcpMultiEndpointChannel.ME_KEY, "unknown"));
+
+            assertThat(createdChannels.get(0).newCallCount()).isEqualTo(3);
+            assertThat(createdChannels.get(1).newCallCount()).isZero();
+            assertThat(createdChannels.get(2).newCallCount()).isEqualTo(2);
+        } finally {
+            channel.shutdownNow();
+            assertThat(channel.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
     void fallbackOptionsConfigureFallbackChannelAndDelegateLifecycle() throws Exception {
         GcpFallbackOpenTelemetry openTelemetry = GcpFallbackOpenTelemetry.newBuilder()
                 .withSdk(OpenTelemetry.noop())
@@ -351,9 +409,15 @@ public class Grpc_gcpTest {
 
     private static final class TestManagedChannelBuilder extends ManagedChannelBuilder<TestManagedChannelBuilder> {
         private final String authority;
+        private final List<CountingManagedChannel> createdChannels;
 
         private TestManagedChannelBuilder(String authority) {
+            this(authority, new ArrayList<>());
+        }
+
+        private TestManagedChannelBuilder(String authority, List<CountingManagedChannel> createdChannels) {
             this.authority = authority;
+            this.createdChannels = createdChannels;
         }
 
         @Override
@@ -408,7 +472,9 @@ public class Grpc_gcpTest {
 
         @Override
         public ManagedChannel build() {
-            return new CountingManagedChannel(authority);
+            CountingManagedChannel channel = new CountingManagedChannel(authority);
+            createdChannels.add(channel);
+            return channel;
         }
     }
 
@@ -467,6 +533,13 @@ public class Grpc_gcpTest {
         @Override
         public ConnectivityState getState(boolean requestConnection) {
             return shutdown ? ConnectivityState.SHUTDOWN : ConnectivityState.READY;
+        }
+
+        @Override
+        public void notifyWhenStateChanged(ConnectivityState source, Runnable callback) {
+            if (!source.equals(getState(false))) {
+                callback.run();
+            }
         }
     }
 

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_google_cloud.grpc_gcp;
+
+import org.junit.jupiter.api.Test;
+
+class Grpc_gcpTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
@@ -6,11 +6,489 @@
  */
 package com_google_cloud.grpc_gcp;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.api.core.ApiFunction;
+import com.google.cloud.grpc.GcpManagedChannel;
+import com.google.cloud.grpc.GcpManagedChannelBuilder;
+import com.google.cloud.grpc.GcpManagedChannelOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions.ChannelPickStrategy;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpChannelPoolOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpResiliencyOptions;
+import com.google.cloud.grpc.GcpMultiEndpointOptions;
+import com.google.cloud.grpc.fallback.GcpFallbackChannel;
+import com.google.cloud.grpc.fallback.GcpFallbackChannelOptions;
+import com.google.cloud.grpc.fallback.GcpFallbackOpenTelemetry;
+import com.google.cloud.grpc.multiendpoint.MultiEndpoint;
+import com.google.cloud.grpc.proto.AffinityConfig;
+import com.google.cloud.grpc.proto.ApiConfig;
+import com.google.cloud.grpc.proto.ChannelPoolConfig;
+import com.google.cloud.grpc.proto.MethodConfig;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.util.JsonFormat;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.CompressorRegistry;
+import io.grpc.ConnectivityState;
+import io.grpc.DecompressorRegistry;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.MethodDescriptor;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.MetricRegistry;
+import io.opencensus.metrics.Metrics;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class Grpc_gcpTest {
+public class Grpc_gcpTest {
+    private static final MethodDescriptor<String, String> METHOD = MethodDescriptor.<String, String>newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("test.Service", "Unary"))
+            .setRequestMarshaller(new StringMarshaller())
+            .setResponseMarshaller(new StringMarshaller())
+            .build();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void managedChannelOptionsRetainConfiguredValuesAndCanBeCopied() {
+        MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+        LabelKey labelKey = LabelKey.create("location", "Cloud location");
+        LabelValue labelValue = LabelValue.create("test-region");
+        Meter meter = OpenTelemetry.noop().getMeter("grpc-gcp-test");
+        GcpChannelPoolOptions poolOptions = GcpChannelPoolOptions.newBuilder()
+                .setMaxSize(5)
+                .setMinSize(1)
+                .setInitSize(2)
+                .setDynamicScaling(3, 9, Duration.ofSeconds(4))
+                .setConcurrentStreamsLowWatermark(17)
+                .setUseRoundRobinOnBind(true)
+                .setAffinityKeyLifetime(Duration.ofMinutes(10))
+                .setChannelPickStrategy(ChannelPickStrategy.LINEAR_SCAN)
+                .build();
+        GcpMetricsOptions metricsOptions = GcpMetricsOptions.newBuilder()
+                .withMetricRegistry(metricRegistry)
+                .withLabels(List.of(labelKey), List.of(labelValue))
+                .withNamePrefix("custom_prefix")
+                .withOpenTelemetryMeter(meter)
+                .withOtelLabels(List.of("service"), List.of("test-service"))
+                .build();
+        GcpResiliencyOptions resiliencyOptions = GcpResiliencyOptions.newBuilder()
+                .setNotReadyFallback(true)
+                .withUnresponsiveConnectionDetection(250, 4)
+                .build();
+
+        GcpManagedChannelOptions options = GcpManagedChannelOptions.newBuilder()
+                .withChannelPoolOptions(poolOptions)
+                .withMetricsOptions(metricsOptions)
+                .withResiliencyOptions(resiliencyOptions)
+                .build();
+        GcpManagedChannelOptions copied = GcpManagedChannelOptions.newBuilder(options).build();
+
+        assertThat(copied.getChannelPoolOptions().getMaxSize()).isEqualTo(5);
+        assertThat(copied.getChannelPoolOptions().getMinSize()).isEqualTo(1);
+        assertThat(copied.getChannelPoolOptions().getInitSize()).isEqualTo(2);
+        assertThat(copied.getChannelPoolOptions().getMinRpcPerChannel()).isEqualTo(3);
+        assertThat(copied.getChannelPoolOptions().getMaxRpcPerChannel()).isEqualTo(9);
+        assertThat(copied.getChannelPoolOptions().getScaleDownInterval()).isEqualTo(Duration.ofSeconds(4));
+        assertThat(copied.getChannelPoolOptions().getConcurrentStreamsLowWatermark()).isEqualTo(17);
+        assertThat(copied.getChannelPoolOptions().isUseRoundRobinOnBind()).isTrue();
+        assertThat(copied.getChannelPoolOptions().getAffinityKeyLifetime()).isEqualTo(Duration.ofMinutes(10));
+        assertThat(copied.getChannelPoolOptions().getCleanupInterval()).isEqualTo(Duration.ofMinutes(1));
+        assertThat(copied.getChannelPoolOptions().getChannelPickStrategy()).isEqualTo(ChannelPickStrategy.LINEAR_SCAN);
+        assertThat(copied.getMetricsOptions().getMetricRegistry()).isSameAs(metricRegistry);
+        assertThat(copied.getMetricsOptions().getLabelKeys()).containsExactly(labelKey);
+        assertThat(copied.getMetricsOptions().getLabelValues()).containsExactly(labelValue);
+        assertThat(copied.getMetricsOptions().getNamePrefix()).isEqualTo("custom_prefix");
+        assertThat(copied.getMetricsOptions().getOpenTelemetryMeter()).isSameAs(meter);
+        assertThat(copied.getMetricsOptions().getOtelLabelKeys()).containsExactly("service");
+        assertThat(copied.getMetricsOptions().getOtelLabelValues()).containsExactly("test-service");
+        assertThat(copied.getResiliencyOptions().isNotReadyFallbackEnabled()).isTrue();
+        assertThat(copied.getResiliencyOptions().isUnresponsiveDetectionEnabled()).isTrue();
+        assertThat(copied.getResiliencyOptions().getUnresponsiveDetectionMs()).isEqualTo(250);
+        assertThat(copied.getResiliencyOptions().getUnresponsiveDetectionDroppedCount()).isEqualTo(4);
+        assertThat(copied.toString()).contains("channelPoolOptions", "metricsOptions", "resiliencyOptions");
+    }
+
+    @Test
+    void optionBuildersValidatePoolAndEndpointInputs() {
+        assertThatThrownBy(() -> GcpChannelPoolOptions.newBuilder().setMaxSize(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+        assertThatThrownBy(() -> GcpChannelPoolOptions.newBuilder().setMinSize(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 or positive");
+        assertThatThrownBy(() -> GcpChannelPoolOptions.newBuilder().setDynamicScaling(1, 2, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Scale down interval");
+        assertThatThrownBy(() -> GcpChannelPoolOptions.newBuilder().setAffinityKeyLifetime(Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("may not be negative");
+        assertThatThrownBy(() -> GcpMultiEndpointOptions.newBuilder(List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one endpoint");
+        assertThatThrownBy(() -> GcpMultiEndpointOptions.newBuilder(List.of("primary", " ")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No empty endpoints");
+    }
+
+    @Test
+    void protoConfigurationSupportsBuildersJsonAndParsing() throws Exception {
+        ApiConfig config = ApiConfig.newBuilder()
+                .setChannelPool(ChannelPoolConfig.newBuilder()
+                        .setMaxSize(4)
+                        .setIdleTimeout(30)
+                        .setMaxConcurrentStreamsLowWatermark(42))
+                .addMethod(MethodConfig.newBuilder()
+                        .addName("/test.Service/Unary")
+                        .setAffinity(AffinityConfig.newBuilder()
+                                .setCommand(AffinityConfig.Command.BIND)
+                                .setAffinityKey("tenant_id")))
+                .build();
+
+        byte[] serialized = config.toByteArray();
+        ApiConfig fromBytes = ApiConfig.parseFrom(serialized);
+        ApiConfig fromByteString = ApiConfig.parseFrom(ByteString.copyFrom(serialized));
+        String json = JsonFormat.printer().print(config);
+        ApiConfig.Builder jsonBuilder = ApiConfig.newBuilder();
+        JsonFormat.parser().merge(json, jsonBuilder);
+        ByteArrayOutputStream delimitedMethod = new ByteArrayOutputStream();
+        config.getMethod(0).writeDelimitedTo(delimitedMethod);
+
+        assertThat(fromBytes).isEqualTo(config);
+        assertThat(fromByteString.getChannelPool().getMaxSize()).isEqualTo(4);
+        assertThat(jsonBuilder.build().getMethod(0).getAffinity().getCommand()).isEqualTo(AffinityConfig.Command.BIND);
+        assertThat(AffinityConfig.Command.forNumber(AffinityConfig.Command.UNBIND_VALUE))
+                .isEqualTo(AffinityConfig.Command.UNBIND);
+        assertThat(MethodConfig.parseDelimitedFrom(new ByteArrayInputStream(delimitedMethod.toByteArray())))
+                .isEqualTo(config.getMethod(0));
+    }
+
+    @Test
+    void managedChannelBuilderLoadsApiConfigFromJsonStringAndFile() throws Exception {
+        String json = """
+                {
+                  "channelPool": {
+                    "maxSize": 3,
+                    "maxConcurrentStreamsLowWatermark": 7
+                  },
+                  "method": [{
+                    "name": ["/test.Service/Unary"],
+                    "affinity": {
+                      "command": "BIND",
+                      "affinityKey": "tenant_id"
+                    }
+                  }]
+                }
+                """;
+        GcpManagedChannel fromString = null;
+        GcpManagedChannel fromFile = null;
+        try {
+            fromString = (GcpManagedChannel) GcpManagedChannelBuilder
+                    .forDelegateBuilder(new TestManagedChannelBuilder("string-config-authority"))
+                    .withApiConfigJsonString(json)
+                    .setPoolSize(2)
+                    .build();
+            File configFile = Files.writeString(Files.createTempFile("grpc-gcp", ".json"), json, StandardCharsets.UTF_8)
+                    .toFile();
+            fromFile = (GcpManagedChannel) GcpManagedChannelBuilder
+                    .forDelegateBuilder(new TestManagedChannelBuilder("file-config-authority"))
+                    .withApiConfigJsonFile(configFile)
+                    .build();
+
+            assertThat(fromString.getMaxSize()).isEqualTo(2);
+            assertThat(fromString.getStreamsLowWatermark()).isEqualTo(7);
+            assertThat(fromString.authority()).isEqualTo("string-config-authority");
+            assertThat(fromString.isShutdown()).isFalse();
+            assertThat(fromFile.getMaxSize()).isEqualTo(3);
+            assertThat(fromFile.getStreamsLowWatermark()).isEqualTo(7);
+            assertThat(CallOptions.DEFAULT.withOption(GcpManagedChannel.AFFINITY_KEY, "tenant-a")
+                    .getOption(GcpManagedChannel.AFFINITY_KEY)).isEqualTo("tenant-a");
+        } finally {
+            shutdown(fromString);
+            shutdown(fromFile);
+        }
+    }
+
+    @Test
+    void multiEndpointOptionsCanBeCopiedAndCoreEndpointSelectionTracksSwitches() {
+        ApiFunction<ManagedChannelBuilder<?>, ManagedChannelBuilder<?>> configurator = builder -> builder;
+        GcpMultiEndpointOptions options = GcpMultiEndpointOptions.newBuilder(List.of("first.example:443"))
+                .withName("test-multi-endpoint")
+                .withEndpoints(List.of("first.example:443", "second.example:443"))
+                .withChannelConfigurator(configurator)
+                .withChannelCredentials(InsecureChannelCredentials.create())
+                .withRecoveryTimeout(Duration.ofMillis(100))
+                .withSwitchingDelay(Duration.ZERO)
+                .build();
+        GcpMultiEndpointOptions copy = GcpMultiEndpointOptions.newBuilder(options).build();
+
+        assertThat(copy.getName()).isEqualTo("test-multi-endpoint");
+        assertThat(copy.getEndpoints()).containsExactly("first.example:443", "second.example:443");
+        assertThat(copy.getChannelConfigurator()).isSameAs(configurator);
+        assertThat(copy.getChannelCredentials()).isNotNull();
+        assertThat(copy.getRecoveryTimeout()).isEqualTo(Duration.ofMillis(100));
+        assertThat(copy.getSwitchingDelay()).isEqualTo(Duration.ZERO);
+
+        MultiEndpoint multiEndpoint = new MultiEndpoint.Builder(List.of("primary", "secondary"))
+                .withRecoveryTimeout(Duration.ZERO)
+                .withSwitchingDelay(Duration.ZERO)
+                .build();
+        assertThat(multiEndpoint.getEndpoints()).containsExactly("primary", "secondary");
+        assertThat(multiEndpoint.getCurrentId()).isEqualTo("primary");
+
+        multiEndpoint.setEndpointAvailable("primary", true);
+        multiEndpoint.setEndpointAvailable("secondary", true);
+        multiEndpoint.setEndpointAvailable("primary", false);
+        assertThat(multiEndpoint.getCurrentId()).isEqualTo("secondary");
+        assertThat(multiEndpoint.getFallbackCnt()).isEqualTo(1);
+
+        multiEndpoint.setEndpointAvailable("primary", true);
+        assertThat(multiEndpoint.getCurrentId()).isEqualTo("primary");
+        assertThat(multiEndpoint.getRecoverCnt()).isEqualTo(1);
+
+        multiEndpoint.setEndpoints(List.of("replacement"));
+        assertThat(multiEndpoint.getEndpoints()).containsExactly("replacement");
+        assertThat(multiEndpoint.getCurrentId()).isEqualTo("replacement");
+        assertThat(multiEndpoint.getReplaceCnt()).isEqualTo(1);
+        assertThat(multiEndpoint.toString()).contains("currentId='replacement'");
+    }
+
+    @Test
+    void fallbackOptionsConfigureFallbackChannelAndDelegateLifecycle() throws Exception {
+        GcpFallbackOpenTelemetry openTelemetry = GcpFallbackOpenTelemetry.newBuilder()
+                .withSdk(OpenTelemetry.noop())
+                .disableAllMetrics()
+                .enableMetrics(List.of("grpc.gcp.fallback.current_channel"))
+                .disableMetrics(List.of("grpc.gcp.fallback.error_rate"))
+                .build();
+        Set<Status.Code> erroneousStates = EnumSet.of(Status.Code.UNAVAILABLE, Status.Code.INTERNAL);
+        GcpFallbackChannelOptions options = GcpFallbackChannelOptions.newBuilder()
+                .setEnableFallback(false)
+                .setErrorRateThreshold(0.75f)
+                .setErroneousStates(erroneousStates)
+                .setPeriod(Duration.ofMillis(100))
+                .setMinFailedCalls(2)
+                .setProbingFunction(channel -> channel.authority())
+                .setPrimaryProbingInterval(Duration.ofSeconds(1))
+                .setFallbackProbingInterval(Duration.ofSeconds(2))
+                .setPrimaryChannelName("primary-channel")
+                .setFallbackChannelName("fallback-channel")
+                .setGcpFallbackOpenTelemetry(openTelemetry)
+                .build();
+        CountingManagedChannel primary = new CountingManagedChannel("primary-authority");
+        CountingManagedChannel fallback = new CountingManagedChannel("fallback-authority");
+        GcpFallbackChannel channel = new GcpFallbackChannel(options, primary, fallback);
+        try {
+            ClientCall<String, String> call = channel.newCall(METHOD, CallOptions.DEFAULT);
+
+            assertThat(call).isNotNull();
+            assertThat(channel.isInFallbackMode()).isFalse();
+            assertThat(channel.authority()).isEqualTo("primary-authority");
+            assertThat(primary.newCallCount()).isEqualTo(1);
+            assertThat(fallback.newCallCount()).isZero();
+            assertThat(options.isEnableFallback()).isFalse();
+            assertThat(options.getErrorRateThreshold()).isEqualTo(0.75f);
+            assertThat(options.getErroneousStates()).containsExactlyInAnyOrderElementsOf(erroneousStates);
+            assertThat(options.getPeriod()).isEqualTo(Duration.ofMillis(100));
+            assertThat(options.getMinFailedCalls()).isEqualTo(2);
+            assertThat(options.getPrimaryProbingFunction().apply(primary)).isEqualTo("primary-authority");
+            assertThat(options.getFallbackProbingFunction().apply(fallback)).isEqualTo("fallback-authority");
+            assertThat(options.getPrimaryProbingInterval()).isEqualTo(Duration.ofSeconds(1));
+            assertThat(options.getFallbackProbingInterval()).isEqualTo(Duration.ofSeconds(2));
+            assertThat(options.getPrimaryChannelName()).isEqualTo("primary-channel");
+            assertThat(options.getFallbackChannelName()).isEqualTo("fallback-channel");
+            assertThat(options.getGcpOpenTelemetry()).isSameAs(openTelemetry);
+        } finally {
+            channel.shutdownNow();
+            assertThat(channel.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+        assertThat(primary.isShutdown()).isTrue();
+        assertThat(fallback.isShutdown()).isTrue();
+    }
+
+    private static void shutdown(ManagedChannel channel) throws InterruptedException {
+        if (channel != null) {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static final class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+        @Override
+        public InputStream stream(String value) {
+            return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String parse(InputStream stream) {
+            try {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to parse test message", e);
+            }
+        }
+    }
+
+    private static final class TestManagedChannelBuilder extends ManagedChannelBuilder<TestManagedChannelBuilder> {
+        private final String authority;
+
+        private TestManagedChannelBuilder(String authority) {
+            this.authority = authority;
+        }
+
+        @Override
+        public TestManagedChannelBuilder directExecutor() {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder executor(Executor executor) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder intercept(List<ClientInterceptor> interceptors) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder intercept(ClientInterceptor... interceptors) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder userAgent(String userAgent) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder overrideAuthority(String authority) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder nameResolverFactory(NameResolver.Factory resolverFactory) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder decompressorRegistry(DecompressorRegistry registry) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder compressorRegistry(CompressorRegistry registry) {
+            return this;
+        }
+
+        @Override
+        public TestManagedChannelBuilder idleTimeout(long value, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public ManagedChannel build() {
+            return new CountingManagedChannel(authority);
+        }
+    }
+
+    private static final class CountingManagedChannel extends ManagedChannel {
+        private final String authority;
+        private final AtomicInteger newCallCount = new AtomicInteger();
+        private volatile boolean shutdown;
+
+        private CountingManagedChannel(String authority) {
+            this.authority = authority;
+        }
+
+        private int newCallCount() {
+            return newCallCount.get();
+        }
+
+        @Override
+        public ManagedChannel shutdown() {
+            shutdown = true;
+            return this;
+        }
+
+        @Override
+        public ManagedChannel shutdownNow() {
+            shutdown = true;
+            return this;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return shutdown;
+        }
+
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+            newCallCount.incrementAndGet();
+            return new NoopClientCall<>();
+        }
+
+        @Override
+        public String authority() {
+            return authority;
+        }
+
+        @Override
+        public ConnectivityState getState(boolean requestConnection) {
+            return shutdown ? ConnectivityState.SHUTDOWN : ConnectivityState.READY;
+        }
+    }
+
+    private static final class NoopClientCall<RequestT, ResponseT> extends ClientCall<RequestT, ResponseT> {
+        @Override
+        public void start(Listener<ResponseT> responseListener, io.grpc.Metadata headers) {
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+        }
+
+        @Override
+        public void halfClose() {
+        }
+
+        @Override
+        public void sendMessage(RequestT message) {
+        }
     }
 }

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/src/test/java/com_google_cloud/grpc_gcp/Grpc_gcpTest.java
@@ -39,6 +39,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.NameResolver;
 import io.grpc.Status;
@@ -62,6 +63,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.Test;
 
 public class Grpc_gcpTest {
@@ -332,6 +334,37 @@ public class Grpc_gcpTest {
     }
 
     @Test
+    void fallbackChannelSwitchesToFallbackWhenPrimaryErrorRateThresholdIsReached() throws Exception {
+        GcpFallbackChannelOptions options = GcpFallbackChannelOptions.newBuilder()
+                .setEnableFallback(true)
+                .setErrorRateThreshold(0.5f)
+                .setErroneousStates(EnumSet.of(Status.Code.UNAVAILABLE))
+                .setPeriod(Duration.ofMillis(100))
+                .setMinFailedCalls(2)
+                .setGcpFallbackOpenTelemetry(GcpFallbackOpenTelemetry.newBuilder().disableAllMetrics().build())
+                .build();
+        StatusManagedChannel primary = new StatusManagedChannel("primary-authority", Status.UNAVAILABLE);
+        StatusManagedChannel fallback = new StatusManagedChannel("fallback-authority", Status.OK);
+        GcpFallbackChannel channel = new GcpFallbackChannel(options, primary, fallback);
+        try {
+            startCall(channel);
+            startCall(channel);
+
+            assertThat(primary.newCallCount()).isEqualTo(2);
+            assertThat(fallback.newCallCount()).isZero();
+
+            waitUntil(channel::isInFallbackMode);
+            assertThat(channel.authority()).isEqualTo("fallback-authority");
+
+            startCall(channel);
+            assertThat(fallback.newCallCount()).isEqualTo(1);
+        } finally {
+            channel.shutdownNow();
+            assertThat(channel.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
     void fallbackOptionsConfigureFallbackChannelAndDelegateLifecycle() throws Exception {
         GcpFallbackOpenTelemetry openTelemetry = GcpFallbackOpenTelemetry.newBuilder()
                 .withSdk(OpenTelemetry.noop())
@@ -389,6 +422,20 @@ public class Grpc_gcpTest {
             channel.shutdownNow();
             channel.awaitTermination(5, TimeUnit.SECONDS);
         }
+    }
+
+    private static void startCall(ManagedChannel channel) {
+        ClientCall<String, String> call = channel.newCall(METHOD, CallOptions.DEFAULT);
+        call.start(new ClientCall.Listener<>() {
+        }, new Metadata());
+    }
+
+    private static void waitUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertThat(condition.getAsBoolean()).isTrue();
     }
 
     private static final class StringMarshaller implements MethodDescriptor.Marshaller<String> {
@@ -543,9 +590,93 @@ public class Grpc_gcpTest {
         }
     }
 
+    private static final class StatusManagedChannel extends ManagedChannel {
+        private final String authority;
+        private final Status closeStatus;
+        private final AtomicInteger newCallCount = new AtomicInteger();
+        private volatile boolean shutdown;
+
+        private StatusManagedChannel(String authority, Status closeStatus) {
+            this.authority = authority;
+            this.closeStatus = closeStatus;
+        }
+
+        private int newCallCount() {
+            return newCallCount.get();
+        }
+
+        @Override
+        public ManagedChannel shutdown() {
+            shutdown = true;
+            return this;
+        }
+
+        @Override
+        public ManagedChannel shutdownNow() {
+            shutdown = true;
+            return this;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return shutdown;
+        }
+
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+            newCallCount.incrementAndGet();
+            return new StatusClientCall<>(closeStatus);
+        }
+
+        @Override
+        public String authority() {
+            return authority;
+        }
+    }
+
+    private static final class StatusClientCall<RequestT, ResponseT> extends ClientCall<RequestT, ResponseT> {
+        private final Status closeStatus;
+
+        private StatusClientCall(Status closeStatus) {
+            this.closeStatus = closeStatus;
+        }
+
+        @Override
+        public void start(Listener<ResponseT> responseListener, Metadata headers) {
+            responseListener.onClose(closeStatus, new Metadata());
+        }
+
+        @Override
+        public void request(int numMessages) {
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+        }
+
+        @Override
+        public void halfClose() {
+        }
+
+        @Override
+        public void sendMessage(RequestT message) {
+        }
+    }
+
     private static final class NoopClientCall<RequestT, ResponseT> extends ClientCall<RequestT, ResponseT> {
         @Override
-        public void start(Listener<ResponseT> responseListener, io.grpc.Metadata headers) {
+        public void start(Listener<ResponseT> responseListener, Metadata headers) {
         }
 
         @Override

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/user-code-filter.json
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.google.cloud.grpc.**"
+      "includeClasses" : "com.google.cloud.grpc.**"
+    },
+    {
+      "includeClasses" : "com_google_cloud.grpc_gcp.**"
     }
   ]
 }

--- a/tests/src/com.google.cloud/grpc-gcp/1.10.0/user-code-filter.json
+++ b/tests/src/com.google.cloud/grpc-gcp/1.10.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.google.cloud.grpc.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4705

This PR introduces tests and metadata for com.google.cloud:grpc-gcp:1.10.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 474137
- Cached input tokens: 7459328
- Output tokens: 40006
- Metadata entries: 18
- Iterations: 6
- Library coverage percentage: 44.52
- Generated lines of code: 618
- Tested library lines of code: 1750

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b208df6e318d3d991b162f197eadfb657e20f6a0`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 6554/15943 (41.11%)
- Line: 1750/3931 (44.52%)
- Method: 414/810 (51.11%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
