### PR TITLE
[GenAI] Add support for io.arrow-kt:arrow-annotations-jvm:2.2.2 using gpt-5.5

### DIFF
--- a/stats/io.arrow-kt/arrow-annotations-jvm/2.2.2/execution-metrics.json
+++ b/stats/io.arrow-kt/arrow-annotations-jvm/2.2.2/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T12:09:50.050200Z",
+    "timestamp": "2026-05-04T14:46:53.939519Z",
     "library": "io.arrow-kt:arrow-annotations-jvm:2.2.2",
-    "starting_commit": "659aac3a351deb620967a69c33b04a58eb8c3306",
-    "ending_commit": "68fb263c3a5989b430d48214feef3e180fcd24a0",
+    "starting_commit": "182d4930cf7800c210d32489ef4b65cff66fab89",
+    "ending_commit": "a033d6d03ae639909a6bae659c7fb032f66f8ad9",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 110791,
-      "cached_input_tokens_used": 438784,
-      "output_tokens_used": 13101,
+      "input_tokens_used": 112316,
+      "cached_input_tokens_used": 785920,
+      "output_tokens_used": 19847,
       "iterations": 4,
-      "cost_usd": 0.6124,
-      "generated_loc": 247,
+      "cost_usd": 0.9884,
+      "generated_loc": 391,
       "tested_library_loc": 1,
       "metadata_entries": 0,
       "code_coverage_percent": 100.0

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -16,6 +16,10 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.EnumMap
 import java.util.EnumSet
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
 import kotlin.properties.Delegates
 
 public class ArrowAnnotationsJvmTest {
@@ -216,6 +220,22 @@ public class ArrowAnnotationsJvmTest {
         assertThat(state.renderWith(formatter)).isEqualTo("state=published")
         assertThat(state.changes()).containsExactly("draft", "published")
     }
+
+    @Test
+    fun syntheticAnnotationCanMarkSuspendApisAndSuspendFunctionTypes() {
+        val workflow: SyntheticSuspendWorkflow = SyntheticSuspendWorkflow(initialState = "queued")
+        val transition:
+            @synthetic suspend (@synthetic SyntheticString) -> @synthetic SyntheticString = { state: SyntheticString ->
+                "$state:completed"
+            }
+
+        val completedState: SyntheticString = runSyntheticSuspend {
+            workflow.advance(transition)
+        }
+
+        assertThat(completedState).isEqualTo("queued:completed")
+        assertThat(workflow.visitedStates()).containsExactly("queued", "queued:completed")
+    }
 }
 
 private fun OpticsTarget.description(): String = when (this) {
@@ -224,6 +244,33 @@ private fun OpticsTarget.description(): String = when (this) {
     OpticsTarget.PRISM -> "prism"
     OpticsTarget.OPTIONAL -> "optional"
     OpticsTarget.DSL -> "dsl"
+}
+
+private object SyntheticSuspendNoValue
+
+private fun <T> runSyntheticSuspend(block: suspend () -> T): T {
+    var value: Any? = SyntheticSuspendNoValue
+    var failure: Throwable? = null
+    var completed: Boolean = false
+
+    block.startCoroutine(
+        object : Continuation<T> {
+            override val context: CoroutineContext = EmptyCoroutineContext
+
+            override fun resumeWith(result: Result<T>) {
+                result
+                    .onSuccess { resultValue: T -> value = resultValue }
+                    .onFailure { throwable: Throwable -> failure = throwable }
+                completed = true
+            }
+        },
+    )
+
+    check(completed) { "Synthetic suspend test block did not complete synchronously" }
+    failure?.let { throwable: Throwable -> throw throwable }
+
+    @Suppress("UNCHECKED_CAST")
+    return value as T
 }
 
 @optics(targets = [OpticsTarget.LENS, OpticsTarget.PRISM, OpticsTarget.OPTIONAL, OpticsTarget.DSL])
@@ -406,4 +453,23 @@ private class SyntheticObservableState(
 
     @synthetic
     fun changes(): List<@synthetic SyntheticString> = history.toList()
+}
+
+@synthetic
+private class SyntheticSuspendWorkflow(
+    initialState: @synthetic SyntheticString,
+) {
+    private val visitedStates: MutableList<SyntheticString> = mutableListOf(initialState)
+
+    @synthetic
+    suspend fun advance(
+        @synthetic transition: @synthetic suspend (@synthetic SyntheticString) -> @synthetic SyntheticString,
+    ): @synthetic SyntheticString {
+        val nextState: SyntheticString = transition(visitedStates.last())
+        visitedStates += nextState
+        return nextState
+    }
+
+    @synthetic
+    fun visitedStates(): List<@synthetic SyntheticString> = visitedStates.toList()
 }

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -64,12 +64,15 @@ public class ArrowAnnotationsJvmTest {
         val defaultConfiguration: optics = optics()
         val prismDslConfiguration: optics = optics(arrayOf(OpticsTarget.PRISM, OpticsTarget.DSL))
         val equivalentConfiguration: optics = optics(arrayOf(OpticsTarget.PRISM, OpticsTarget.DSL))
+        val reorderedConfiguration: optics = optics(arrayOf(OpticsTarget.DSL, OpticsTarget.PRISM))
         val lensConfiguration: optics = optics(arrayOf(OpticsTarget.LENS))
 
         assertThat(defaultConfiguration.targets).isEmpty()
         assertThat(prismDslConfiguration.targets)
             .containsExactly(OpticsTarget.PRISM, OpticsTarget.DSL)
         assertThat(prismDslConfiguration).isEqualTo(equivalentConfiguration)
+        assertThat(prismDslConfiguration.hashCode()).isEqualTo(equivalentConfiguration.hashCode())
+        assertThat(prismDslConfiguration).isNotEqualTo(reorderedConfiguration)
         assertThat(prismDslConfiguration).isNotEqualTo(lensConfiguration)
     }
 
@@ -132,6 +135,21 @@ public class ArrowAnnotationsJvmTest {
     }
 
     @Test
+    fun opticsAnnotationsCanDecorateObjectsEnumsAndNestedDomainTypes() {
+        val original: OpticsAnnotatedSession = OpticsAnnotatedSession(
+            id = "session-1",
+            state = OpticsAnnotatedSession.State.OPEN,
+            defaults = OpticsAnnotatedDefaults,
+        )
+
+        val closed: OpticsAnnotatedSession = original.close()
+
+        assertThat(original.state.isTerminal()).isFalse()
+        assertThat(closed.state).isEqualTo(OpticsAnnotatedSession.State.CLOSED)
+        assertThat(closed.summary()).isEqualTo("session-1:closed:standard")
+    }
+
+    @Test
     fun opticsAnnotationCanUseDefaultTargetsOnSealedDomainModels() {
         val authorized: DefaultOpticsPayment = DefaultOpticsPayment.Authorized(reference = "auth-1")
         val rejected: DefaultOpticsPayment = DefaultOpticsPayment.Rejected(reason = "insufficient funds")
@@ -174,6 +192,16 @@ public class ArrowAnnotationsJvmTest {
         assertThat(SyntheticRegistry.names()).containsExactly("alpha", "beta")
         assertThat(SyntheticMode.ENABLED.render()).isEqualTo("enabled")
     }
+
+    @Test
+    fun syntheticAnnotationCanMarkReceiversAndLocalValues() {
+        val receiver: SyntheticAnnotatedReceiver = SyntheticAnnotatedReceiver("arrow")
+        val branchSelector: SyntheticLocalValueSelector = SyntheticLocalValueSelector(prefix = "mode")
+
+        assertThat(receiver.renderWithSyntheticReceiver("annotations")).isEqualTo("arrow:annotations")
+        assertThat(branchSelector.localValueBranch(enabled = true)).isEqualTo("mode:enabled")
+        assertThat(branchSelector.localValueBranch(enabled = false)).isEqualTo("mode:disabled")
+    }
 }
 
 private fun OpticsTarget.description(): String = when (this) {
@@ -215,6 +243,33 @@ private data class CopyAnnotatedPricing(
     val amount: Double,
     val currency: String,
 )
+
+@optics(targets = [OpticsTarget.LENS, OpticsTarget.DSL])
+private data class OpticsAnnotatedSession(
+    val id: String,
+    val state: State,
+    val defaults: OpticsAnnotatedDefaults,
+) {
+    fun close(): OpticsAnnotatedSession = copy(state = State.CLOSED)
+
+    fun summary(): String = "$id:${state.label}:${defaults.profileName}"
+
+    @optics(targets = [OpticsTarget.PRISM])
+    enum class State(
+        val label: String,
+    ) {
+        OPEN("open"),
+        CLOSED("closed"),
+        ;
+
+        fun isTerminal(): Boolean = this == CLOSED
+    }
+}
+
+@optics(targets = [OpticsTarget.ISO])
+private object OpticsAnnotatedDefaults {
+    const val profileName: String = "standard"
+}
 
 @optics
 private sealed interface DefaultOpticsPayment {
@@ -296,4 +351,25 @@ private enum class SyntheticMode {
 
     @synthetic
     fun render(): @synthetic SyntheticString = name.lowercase()
+}
+
+@synthetic
+private data class SyntheticAnnotatedReceiver(
+    val value: @synthetic SyntheticString,
+)
+
+@synthetic
+private fun @receiver:synthetic SyntheticAnnotatedReceiver.renderWithSyntheticReceiver(
+    @synthetic suffix: @synthetic SyntheticString,
+): @synthetic SyntheticString = "$value:$suffix"
+
+@synthetic
+private class SyntheticLocalValueSelector(
+    private val prefix: @synthetic SyntheticString,
+) {
+    @synthetic
+    fun localValueBranch(@synthetic enabled: Boolean): @synthetic SyntheticString {
+        @synthetic val mode: @synthetic SyntheticString = if (enabled) "enabled" else "disabled"
+        return "$prefix:$mode"
+    }
 }

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/src/test/kotlin/io_arrow_kt/arrow_annotations_jvm/Arrow_annotations_jvmTest.kt
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.EnumMap
 import java.util.EnumSet
+import kotlin.properties.Delegates
 
 public class ArrowAnnotationsJvmTest {
     @Test
@@ -202,6 +203,19 @@ public class ArrowAnnotationsJvmTest {
         assertThat(branchSelector.localValueBranch(enabled = true)).isEqualTo("mode:enabled")
         assertThat(branchSelector.localValueBranch(enabled = false)).isEqualTo("mode:disabled")
     }
+
+    @Test
+    fun syntheticAnnotationCanMarkDelegatedPropertiesAndFunctionTypes() {
+        val state: SyntheticObservableState = SyntheticObservableState(initialValue = "draft")
+        val formatter: @synthetic (@synthetic SyntheticString) -> @synthetic SyntheticString = { value: SyntheticString ->
+            "state=$value"
+        }
+
+        state.value = "published"
+
+        assertThat(state.renderWith(formatter)).isEqualTo("state=published")
+        assertThat(state.changes()).containsExactly("draft", "published")
+    }
 }
 
 private fun OpticsTarget.description(): String = when (this) {
@@ -372,4 +386,24 @@ private class SyntheticLocalValueSelector(
         @synthetic val mode: @synthetic SyntheticString = if (enabled) "enabled" else "disabled"
         return "$prefix:$mode"
     }
+}
+
+@synthetic
+private class SyntheticObservableState(
+    initialValue: @synthetic SyntheticString,
+) {
+    private val history: MutableList<SyntheticString> = mutableListOf(initialValue)
+
+    @synthetic
+    var value: @synthetic SyntheticString by Delegates.observable(initialValue) { _, _, newValue: SyntheticString ->
+        history += newValue
+    }
+
+    @synthetic
+    fun renderWith(
+        @synthetic formatter: @synthetic (@synthetic SyntheticString) -> @synthetic SyntheticString,
+    ): @synthetic SyntheticString = formatter(value)
+
+    @synthetic
+    fun changes(): List<@synthetic SyntheticString> = history.toList()
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5378

This PR introduces tests and metadata for io.arrow-kt:arrow-annotations-jvm:2.2.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 112316
- Cached input tokens: 785920
- Output tokens: 19847
- Metadata entries: 0
- Iterations: 4
- Library coverage percentage: 100.0
- Generated lines of code: 391
- Tested library lines of code: 1

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `182d4930cf7800c210d32489ef4b65cff66fab89`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 37/37 (100.00%)
- Line: 1/1 (100.00%)
- Method: 1/1 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
