### PR TITLE
[GenAI] Test fix for com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9 using gpt-5.5

### DIFF
--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -51,12 +51,14 @@ class JavaFailWorkflowConfig:
         task_type: str,
         branch_prefix: str,
         metrics_filename: str,
+        metadata_index_task: str,
     ):
         self.mode = mode
         self.default_strategy_name = default_strategy_name
         self.task_type = task_type
         self.branch_prefix = branch_prefix
         self.metrics_filename = metrics_filename
+        self.metadata_index_task = metadata_index_task
 
 
 JAVAC_CONFIG = JavaFailWorkflowConfig(
@@ -65,6 +67,7 @@ JAVAC_CONFIG = JavaFailWorkflowConfig(
     task_type="fix-javac-fail",
     branch_prefix="fix-javac",
     metrics_filename="fix_javac_fail.json",
+    metadata_index_task="addLibraryMetadataIndexJson",
 )
 
 JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
@@ -73,6 +76,7 @@ JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
     task_type="fix-java-run-fail",
     branch_prefix="fix-java-run",
     metrics_filename="fix_java_run_fail.json",
+    metadata_index_task="addLibraryAsLatestMetadataIndexJson",
 )
 
 
@@ -229,10 +233,10 @@ def run_gradle_task(task: str, coordinates: str) -> None:
     subprocess.run(command, shell=True, check=True)
 
 
-def update_metadata_index_json(group, artifact, updated_library_version):
-    """Update metadata index.json to point to the new library version."""
+def update_metadata_index_json(config, group, artifact, updated_library_version):
+    """Update metadata index.json for the target library version."""
     new_version_coordinates = f"{group}:{artifact}:{updated_library_version}"
-    run_gradle_task("addLibraryAsLatestMetadataIndexJson", new_version_coordinates)
+    run_gradle_task(config.metadata_index_task, new_version_coordinates)
 
 
 def create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version):
@@ -378,7 +382,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     metadata_dir_preexisted = os.path.exists(metadata_dir)
 
     copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
-    update_metadata_index_json(group, artifact, updated_library_version)
+    update_metadata_index_json(config, group, artifact, updated_library_version)
     create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
     commit_checkpoint = create_project_prep_checkpoint(config, group, artifact, updated_library_version)
     updated_library = f"{group}:{artifact}:{updated_library_version}"

--- a/metadata/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "bundle" : "i18n.General"
+    },
+    {
+      "bundle" : "i18n.Parsing"
+    },
+    {
+      "bundle" : "i18n.Scalars"
+    },
+    {
+      "bundle" : "i18n.Validation"
+    }
+  ]
+}

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -1,6 +1,5 @@
 [
   {
-    "latest" : true,
     "metadata-version" : "2018-06-27T00-18-28-1e12da9",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
     "repository-url" : "https://github.com/graphql-java/graphql-java",
@@ -15,6 +14,7 @@
     ]
   },
   {
+    "latest" : true,
     "metadata-version" : "19.7",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
     "repository-url" : "https://github.com/graphql-java/graphql-java",
@@ -52,7 +52,10 @@
       "23.1",
       "24.0",
       "24.1",
-      "24.2"
+      "24.2",
+      "24.3",
+      "25.0",
+      "26.0"
     ],
     "allowed-packages" : [
       "graphql"

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2018-06-27T00-18-28-1e12da9",
+    "tested-versions" : [
+      "2018-06-27T00-18-28-1e12da9"
+    ],
+    "allowed-packages" : [
+      "graphql"
+    ]
+  },
+  {
     "metadata-version" : "19.7",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
     "repository-url" : "https://github.com/graphql-java/graphql-java",

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2018-06-27T00-18-28-1e12da9",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/graphql-java/graphql-java",
+    "test-code-url" : "https://github.com/graphql-java/graphql-java/tree/1e12da93a692b8fff549e417906c899c9bf21345/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-javadoc.jar",
+    "description" : "GraphQL Java is a Java implementation of the GraphQL specification for building and executing GraphQL schemas. It provides APIs for schema definition, validation, parsing, and query execution against application data.",
     "tested-versions" : [
       "2018-06-27T00-18-28-1e12da9"
     ],

--- a/stats/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/execution-metrics.json
+++ b/stats/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-05-04": {
+    "timestamp": "2026-05-04T14:48:40.434061Z",
+    "library": "com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9",
+    "starting_commit": "bff1ca0a900e217ec80ef2c22189d26f4a6fd143",
+    "ending_commit": "c97a808445831262bed2a0a6edc9f3738acac973",
+    "previous_library": "com.graphql-java:graphql-java:19.7",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2018-06-27T00-18-28-1e12da9",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 10,
+            "totalCalls": 10
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 23005,
+          "missed": 46160,
+          "ratio": 0.33261,
+          "total": 69165
+        },
+        "line": {
+          "covered": 5406,
+          "missed": 9932,
+          "ratio": 0.352458,
+          "total": 15338
+        },
+        "method": {
+          "covered": 1429,
+          "missed": 2997,
+          "ratio": 0.322865,
+          "total": 4426
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "19.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.909091,
+            "coveredCalls": 10,
+            "totalCalls": 11
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.916667,
+        "coveredCalls": 11,
+        "totalCalls": 12
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 42419,
+          "missed": 107078,
+          "ratio": 0.283745,
+          "total": 149497
+        },
+        "line": {
+          "covered": 10223,
+          "missed": 22881,
+          "ratio": 0.308815,
+          "total": 33104
+        },
+        "method": {
+          "covered": 2959,
+          "missed": 6763,
+          "ratio": 0.304361,
+          "total": 9722
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 269441,
+      "cached_input_tokens_used": 2224640,
+      "output_tokens_used": 25461,
+      "iterations": 5,
+      "cost_usd": 1.8761,
+      "tested_library_loc": 5406,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 44,
+      "previous_library_metadata_entries": 4,
+      "previous_library_test_only_metadata_entries": 26,
+      "code_coverage_percent": 35.25,
+      "previous_library_coverage_percent": 30.88
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java",
+      "metadata_file": "metadata/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/stats.json
+++ b/stats/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2018-06-27T00-18-28-1e12da9",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 10,
+          "totalCalls" : 10
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 10,
+      "totalCalls" : 10
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 23005,
+        "missed" : 46160,
+        "ratio" : 0.33261,
+        "total" : 69165
+      },
+      "line" : {
+        "covered" : 5406,
+        "missed" : 9932,
+        "ratio" : 0.352458,
+        "total" : 15338
+      },
+      "method" : {
+        "covered" : 1429,
+        "missed" : 2997,
+        "ratio" : 0.322865,
+        "total" : 4426
+      }
+    }
+  } ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/.gitignore
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/build.gradle
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/build.gradle
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.tasks.TaskProvider
+
+plugins {
+    id "org.graalvm.internal.tck"
+    id "com.gradleup.shadow" version "9.4.1"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+configurations {
+    relocatedGuava
+}
+
+// graphql-java 19.7 bytecode references relocated Guava classes that are not present in the published jar.
+TaskProvider relocatedGuavaJar = tasks.register("relocatedGuavaJar", ShadowJar) {
+    archiveClassifier = "relocated-guava"
+    configurations = [project.configurations.relocatedGuava]
+    relocate "com.google.common", "graphql.com.google.common"
+}
+
+dependencies {
+    testImplementation "com.graphql-java:graphql-java:$libraryVersion"
+    testRuntimeOnly files(relocatedGuavaJar).builtBy(relocatedGuavaJar)
+    relocatedGuava 'com.google.guava:guava:32.0.0-jre'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/gradle.properties
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/gradle.properties
@@ -1,0 +1,2 @@
+library.version = 2018-06-27T00-18-28-1e12da9
+metadata.dir = com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/settings.gradle
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'graphql-java-tests'

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import graphql.language.AstValueHelper;
+import graphql.language.IntValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLLong;
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AstValueHelperTest {
+
+  @Test
+  void convertsJavaBeanInputObjectToAstObjectValue() {
+    GraphQLInputObjectType inputType = GraphQLInputObjectType.newInputObject()
+        .name("HumanInput")
+        .field(field -> field.name("id").type(GraphQLLong))
+        .field(field -> field.name("name").type(GraphQLString))
+        .build();
+
+    Value value = AstValueHelper.astFromValue(new Human(), inputType);
+
+    assertThat(value).isInstanceOf(ObjectValue.class);
+    ObjectValue objectValue = (ObjectValue) value;
+    List<ObjectField> objectFields = objectValue.getObjectFields();
+
+    assertThat(objectFields).hasSize(2);
+    assertThat(objectFields.get(0).getName()).isEqualTo("id");
+    assertThat(((IntValue) objectFields.get(0).getValue()).getValue()).isEqualTo(BigInteger.valueOf(42));
+    assertThat(objectFields.get(1).getName()).isEqualTo("name");
+    assertThat(((StringValue) objectFields.get(1).getValue()).getValue()).isEqualTo("GraalVM");
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.execution.batched.Batched;
+import graphql.execution.batched.BatchedDataFetcher;
+import graphql.execution.batched.BatchedDataFetcherFactory;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BatchedDataFetcherFactoryTest {
+
+  @Test
+  void createsBatchedFetcherFromAnnotatedDataFetcherMethod() {
+    AnnotatedListFetcher supplied = new AnnotatedListFetcher();
+    DataFetchingEnvironment environment = new TestDataFetchingEnvironment(List.of("Ada", "Bob"));
+
+    BatchedDataFetcher fetcher = new BatchedDataFetcherFactory().create(supplied);
+    Object result = fetcher.get(environment);
+
+    assertThat(result).isEqualTo(List.of("Hello Ada", "Hello Bob"));
+  }
+
+  private static class TestDataFetchingEnvironment implements DataFetchingEnvironment {
+
+    private final Object source;
+
+    TestDataFetchingEnvironment(Object source) {
+      this.source = source;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return null;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
+    }
+  }
+
+  public static class AnnotatedListFetcher implements DataFetcher<Object> {
+
+    @Override
+    @Batched
+    public Object get(DataFetchingEnvironment environment) {
+      List<String> names = environment.getSource();
+      return names.stream()
+          .map(name -> "Hello " + name)
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
@@ -6,6 +6,10 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static graphql.Scalars.GraphQLString;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PropertyFetchingImplTest {
+public class PropertyDataFetcherTest {
 
   @BeforeEach
   void resetPropertyFetcher() {
@@ -79,6 +83,22 @@ public class PropertyFetchingImplTest {
 
     assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
     assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+  }
+
+  @Test
+  void findsPublicMethodOnRootInterfaceWhenNoSuperclassExists() throws Throwable {
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("name");
+    // A non-public interface has no superclass, so it exercises the root interface lookup path.
+    MethodHandle finder = MethodHandles.privateLookupIn(PropertyDataFetcher.class, MethodHandles.lookup())
+        .findVirtual(
+            PropertyDataFetcher.class,
+            "findPubliclyAccessibleMethod",
+            MethodType.methodType(Method.class, Class.class, String.class));
+
+    Method method = (Method) finder.invoke(fetcher, NonPublicNameSource.class, "getName");
+
+    assertThat(method.getDeclaringClass()).isEqualTo(NonPublicNameSource.class);
+    assertThat(method.getName()).isEqualTo("getName");
   }
 
   private DataFetchingEnvironment environmentFor(Object source) {
@@ -211,5 +231,10 @@ public class PropertyFetchingImplTest {
   public static class PrivateFieldSource {
 
     private final String privateField = "private field value";
+  }
+
+  interface NonPublicNameSource {
+
+    String getName();
   }
 }

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFetchingImplTest {
+
+  @BeforeEach
+  void resetPropertyFetcher() {
+    PropertyDataFetcher.clearReflectionCache();
+    PropertyDataFetcher.setUseSetAccessible(true);
+    PropertyDataFetcher.setUseNegativeCache(true);
+  }
+
+  @Test
+  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
+    EnvironmentAwareSource source = new EnvironmentAwareSource();
+    DataFetchingEnvironment environment = environmentFor(source);
+
+    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
+
+    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
+    assertThat(source.seenEnvironment).isSameAs(environment);
+  }
+
+  @Test
+  void invokesPublicZeroArgumentGetter() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("zero argument getter value");
+  }
+
+  @Test
+  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("private getter value");
+  }
+
+  @Test
+  void readsAndCachesPublicField() throws Exception {
+    PublicFieldSource source = new PublicFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+  }
+
+  @Test
+  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
+    PrivateFieldSource source = new PrivateFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+  }
+
+  private DataFetchingEnvironment environmentFor(Object source) {
+    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+        .source(source)
+        .fieldType(GraphQLString)
+        .build();
+  }
+
+  public static class EnvironmentAwareSource {
+
+    private DataFetchingEnvironment seenEnvironment;
+
+    public String getValue(DataFetchingEnvironment environment) {
+      this.seenEnvironment = environment;
+      return "value from " + getClass().getSimpleName();
+    }
+  }
+
+  public static class ZeroArgumentGetterSource {
+
+    public String getName() {
+      return "zero argument getter value";
+    }
+  }
+
+  public static class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private getter value";
+    }
+  }
+
+  public static class PublicFieldSource {
+
+    public final String publicField = "public field value";
+  }
+
+  public static class PrivateFieldSource {
+
+    private final String privateField = "private field value";
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
@@ -6,8 +6,21 @@
  */
 package com_graphql_java.graphql_java;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
 import graphql.schema.PropertyDataFetcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,19 +33,16 @@ public class PropertyFetchingImplTest {
   @BeforeEach
   void resetPropertyFetcher() {
     PropertyDataFetcher.clearReflectionCache();
-    PropertyDataFetcher.setUseSetAccessible(true);
-    PropertyDataFetcher.setUseNegativeCache(true);
   }
 
   @Test
-  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
-    EnvironmentAwareSource source = new EnvironmentAwareSource();
-    DataFetchingEnvironment environment = environmentFor(source);
+  void invokesFunctionFetcherWithSource() throws Exception {
+    FunctionSource source = new FunctionSource();
 
-    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
+    String value = PropertyDataFetcher.<String, FunctionSource>fetching(FunctionSource::value)
+        .get(environmentFor(source));
 
-    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
-    assertThat(source.seenEnvironment).isSameAs(environment);
+    assertThat(value).isEqualTo("value from " + FunctionSource.class.getSimpleName());
   }
 
   @Test
@@ -72,18 +82,109 @@ public class PropertyFetchingImplTest {
   }
 
   private DataFetchingEnvironment environmentFor(Object source) {
-    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-        .source(source)
-        .fieldType(GraphQLString)
-        .build();
+    return new TestDataFetchingEnvironment(source, GraphQLString);
   }
 
-  public static class EnvironmentAwareSource {
+  private static class TestDataFetchingEnvironment implements DataFetchingEnvironment {
 
-    private DataFetchingEnvironment seenEnvironment;
+    private final Object source;
+    private final GraphQLOutputType fieldType;
 
-    public String getValue(DataFetchingEnvironment environment) {
-      this.seenEnvironment = environment;
+    TestDataFetchingEnvironment(Object source, GraphQLOutputType fieldType) {
+      this.source = source;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
+    }
+  }
+
+  public static class FunctionSource {
+
+    public String value() {
       return "value from " + getClass().getSimpleName();
     }
   }

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Consumer;
+
+import graphql.introspection.IntrospectionQuery;
+import graphql.relay.Connection;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.Edge;
+import graphql.relay.PageInfo;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.StaticDataFetcher;
+import graphql.schema.TypeResolver;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.starwars.Droid;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Brian Clozel
+ */
+public class GraphQlTests {
+
+
+  @Test
+  void greetingQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("greeting", runtimeWiringBuilder ->
+        runtimeWiringBuilder.type("Query", builder ->
+            builder.dataFetcher("greeting", new StaticDataFetcher("Hello GraphQL"))));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ greeting }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{greeting=Hello GraphQL}");
+  }
+
+  @Test
+  void introspectionQuery() throws Exception {
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder -> {
+      runtimeWiringBuilder.type("Query", builder -> builder.typeName("Character").typeResolver(characterTypeResolver()));
+    });
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute(IntrospectionQuery.INTROSPECTION_QUERY);
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).contains("{__schema={queryType={name=QueryType}");
+  }
+
+  @Test
+  void paginatedQuery() throws Exception {
+    PageInfo pageInfo = new DefaultPageInfo(new DefaultConnectionCursor("start"),
+            new DefaultConnectionCursor("end"), true, true);
+    Edge<Human> edge = new DefaultEdge<>(new Human(), new DefaultConnectionCursor("current"));
+    Connection<Human> connection = new DefaultConnection<>(List.of(edge), pageInfo);
+    GraphQLSchema graphQLSchema = parseSchema("starwars", runtimeWiringBuilder ->
+            runtimeWiringBuilder.type("QueryType", builder ->
+                    builder.dataFetcher("humans", new StaticDataFetcher(connection)))
+                    .type("Character", typeBuilder -> typeBuilder.typeResolver(characterTypeResolver())));
+    GraphQL graphQl = GraphQL.newGraphQL(graphQLSchema).build();
+    ExecutionResult result = graphQl.execute("{ humans { edges { node { id name } } pageInfo { startCursor } } }");
+    assertThat(result.getErrors()).isEmpty();
+    assertThat(result.getData().toString()).isEqualTo("{humans={edges=[{node={id=42, name=GraalVM}}], pageInfo={startCursor=start}}}");
+  }
+
+  private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+      consumer.accept(runtimeWiringBuilder);
+      return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
+    }
+  }
+
+  private TypeResolver characterTypeResolver() {
+    return env -> {
+      Object javaObject = env.getObject();
+      if (javaObject instanceof Droid) {
+        return env.getSchema().getObjectType("Droid");
+      } else if (javaObject instanceof Human) {
+        return env.getSchema().getObjectType("Human");
+      } else {
+        throw new IllegalStateException("Unknown Character type");
+      }
+    };
+  }
+
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
@@ -8,6 +8,8 @@ package graphql;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -78,7 +80,9 @@ public class GraphQlTests {
 
   private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
     try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
-      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      assertThat(inputStream).isNotNull();
+      TypeDefinitionRegistry registry = new SchemaParser().parse(
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8));
       RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
       consumer.accept(runtimeWiringBuilder);
       return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Character.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Droid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Droid implements Character {
+
+  @Override
+  public Long getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getPrimaryFunction() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Episode.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+/**
+ * @author Brian Clozel
+ */
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/starwars/Human.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package graphql.starwars;
+
+import java.util.List;
+
+/**
+ * @author Brian Clozel
+ */
+public class Human implements Character {
+
+  @Override
+  public Long getId() {
+    return 42L;
+  }
+
+  @Override
+  public String getName() {
+    return "GraalVM";
+  }
+
+  @Override
+  public Character getFriends() {
+    return null;
+  }
+
+  @Override
+  public List<Episode> getAppearsIn() {
+    return null;
+  }
+
+  public String getHomePlanet() {
+    return null;
+  }
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,104 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnection",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnectionCursor",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultEdge",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultPageInfo",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLArgument",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLDirective",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLEnumValueDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLFieldDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectField",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLOutputType",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "graphql.starwars.Human",
+      "allPublicMethods" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/greeting.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQlTests"
+      },
+      "glob" : "graphql/starwars.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
+      },
+      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -80,6 +80,69 @@
     {
       "type" : "graphql.starwars.Human",
       "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLObjectType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLInterfaceType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLEnumType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLScalarType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLUnionType",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLTypeReference",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLList",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.introspection.Introspection"
+      },
+      "type" : "graphql.schema.GraphQLNonNull",
+      "allPublicMethods" : true
     }
   ],
   "resources" : [
@@ -94,18 +157,6 @@
         "typeReached" : "graphql.GraphQlTests"
       },
       "glob" : "graphql/starwars.graphqls"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
     }
   ]
 }

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -2,6 +2,13 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "graphql.execution.batched.BatchedDataFetcherFactory"
+      },
+      "type" : "com_graphql_java.graphql_java.BatchedDataFetcherFactoryTest$AnnotatedListFetcher",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "graphql.relay.Connection"
       },
       "type" : "graphql.relay.DefaultConnection",

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/graphql/greeting.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/graphql/greeting.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    greeting: String
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/graphql/starwars.graphqls
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/resources/graphql/starwars.graphqls
@@ -1,0 +1,63 @@
+schema {
+    query: QueryType
+    mutation: Mutation
+}
+
+type Mutation {
+    addFriend(characterId: ID!, newFriend: NewCharacter!) : Character!
+}
+
+type QueryType {
+    hero(episode: Episode): Character!
+    human(id : String) : Human
+    droid(id: ID!): Droid
+    humans: HumanConnection
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]
+    homePlanet: String
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+}
+
+interface Character {
+    id: ID!
+    name: String!
+}
+
+input NewCharacter {
+    name: String
+}
+
+type HumanConnection {
+    edges: [HumanEdge]
+    pageInfo: PageInfo!
+}
+
+type HumanEdge {
+    cursor: String!
+    node: Human
+}
+
+type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "graphql.**"
+    }
+  ]
+}

--- a/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
+++ b/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
@@ -5,6 +5,12 @@
     },
     {
       "includeClasses" : "graphql.**"
+    },
+    {
+      "includeClasses" : "com_graphql_java.graphql_java.**"
+    },
+    {
+      "includeClasses" : "graphql.starwars.**"
     }
   ]
 }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -804,6 +804,21 @@ tasks.register("addLibraryAsLatestMetadataIndexJson", DefaultTask) { task ->
     }
 }
 
+// gradle addLibraryMetadataIndexJson -Pcoordinates=<maven-coordinates> [-PtestVersion=<version>]
+tasks.register("addLibraryMetadataIndexJson", DefaultTask) { task ->
+    task.setDescription("Adds given coordinates to metadata/group/artifact/index.json without changing the latest entry")
+    task.setGroup(METADATA_GROUP)
+    task.doFirst {
+        if (!project.hasProperty("coordinates")) {
+            throw new GradleException("Missing 'coordinates' property! Rerun Gradle with -Pcoordinates=<group:artifact:version>")
+        }
+        def coordsStr = project.findProperty("coordinates").toString()
+        def coords = CoordinateUtils.fromString(coordsStr)
+        def testVersion = project.hasProperty("testVersion") ? project.findProperty("testVersion").toString() : null
+        MetadataGenerationUtils.addVersionToIndexJson(project.layout, coords, testVersion)
+    }
+}
+
 // gradle extractLibraryTestParams -Pcoordinates=<group:artifact[:version]>
 tasks.register("extractLibraryTestParams", DefaultTask) { task ->
     task.setDescription("Extracts TEST_PATH, LATEST_VERSION and TEST_COORDINATES for given coordinates (group:artifact[:version]). Writes them into GITHUB_ENV.")

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -274,6 +274,18 @@ public final class MetadataGenerationUtils {
      * within its corresponding {@code index.json}.
      */
     public static void makeVersionLatestInIndexJson(ProjectLayout layout, Coordinates newCoords, String testVersion) throws IOException {
+        addVersionToIndexJson(layout, newCoords, testVersion, true);
+    }
+
+    /**
+     * Adds a metadata entry for {@code newCoords} while preserving the current {@code latest}
+     * entry within its corresponding {@code index.json}.
+     */
+    public static void addVersionToIndexJson(ProjectLayout layout, Coordinates newCoords, String testVersion) throws IOException {
+        addVersionToIndexJson(layout, newCoords, testVersion, false);
+    }
+
+    private static void addVersionToIndexJson(ProjectLayout layout, Coordinates newCoords, String testVersion, boolean markAsLatest) throws IOException {
         String indexPathTemplate = "metadata/$group$/$artifact$/index.json";
         File indexFile = GeneralUtils.getPathFromProject(layout, CoordinateUtils.replace(indexPathTemplate, newCoords)).toFile();
 
@@ -305,42 +317,24 @@ public final class MetadataGenerationUtils {
         List<String> latestAllowedPackages = null;
         List<String> latestRequires = null;
         LibraryLanguage latestLanguage = null;
-        // Remove 'latest' flag from any existing latest entry
+        // Copy default metadata properties from the current latest entry.
         for (int i = 0; i < entries.size(); i++) {
             MetadataVersionsIndexEntry entry = entries.get(i);
             if (Boolean.TRUE.equals(entry.latest())) {
-                entries.set(i, new MetadataVersionsIndexEntry(
-                        null, // latest removed
-                        entry.override(),
-                        entry.defaultFor(),
-                        entry.metadataVersion(),
-                        entry.testVersion(),
-                        entry.sourceCodeUrl(),
-                        entry.repositoryUrl(),
-                        entry.testCodeUrl(),
-                        entry.documentationUrl(),
-                        entry.description(),
-                        entry.language(),
-                        entry.testedVersions(),
-                        entry.skippedVersions(),
-                        entry.allowedPackages(),
-                        entry.requires(),
-                        null,
-                        null,
-                        null
-                ));
                 latestAllowedPackages = entry.allowedPackages();
                 latestRequires = entry.requires();
                 latestLanguage = entry.language();
+                if (markAsLatest) {
+                    entries.set(i, copyWithLatest(entry, null));
+                }
             }
         }
 
-        // Add the new entry and mark it as latest.
         // When this creates a new metadata boundary inside an existing range,
         // move covered tested versions to the new entry so index validation keeps passing.
         List<String> testedVersions = moveTestedVersionsCoveredByNewMetadata(entries, newCoords.version());
         MetadataVersionsIndexEntry newEntry = new MetadataVersionsIndexEntry(
-                Boolean.TRUE, // latest
+                markAsLatest ? Boolean.TRUE : null, // latest
                 null, // override
                 null, // default-for
                 newCoords.version(), // metadata-version
@@ -359,7 +353,11 @@ public final class MetadataGenerationUtils {
                 null, // reason
                 null // replacement
         );
-        entries.addFirst(newEntry);
+        if (markAsLatest) {
+            entries.addFirst(newEntry);
+        } else {
+            entries.add(insertIndexAfterLatest(entries), newEntry);
+        }
 
         DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
         prettyPrinter.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
@@ -368,6 +366,15 @@ public final class MetadataGenerationUtils {
             json = json + System.lineSeparator();
         }
         Files.writeString(indexFile.toPath(), json, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private static int insertIndexAfterLatest(List<MetadataVersionsIndexEntry> entries) {
+        for (int i = 0; i < entries.size(); i++) {
+            if (Boolean.TRUE.equals(entries.get(i).latest())) {
+                return i + 1;
+            }
+        }
+        return 0;
     }
 
     private static List<String> moveTestedVersionsCoveredByNewMetadata(List<MetadataVersionsIndexEntry> entries, String newVersion) {
@@ -457,6 +464,29 @@ public final class MetadataGenerationUtils {
                 entry.description(),
                 entry.language(),
                 testedVersions,
+                entry.skippedVersions(),
+                entry.allowedPackages(),
+                entry.requires(),
+                entry.notForNativeImage(),
+                entry.reason(),
+                entry.replacement()
+        );
+    }
+
+    private static MetadataVersionsIndexEntry copyWithLatest(MetadataVersionsIndexEntry entry, Boolean latest) {
+        return new MetadataVersionsIndexEntry(
+                latest,
+                entry.override(),
+                entry.defaultFor(),
+                entry.metadataVersion(),
+                entry.testVersion(),
+                entry.sourceCodeUrl(),
+                entry.repositoryUrl(),
+                entry.testCodeUrl(),
+                entry.documentationUrl(),
+                entry.description(),
+                entry.language(),
+                entry.testedVersions(),
                 entry.skippedVersions(),
                 entry.allowedPackages(),
                 entry.requires(),

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -131,6 +131,63 @@ class MetadataGenerationUtilsTests {
                 .containsEntry("tested-versions", List.of("2.0.0", "2.1.0"));
     }
 
+    @Test
+    void addVersionToIndexJsonPreservesLatestEntryForHistoricalBackfill() throws IOException {
+        String group = "com.graphql-java";
+        String artifact = "graphql-java";
+        String backfillVersion = "2018-06-27T00-18-28-1e12da9";
+        writeIndex(
+                group,
+                artifact,
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "19.7",
+                    "tested-versions" : [
+                      "19.7",
+                      "24.3",
+                      "25.0",
+                      "26.0"
+                    ],
+                    "allowed-packages" : [
+                      "graphql"
+                    ]
+                  },
+                  {
+                    "metadata-version" : "19.2",
+                    "tested-versions" : [
+                      "19.2",
+                      "19.3"
+                    ],
+                    "allowed-packages" : [
+                      "graphql"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        MetadataGenerationUtils.addVersionToIndexJson(
+                createProject().getLayout(),
+                Coordinates.parse(group + ":" + artifact + ":" + backfillVersion),
+                null
+        );
+
+        List<Map<String, Object>> entries = readIndex(group, artifact);
+        assertThat(entries.stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.get("latest")))
+                .map(entry -> entry.get("metadata-version")))
+                .containsExactly("19.7");
+        assertThat(findEntry(entries, "19.7"))
+                .containsEntry("tested-versions", List.of("19.7", "24.3", "25.0", "26.0"));
+        assertThat(entries.get(1))
+                .doesNotContainKey("latest")
+                .containsEntry("metadata-version", backfillVersion)
+                .containsEntry("tested-versions", List.of(backfillVersion))
+                .containsEntry("allowed-packages", List.of("graphql"));
+    }
+
     private Project createProject() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())


### PR DESCRIPTION
## What does this PR do?

Fixes: #5780

This PR provides test fixes and new metadata for com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 269441
- Cached input tokens: 2224640
- Output tokens: 25461
- Metadata entries: 4
- Test-only metadata entries: 44
- Iterations: 5
- Library coverage percentage: 35.25
- Previous library version metadata entries: 4
- Previous library version test-only metadata entries: 26
- Previous library version coverage percentage: 30.88

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `6461641238ba1ef5d299d4e2f1e0f50560805add`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.graphql-java:graphql-java:19.7: 11/12 covered calls (91.67%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: 10/10 covered calls (100.00%)

**Reflection:**
- com.graphql-java:graphql-java:19.7: 10/11 covered calls (90.91%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: 10/10 covered calls (100.00%)

**Resources:**
- com.graphql-java:graphql-java:19.7: 1/1 covered calls (100.00%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: N/A

#### Library coverage

**Instruction:**
- com.graphql-java:graphql-java:19.7: 42419/149497 (28.37%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: 23005/69165 (33.26%)

**Line:**
- com.graphql-java:graphql-java:19.7: 10223/33104 (30.88%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: 5406/15338 (35.25%)

**Method:**
- com.graphql-java:graphql-java:19.7: 2959/9722 (30.44%)
- com.graphql-java:graphql-java:2018-06-27T00-18-28-1e12da9: 1429/4426 (32.29%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
new file mode 100644
index 0000000000..7d74433fe5
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/AstValueHelperTest.java
@@ -0,0 +1,48 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import graphql.language.AstValueHelper;
+import graphql.language.IntValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.starwars.Human;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLLong;
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AstValueHelperTest {
+
+  @Test
+  void convertsJavaBeanInputObjectToAstObjectValue() {
+    GraphQLInputObjectType inputType = GraphQLInputObjectType.newInputObject()
+        .name("HumanInput")
+        .field(field -> field.name("id").type(GraphQLLong))
+        .field(field -> field.name("name").type(GraphQLString))
+        .build();
+
+    Value value = AstValueHelper.astFromValue(new Human(), inputType);
+
+    assertThat(value).isInstanceOf(ObjectValue.class);
+    ObjectValue objectValue = (ObjectValue) value;
+    List<ObjectField> objectFields = objectValue.getObjectFields();
+
+    assertThat(objectFields).hasSize(2);
+    assertThat(objectFields.get(0).getName()).isEqualTo("id");
+    assertThat(((IntValue) objectFields.get(0).getValue()).getValue()).isEqualTo(BigInteger.valueOf(42));
+    assertThat(objectFields.get(1).getName()).isEqualTo("name");
+    assertThat(((StringValue) objectFields.get(1).getValue()).getValue()).isEqualTo("GraalVM");
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
new file mode 100644
index 0000000000..b063083769
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/BatchedDataFetcherFactoryTest.java
@@ -0,0 +1,152 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.execution.batched.Batched;
+import graphql.execution.batched.BatchedDataFetcher;
+import graphql.execution.batched.BatchedDataFetcherFactory;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BatchedDataFetcherFactoryTest {
+
+  @Test
+  void createsBatchedFetcherFromAnnotatedDataFetcherMethod() {
+    AnnotatedListFetcher supplied = new AnnotatedListFetcher();
+    DataFetchingEnvironment environment = new TestDataFetchingEnvironment(List.of("Ada", "Bob"));
+
+    BatchedDataFetcher fetcher = new BatchedDataFetcherFactory().create(supplied);
+    Object result = fetcher.get(environment);
+
+    assertThat(result).isEqualTo(List.of("Hello Ada", "Hello Bob"));
+  }
+
+  private static class TestDataFetchingEnvironment implements DataFetchingEnvironment {
+
+    private final Object source;
+
+    TestDataFetchingEnvironment(Object source) {
+      this.source = source;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return null;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
+    }
+  }
+
+  public static class AnnotatedListFetcher implements DataFetcher<Object> {
+
+    @Override
+    @Batched
+    public Object get(DataFetchingEnvironment environment) {
+      List<String> names = environment.getSource();
+      return names.stream()
+          .map(name -> "Hello " + name)
+          .collect(Collectors.toList());
+    }
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
new file mode 100644
index 0000000000..e00b1a6c4d
--- /dev/null
+++ 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/com_graphql_java/graphql_java/PropertyDataFetcherTest.java
@@ -0,0 +1,240 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_graphql_java.graphql_java;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionTypeInfo;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.PropertyDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static graphql.Scalars.GraphQLString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyDataFetcherTest {
+
+  @BeforeEach
+  void resetPropertyFetcher() {
+    PropertyDataFetcher.clearReflectionCache();
+  }
+
+  @Test
+  void invokesFunctionFetcherWithSource() throws Exception {
+    FunctionSource source = new FunctionSource();
+
+    String value = PropertyDataFetcher.<String, FunctionSource>fetching(FunctionSource::value)
+        .get(environmentFor(source));
+
+    assertThat(value).isEqualTo("value from " + FunctionSource.class.getSimpleName());
+  }
+
+  @Test
+  void invokesPublicZeroArgumentGetter() throws Exception {
+    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("zero argument getter value");
+  }
+
+  @Test
+  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
+    PrivateGetterSource source = new PrivateGetterSource();
+
+    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
+
+    assertThat(value).isEqualTo("private getter value");
+  }
+
+  @Test
+  void readsAndCachesPublicField() throws Exception {
+    PublicFieldSource source = new PublicFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
+  }
+
+  @Test
+  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
+    PrivateFieldSource source = new PrivateFieldSource();
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
+
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
+  }
+
+  @Test
+  void findsPublicMethodOnRootInterfaceWhenNoSuperclassExists() throws Throwable {
+    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("name");
+    // A non-public interface has no superclass, so it exercises the root interface lookup path.
+    MethodHandle finder = MethodHandles.privateLookupIn(PropertyDataFetcher.class, MethodHandles.lookup())
+        .findVirtual(
+            PropertyDataFetcher.class,
+            "findPubliclyAccessibleMethod",
+            MethodType.methodType(Method.class, Class.class, String.class));
+
+    Method method = (Method) finder.invoke(fetcher, NonPublicNameSource.class, "getName");
+
+    assertThat(method.getDeclaringClass()).isEqualTo(NonPublicNameSource.class);
+    assertThat(method.getName()).isEqualTo("getName");
+  }
+
+  private DataFetchingEnvironment environmentFor(Object source) {
+    return new TestDataFetchingEnvironment(source, GraphQLString);
+  }
+
+  private static class TestDataFetchingEnvironment implements DataFetchingEnvironment {
+
+    private final Object source;
+    private final GraphQLOutputType fieldType;
+
+    TestDataFetchingEnvironment(Object source, GraphQLOutputType fieldType) {
+      this.source = source;
+      this.fieldType = fieldType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getSource() {
+      return (T) source;
+    }
+
+    @Override
+    public Map<String, Object> getArguments() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public boolean containsArgument(String name) {
+      return false;
+    }
+
+    @Override
+    public <T> T getArgument(String name) {
+      return null;
+    }
+
+    @Override
+    public <T> T getContext() {
+      return null;
+    }
+
+    @Override
+    public <T> T getRoot() {
+      return null;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getFieldDefinition() {
+      return null;
+    }
+
+    @Override
+    public List<Field> getFields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Field getField() {
+      return null;
+    }
+
+    @Override
+    public GraphQLOutputType getFieldType() {
+      return fieldType;
+    }
+
+    @Override
+    public ExecutionTypeInfo getFieldTypeInfo() {
+      return null;
+    }
+
+    @Override
+    public GraphQLType getParentType() {
+      return null;
+    }
+
+    @Override
+    public GraphQLSchema getGraphQLSchema() {
+      return null;
+    }
+
+    @Override
+    public Map<String, FragmentDefinition> getFragmentsByName() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public ExecutionId getExecutionId() {
+      return null;
+    }
+
+    @Override
+    public DataFetchingFieldSelectionSet getSelectionSet() {
+      return null;
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext() {
+      return null;
+    }
+  }
+
+  public static class FunctionSource {
+
+    public String value() {
+      return "value from " + getClass().getSimpleName();
+    }
+  }
+
+  public static class ZeroArgumentGetterSource {
+
+    public String getName() {
+      return "zero argument getter value";
+    }
+  }
+
+  public static class PrivateGetterSource {
+
+    private String getSecret() {
+      return "private getter value";
+    }
+  }
+
+  public static class PublicFieldSource {
+
+    public final String publicField = "public field value";
+  }
+
+  public static class PrivateFieldSource {
+
+    private final String privateField = "private field value";
+  }
+
+  interface NonPublicNameSource {
+
+    String getName();
+  }
+}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java 2/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
deleted file mode 100644
index e36e5f0ffe..0000000000
--- 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/PropertyFetchingImplTest.java
+++ /dev/null
@@ -1,114 +0,0 @@
-/*
- * Copyright and related rights waived via CC0
- *
- * You should have received a copy of the CC0 legalcode along with this
- * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
- */
-package com_graphql_java.graphql_java;
-
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingEnvironmentImpl;
-import graphql.schema.PropertyDataFetcher;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static graphql.Scalars.GraphQLString;
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class PropertyFetchingImplTest {
-
-  @BeforeEach
-  void resetPropertyFetcher() {
-    PropertyDataFetcher.clearReflectionCache();
-    PropertyDataFetcher.setUseSetAccessible(true);
-    PropertyDataFetcher.setUseNegativeCache(true);
-  }
-
-  @Test
-  void invokesPublicGetterWithDataFetchingEnvironmentArgument() throws Exception {
-    EnvironmentAwareSource source = new EnvironmentAwareSource();
-    DataFetchingEnvironment environment = environmentFor(source);
-
-    String value = PropertyDataFetcher.<String>fetching("value").get(environment);
-
-    assertThat(value).isEqualTo("value from " + EnvironmentAwareSource.class.getSimpleName());
-    assertThat(source.seenEnvironment).isSameAs(environment);
-  }
-
-  @Test
-  void invokesPublicZeroArgumentGetter() throws Exception {
-    ZeroArgumentGetterSource source = new ZeroArgumentGetterSource();
-
-    String value = PropertyDataFetcher.<String>fetching("name").get(environmentFor(source));
-
-    assertThat(value).isEqualTo("zero argument getter value");
-  }
-
-  @Test
-  void invokesPrivateGetterViaSetAccessibleLookup() throws Exception {
-    PrivateGetterSource source = new PrivateGetterSource();
-
-    String value = PropertyDataFetcher.<String>fetching("secret").get(environmentFor(source));
-
-    assertThat(value).isEqualTo("private getter value");
-  }
-
-  @Test
-  void readsAndCachesPublicField() throws Exception {
-    PublicFieldSource source = new PublicFieldSource();
-    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("publicField");
-
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("public field value");
-  }
-
-  @Test
-  void readsAndCachesPrivateFieldViaSetAccessibleLookup() throws Exception {
-    PrivateFieldSource source = new PrivateFieldSource();
-    PropertyDataFetcher<String> fetcher = PropertyDataFetcher.fetching("privateField");
-
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
-    assertThat(fetcher.get(environmentFor(source))).isEqualTo("private field value");
-  }
-
-  private DataFetchingEnvironment environmentFor(Object source) {
-    return DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-        .source(source)
-        .fieldType(GraphQLString)
-        .build();
-  }
-
-  public static class EnvironmentAwareSource {
-
-    private DataFetchingEnvironment seenEnvironment;
-
-    public String getValue(DataFetchingEnvironment environment) {
-      this.seenEnvironment = environment;
-      return "value from " + getClass().getSimpleName();
-    }
-  }
-
-  public static class ZeroArgumentGetterSource {
-
-    public String getName() {
-      return "zero argument getter value";
-    }
-  }
-
-  public static class PrivateGetterSource {
-
-    private String getSecret() {
-      return "private getter value";
-    }
-  }
-
-  public static class PublicFieldSource {
-
-    public final String publicField = "public field value";
-  }
-
-  public static class PrivateFieldSource {
-
-    private final String privateField = "private field value";
-  }
-}
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
index bc57b070ff..36a29b16c7 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/graphql/GraphQlTests.java
+++ 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/src/test/java/graphql/GraphQlTests.java
@@ -8,6 +8,8 @@ package graphql;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -78,7 +80,9 @@ public class GraphQlTests {
 
   private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
     try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
-      TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
+      assertThat(inputStream).isNotNull();
+      TypeDefinitionRegistry registry = new SchemaParser().parse(
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8));
       RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
       consumer.accept(runtimeWiringBuilder);
       return new SchemaGenerator().makeExecutableSchema(registry, runtimeWiringBuilder.build());
diff --git 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
index b154f38b11..3d996b1625 100644
--- 1/tests/src/com.graphql-java/graphql-java/19.7/user-code-filter.json
+++ 2/tests/src/com.graphql-java/graphql-java/2018-06-27T00-18-28-1e12da9/user-code-filter.json
@@ -5,6 +5,12 @@
     },
     {
       "includeClasses" : "graphql.**"
+    },
+    {
+      "includeClasses" : "com_graphql_java.graphql_java.**"
+    },
+    {
+      "includeClasses" : "graphql.starwars.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
