### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-benchmark-runtime as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-benchmark-runtime/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-benchmark-runtime/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The root multiplatform artifact publishes a non-JVM Kotlin metadata jar with no JVM class files; JVM consumers resolve the separate JVM variant.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-benchmark-runtime-jvm:0.4.16"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5281

This PR records `org.jetbrains.kotlinx:kotlinx-benchmark-runtime` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The root multiplatform artifact publishes a non-JVM Kotlin metadata jar with no JVM class files; JVM consumers resolve the separate JVM variant.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-benchmark-runtime-jvm:0.4.16

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `966015b2e06ed7a105da7bf751a37bc6d6d0d4fc`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
