### PR TITLE
[GenAI] Add support for io.arrow-kt:arrow-atomic-jvm:2.2.2 using gpt-5.5

### DIFF
--- a/stats/io.arrow-kt/arrow-atomic-jvm/2.2.2/execution-metrics.json
+++ b/stats/io.arrow-kt/arrow-atomic-jvm/2.2.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T12:06:03.605996Z",
+    "timestamp": "2026-05-04T13:24:48.324307Z",
     "library": "io.arrow-kt:arrow-atomic-jvm:2.2.2",
-    "starting_commit": "659aac3a351deb620967a69c33b04a58eb8c3306",
-    "ending_commit": "8530cf0f3f25c2d56cd63653b571cf9134d70e72",
+    "starting_commit": "3b5781ab036bcf9287c371dae0344822856360b3",
+    "ending_commit": "9fc0317179681d9a1e6073deea0c49c3ebc6dee7",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 185345,
-      "cached_input_tokens_used": 860672,
-      "output_tokens_used": 15757,
-      "iterations": 5,
-      "cost_usd": 0.903,
-      "generated_loc": 376,
+      "input_tokens_used": 180378,
+      "cached_input_tokens_used": 1144320,
+      "output_tokens_used": 22166,
+      "iterations": 6,
+      "cost_usd": 1.2372,
+      "generated_loc": 450,
       "tested_library_loc": 20,
       "metadata_entries": 0,
       "code_coverage_percent": 27.78

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -175,6 +175,21 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicIntCompareAndExchangeReturnsWitnessValueAndOnlyUpdatesOnMatch() {
+        val counter = AtomicInt(4)
+
+        val failedWitness = counter.compareAndExchange(0, 9)
+
+        assertThat(failedWitness).isEqualTo(4)
+        assertThat(counter.value).isEqualTo(4)
+
+        val successfulWitness = counter.compareAndExchange(4, 9)
+
+        assertThat(successfulWitness).isEqualTo(4)
+        assertThat(counter.value).isEqualTo(9)
+    }
+
+    @Test
     fun atomicIntUpdatesAreSafeUnderContention() {
         val counter = AtomicInt(0)
         val workers = 4
@@ -297,6 +312,21 @@ public class Arrow_atomic_jvmTest {
         val updated = total.updateAndGet { current -> current * 2L }
         assertThat(updated).isEqualTo(84L)
         assertThat(total.value).isEqualTo(84L)
+    }
+
+    @Test
+    fun atomicLongCompareAndExchangeReturnsWitnessValueAndOnlyUpdatesOnMatch() {
+        val total = AtomicLong(40L)
+
+        val failedWitness = total.compareAndExchange(0L, 99L)
+
+        assertThat(failedWitness).isEqualTo(40L)
+        assertThat(total.value).isEqualTo(40L)
+
+        val successfulWitness = total.compareAndExchange(40L, 99L)
+
+        assertThat(successfulWitness).isEqualTo(40L)
+        assertThat(total.value).isEqualTo(99L)
     }
 
     @Test

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -372,6 +372,31 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicReferenceSupportsPolymorphicStateTransitions() {
+        val state = Atomic<ConnectionState>(Disconnected(reason = "idle"))
+
+        val previous = state.getAndUpdate { current ->
+            when (current) {
+                is Disconnected -> Connected(activeRequests = current.reason.length)
+                is Connected -> current.copy(activeRequests = current.activeRequests + 1)
+            }
+        }
+
+        assertThat(previous).isEqualTo(Disconnected(reason = "idle"))
+        assertThat(state.value).isEqualTo(Connected(activeRequests = 4))
+
+        val updated = state.updateAndGet { current ->
+            when (current) {
+                is Disconnected -> current
+                is Connected -> current.copy(activeRequests = current.activeRequests + 1)
+            }
+        }
+
+        assertThat(updated).isEqualTo(Connected(activeRequests = 5))
+        assertThat(state.value).isEqualTo(Connected(activeRequests = 5))
+    }
+
+    @Test
     fun atomicReferenceSupportsNullableValues() {
         val state = Atomic<String?>(null)
 
@@ -508,6 +533,16 @@ public class Arrow_atomic_jvmTest {
         assertThat(transitions).containsExactly("5->7")
         assertThat(state.value).isEqualTo(State(step = 100, label = "interfering write"))
     }
+
+    private sealed interface ConnectionState
+
+    private data class Disconnected(
+        val reason: String,
+    ) : ConnectionState
+
+    private data class Connected(
+        val activeRequests: Int,
+    ) : ConnectionState
 
     private data class State(
         val step: Int,

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_atomic_jvm/Arrow_atomic_jvmTest.kt
@@ -130,6 +130,16 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicIntArithmeticFollowsJvmOverflowSemantics() {
+        val counter = AtomicInt(Int.MAX_VALUE)
+
+        assertThat(counter.incrementAndGet()).isEqualTo(Int.MIN_VALUE)
+        assertThat(counter.getAndAdd(-1)).isEqualTo(Int.MIN_VALUE)
+        assertThat(counter.value).isEqualTo(Int.MAX_VALUE)
+        assertThat(counter.addAndGet(2)).isEqualTo(Int.MIN_VALUE + 1)
+    }
+
+    @Test
     fun atomicIntSupportsPublicUpdateFunctionsAndRetriesOnInterference() {
         val counter = AtomicInt(0)
         val seenValues = mutableListOf<Int>()
@@ -253,6 +263,16 @@ public class Arrow_atomic_jvmTest {
     }
 
     @Test
+    fun atomicLongArithmeticFollowsJvmOverflowSemantics() {
+        val total = AtomicLong(Long.MAX_VALUE)
+
+        assertThat(total.incrementAndGet()).isEqualTo(Long.MIN_VALUE)
+        assertThat(total.getAndAdd(-1L)).isEqualTo(Long.MIN_VALUE)
+        assertThat(total.value).isEqualTo(Long.MAX_VALUE)
+        assertThat(total.addAndGet(2L)).isEqualTo(Long.MIN_VALUE + 1L)
+    }
+
+    @Test
     fun atomicLongSupportsPublicUpdateFunctionsAndReportsFailedTryUpdate() {
         val total = AtomicLong(7L)
 
@@ -319,6 +339,20 @@ public class Arrow_atomic_jvmTest {
         assertThat(state.compareAndSet(expected, replacement)).isTrue()
         assertThat(state.compareAndSet(expected, State(step = 6, label = "stale"))).isFalse()
         assertThat(state.value).isSameAs(replacement)
+    }
+
+    @Test
+    fun atomicReferenceSupportsNullableValues() {
+        val state = Atomic<String?>(null)
+
+        assertThat(state.value).isNull()
+        assertThat(state.compareAndSet(null, "ready")).isTrue()
+        assertThat(state.value).isEqualTo("ready")
+        assertThat(state.getAndSet(null)).isEqualTo("ready")
+        assertThat(state.value).isNull()
+
+        state.update { current -> current ?: "created" }
+        assertThat(state.value).isEqualTo("created")
     }
 
     @Test


### PR DESCRIPTION

## What does this PR do?

Fixes: #5381

This PR introduces tests and metadata for io.arrow-kt:arrow-atomic-jvm:2.2.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 180378
- Cached input tokens: 1144320
- Output tokens: 22166
- Metadata entries: 0
- Iterations: 6
- Library coverage percentage: 27.78
- Generated lines of code: 450
- Tested library lines of code: 20

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b5781ab036bcf9287c371dae0344822856360b3`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 81/210 (38.57%)
- Line: 20/72 (27.78%)
- Method: 14/42 (33.33%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
