### PR TITLE
[GenAI] Add support for io.github.pdvrieze.xmlutil:core-jvmcommon:0.91.3 using gpt-5.5

### DIFF
--- a/stats/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/execution-metrics.json
+++ b/stats/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/execution-metrics.json
@@ -1,9 +1,9 @@
 {
   "add_new_library_support:2026-05-04": {
-    "timestamp": "2026-05-04T13:02:19.400676Z",
+    "timestamp": "2026-05-04T15:08:49.783945Z",
     "library": "io.github.pdvrieze.xmlutil:core-jvmcommon:0.91.3",
-    "starting_commit": "9e88ca8964db93b9eb51d3fa3414c2062d156cfc",
-    "ending_commit": "b7e8436bc41bdd3e3ac25c53d7d6cee4d7d5bef2",
+    "starting_commit": "e909589284d7b03929440a78266919238302ac77",
+    "ending_commit": "e44080b1daf0a9fc3764fb3db015e3b8e8a81855",
     "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
     "agent": "pi",
     "model": "oca/gpt-5.5",
@@ -12,35 +12,35 @@
       "version": "0.91.3",
       "libraryCoverage": {
         "instruction": {
-          "covered": 8716,
-          "missed": 20083,
-          "ratio": 0.302649,
+          "covered": 9187,
+          "missed": 19612,
+          "ratio": 0.319004,
           "total": 28799
         },
         "line": {
-          "covered": 1738,
-          "missed": 3062,
-          "ratio": 0.362083,
+          "covered": 1814,
+          "missed": 2986,
+          "ratio": 0.377917,
           "total": 4800
         },
         "method": {
-          "covered": 484,
-          "missed": 1137,
-          "ratio": 0.298581,
+          "covered": 540,
+          "missed": 1081,
+          "ratio": 0.333128,
           "total": 1621
         }
       }
     },
     "metrics": {
-      "input_tokens_used": 317133,
-      "cached_input_tokens_used": 3325952,
-      "output_tokens_used": 35668,
-      "iterations": 9,
-      "cost_usd": 2.733,
-      "generated_loc": 305,
-      "tested_library_loc": 1738,
+      "input_tokens_used": 444884,
+      "cached_input_tokens_used": 4049408,
+      "output_tokens_used": 37593,
+      "iterations": 15,
+      "cost_usd": 3.1525,
+      "generated_loc": 449,
+      "tested_library_loc": 1814,
       "metadata_entries": 0,
-      "code_coverage_percent": 36.21
+      "code_coverage_percent": 37.79
     },
     "artifacts": {
       "test_file": "tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt",

--- a/stats/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/stats.json
+++ b/stats/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/stats.json
@@ -4,21 +4,21 @@
     "dynamicAccess" : "N/A",
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 8716,
-        "missed" : 20083,
-        "ratio" : 0.302649,
+        "covered" : 9187,
+        "missed" : 19612,
+        "ratio" : 0.319004,
         "total" : 28799
       },
       "line" : {
-        "covered" : 1738,
-        "missed" : 3062,
-        "ratio" : 0.362083,
+        "covered" : 1814,
+        "missed" : 2986,
+        "ratio" : 0.377917,
         "total" : 4800
       },
       "method" : {
-        "covered" : 484,
-        "missed" : 1137,
-        "ratio" : 0.298581,
+        "covered" : 540,
+        "missed" : 1081,
+        "ratio" : 0.333128,
         "total" : 1621
       }
     }

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
@@ -13,19 +13,24 @@ import nl.adaptivity.xmlutil.XmlDeclMode
 import nl.adaptivity.xmlutil.XmlEvent
 import nl.adaptivity.xmlutil.XmlReader
 import nl.adaptivity.xmlutil.XmlWriter
+import nl.adaptivity.xmlutil.dom2.Attr
 import nl.adaptivity.xmlutil.dom2.CharacterData
 import nl.adaptivity.xmlutil.dom2.Element
 import nl.adaptivity.xmlutil.dom2.Node
 import nl.adaptivity.xmlutil.dom2.NodeType
+import nl.adaptivity.xmlutil.dom2.attributes
 import nl.adaptivity.xmlutil.dom2.childNodes
 import nl.adaptivity.xmlutil.dom2.documentElement
 import nl.adaptivity.xmlutil.dom2.length
+import nl.adaptivity.xmlutil.dom2.name
 import nl.adaptivity.xmlutil.dom2.namespaceURI
 import nl.adaptivity.xmlutil.dom2.nodeName
+import nl.adaptivity.xmlutil.dom2.ownerElement
 import nl.adaptivity.xmlutil.dom2.parentNode
 import nl.adaptivity.xmlutil.dom2.prefix
 import nl.adaptivity.xmlutil.dom2.previousSibling
 import nl.adaptivity.xmlutil.dom2.textContent
+import nl.adaptivity.xmlutil.dom2.value
 import nl.adaptivity.xmlutil.elementToFragment
 import nl.adaptivity.xmlutil.isElement
 import nl.adaptivity.xmlutil.newWriter
@@ -321,6 +326,52 @@ public class CoreJvmcommonTest {
                 .forEach { it.writeTo(writer) }
         }
         assertThat(replayed).contains("<events", "e:item", "id=\"42\"", "payload")
+    }
+
+    @Test
+    fun domAttributeNodesCharacterDataAndChildMutationsUpdateTree(): Unit {
+        val document = xmlStreaming.genericDomImplementation.createDocument(STORE_NS, "s:store", null)
+        val root = requireNotNull(document.documentElement)
+
+        val statusAttribute: Attr = document.createAttributeNS(ATTR_NS, "a:status")
+        statusAttribute.value = "draft"
+        assertThat(root.setAttributeNodeNS(statusAttribute)).isNull()
+        assertThat(root.hasAttributeNS(ATTR_NS, "status")).isTrue()
+        val statusOwner: Element = requireNotNull(requireNotNull(root.getAttributeNodeNS(ATTR_NS, "status")).ownerElement)
+        assertThat(statusOwner.nodeName).isEqualTo(root.nodeName)
+        assertThat(requireNotNull(root.attributes.getNamedItemNS(ATTR_NS, "status")).value).isEqualTo("draft")
+
+        val ownerAttribute: Attr = document.createAttribute("owner")
+        ownerAttribute.value = "catalog-team"
+        assertThat(root.attributes.setNamedItem(ownerAttribute)).isNull()
+        assertThat(requireNotNull(root.getAttributeNode("owner")).value).isEqualTo("catalog-team")
+        assertThat(root.attributes.toList()).hasSize(2)
+
+        val label = document.createElementNS(STORE_NS, "s:label")
+        val labelText: CharacterData = document.createTextNode("catalog")
+        labelText.insertData(0, "book ")
+        labelText.appendData(" ready")
+        assertThat(labelText.substringData(5, 7)).isEqualTo("catalog")
+        labelText.replaceData(13, 5, "open")
+        labelText.deleteData(12, 5)
+        label.appendChild(labelText)
+        root.appendChild(label)
+
+        val oldItem = document.createElementNS(STORE_NS, "s:oldItem")
+        val currentItem = document.createElementNS(STORE_NS, "s:currentItem")
+        root.appendChild(oldItem)
+        val replaced: Node = root.replaceChild(currentItem, oldItem)
+        assertThat(replaced.nodeName).isEqualTo("s:oldItem")
+        assertThat(replaced.parentNode).isNull()
+        assertThat(requireNotNull(currentItem.parentNode).nodeName).isEqualTo(root.nodeName)
+
+        val removedOwner: Attr = root.removeAttributeNode(ownerAttribute)
+        assertThat(removedOwner.name).isEqualTo("owner")
+        assertThat(root.hasAttribute("owner")).isFalse()
+        assertThat(root.attributes.toList()).hasSize(1)
+        assertThat(root.textContent).isEqualTo("book catalog")
+        assertThat(root.childNodes.length).isEqualTo(2)
+        assertThat(root.childNodes.toList().map { it.nodeName }).containsExactly("s:label", "s:currentItem")
     }
 
     @Test

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
@@ -20,15 +20,20 @@ import nl.adaptivity.xmlutil.dom2.Node
 import nl.adaptivity.xmlutil.dom2.NodeType
 import nl.adaptivity.xmlutil.dom2.attributes
 import nl.adaptivity.xmlutil.dom2.childNodes
+import nl.adaptivity.xmlutil.dom2.data
 import nl.adaptivity.xmlutil.dom2.documentElement
 import nl.adaptivity.xmlutil.dom2.length
 import nl.adaptivity.xmlutil.dom2.name
 import nl.adaptivity.xmlutil.dom2.namespaceURI
+import nl.adaptivity.xmlutil.dom2.nextSibling
 import nl.adaptivity.xmlutil.dom2.nodeName
 import nl.adaptivity.xmlutil.dom2.ownerElement
 import nl.adaptivity.xmlutil.dom2.parentNode
 import nl.adaptivity.xmlutil.dom2.prefix
 import nl.adaptivity.xmlutil.dom2.previousSibling
+import nl.adaptivity.xmlutil.dom2.publicId
+import nl.adaptivity.xmlutil.dom2.systemId
+import nl.adaptivity.xmlutil.dom2.target
 import nl.adaptivity.xmlutil.dom2.textContent
 import nl.adaptivity.xmlutil.dom2.value
 import nl.adaptivity.xmlutil.elementToFragment
@@ -416,6 +421,64 @@ public class CoreJvmcommonTest {
             assertThat(reader.nextTag()).isEqualTo(EventType.END_ELEMENT)
             assertThat(reader.localName).isEqualTo("lines")
         }
+    }
+
+    @Test
+    fun genericDomSupportsDocumentTypeFragmentsAndProcessingInstructions(): Unit {
+        val implementation = xmlStreaming.genericDomImplementation
+        val documentType = implementation.createDocumentType(
+            "s:store",
+            "-//xmlutil//Store Catalog//EN",
+            "store-catalog.dtd",
+        )
+        val document = implementation.createDocument(STORE_NS, "s:store", null)
+        val root = requireNotNull(document.documentElement)
+
+        assertThat(documentType.name).isEqualTo("s:store")
+        assertThat(documentType.publicId).isEqualTo("-//xmlutil//Store Catalog//EN")
+        assertThat(documentType.systemId).isEqualTo("store-catalog.dtd")
+
+        val instruction = document.createProcessingInstruction("review", "status=\"draft\"")
+        instruction.data = "status=\"published\""
+        root.appendChild(instruction)
+
+        val fragment = document.createDocumentFragment()
+        val paperback = document.createElementNS(STORE_NS, "s:item")
+        paperback.setAttribute("sku", "frag-1")
+        paperback.appendChild(document.createTextNode("Paperback"))
+        val hardback = document.createElementNS(STORE_NS, "s:item")
+        hardback.setAttribute("sku", "frag-2")
+        hardback.appendChild(document.createTextNode("Hardback"))
+        fragment.appendChild(paperback)
+        fragment.appendChild(hardback)
+
+        val appendedFragment = root.appendChild(fragment)
+        assertThat(appendedFragment.nodetype).isEqualTo(NodeType.DOCUMENT_FRAGMENT_NODE)
+        assertThat(fragment.childNodes.length).isEqualTo(0)
+        assertThat(root.childNodes.toList().map { it.nodeName })
+            .containsExactly("review", "s:item", "s:item")
+        assertThat(instruction.target).isEqualTo("review")
+        assertThat(instruction.data).isEqualTo("status=\"published\"")
+        assertThat(requireNotNull(instruction.nextSibling).nodeName).isEqualTo("s:item")
+        assertThat(requireNotNull(hardback.previousSibling).textContent).isEqualTo("Paperback")
+
+        val itemText: MutableList<String> = mutableListOf()
+        var sawProcessingInstruction: Boolean = false
+        xmlStreaming.newReader(document).use { reader: XmlReader ->
+            while (reader.hasNext()) {
+                when (reader.next()) {
+                    EventType.PROCESSING_INSTRUCTION -> sawProcessingInstruction = reader.piTarget == "review" &&
+                        reader.piData == "status=\"published\""
+                    EventType.START_ELEMENT -> if (reader.localName == "item") {
+                        itemText += reader.readSimpleElement()
+                    }
+                    else -> Unit
+                }
+            }
+        }
+
+        assertThat(sawProcessingInstruction).isTrue()
+        assertThat(itemText).containsExactly("Paperback", "Hardback")
     }
 
     private fun buildXml(block: (XmlWriter) -> Unit): String {

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/src/test/kotlin/io_github_pdvrieze_xmlutil/core_jvmcommon/Core_jvmcommonTest.kt
@@ -33,6 +33,9 @@ import nl.adaptivity.xmlutil.readSimpleElement
 import nl.adaptivity.xmlutil.serialize
 import nl.adaptivity.xmlutil.skipElement
 import nl.adaptivity.xmlutil.util.CompactFragment
+import nl.adaptivity.xmlutil.writeAttribute
+import nl.adaptivity.xmlutil.writeListIfNotEmpty
+import nl.adaptivity.xmlutil.writeSimpleElement
 import nl.adaptivity.xmlutil.xmlStreaming
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -318,6 +321,50 @@ public class CoreJvmcommonTest {
                 .forEach { it.writeTo(writer) }
         }
         assertThat(replayed).contains("<events", "e:item", "id=\"42\"", "payload")
+    }
+
+    @Test
+    fun writerUtilitiesCreateAttributedContainerAndSimpleChildren(): Unit {
+        val xml: String = buildXml { writer: XmlWriter ->
+            writer.setPrefix("bk", BOOK_NS)
+            writer.startTag(BOOK_NS, "order", "bk")
+            writer.namespaceAttr("bk", BOOK_NS)
+            writer.writeAttribute("id", "order-7")
+            writer.writeAttribute("lineCount", 2L)
+            writer.writeAttribute(QName(BOOK_NS, "category", "bk"), "fiction")
+            writer.writeListIfNotEmpty(
+                listOf("Alpha & Beta", "Gamma < Delta"),
+                BOOK_NS,
+                "lines",
+                "bk",
+            ) { value: String ->
+                writeSimpleElement(BOOK_NS, "line", "bk", value)
+            }
+            writer.endTag(BOOK_NS, "order", "bk")
+        }
+
+        assertThat(xml)
+            .contains("order-7")
+            .contains("lineCount=\"2\"")
+            .contains("Alpha &amp; Beta")
+            .contains("Gamma &lt; Delta")
+
+        xmlStreaming.newGenericReader(xml).use { reader: XmlReader ->
+            moveToStartElement(reader, "order")
+            assertThat(reader.name).isEqualTo(QName(BOOK_NS, "order", "bk"))
+            assertThat(reader.getAttributeValue("", "id")).isEqualTo("order-7")
+            assertThat(reader.getAttributeValue("", "lineCount")).isEqualTo("2")
+            assertThat(reader.getAttributeValue(BOOK_NS, "category")).isEqualTo("fiction")
+
+            assertThat(reader.nextTag()).isEqualTo(EventType.START_ELEMENT)
+            assertThat(reader.name).isEqualTo(QName(BOOK_NS, "lines", "bk"))
+            assertThat(reader.nextTag()).isEqualTo(EventType.START_ELEMENT)
+            assertThat(reader.readSimpleElement()).isEqualTo("Alpha & Beta")
+            assertThat(reader.nextTag()).isEqualTo(EventType.START_ELEMENT)
+            assertThat(reader.readSimpleElement()).isEqualTo("Gamma < Delta")
+            assertThat(reader.nextTag()).isEqualTo(EventType.END_ELEMENT)
+            assertThat(reader.localName).isEqualTo("lines")
+        }
     }
 
     private fun buildXml(block: (XmlWriter) -> Unit): String {


### PR DESCRIPTION

## What does this PR do?

Fixes: #5375

This PR introduces tests and metadata for io.github.pdvrieze.xmlutil:core-jvmcommon:0.91.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 444884
- Cached input tokens: 4049408
- Output tokens: 37593
- Metadata entries: 0
- Iterations: 15
- Library coverage percentage: 37.79
- Generated lines of code: 449
- Tested library lines of code: 1814

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e909589284d7b03929440a78266919238302ac77`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 9187/28799 (31.90%)
- Line: 1814/4800 (37.79%)
- Method: 540/1621 (33.31%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
