### PR TITLE
[GenAI] Add support for software.amazon.awssdk:retries:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T11:34:09.949148Z",
+    "timestamp": "2026-05-04T13:11:40.463324Z",
     "library": "software.amazon.awssdk:retries:2.34.0",
-    "starting_commit": "d21334aa146de20e69d36ea11c3cd729991a7715",
-    "ending_commit": "ea768223cdad88ac4fe12cda7e432400dfd83f03",
+    "starting_commit": "ffe7849a73fd519ba1f269bd1b57f71c29e6cc7d",
+    "ending_commit": "3a463456efef857ad8f44275cf08e199291f4adc",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -18,35 +18,35 @@
       },
       "libraryCoverage": {
         "instruction": {
-          "covered": 2174,
-          "missed": 464,
-          "ratio": 0.824109,
+          "covered": 2356,
+          "missed": 282,
+          "ratio": 0.893101,
           "total": 2638
         },
         "line": {
-          "covered": 596,
-          "missed": 101,
-          "ratio": 0.855093,
+          "covered": 642,
+          "missed": 55,
+          "ratio": 0.92109,
           "total": 697
         },
         "method": {
-          "covered": 186,
-          "missed": 41,
-          "ratio": 0.819383,
+          "covered": 198,
+          "missed": 29,
+          "ratio": 0.872247,
           "total": 227
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 146922,
-      "cached_input_tokens_used": 1445376,
-      "output_tokens_used": 15078,
+      "input_tokens_used": 180113,
+      "cached_input_tokens_used": 1789440,
+      "output_tokens_used": 14486,
       "iterations": 3,
-      "cost_usd": 1.175,
-      "generated_loc": 456,
-      "tested_library_loc": 596,
+      "cost_usd": 1.3293,
+      "generated_loc": 608,
+      "tested_library_loc": 642,
       "metadata_entries": 0,
-      "code_coverage_percent": 85.51
+      "code_coverage_percent": 92.11
     },
     "artifacts": {
       "test_file": "tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java",

--- a/stats/software.amazon.awssdk/retries/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/retries/2.34.0/stats.json
@@ -9,21 +9,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 2174,
-        "missed" : 464,
-        "ratio" : 0.824109,
+        "covered" : 2356,
+        "missed" : 282,
+        "ratio" : 0.893101,
         "total" : 2638
       },
       "line" : {
-        "covered" : 596,
-        "missed" : 101,
-        "ratio" : 0.855093,
+        "covered" : 642,
+        "missed" : 55,
+        "ratio" : 0.92109,
         "total" : 697
       },
       "method" : {
-        "covered" : 186,
-        "missed" : 41,
-        "ratio" : 0.819383,
+        "covered" : 198,
+        "missed" : 29,
+        "ratio" : 0.872247,
         "total" : 227
       }
     }

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -493,6 +493,105 @@ public class RetriesTest {
         assertThat(successToken).isNotSameAs(initialToken);
     }
 
+    @Test
+    void standardStrategyToBuilderCopiesConfigurationAndUseClientDefaults() {
+        StandardRetryStrategy original = StandardRetryStrategy.builder()
+            .maxAttempts(4)
+            .useClientDefaults(false)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(6)))
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(18)))
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+
+        StandardRetryStrategy copied = original.toBuilder()
+            .maxAttempts(3)
+            .build();
+
+        assertThat(original.maxAttempts()).isEqualTo(4);
+        assertThat(original.useClientDefaults()).isFalse();
+        assertThat(copied.maxAttempts()).isEqualTo(3);
+        assertThat(copied.useClientDefaults()).isFalse();
+        assertThat(refreshDelay(copied, new RuntimeException("normal"), "standard-copy-normal"))
+            .isEqualTo(Duration.ofMillis(6));
+        assertThat(refreshDelay(copied, new ThrottlingFailure(), "standard-copy-throttled"))
+            .isEqualTo(Duration.ofMillis(18));
+    }
+
+    @Test
+    void legacyStrategyToBuilderCopiesConfigurationAndUseClientDefaults() {
+        LegacyRetryStrategy original = LegacyRetryStrategy.builder()
+            .maxAttempts(4)
+            .useClientDefaults(false)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(5)))
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(21)))
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+
+        LegacyRetryStrategy copied = original.toBuilder()
+            .maxAttempts(2)
+            .build();
+
+        assertThat(original.maxAttempts()).isEqualTo(4);
+        assertThat(original.useClientDefaults()).isFalse();
+        assertThat(copied.maxAttempts()).isEqualTo(2);
+        assertThat(copied.useClientDefaults()).isFalse();
+        assertThat(refreshDelay(copied, new RuntimeException("normal"), "legacy-copy-normal"))
+            .isEqualTo(Duration.ofMillis(5));
+        assertThat(refreshDelay(copied, new ThrottlingFailure(), "legacy-copy-throttled"))
+            .isEqualTo(Duration.ofMillis(21));
+    }
+
+    @Test
+    void adaptiveStrategyRecordsSuccessAfterThrottledRetry() {
+        AdaptiveRetryStrategy strategy = AdaptiveRetryStrategy.builder()
+            .maxAttempts(3)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .throttlingBackoffStrategy(BackoffStrategy.retryImmediately())
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .useClientDefaults(false)
+            .build();
+        RetryToken initialToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("adaptive-success"))
+            .token();
+        RefreshRetryTokenResponse retry = strategy.refreshRetryToken(
+            refreshRequest(initialToken, new ThrottlingFailure()).build());
+
+        RecordSuccessResponse success = strategy.recordSuccess(RecordSuccessRequest.create(retry.token()));
+
+        assertThat(success.token()).isNotNull();
+        assertThat(success.token()).isNotSameAs(retry.token());
+    }
+
+    @Test
+    void strategiesAndTokensExposeReadableDiagnosticStrings() {
+        StandardRetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .useClientDefaults(false)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(4)))
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(14)))
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+
+        RetryToken initialToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("diagnostic-scope"))
+            .token();
+        RefreshRetryTokenResponse retry = strategy.refreshRetryToken(
+            refreshRequest(initialToken, new RuntimeException("diagnostic failure")).build());
+
+        assertThat(strategy.toString())
+            .contains("BaseRetryStrategy", "maxAttempts=2", "circuitBreakerEnabled=false", "useClientDefaults=false")
+            .contains("backoffStrategy", "throttlingBackoffStrategy");
+        assertThat(initialToken.toString())
+            .contains("StandardRetryToken", "scope=diagnostic-scope", "attempt=1", "capacityAcquired=0");
+        assertThat(retry.token().toString())
+            .contains("StandardRetryToken", "scope=diagnostic-scope", "attempt=2", "diagnostic failure");
+    }
+
     private static RefreshRetryTokenRequest.Builder refreshRequest(RetryToken token, Throwable failure) {
         return RefreshRetryTokenRequest.builder()
             .token(token)
@@ -504,6 +603,11 @@ public class RetriesTest {
             AcquireInitialTokenRequest.create("success-" + failure.getClass().getName()))
             .token();
         assertThat(strategy.refreshRetryToken(refreshRequest(token, failure).build()).token()).isNotNull();
+    }
+
+    private static Duration refreshDelay(RetryStrategy strategy, Throwable failure, String scope) {
+        RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create(scope)).token();
+        return strategy.refreshRetryToken(refreshRequest(token, failure).build()).delay();
     }
 
     private static void assertRefreshFails(RetryStrategy strategy, Throwable failure) {

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -182,6 +182,39 @@ public class RetriesTest {
     }
 
     @Test
+    void circuitBreakerCapacityIsIsolatedByRequestScope() {
+        StandardRetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .circuitBreakerEnabled(true)
+            .build();
+        String exhaustedScope = "exhausted-scope";
+        TokenAcquisitionFailedException blockedRetry = null;
+
+        for (int attempt = 0; attempt < 200 && blockedRetry == null; attempt++) {
+            RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create(exhaustedScope)).token();
+            RuntimeException failure = new RuntimeException("scope failure " + attempt);
+            try {
+                strategy.refreshRetryToken(refreshRequest(token, failure).build());
+            } catch (TokenAcquisitionFailedException e) {
+                assertThat(e).hasCause(failure);
+                blockedRetry = e;
+            }
+        }
+
+        assertThat(blockedRetry).isNotNull()
+            .hasMessageContaining("protect the caller");
+
+        RetryToken independentScopeToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create(
+            "independent-scope")).token();
+        RefreshRetryTokenResponse retry = strategy.refreshRetryToken(
+            refreshRequest(independentScopeToken, new RuntimeException("independent failure")).build());
+
+        assertThat(retry.token()).isNotNull();
+    }
+
+    @Test
     void legacyStrategyUsesThrottlingBackoffForFailuresMarkedAsThrottling() {
         LegacyRetryStrategy strategy = LegacyRetryStrategy.builder()
             .maxAttempts(3)

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -205,6 +205,43 @@ public class RetriesTest {
     }
 
     @Test
+    void legacyStrategyDoesNotSpendCircuitBreakerCapacityForThrottlingFailures() {
+        LegacyRetryStrategy strategy = LegacyRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .throttlingBackoffStrategy(BackoffStrategy.retryImmediately())
+            .circuitBreakerEnabled(true)
+            .build();
+        String throttledScope = "legacy-throttling-capacity";
+
+        for (int attempt = 0; attempt < 120; attempt++) {
+            RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create(throttledScope)).token();
+            RefreshRetryTokenResponse retry = strategy.refreshRetryToken(
+                refreshRequest(token, new ThrottlingFailure()).build());
+            assertThat(retry.token()).isNotNull();
+        }
+
+        TokenAcquisitionFailedException blockedRetry = null;
+        for (int attempt = 0; attempt < 200 && blockedRetry == null; attempt++) {
+            RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("legacy-normal-capacity"))
+                .token();
+            RuntimeException failure = new RuntimeException("normal-" + attempt);
+            try {
+                strategy.refreshRetryToken(refreshRequest(token, failure).build());
+            } catch (TokenAcquisitionFailedException e) {
+                assertThat(e).hasCause(failure);
+                blockedRetry = e;
+            }
+        }
+
+        assertThat(blockedRetry).isNotNull()
+            .hasMessageContaining("protect the caller")
+            .satisfies(exception -> assertThat(exception.token()).isNotNull());
+    }
+
+    @Test
     void adaptiveStrategyAppliesConfiguredBackoffAndCanBeCopied() {
         AdaptiveRetryStrategy strategy = AdaptiveRetryStrategy.builder()
             .maxAttempts(4)


### PR DESCRIPTION

## What does this PR do?

Fixes: #4589

This PR introduces tests and metadata for software.amazon.awssdk:retries:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 180113
- Cached input tokens: 1789440
- Output tokens: 14486
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 92.11
- Generated lines of code: 608
- Tested library lines of code: 642

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ffe7849a73fd519ba1f269bd1b57f71c29e6cc7d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2356/2638 (89.31%)
- Line: 642/697 (92.11%)
- Method: 198/227 (87.22%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
