### PR TITLE
[GenAI] Add support for software.amazon.awssdk:retries:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/retries/2.34.0/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T13:11:40.463324Z",
+    "timestamp": "2026-05-04T14:50:54.485276Z",
     "library": "software.amazon.awssdk:retries:2.34.0",
-    "starting_commit": "ffe7849a73fd519ba1f269bd1b57f71c29e6cc7d",
-    "ending_commit": "3a463456efef857ad8f44275cf08e199291f4adc",
+    "starting_commit": "576f9681c0e2e88318795760d4225fc719f5f8d7",
+    "ending_commit": "7f1b42867955391fb83d0463b23ad13dd9e95111",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -38,12 +38,12 @@
       }
     },
     "metrics": {
-      "input_tokens_used": 180113,
-      "cached_input_tokens_used": 1789440,
-      "output_tokens_used": 14486,
+      "input_tokens_used": 185226,
+      "cached_input_tokens_used": 2718208,
+      "output_tokens_used": 17905,
       "iterations": 3,
-      "cost_usd": 1.3293,
-      "generated_loc": 608,
+      "cost_usd": 1.8963,
+      "generated_loc": 733,
       "tested_library_loc": 642,
       "metadata_entries": 0,
       "code_coverage_percent": 92.11

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
 import software.amazon.awssdk.retries.DefaultRetryStrategy;
@@ -383,6 +384,30 @@ public class RetriesTest {
         assertRefreshSucceeds(strategy, new IllegalStateException("transient connection reset"));
         assertRefreshSucceeds(strategy, new UnsupportedOperationException("retryable by second predicate"));
         assertRefreshFails(strategy, new IllegalStateException("permanent validation failure"));
+    }
+
+    @Test
+    void throttlingPredicateIsNotEvaluatedForNonRetryableFailures() {
+        AtomicBoolean throttlingPredicateCalled = new AtomicBoolean(false);
+        RetryStrategy strategy = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnException(IllegalStateException.class)
+            .treatAsThrottling(failure -> {
+                throttlingPredicateCalled.set(true);
+                return true;
+            })
+            .throttlingBackoffStrategy(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(17)))
+            .circuitBreakerEnabled(false)
+            .build();
+        RetryToken token = strategy.acquireInitialToken(AcquireInitialTokenRequest.create("non-retryable-throttling"))
+            .token();
+        IllegalArgumentException failure = new IllegalArgumentException("not retryable");
+
+        assertThatExceptionOfType(TokenAcquisitionFailedException.class)
+            .isThrownBy(() -> strategy.refreshRetryToken(refreshRequest(token, failure).build()))
+            .withCause(failure)
+            .withMessageContaining("non-retryable");
+        assertThat(throttlingPredicateCalled).isFalse();
     }
 
     @Test

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -320,6 +320,29 @@ public class RetriesTest {
     }
 
     @Test
+    void adaptiveStrategyRateLimitsInitialAttemptsWithinThrottledScope() {
+        AdaptiveRetryStrategy strategy = AdaptiveRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .throttlingBackoffStrategy(BackoffStrategy.retryImmediately())
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .useClientDefaults(false)
+            .build();
+        String scope = "adaptive-throttled-initial-attempt";
+        RetryToken firstAttemptToken = strategy.acquireInitialToken(AcquireInitialTokenRequest.create(scope)).token();
+
+        RefreshRetryTokenResponse throttledRetry = strategy.refreshRetryToken(
+            refreshRequest(firstAttemptToken, new ThrottlingFailure()).build());
+        AcquireInitialTokenResponse nextInitialAttempt = strategy.acquireInitialToken(
+            AcquireInitialTokenRequest.create(scope));
+
+        assertThat(throttledRetry.token()).isNotNull();
+        assertThat(nextInitialAttempt.token()).isNotNull();
+        assertThat(nextInitialAttempt.delay()).isGreaterThan(Duration.ZERO);
+    }
+
+    @Test
     void retryPredicateConvenienceMethodsHandleExactTypeCauseAndRootCause() {
         assertRefreshSucceeds(StandardRetryStrategy.builder()
             .maxAttempts(2)

--- a/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
+++ b/tests/src/software.amazon.awssdk/retries/2.34.0/src/test/java/software_amazon_awssdk/retries/RetriesTest.java
@@ -637,6 +637,98 @@ public class RetriesTest {
     }
 
     @Test
+    void defaultStrategyBuildersProvideConfiguredRetryBehaviorWithoutCustomBackoff() {
+        StandardRetryStrategy standard = DefaultRetryStrategy.standardStrategyBuilder()
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+        LegacyRetryStrategy legacy = DefaultRetryStrategy.legacyStrategyBuilder()
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .circuitBreakerEnabled(false)
+            .build();
+        AdaptiveRetryStrategy adaptive = DefaultRetryStrategy.adaptiveStrategyBuilder()
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .treatAsThrottling(ThrottlingFailure.class::isInstance)
+            .useClientDefaults(false)
+            .build();
+
+        assertThat(standard.maxAttempts()).isEqualTo(3);
+        assertThat(standard.useClientDefaults()).isTrue();
+        assertThat(refreshDelay(standard, new RuntimeException("standard default"), "default-standard-normal"))
+            .isBetween(Duration.ZERO, Duration.ofMillis(99));
+        assertThat(refreshDelay(standard, new ThrottlingFailure(), "default-standard-throttled"))
+            .isBetween(Duration.ZERO, Duration.ofMillis(999));
+
+        assertThat(legacy.maxAttempts()).isEqualTo(4);
+        assertThat(legacy.useClientDefaults()).isTrue();
+        assertThat(refreshDelay(legacy, new RuntimeException("legacy default"), "default-legacy-normal"))
+            .isBetween(Duration.ZERO, Duration.ofMillis(99));
+        assertThat(refreshDelay(legacy, new ThrottlingFailure(), "default-legacy-throttled"))
+            .isBetween(Duration.ofMillis(250), Duration.ofMillis(500));
+
+        assertThat(adaptive.maxAttempts()).isEqualTo(3);
+        assertThat(adaptive.useClientDefaults()).isFalse();
+        assertThat(adaptive.acquireInitialToken(AcquireInitialTokenRequest.create("default-adaptive-initial"))
+            .delay()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void retryStrategyInterfaceBuilderCanCopyAndRebuildStrategies() {
+        RetryStrategy original = StandardRetryStrategy.builder()
+            .maxAttempts(2)
+            .retryOnExceptionInstanceOf(RuntimeException.class)
+            .backoffStrategy(BackoffStrategy.retryImmediately())
+            .circuitBreakerEnabled(false)
+            .build();
+
+        RetryStrategy rebuilt = original.toBuilder()
+            .maxAttempts(3)
+            .build();
+
+        assertThat(original.maxAttempts()).isEqualTo(2);
+        assertThat(rebuilt.maxAttempts()).isEqualTo(3);
+        assertThat(rebuilt.refreshRetryToken(refreshRequest(
+            rebuilt.acquireInitialToken(AcquireInitialTokenRequest.create("rebuilt-interface")).token(),
+            new RuntimeException("retryable through rebuilt strategy")).build()).delay()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void factoryMethodsRejectNullTokensAndDelays() {
+        RetryToken token = new ForeignRetryToken();
+
+        assertThatThrownBy(() -> RecordSuccessRequest.create(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> AcquireInitialTokenResponse.create(null, Duration.ZERO))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> AcquireInitialTokenResponse.create(token, null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> RefreshRetryTokenResponse.create(null, Duration.ZERO))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> RefreshRetryTokenResponse.create(token, null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> RecordSuccessResponse.create(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void backoffStrategiesExposeReadableConfigurationStrings() {
+        assertThat(BackoffStrategy.retryImmediately().toString())
+            .contains("Immediately");
+        assertThat(BackoffStrategy.fixedDelay(Duration.ofMillis(12)).toString())
+            .contains("FixedDelayWithJitter", "delay=PT0.012S");
+        assertThat(BackoffStrategy.fixedDelayWithoutJitter(Duration.ofMillis(12)).toString())
+            .contains("FixedDelayWithoutJitter", "delay=PT0.012S");
+        assertThat(BackoffStrategy.exponentialDelay(Duration.ofMillis(10), Duration.ofMillis(30)).toString())
+            .contains("ExponentialDelayWithJitter", "baseDelay=PT0.01S", "maxDelay=PT0.03S");
+        assertThat(BackoffStrategy.exponentialDelayHalfJitter(Duration.ofMillis(10), Duration.ofMillis(30)).toString())
+            .contains("ExponentialDelayWithHalfJitter", "baseDelay=PT0.01S", "maxDelay=PT0.03S");
+        assertThat(BackoffStrategy.exponentialDelayWithoutJitter(Duration.ofMillis(10), Duration.ofMillis(30))
+            .toString()).contains("ExponentialDelayWithoutJitter", "baseDelay=PT0.01S", "maxDelay=PT0.03S");
+    }
+
+    @Test
     void strategiesAndTokensExposeReadableDiagnosticStrings() {
         StandardRetryStrategy strategy = StandardRetryStrategy.builder()
             .maxAttempts(2)


### PR DESCRIPTION

## What does this PR do?

Fixes: #4612

This PR introduces tests and metadata for software.amazon.awssdk:retries:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 185226
- Cached input tokens: 2718208
- Output tokens: 17905
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 92.11
- Generated lines of code: 733
- Tested library lines of code: 642

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `576f9681c0e2e88318795760d4225fc719f5f8d7`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2356/2638 (89.31%)
- Line: 642/697 (92.11%)
- Method: 198/227 (87.22%)

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
