### PR TITLE
[GenAI] Add support for software.amazon.awssdk:retries-spi:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/retries-spi/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/retries-spi/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T10:08:31.258064Z",
+    "timestamp": "2026-05-04T12:30:48.761423Z",
     "library": "software.amazon.awssdk:retries-spi:2.34.0",
-    "starting_commit": "2af50df6b3b78b2ccd11961dff1c80140350eef5",
-    "ending_commit": "34fde6e5a5588200b97f38f7dc0609baccf20888",
+    "starting_commit": "1d01dcd700f9deea15a129b7580c040035abe30b",
+    "ending_commit": "1b8cd23afc08f7aace8da306114842375ebc9357",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 184126,
-      "cached_input_tokens_used": 1285120,
-      "output_tokens_used": 13944,
-      "iterations": 3,
-      "cost_usd": 1.0609,
-      "generated_loc": 456,
+      "input_tokens_used": 181386,
+      "cached_input_tokens_used": 1177600,
+      "output_tokens_used": 15465,
+      "iterations": 5,
+      "cost_usd": 1.0527,
+      "generated_loc": 570,
       "tested_library_loc": 179,
       "metadata_entries": 0,
       "code_coverage_percent": 100.0

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class Retries_spiTest {
+    private static final Duration ONE_MILLI = Duration.ofMillis(1);
     private static final Duration FIFTY_MILLIS = Duration.ofMillis(50);
     private static final Duration HUNDRED_MILLIS = Duration.ofMillis(100);
     private static final Duration TWO_HUNDRED_MILLIS = Duration.ofMillis(200);
@@ -225,6 +226,17 @@ public class Retries_spiTest {
         assertThat(strategy.computeDelay(3)).isEqualTo(TWO_HUNDRED_MILLIS);
         assertThat(strategy.computeDelay(4)).isEqualTo(Duration.ofMillis(400));
         assertThat(strategy.computeDelay(20)).isEqualTo(ONE_SECOND);
+    }
+
+    @Test
+    void exponentialBackoffCapsAttemptGrowthBeforeIntegerOverflow() {
+        BackoffStrategy strategy = BackoffStrategy.exponentialDelayWithoutJitter(
+                ONE_MILLI, Duration.ofMillis(Integer.MAX_VALUE));
+        Duration highestCalculatedDelay = Duration.ofMillis(1L << 28);
+
+        assertThat(strategy.computeDelay(30)).isEqualTo(highestCalculatedDelay);
+        assertThat(strategy.computeDelay(31)).isEqualTo(highestCalculatedDelay);
+        assertThat(strategy.computeDelay(Integer.MAX_VALUE)).isEqualTo(highestCalculatedDelay);
     }
 
     @Test

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -51,6 +51,23 @@ public class Retries_spiTest {
     }
 
     @Test
+    void factoriesTreatScopeAsOpaqueAndAllowZeroDelays() {
+        RetryToken token = new TestRetryToken("zero-delay");
+
+        AcquireInitialTokenRequest emptyScopeRequest = AcquireInitialTokenRequest.create("");
+        AcquireInitialTokenRequest spacedScopeRequest = AcquireInitialTokenRequest.create("  scoped operation  ");
+        AcquireInitialTokenResponse initialResponse = AcquireInitialTokenResponse.create(token, Duration.ZERO);
+        RefreshRetryTokenResponse refreshResponse = RefreshRetryTokenResponse.create(token, Duration.ZERO);
+
+        assertThat(emptyScopeRequest.scope()).isEmpty();
+        assertThat(spacedScopeRequest.scope()).isEqualTo("  scoped operation  ");
+        assertThat(initialResponse.token()).isSameAs(token);
+        assertThat(initialResponse.delay()).isEqualTo(Duration.ZERO);
+        assertThat(refreshResponse.token()).isSameAs(token);
+        assertThat(refreshResponse.delay()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
     void factoriesRejectMissingRequiredValues() {
         RetryToken token = new TestRetryToken("token");
 
@@ -92,6 +109,22 @@ public class Retries_spiTest {
         assertThat(request.token()).isSameAs(token);
         assertThat(request.failure()).isSameAs(failure);
         assertThat(request.suggestedDelay()).contains(Duration.ZERO);
+    }
+
+    @Test
+    void refreshRetryTokenRequestBuilderMethodsAreChainable() {
+        RetryToken token = new TestRetryToken("retry");
+        RuntimeException failure = new RuntimeException("failure");
+        RefreshRetryTokenRequest.Builder builder = RefreshRetryTokenRequest.builder();
+
+        assertThat(builder.token(token)).isSameAs(builder);
+        assertThat(builder.suggestedDelay(FIFTY_MILLIS)).isSameAs(builder);
+        assertThat(builder.failure(failure)).isSameAs(builder);
+
+        RefreshRetryTokenRequest request = builder.build();
+        assertThat(request.token()).isSameAs(token);
+        assertThat(request.suggestedDelay()).contains(FIFTY_MILLIS);
+        assertThat(request.failure()).isSameAs(failure);
     }
 
     @Test
@@ -267,6 +300,37 @@ public class Retries_spiTest {
     }
 
     @Test
+    void backoffStrategyFactoriesRejectNullDurations() {
+        assertThatThrownBy(() -> BackoffStrategy.fixedDelayWithoutJitter(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> BackoffStrategy.fixedDelay(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> BackoffStrategy.exponentialDelayWithoutJitter(null, ONE_SECOND))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> BackoffStrategy.exponentialDelay(HUNDRED_MILLIS, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> BackoffStrategy.exponentialDelayHalfJitter(null, ONE_SECOND))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void exponentialBackoffUsesMaximumDelayWhenMaximumIsLowerThanBase() {
+        BackoffStrategy withoutJitter = BackoffStrategy.exponentialDelayWithoutJitter(ONE_SECOND, HUNDRED_MILLIS);
+        BackoffStrategy fullJitter = BackoffStrategy.exponentialDelay(ONE_SECOND, HUNDRED_MILLIS);
+        BackoffStrategy halfJitter = BackoffStrategy.exponentialDelayHalfJitter(ONE_SECOND, HUNDRED_MILLIS);
+
+        assertThat(withoutJitter.computeDelay(1)).isEqualTo(Duration.ZERO);
+        assertThat(withoutJitter.computeDelay(2)).isEqualTo(HUNDRED_MILLIS);
+        assertThat(withoutJitter.computeDelay(10)).isEqualTo(HUNDRED_MILLIS);
+        assertThat(fullJitter.computeDelay(2))
+                .isGreaterThanOrEqualTo(Duration.ZERO)
+                .isLessThan(HUNDRED_MILLIS);
+        assertThat(halfJitter.computeDelay(2))
+                .isGreaterThanOrEqualTo(FIFTY_MILLIS)
+                .isLessThanOrEqualTo(HUNDRED_MILLIS);
+    }
+
+    @Test
     void backoffStrategiesExposeReadableDescriptions() {
         assertThat(BackoffStrategy.retryImmediately().toString()).isEqualTo("(Immediately)");
         assertThat(BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS).toString())
@@ -353,6 +417,20 @@ public class Retries_spiTest {
     }
 
     @Test
+    void retryStrategyBuilderRootCausePredicatesRequireACauseChain() {
+        TestRetryStrategyBuilder builder = new TestRetryStrategyBuilder();
+
+        builder.retryOnRootCause(IllegalArgumentException.class);
+        assertThat(builder.shouldRetry(new IllegalArgumentException("direct root candidate"))).isFalse();
+        assertThat(builder.shouldRetry(new RuntimeException("outer", new IllegalArgumentException("root")))).isTrue();
+
+        builder.retryOnRootCauseInstanceOf(IllegalArgumentException.class);
+        assertThat(builder.shouldRetry(new NumberFormatException("direct subclass root candidate"))).isFalse();
+        assertThat(builder.shouldRetry(new RuntimeException(
+                "outer", new NumberFormatException("subclass root")))).isTrue();
+    }
+
+    @Test
     void retryStrategyBuilderUseClientDefaultsDefaultMethodIsChainable() {
         TestRetryStrategyBuilder builder = new TestRetryStrategyBuilder();
 
@@ -387,6 +465,30 @@ public class Retries_spiTest {
         assertThat(copied.isThrottling(new IllegalStateException("throttle"))).isTrue();
         assertThat(copied.acquireInitialToken(AcquireInitialTokenRequest.create("copy")).delay())
                 .isEqualTo(FIFTY_MILLIS);
+    }
+
+    @Test
+    void retryStrategyUsesDefaultZeroSuggestedDelayWhenNoneIsConfigured() {
+        TestRetryStrategy strategy = new TestRetryStrategyBuilder()
+                .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS))
+                .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(TWO_HUNDRED_MILLIS))
+                .treatAsThrottling(IllegalStateException.class::isInstance)
+                .build();
+        RetryToken token = new TestRetryToken("retry");
+
+        RefreshRetryTokenResponse regularRetry = strategy.refreshRetryToken(RefreshRetryTokenRequest.builder()
+                .token(token)
+                .failure(new RuntimeException("regular failure"))
+                .build());
+        RefreshRetryTokenResponse throttledRetry = strategy.refreshRetryToken(RefreshRetryTokenRequest.builder()
+                .token(token)
+                .failure(new IllegalStateException("throttled"))
+                .build());
+
+        assertThat(regularRetry.token()).isSameAs(token);
+        assertThat(regularRetry.delay()).isEqualTo(Duration.ZERO);
+        assertThat(throttledRetry.token()).isSameAs(token);
+        assertThat(throttledRetry.delay()).isEqualTo(Duration.ZERO);
     }
 
     @Test

--- a/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
+++ b/tests/src/software.amazon.awssdk/retries-spi/2.34.0/src/test/java/software_amazon_awssdk/retries_spi/Retries_spiTest.java
@@ -443,6 +443,26 @@ public class Retries_spiTest {
     }
 
     @Test
+    void retryStrategyBuilderSupportsConsumerBasedMutation() {
+        TestRetryStrategyBuilder builder = new TestRetryStrategyBuilder();
+
+        TestRetryStrategyBuilder returnedBuilder = builder.applyMutation(mutableBuilder -> mutableBuilder
+                .retryOnExceptionInstanceOf(IllegalArgumentException.class)
+                .maxAttempts(3)
+                .backoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(FIFTY_MILLIS))
+                .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(HUNDRED_MILLIS))
+                .treatAsThrottling(IllegalStateException.class::isInstance));
+        TestRetryStrategy strategy = returnedBuilder.build();
+
+        assertThat(returnedBuilder).isSameAs(builder);
+        assertThat(strategy.maxAttempts()).isEqualTo(3);
+        assertThat(strategy.shouldRetry(new NumberFormatException("subclass"))).isTrue();
+        assertThat(strategy.acquireInitialToken(AcquireInitialTokenRequest.create("mutated")).delay())
+                .isEqualTo(FIFTY_MILLIS);
+        assertThat(strategy.isThrottling(new IllegalStateException("throttled"))).isTrue();
+    }
+
+    @Test
     void retryStrategyBuilderUseClientDefaultsDefaultMethodIsChainable() {
         TestRetryStrategyBuilder builder = new TestRetryStrategyBuilder();
 


### PR DESCRIPTION

## What does this PR do?

Fixes: #4592

This PR introduces tests and metadata for software.amazon.awssdk:retries-spi:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 181386
- Cached input tokens: 1177600
- Output tokens: 15465
- Metadata entries: 0
- Iterations: 5
- Library coverage percentage: 100.0
- Generated lines of code: 570
- Tested library lines of code: 179

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1d01dcd700f9deea15a129b7580c040035abe30b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 691/691 (100.00%)
- Line: 179/179 (100.00%)
- Method: 79/79 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 18
- Fixup attempts: 0
