### PR TITLE
[GenAI] Add support for io.arrow-kt:arrow-exception-utils-jvm:2.2.2 using gpt-5.5

### DIFF
--- a/stats/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/execution-metrics.json
+++ b/stats/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T11:52:54.382571Z",
+    "timestamp": "2026-05-04T13:37:40.135700Z",
     "library": "io.arrow-kt:arrow-exception-utils-jvm:2.2.2",
-    "starting_commit": "8d031b071db127783506dbda798f4146dc0979a3",
-    "ending_commit": "7fdaa2971139b6bf65e732d986ab67f64bd42cb8",
+    "starting_commit": "3b5781ab036bcf9287c371dae0344822856360b3",
+    "ending_commit": "3363a5d747b2aaa326c2dce0ef29be370c1f9160",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 172049,
-      "cached_input_tokens_used": 896000,
-      "output_tokens_used": 17722,
-      "iterations": 5,
-      "cost_usd": 0.9797,
-      "generated_loc": 150,
+      "input_tokens_used": 67775,
+      "cached_input_tokens_used": 528384,
+      "output_tokens_used": 9536,
+      "iterations": 3,
+      "cost_usd": 0.5503,
+      "generated_loc": 181,
       "tested_library_loc": 8,
       "metadata_entries": 0,
       "code_coverage_percent": 80.0

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
@@ -204,6 +204,17 @@ public class ArrowExceptionUtilsJvmTest {
     }
 
     @Test
+    fun `mergeSuppressed leaves primary unchanged when suppression is disabled`() {
+        val primary: SuppressionDisabledException = SuppressionDisabledException("primary")
+        val secondary: IllegalStateException = IllegalStateException("secondary")
+
+        val result: Throwable? = primary.mergeSuppressed(secondary)
+
+        assertThat(result).isSameAs(primary)
+        assertThat(primary.suppressed).isEmpty()
+    }
+
+    @Test
     fun `mergeSuppressed rethrows fatal secondary failures unchanged`() {
         val primary: IllegalArgumentException = IllegalArgumentException("primary")
         val fatal: LinkageError = LinkageError("linkage")
@@ -212,4 +223,8 @@ public class ArrowExceptionUtilsJvmTest {
             .isSameAs(fatal)
         assertThat(primary.suppressed).isEmpty()
     }
+
+    private class SuppressionDisabledException(
+        message: String,
+    ) : Exception(message, null, false, true)
 }

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
@@ -144,6 +144,18 @@ public class ArrowExceptionUtilsJvmTest {
     }
 
     @Test
+    fun `mergeSuppressed returns a fatal throwable unchanged when it is the only failure`() {
+        val fatalPrimary: LinkageError = LinkageError("primary fatal")
+        val fatalSecondary: OutOfMemoryError = OutOfMemoryError("secondary fatal")
+        val noPrimary: Throwable? = null
+
+        assertThat(fatalPrimary.mergeSuppressed(null)).isSameAs(fatalPrimary)
+        assertThat(noPrimary.mergeSuppressed(fatalSecondary)).isSameAs(fatalSecondary)
+        assertThat(fatalPrimary.suppressed).isEmpty()
+        assertThat(fatalSecondary.suppressed).isEmpty()
+    }
+
+    @Test
     fun `mergeSuppressed accumulates cleanup failures starting from no primary failure`() {
         var accumulated: Throwable? = null
         val firstCleanupFailure: IllegalStateException = IllegalStateException("first cleanup")

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_exception_utils_jvm/Arrow_exception_utils_jvmTest.kt
@@ -83,6 +83,18 @@ public class ArrowExceptionUtilsJvmTest {
     }
 
     @Test
+    fun `throwIfFatal works when used as a Throwable function reference`() {
+        val rejectFatal: (Throwable) -> Unit = Throwable::throwIfFatal
+        val nonFatal: IllegalArgumentException = IllegalArgumentException("recoverable")
+        val fatal: LinkageError = LinkageError("fatal")
+
+        assertThatCode { rejectFatal(nonFatal) }
+            .doesNotThrowAnyException()
+        assertThatThrownBy { rejectFatal(fatal) }
+            .isSameAs(fatal)
+    }
+
+    @Test
     fun `throwIfNotNull does nothing for null`() {
         val failure: Throwable? = null
 


### PR DESCRIPTION

## What does this PR do?

Fixes: #5376

This PR introduces tests and metadata for io.arrow-kt:arrow-exception-utils-jvm:2.2.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 67775
- Cached input tokens: 528384
- Output tokens: 9536
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 80.0
- Generated lines of code: 181
- Tested library lines of code: 8

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3b5781ab036bcf9287c371dae0344822856360b3`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 48/52 (92.31%)
- Line: 8/10 (80.00%)
- Method: 4/5 (80.00%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
