### PR TITLE
Cache Forge issue searches across local workers

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -32,6 +32,7 @@ Common options:
 - `--stop`: ask all Forge `do-work` loops for the current user to exit by creating `~/.metadata-forge-stop`.
 - `--stop --branch BRANCH`: ask only loops monitoring `BRANCH` to exit, using a branch-scoped marker such as `~/.metadata-forge-stop.master`.
 - `--clear-stop`: remove the matching global or branch-scoped stop marker so future `do-work` loops can run.
+- `--clear-issue-caches`: delete local issue claim/search caches used by work-queue scanning and exit.
 
 Examples:
 
@@ -44,6 +45,7 @@ FORGE_REVIEW_LABEL=library-new-request ./do-work.sh --review-limit 2
 ./do-work.sh --stop --branch master
 ./do-work.sh --clear-stop
 ./do-work.sh --clear-stop --branch master
+./do-work.sh --clear-issue-caches
 ```
 
 The same limits can be controlled with environment variables such as

--- a/forge/README.md
+++ b/forge/README.md
@@ -28,6 +28,7 @@ Common options:
 - `--ni-run-limit N`: process up to `N` Native Image runtime failure tasks per cycle.
 - `--parallelism N`: run up to `N` issue workflows in parallel. Maximum: 4.
 - `--review-limit N`: process up to `N` PR review tasks per label per cycle.
+- `--random-offset`: start new-library issue scans at a random offset instead of the newest issues first.
 - `--once`: run a single update/work cycle through `do_up_to_date_work.sh` and exit.
 - `--stop`: ask all Forge `do-work` loops for the current user to exit by creating `~/.metadata-forge-stop`.
 - `--stop --branch BRANCH`: ask only loops monitoring `BRANCH` to exit, using a branch-scoped marker such as `~/.metadata-forge-stop.master`.

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -31,6 +31,7 @@ MAX_PARALLELISM=4
 RUN_ONCE=0
 REQUEST_STOP=0
 CLEAR_STOP=0
+CLEAR_ISSUE_CACHES=0
 BRANCH_ARG_PROVIDED=0
 SLEEP_POLL_SECONDS="${FORGE_DO_WORK_SLEEP_POLL_SECONDS:-5}"
 
@@ -76,6 +77,9 @@ Options:
   --clear-stop, --resume
       Clear the matching global or branch-scoped stop marker so future do-work
       loops can run.
+  --clear-issue-caches
+      Delete local issue claim/search caches used by work-queue scanning and
+      exit.
   --branch BRANCH
       Branch to monitor on origin. Equivalent to the optional positional
       metadata-forge-branch argument.
@@ -134,6 +138,7 @@ Examples:
   $0 master
   $0 --javac-limit 3 --new-limit 1
   $0 --once --branch master
+  $0 --clear-issue-caches
   DO_WORK_SLEEP_SECONDS=60 $0 origin/main
 EOF
 }
@@ -446,6 +451,10 @@ while [[ "$#" -gt 0 ]]; do
             CLEAR_STOP=1
             shift
             ;;
+        --clear-issue-caches)
+            CLEAR_ISSUE_CACHES=1
+            shift
+            ;;
         --branch)
             require_option_value "$1" "${2:-}"
             BRANCH_ARG="$2"
@@ -555,6 +564,11 @@ if [[ "$MONITORED_BRANCH" == "" ]]; then
     echo "metadata-forge branch must not be empty." >&2
     usage >&2
     exit 1
+fi
+
+if [[ "$CLEAR_ISSUE_CACHES" == "1" ]]; then
+    "$PYTHON_BIN" "$SCRIPT_DIR/forge_metadata.py" --clear-issue-caches
+    exit 0
 fi
 
 require_stop_file

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -20,7 +20,7 @@ LIBRARY_UPDATE_WORK_LIMIT="${FORGE_LIBRARY_UPDATE_WORK_LIMIT:-1}"
 LIBRARY_UPDATE_WORK_STRATEGY_NAME="${FORGE_LIBRARY_UPDATE_STRATEGY_NAME:-}"
 WORK_LABEL="${FORGE_WORK_LABEL:-library-new-request}"
 WORK_LIMIT="${FORGE_WORK_LIMIT:-1}"
-RANDOM_WORK_OFFSET="${FORGE_RANDOM_WORK_OFFSET:-1}"
+RANDOM_WORK_OFFSET="${FORGE_RANDOM_WORK_OFFSET:-0}"
 PARALLELISM="${FORGE_PARALLELISM:-1}"
 REVIEW_LABEL="${FORGE_REVIEW_LABEL:-}"
 REVIEW_LIMIT="${FORGE_REVIEW_LIMIT:-1}"
@@ -96,9 +96,10 @@ Options:
       Process up to N new-library tasks per run; 0 disables it. Defaults to
       FORGE_WORK_LIMIT, then 1.
   --random-offset
-      Start new-library issue scans at a random offset. This is the default.
+      Start new-library issue scans at a random offset.
   --no-random-offset
-      Start new-library issue scans from the beginning of the issue list.
+      Start new-library issue scans from the beginning of the issue list. This
+      is the default.
   --parallelism N
       Run up to N issue workflows in parallel. Defaults to FORGE_PARALLELISM,
       then 1. The maximum is 4.
@@ -122,7 +123,7 @@ Environment:
       Path to the shared stop marker. Defaults to ~/.metadata-forge-stop.
   FORGE_RANDOM_WORK_OFFSET
       Set to 1 to start new-library issue scans at a random offset, or 0 to
-      scan from the beginning. Defaults to 1.
+      scan from the beginning. Defaults to 0.
   FORGE_PARALLELISM
       Run up to this many issue workflows in parallel. Defaults to 1. The
       maximum is 4.

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -18,6 +18,7 @@ Usage:
 import argparse
 import concurrent.futures
 import errno
+import hashlib
 import json
 import os
 import random
@@ -123,6 +124,10 @@ ISSUE_CLAIM_CACHE_VERSION = 1
 ISSUE_CLAIM_CACHE_FILENAME = "issue-cache-v1.json"
 ISSUE_CLAIM_CACHE_LOCK_FILENAME = "issue-cache-v1.lock"
 DEFAULT_ISSUE_CLAIM_CACHE_TTL_SECONDS = 15 * 60
+ISSUE_SEARCH_CACHE_VERSION = 1
+ISSUE_SEARCH_CACHE_FILENAME = "issue-search-cache-v1.json"
+ISSUE_SEARCH_CACHE_LOCK_FILENAME = "issue-search-cache-v1.lock"
+DEFAULT_ISSUE_SEARCH_CACHE_TTL_SECONDS = 10 * 60
 GITHUB_RATE_LIMIT_EXIT_CODE = 75
 REVIEW_PERIOD_SUFFIX_SECONDS = {
     "s": 1,
@@ -503,6 +508,12 @@ def search_issues_with_label(
     page = (offset // per_page) + 1
     page_offset = offset % per_page
     query = build_issue_search_query(label, extra_labels)
+    items = get_issue_search_page(query, page, per_page)
+    return items[page_offset:page_offset + limit]
+
+
+def fetch_issue_search_page(query: str, page: int, per_page: int) -> list[dict]:
+    """Fetch and normalize one GitHub search result page for issues."""
     data = gh_json(
         "api", "--method", "GET", "/search/issues",
         "-f", f"q={query}",
@@ -511,16 +522,47 @@ def search_issues_with_label(
         "-F", f"per_page={per_page}",
         "-F", f"page={page}",
     )
-    items = data.get("items", [])
     return [
         normalize_github_issue_search_item(item)
-        for item in items[page_offset:page_offset + limit]
+        for item in data.get("items", [])
     ]
+
+
+def get_issue_search_page(query: str, page: int, per_page: int) -> list[dict]:
+    """Return one issue search page, using the shared local cache when fresh."""
+    if not is_issue_search_cache_enabled() or get_issue_search_cache_ttl_seconds() <= 0:
+        return fetch_issue_search_page(query, page, per_page)
+
+    ttl_seconds = get_issue_search_cache_ttl_seconds()
+    cache_key = build_issue_search_cache_key("page", query, "created", "desc", page, per_page)
+    now = time.time()
+    cached_payload = _read_issue_search_cache_payload()
+    if cached_payload is not None:
+        cached_page = _get_cached_issue_search_page(cached_payload, cache_key, now, ttl_seconds)
+        if cached_page is not None:
+            return cached_page
+
+    with LocalIssueSearchCacheWriterLock():
+        now = time.time()
+        payload = _read_issue_search_cache_payload_or_empty(now)
+        cached_page = _get_cached_issue_search_page(payload, cache_key, now, ttl_seconds)
+        if cached_page is not None:
+            return cached_page
+
+        issues = fetch_issue_search_page(query, page, per_page)
+        _set_cached_issue_search_page(payload, cache_key, issues, now)
+        _write_issue_search_cache_payload(payload, now)
+        return issues
 
 
 def count_issues_with_label(label: str, extra_labels: list[str] | None = None) -> int:
     """Return GitHub's count of open issues carrying the given label set."""
     query = build_issue_search_query(label, extra_labels)
+    return get_issue_search_count(query)
+
+
+def fetch_issue_search_count(query: str) -> int:
+    """Fetch GitHub's count of open issues for a search query."""
     data = gh_json(
         "api", "--method", "GET", "/search/issues",
         "-f", f"q={query}",
@@ -529,11 +571,35 @@ def count_issues_with_label(label: str, extra_labels: list[str] | None = None) -
     return int(data.get("total_count", 0))
 
 
+def get_issue_search_count(query: str) -> int:
+    """Return an issue search count, using the shared local cache when fresh."""
+    if not is_issue_search_cache_enabled() or get_issue_search_cache_ttl_seconds() <= 0:
+        return fetch_issue_search_count(query)
+
+    ttl_seconds = get_issue_search_cache_ttl_seconds()
+    cache_key = build_issue_search_cache_key("count", query)
+    now = time.time()
+    cached_payload = _read_issue_search_cache_payload()
+    if cached_payload is not None:
+        cached_count = _get_cached_issue_search_count(cached_payload, cache_key, now, ttl_seconds)
+        if cached_count is not None:
+            return cached_count
+
+    with LocalIssueSearchCacheWriterLock():
+        now = time.time()
+        payload = _read_issue_search_cache_payload_or_empty(now)
+        cached_count = _get_cached_issue_search_count(payload, cache_key, now, ttl_seconds)
+        if cached_count is not None:
+            return cached_count
+
+        total_count = fetch_issue_search_count(query)
+        _set_cached_issue_search_count(payload, cache_key, total_count, now)
+        _write_issue_search_cache_payload(payload, now)
+        return total_count
+
+
 def get_issues_with_label(label: str, limit: int, offset: int = 0, extra_labels: list[str] | None = None) -> list[dict]:
     """Fetch open issues that carry the given label (and any extra labels)."""
-    label_desc = f"'{label}'" + (f" + {extra_labels}" if extra_labels else "")
-    print()
-    log_stage("issue-scan", f"Fetching issues with label {label_desc} from {REPO} (offset={offset}, limit={limit})")
     return search_issues_with_label(label, limit, offset, extra_labels)
 
 
@@ -725,6 +791,51 @@ class LocalIssueClaimCacheWriterLock:
                 time.sleep(0.05)
 
 
+class LocalIssueSearchCacheWriterLock:
+    """Short-lived exclusive lock for shared issue-search cache updates."""
+
+    def __init__(self):
+        self.lock_path = get_issue_search_cache_lock_path()
+        self.lock_file = None
+        self.fallback_lock_path = f"{self.lock_path}.exclusive"
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.release()
+
+    def acquire(self) -> None:
+        os.makedirs(os.path.dirname(self.lock_path), exist_ok=True)
+        if fcntl is None:
+            self._acquire_exclusive_file_lock()
+            return
+        self.lock_file = open(self.lock_path, "a+", encoding="utf-8")
+        fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX)
+
+    def release(self) -> None:
+        if self.lock_file is None:
+            return
+        try:
+            if fcntl is not None:
+                fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
+        finally:
+            self.lock_file.close()
+            self.lock_file = None
+            if fcntl is None and os.path.exists(self.fallback_lock_path):
+                os.unlink(self.fallback_lock_path)
+
+    def _acquire_exclusive_file_lock(self) -> None:
+        while True:
+            try:
+                fd = os.open(self.fallback_lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                self.lock_file = os.fdopen(fd, "w", encoding="utf-8")
+                return
+            except FileExistsError:
+                time.sleep(0.05)
+
+
 def get_issue_claim_locks_root() -> str:
     """Return the shared local directory for issue claim locks."""
     return os.path.join(
@@ -747,6 +858,16 @@ def get_issue_claim_cache_path() -> str:
 def get_issue_claim_cache_lock_path() -> str:
     """Return the shared local issue-claim cache writer lock path."""
     return os.path.join(get_issue_claim_locks_root(), ISSUE_CLAIM_CACHE_LOCK_FILENAME)
+
+
+def get_issue_search_cache_path() -> str:
+    """Return the shared local issue-search cache path."""
+    return os.path.join(get_issue_claim_locks_root(), ISSUE_SEARCH_CACHE_FILENAME)
+
+
+def get_issue_search_cache_lock_path() -> str:
+    """Return the shared local issue-search cache writer lock path."""
+    return os.path.join(get_issue_claim_locks_root(), ISSUE_SEARCH_CACHE_LOCK_FILENAME)
 
 
 def try_acquire_issue_claim_lock(issue_number: int) -> LocalIssueClaimLock | None:
@@ -945,6 +1066,145 @@ def invalidate_issue_claim_cache_entry(issue_number: int, now: float | None = No
         _write_issue_claim_cache_entries(cache, now)
 
 
+def is_issue_search_cache_enabled() -> bool:
+    """Return True when the shared local issue-search cache is enabled."""
+    return os.environ.get("FORGE_ISSUE_SEARCH_CACHE", "1") != "0"
+
+
+def get_issue_search_cache_ttl_seconds() -> int:
+    """Return the issue-search cache TTL in seconds."""
+    raw_value = os.environ.get("FORGE_ISSUE_SEARCH_CACHE_TTL_SECONDS")
+    if raw_value is None or raw_value == "":
+        return DEFAULT_ISSUE_SEARCH_CACHE_TTL_SECONDS
+    try:
+        value = int(raw_value)
+    except ValueError:
+        print("ERROR: FORGE_ISSUE_SEARCH_CACHE_TTL_SECONDS must be a non-negative integer.", file=sys.stderr)
+        sys.exit(1)
+    if value < 0:
+        print("ERROR: FORGE_ISSUE_SEARCH_CACHE_TTL_SECONDS must be a non-negative integer.", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _read_issue_search_cache_payload() -> dict | None:
+    cache_path = get_issue_search_cache_path()
+    try:
+        with open(cache_path, "r", encoding="utf-8") as cache_file:
+            payload = json.load(cache_file)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("version") != ISSUE_SEARCH_CACHE_VERSION:
+        return None
+    if payload.get("repo") != REPO:
+        return None
+    if not isinstance(payload.get("pages"), dict):
+        return None
+    if not isinstance(payload.get("counts"), dict):
+        return None
+    return payload
+
+
+def _empty_issue_search_cache_payload(now: float) -> dict:
+    return {
+        "version": ISSUE_SEARCH_CACHE_VERSION,
+        "repo": REPO,
+        "updated_at_epoch": now,
+        "pages": {},
+        "counts": {},
+    }
+
+
+def _read_issue_search_cache_payload_or_empty(now: float) -> dict:
+    return _read_issue_search_cache_payload() or _empty_issue_search_cache_payload(now)
+
+
+def _write_issue_search_cache_payload(payload: dict, updated_at_epoch: float) -> None:
+    cache_path = get_issue_search_cache_path()
+    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+    payload["version"] = ISSUE_SEARCH_CACHE_VERSION
+    payload["repo"] = REPO
+    payload["updated_at_epoch"] = updated_at_epoch
+    payload.setdefault("pages", {})
+    payload.setdefault("counts", {})
+
+    temp_path = f"{cache_path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    try:
+        with open(temp_path, "w", encoding="utf-8") as cache_file:
+            json.dump(payload, cache_file, sort_keys=True)
+            cache_file.write("\n")
+            cache_file.flush()
+            os.fsync(cache_file.fileno())
+        os.replace(temp_path, cache_path)
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+
+def build_issue_search_cache_key(*parts: object) -> str:
+    """Return a stable compact cache key for a GitHub issue-search request."""
+    key_payload = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(key_payload.encode("utf-8")).hexdigest()
+
+
+def _is_fresh_issue_search_entry(entry: dict, now: float, ttl_seconds: int) -> bool:
+    try:
+        observed_at_epoch = float(entry.get("observed_at_epoch"))
+    except (TypeError, ValueError):
+        return False
+    return now - observed_at_epoch <= ttl_seconds
+
+
+def _get_cached_issue_search_page(
+        payload: dict,
+        cache_key: str,
+        now: float,
+        ttl_seconds: int,
+) -> list[dict] | None:
+    entry = payload.get("pages", {}).get(cache_key)
+    if not isinstance(entry, dict) or not _is_fresh_issue_search_entry(entry, now, ttl_seconds):
+        return None
+    issues = entry.get("issues")
+    if not isinstance(issues, list):
+        return None
+    return [
+        issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    ]
+
+
+def _set_cached_issue_search_page(payload: dict, cache_key: str, issues: list[dict], now: float) -> None:
+    payload.setdefault("pages", {})[cache_key] = {
+        "observed_at_epoch": now,
+        "issues": issues,
+    }
+
+
+def _get_cached_issue_search_count(
+        payload: dict,
+        cache_key: str,
+        now: float,
+        ttl_seconds: int,
+) -> int | None:
+    entry = payload.get("counts", {}).get(cache_key)
+    if not isinstance(entry, dict) or not _is_fresh_issue_search_entry(entry, now, ttl_seconds):
+        return None
+    total_count = entry.get("total_count")
+    if not isinstance(total_count, int):
+        return None
+    return total_count
+
+
+def _set_cached_issue_search_count(payload: dict, cache_key: str, total_count: int, now: float) -> None:
+    payload.setdefault("counts", {})[cache_key] = {
+        "observed_at_epoch": now,
+        "total_count": total_count,
+    }
+
+
 def pull_request_has_label(pr: dict, label_name: str) -> bool:
     """Return True when the GitHub pull request payload contains the given label."""
     return issue_has_label(pr, label_name)
@@ -958,8 +1218,6 @@ def get_prioritized_issues_with_label(
         priority_exhausted: bool = False,
 ) -> tuple[list[dict], int, int, bool, bool]:
     """Fetch one issue batch and return priority issues first within that batch."""
-    print()
-    log_stage("issue-scan", f"Searching issues for label '{label}' with priority issues first in the fetched batch")
     regular_issues = get_issues_with_label(label, limit, regular_offset)
     regular_offset += len(regular_issues)
     sorted_issues = sorted(
@@ -4572,6 +4830,7 @@ def process_issues_with_label(
     authenticated_user = resolve_authenticated_user(authenticated_user)
 
     processed_count = 0
+    scanned_count = 0
     current_offset = offset
     priority_offset = 0
     regular_offset = 0
@@ -4634,8 +4893,7 @@ def process_issues_with_label(
                             (issue, cached_skips.get(issue["number"]))
                             for issue in issues
                         )
-                        print()
-                        log_stage("issue-scan", f"Found {len(issues)} issue(s) to consider")
+                        scanned_count += len(issues)
                         continue
                     else:
                         break
@@ -4706,6 +4964,8 @@ def process_issues_with_label(
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
 
+    print()
+    log_stage("issue-scan", f"Scanned {scanned_count} issue(s) for label '{label}'")
     return processed_count
 
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -120,6 +120,8 @@ DEFAULT_ISSUE_SCAN_BATCH_SIZE = 25
 ISSUE_SCAN_PROGRESS_LOG_INTERVAL = 100
 GITHUB_API_MAX_PAGE_SIZE = 100
 GITHUB_SEARCH_MAX_RESULTS = 1000
+PRIORITY_BLOCKING_LIBRARY_THRESHOLD = 10
+PRIORITY_BLOCKING_ISSUE_QUERY_CHUNK_SIZE = 25
 # GitHub validates GraphQL node cost against worst-case first values; 5 issues can exceed 500k here.
 ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE = 4
 ISSUE_CLAIM_CACHE_VERSION = 1
@@ -198,6 +200,8 @@ NOT_FOR_NATIVE_IMAGE_LABEL_COLOR = "5319E7"
 NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION = (
     "Artifact is tracked but is not applicable to GraalVM Native Image reachability metadata"
 )
+PRIORITY_LABEL_COLOR = "FBCA04"
+PRIORITY_LABEL_DESCRIPTION = "Automation should process this issue before regular queue items"
 LARGE_LIBRARY_LABEL_COLOR = "C5DEF5"
 LARGE_LIBRARY_SERIES_LABEL_DESCRIPTION = "Issue is intentionally split across multiple reviewable PR parts"
 LARGE_LIBRARY_NEXT_PART_LABEL_DESCRIPTION = "Previous large-library part merged; automation may resume the next part"
@@ -638,6 +642,17 @@ def issue_has_label(issue: dict, label_name: str) -> bool:
         if isinstance(label, dict) and label.get("name") == label_name:
             return True
     return False
+
+
+def add_issue_label_to_payload(issue: dict, label_name: str) -> None:
+    """Update a local issue payload after a label was applied remotely."""
+    if issue_has_label(issue, label_name):
+        return
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        labels = []
+        issue["labels"] = labels
+    labels.append({"name": label_name})
 
 
 def get_issue_payload_assignees(issue: dict) -> Optional[list[str]]:
@@ -1249,6 +1264,151 @@ def pull_request_has_label(pr: dict, label_name: str) -> bool:
     return issue_has_label(pr, label_name)
 
 
+def get_open_issues_blocked_by_issue_counts(
+        issue_numbers: list[int],
+        minimum_count: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
+        chunk_size: int = PRIORITY_BLOCKING_ISSUE_QUERY_CHUNK_SIZE,
+) -> dict[int, int]:
+    """Return open issue counts blocked by each issue, capped after `minimum_count`."""
+    if minimum_count <= 0 or chunk_size <= 0:
+        return {}
+
+    owner, repo_name = REPO.split("/")
+    unique_issue_numbers = list(dict.fromkeys(issue_numbers))
+    counts = {issue_number: 0 for issue_number in unique_issue_numbers}
+    cursors: dict[int, str | None] = {issue_number: None for issue_number in unique_issue_numbers}
+    remaining_issue_numbers = set(unique_issue_numbers)
+
+    while remaining_issue_numbers:
+        batch = list(remaining_issue_numbers)[:chunk_size]
+        issue_fields = "\n".join(
+            f"""
+        issue_{issue_number}: issue(number: {issue_number}) {{
+          blocking(first: 100{f', after: "{cursors[issue_number]}"' if cursors[issue_number] else ""}) {{
+            nodes {{
+              number
+              closed
+            }}
+            pageInfo {{
+              hasNextPage
+              endCursor
+            }}
+          }}
+        }}
+            """
+            for issue_number in batch
+        )
+        query = f"""
+        query {{
+          repository(owner: "{owner}", name: "{repo_name}") {{
+{issue_fields}
+          }}
+        }}
+        """
+        result = gh_json("api", "graphql", "-f", f"query={query}", quiet=True)
+        repository = (
+            result.get("data", {})
+            .get("repository", {})
+        ) or {}
+
+        for issue_number in batch:
+            issue = repository.get(f"issue_{issue_number}")
+            blocking = issue.get("blocking", {}) if isinstance(issue, dict) else {}
+            for blocked_issue in blocking.get("nodes", []):
+                if isinstance(blocked_issue, dict) and not blocked_issue.get("closed", False):
+                    counts[issue_number] += 1
+                    if counts[issue_number] >= minimum_count:
+                        break
+
+            page_info = blocking.get("pageInfo", {}) if isinstance(blocking, dict) else {}
+            if counts[issue_number] >= minimum_count or not page_info.get("hasNextPage"):
+                remaining_issue_numbers.discard(issue_number)
+                continue
+
+            cursor = page_info.get("endCursor")
+            if cursor:
+                cursors[issue_number] = cursor
+            else:
+                remaining_issue_numbers.discard(issue_number)
+
+    return counts
+
+
+def mark_issue_numbers_blocking_many_libraries_as_priority(
+        issue_numbers: list[int],
+        threshold: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
+) -> set[int]:
+    """Apply the priority label to issues that block at least `threshold` open issues."""
+    priority_issue_numbers: set[int] = set()
+    if not issue_numbers:
+        return priority_issue_numbers
+
+    counts = get_open_issues_blocked_by_issue_counts(issue_numbers, threshold)
+    for issue_number in issue_numbers:
+        if counts.get(issue_number, 0) < threshold or issue_number in priority_issue_numbers:
+            continue
+        add_issue_label(issue_number, LABEL_PRIORITY)
+        priority_issue_numbers.add(issue_number)
+        log_stage(
+            "priority",
+            (
+                f"Issue #{issue_number} blocks at least {threshold} open issue(s); "
+                f"added label '{LABEL_PRIORITY}'"
+            ),
+        )
+    return priority_issue_numbers
+
+
+def mark_issues_blocking_many_libraries_as_priority(
+        issues: list[dict],
+        threshold: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
+) -> None:
+    """Mark unprioritized issue payloads as priority when they block many open issues."""
+    candidate_issue_numbers = [
+        issue["number"]
+        for issue in issues
+        if isinstance(issue, dict)
+        and isinstance(issue.get("number"), int)
+        and not issue_has_label(issue, LABEL_PRIORITY)
+    ]
+    priority_issue_numbers = mark_issue_numbers_blocking_many_libraries_as_priority(
+        candidate_issue_numbers,
+        threshold,
+    )
+    for issue in issues:
+        issue_number = issue.get("number") if isinstance(issue, dict) else None
+        if issue_number in priority_issue_numbers:
+            add_issue_label_to_payload(issue, LABEL_PRIORITY)
+
+
+def try_mark_issues_blocking_many_libraries_as_priority(issues: list[dict]) -> None:
+    """Best-effort priority labeling for queue ordering."""
+    try:
+        mark_issues_blocking_many_libraries_as_priority(issues)
+    except GitHubRateLimitExceeded:
+        raise
+    except Exception as exc:
+        print(
+            "ERROR: Failed to mark blocker issues as priority; "
+            f"continuing without dependency priority updates: {format_github_exception_details(exc)}",
+            file=sys.stderr,
+        )
+
+
+def try_mark_issue_numbers_blocking_many_libraries_as_priority(issue_numbers: list[int]) -> None:
+    """Best-effort priority labeling for blockers discovered during claim checks."""
+    try:
+        mark_issue_numbers_blocking_many_libraries_as_priority(issue_numbers)
+    except GitHubRateLimitExceeded:
+        raise
+    except Exception as exc:
+        print(
+            "ERROR: Failed to mark blocker issues as priority; "
+            f"continuing without dependency priority updates: {format_github_exception_details(exc)}",
+            file=sys.stderr,
+        )
+
+
 def get_prioritized_issues_with_label(
         label: str,
         limit: int,
@@ -1259,6 +1419,7 @@ def get_prioritized_issues_with_label(
     """Fetch one issue batch and return priority issues first within that batch."""
     regular_issues = get_issues_with_label(label, limit, regular_offset)
     regular_offset += len(regular_issues)
+    try_mark_issues_blocking_many_libraries_as_priority(regular_issues)
     sorted_issues = sorted(
         regular_issues,
         key=lambda issue: not issue_has_label(issue, LABEL_PRIORITY),
@@ -2804,6 +2965,9 @@ def add_issue_label(issue_number: int, label_name: str) -> None:
     if label_name == LABEL_NOT_FOR_NATIVE_IMAGE:
         label_color = NOT_FOR_NATIVE_IMAGE_LABEL_COLOR
         label_description = NOT_FOR_NATIVE_IMAGE_LABEL_DESCRIPTION
+    elif label_name == LABEL_PRIORITY:
+        label_color = PRIORITY_LABEL_COLOR
+        label_description = PRIORITY_LABEL_DESCRIPTION
     elif label_name == LABEL_LARGE_LIBRARY_SERIES:
         label_color = LARGE_LIBRARY_LABEL_COLOR
         label_description = LARGE_LIBRARY_SERIES_LABEL_DESCRIPTION
@@ -4732,6 +4896,7 @@ def try_claim_issue_with_local_lock(issue: dict, authenticated_user: str) -> Opt
     # Skip if blocked by another issue
     open_blockers = get_open_blocking_issue_numbers(number)
     if open_blockers:
+        try_mark_issue_numbers_blocking_many_libraries_as_priority(open_blockers)
         record_issue_claim_cache_observations([
             IssueClaimCacheObservation(
                 issue_number=number,

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -1067,6 +1067,20 @@ def invalidate_issue_claim_cache_entry(issue_number: int, now: float | None = No
         _write_issue_claim_cache_entries(cache, now)
 
 
+def _remove_file_if_exists(path: str) -> bool:
+    try:
+        os.unlink(path)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def clear_issue_claim_cache() -> bool:
+    """Delete the shared local issue-claim cache file."""
+    with LocalIssueClaimCacheWriterLock():
+        return _remove_file_if_exists(get_issue_claim_cache_path())
+
+
 def is_issue_search_cache_enabled() -> bool:
     """Return True when the shared local issue-search cache is enabled."""
     return os.environ.get("FORGE_ISSUE_SEARCH_CACHE", "1") != "0"
@@ -1142,6 +1156,29 @@ def _write_issue_search_cache_payload(payload: dict, updated_at_epoch: float) ->
     finally:
         if os.path.exists(temp_path):
             os.unlink(temp_path)
+
+
+def clear_issue_search_cache() -> bool:
+    """Delete the shared local issue-search cache file."""
+    with LocalIssueSearchCacheWriterLock():
+        return _remove_file_if_exists(get_issue_search_cache_path())
+
+
+def clear_issue_caches() -> None:
+    """Delete local issue queue caches used by work-queue scanning."""
+    removed_claim_cache = clear_issue_claim_cache()
+    removed_search_cache = clear_issue_search_cache()
+    print()
+    log_stage(
+        "issue-cache",
+        f"Cleared issue claim cache at {get_issue_claim_cache_path()} "
+        f"({'removed' if removed_claim_cache else 'not present'})",
+    )
+    log_stage(
+        "issue-cache",
+        f"Cleared issue search cache at {get_issue_search_cache_path()} "
+        f"({'removed' if removed_search_cache else 'not present'})",
+    )
 
 
 def build_issue_search_cache_key(*parts: object) -> str:
@@ -5121,6 +5158,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar="PATH",
         help="Resume a large-library series from a durable progress state JSON artifact.",
     )
+    mode.add_argument(
+        "--clear-issue-caches",
+        action="store_true",
+        help="Delete local issue claim/search caches used by work-queue scanning and exit.",
+    )
 
     parser.add_argument(
         "--limit", type=int, default=DEFAULT_MAX_ISSUES,
@@ -5270,6 +5312,9 @@ def main() -> None:
     args = parse_args()
 
     try:
+        if args.clear_issue_caches:
+            clear_issue_caches()
+            return
         if args.strategy_name:
             require_strategy_by_name(args.strategy_name)
         if args.review_pr is None and not args.run_work_queues:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -62,6 +62,7 @@ from git_scripts.common_git import (
     get_origin_owner,
     is_github_rate_limit_text,
     log_github_query,
+    run_github_command_with_retries,
     run_github_json_with_retries,
     run_github_with_retries,
 )
@@ -2157,7 +2158,7 @@ def get_cached_field_info() -> tuple[str, str, dict[str, str]]:
     return project_node_id, field_id, option_ids
 
 
-def set_item_status(item_id: str, status: str):
+def set_item_status(item_id: str, status: str) -> None:
     """
     Update the Status field of a project item to the given status option name.
     """
@@ -2165,12 +2166,15 @@ def set_item_status(item_id: str, status: str):
     log_stage("project-status", f"Setting project item {item_id} -> {status}")
     project_node_id, field_id, option_ids = get_cached_field_info()
     option_id = option_ids.get(status)
-    gh(
-        "project", "item-edit",
-        "--id", item_id,
-        "--project-id", project_node_id,
-        "--field-id", field_id,
-        "--single-select-option-id", option_id,
+    run_github_command_with_retries(
+        gh,
+        (
+            "project", "item-edit",
+            "--id", item_id,
+            "--project-id", project_node_id,
+            "--field-id", field_id,
+            "--single-select-option-id", option_id,
+        ),
     )
 
 
@@ -3861,17 +3865,37 @@ def run_claimed_issue(
 def revert_issue_claim(item_id: str, issue_number: int, reason: str) -> None:
     """Reset an issue claim back to Todo and clear all assignment, with verification."""
     print(f"\n[issue-revert] Reverting issue #{issue_number} claim because {reason}", file=sys.stderr)
+    revert_errors: list[Exception] = []
     print(f"[issue-revert] Reverting issue #{issue_number}: setting project item {item_id} -> {STATUS_TODO}", file=sys.stderr)
-    set_item_status(item_id, STATUS_TODO)
+    try:
+        set_item_status(item_id, STATUS_TODO)
+    except Exception as exc:
+        revert_errors.append(exc)
+        print(
+            f"ERROR: Issue #{issue_number} revert could not set project item {item_id} "
+            f"to {STATUS_TODO}: {format_github_exception_details(exc)}",
+            file=sys.stderr,
+        )
     print(f"[issue-revert] Reverting issue #{issue_number}: clearing all assignees", file=sys.stderr)
-    clear_issue_assignees(issue_number)
+    try:
+        clear_issue_assignees(issue_number)
+    except Exception as exc:
+        revert_errors.append(exc)
+        print(
+            f"ERROR: Issue #{issue_number} revert could not clear assignees: "
+            f"{format_github_exception_details(exc)}",
+            file=sys.stderr,
+        )
     verified_status = get_item_status(item_id)
     verified_assignees = get_issue_assignees(issue_number)
     if verified_status != STATUS_TODO or verified_assignees:
-        raise RuntimeError(
+        verification_error = RuntimeError(
             f"Issue #{issue_number} revert verification failed: "
             f"status={verified_status!r}, assignees={verified_assignees!r}"
         )
+        if revert_errors:
+            raise verification_error from revert_errors[0]
+        raise verification_error
     invalidate_issue_claim_cache_entry(issue_number)
     print(
         f"ERROR: Issue #{issue_number} failed due to {reason}; verified revert with "

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -519,7 +519,7 @@ def fetch_issue_search_page(query: str, page: int, per_page: int) -> list[dict]:
     data = gh_json(
         "api", "--method", "GET", "/search/issues",
         "-f", f"q={query}",
-        "-f", "sort=created",
+        "-f", "sort=updated",
         "-f", "order=desc",
         "-F", f"per_page={per_page}",
         "-F", f"page={page}",
@@ -536,7 +536,7 @@ def get_issue_search_page(query: str, page: int, per_page: int) -> list[dict]:
         return fetch_issue_search_page(query, page, per_page)
 
     ttl_seconds = get_issue_search_cache_ttl_seconds()
-    cache_key = build_issue_search_cache_key("page", query, "created", "desc", page, per_page)
+    cache_key = build_issue_search_cache_key("page", query, "updated", "desc", page, per_page)
     now = time.time()
     cached_payload = _read_issue_search_cache_payload()
     if cached_payload is not None:
@@ -4874,7 +4874,7 @@ def format_issue_scan_position(
 def log_issue_scan_start(label: str, offset: int) -> None:
     """Log where an issue scan starts."""
     if offset == 0:
-        position = "from the beginning with priority-first ordering"
+        position = "from the most recently updated issues with priority-first ordering"
     else:
         position = f"from offset {offset}"
     print()

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -3991,7 +3991,7 @@ def claim_issue_for_processing(
         large_library_resume_artifact_override: str | None = None,
 ) -> Optional[ClaimedIssue]:
     """Claim an issue and prepare its isolated execution workspace."""
-    if not refresh_issue_payload_for_claim(issue, label):
+    if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
         return None
 
     if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
@@ -4616,7 +4616,11 @@ def get_issue_claim_cache_observation_from_payload(
     return None
 
 
-def refresh_issue_payload_for_claim(issue: dict, required_label: str | None = None) -> bool:
+def refresh_issue_payload_for_claim(
+        issue: dict,
+        required_label: str | None = None,
+        authenticated_user: str | None = None,
+) -> bool:
     """Refresh mutable issue state and return whether it remains claimable."""
     issue_number = issue.get("number")
     if not isinstance(issue_number, int):
@@ -4643,11 +4647,8 @@ def refresh_issue_payload_for_claim(issue: dict, required_label: str | None = No
         )
         return False
 
-    observation = get_issue_claim_cache_observation_from_payload(issue)
-    if observation is not None and observation.reason in {
-            ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
-            ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
-    }:
+    observation = get_issue_claim_cache_observation_from_payload(issue, authenticated_user)
+    if observation is not None:
         record_issue_claim_cache_observations([observation])
         return False
 
@@ -4917,7 +4918,7 @@ def try_claim_issue(
         return None
 
     try:
-        if not refresh_issue_payload_for_claim(issue, required_label):
+        if not refresh_issue_payload_for_claim(issue, required_label, authenticated_user):
             return None
         return try_claim_issue_with_local_lock(issue, authenticated_user)
     finally:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -1280,7 +1280,14 @@ def get_project_item_state(issue_number: int) -> tuple[str | None, str | None]:
     )
     if item_id:
         print()
-        log_stage("project-item", f"{item_id} Issue number: {issue_number}")
+        status_text = status if status is not None else "unknown"
+        log_stage(
+            "project-item",
+            (
+                f"Issue #{issue_number} is linked to GitHub project item {item_id} "
+                f"in project {PROJECT_NUMBER} with Status '{status_text}'"
+            ),
+        )
     return item_id, status
 
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -174,6 +174,7 @@ ISSUE_CLAIM_CACHE_REASON_ASSIGNED = "assigned"
 ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION = "human_intervention"
 ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE = "not_for_native_image"
 ISSUE_CLAIM_CACHE_REASON_BLOCKED = "blocked"
+ISSUE_CLAIM_CACHE_REASON_CLOSED = "closed"
 ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM = "missing_project_item"
 ISSUE_CLAIM_CACHE_REASON_NON_TODO = "non_todo"
 ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS = "in_progress"
@@ -182,6 +183,7 @@ ISSUE_CLAIM_CACHE_REASONS = {
     ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
     ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
     ISSUE_CLAIM_CACHE_REASON_BLOCKED,
+    ISSUE_CLAIM_CACHE_REASON_CLOSED,
     ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM,
     ISSUE_CLAIM_CACHE_REASON_NON_TODO,
     ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS,
@@ -459,6 +461,16 @@ def get_issue_by_number(issue_number: int) -> tuple[dict, str]:
         file=sys.stderr,
     )
     sys.exit(1)
+
+
+def get_issue_claim_payload(issue_number: int) -> dict:
+    """Fetch mutable issue state immediately before claim decisions."""
+    return gh_json(
+        "issue", "view",
+        str(issue_number),
+        "--repo", REPO,
+        "--json", "number,title,url,state,labels,assignees",
+    )
 
 
 def build_issue_search_query(
@@ -3979,6 +3991,9 @@ def claim_issue_for_processing(
         large_library_resume_artifact_override: str | None = None,
 ) -> Optional[ClaimedIssue]:
     """Claim an issue and prepare its isolated execution workspace."""
+    if not refresh_issue_payload_for_claim(issue, label):
+        return None
+
     if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
         return None
 
@@ -4000,7 +4015,7 @@ def claim_issue_for_processing(
         )
         return None
 
-    item_id = try_claim_issue(issue, authenticated_user)
+    item_id = try_claim_issue(issue, authenticated_user, label)
     if not item_id:
         return None
 
@@ -4601,6 +4616,44 @@ def get_issue_claim_cache_observation_from_payload(
     return None
 
 
+def refresh_issue_payload_for_claim(issue: dict, required_label: str | None = None) -> bool:
+    """Refresh mutable issue state and return whether it remains claimable."""
+    issue_number = issue.get("number")
+    if not isinstance(issue_number, int):
+        return False
+
+    fresh_issue = get_issue_claim_payload(issue_number)
+    issue.clear()
+    issue.update(fresh_issue)
+
+    state = str(issue.get("state", "")).upper()
+    if state and state != "OPEN":
+        record_issue_claim_cache_observations([
+            IssueClaimCacheObservation(
+                issue_number=issue_number,
+                reason=ISSUE_CLAIM_CACHE_REASON_CLOSED,
+            )
+        ])
+        return False
+
+    if required_label is not None and not issue_has_label(issue, required_label):
+        log_stage(
+            "issue-claim",
+            f"Skipping issue #{issue_number}: it no longer has label '{required_label}'",
+        )
+        return False
+
+    observation = get_issue_claim_cache_observation_from_payload(issue)
+    if observation is not None and observation.reason in {
+            ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
+            ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
+    }:
+        record_issue_claim_cache_observations([observation])
+        return False
+
+    return True
+
+
 def get_issue_claim_cache_observation_from_preflight(
         preflight: IssueClaimPreflight,
         authenticated_user: str | None = None,
@@ -4650,6 +4703,8 @@ def format_cached_issue_claim_skip(cached_skip: CachedIssueClaimSkip) -> str:
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_BLOCKED:
         blockers_text = ", ".join(f"#{blocker}" for blocker in cached_skip.open_blockers)
         return f"recently cached as blocked by open issue(s) {blockers_text}"
+    if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_CLOSED:
+        return "recently cached as closed"
     if cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_MISSING_PROJECT_ITEM:
         return f"recently cached as missing project {PROJECT_NUMBER} item"
     if cached_skip.reason in {ISSUE_CLAIM_CACHE_REASON_NON_TODO, ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS}:
@@ -4775,15 +4830,6 @@ def should_skip_issue_from_preflight(
 ) -> bool:
     number = issue["number"]
 
-    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
-        return True
-    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
-        return True
-
-    payload_assignees = get_issue_payload_assignees(issue)
-    if payload_assignees and not is_assigned_only_to_authenticated_user(payload_assignees, authenticated_user):
-        return True
-
     cached_large_library_continuation = (
         cached_skip is not None
         and cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS
@@ -4847,7 +4893,11 @@ def is_issue_blocked(issue_number: int) -> bool:
     return bool(get_open_blocking_issue_numbers(issue_number))
 
 
-def try_claim_issue(issue: dict, authenticated_user: str) -> Optional[str]:
+def try_claim_issue(
+        issue: dict,
+        authenticated_user: str,
+        required_label: str | None = None,
+) -> Optional[str]:
     """
     Attempt to exclusively claim an issue.
 
@@ -4862,28 +4912,13 @@ def try_claim_issue(issue: dict, authenticated_user: str) -> Optional[str]:
     """
     number = issue["number"]
 
-    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
-        record_issue_claim_cache_observations([
-            IssueClaimCacheObservation(
-                issue_number=number,
-                reason=ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
-            )
-        ])
-        return None
-    if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
-        record_issue_claim_cache_observations([
-            IssueClaimCacheObservation(
-                issue_number=number,
-                reason=ISSUE_CLAIM_CACHE_REASON_NOT_FOR_NATIVE_IMAGE,
-            )
-        ])
-        return None
-
     claim_lock = try_acquire_issue_claim_lock(number)
     if claim_lock is None:
         return None
 
     try:
+        if not refresh_issue_payload_for_claim(issue, required_label):
+            return None
         return try_claim_issue_with_local_lock(issue, authenticated_user)
     finally:
         claim_lock.release()
@@ -5153,16 +5188,6 @@ def process_issues_with_label(
                                     log_stage("issue-scan", f"No open issues found with label '{label}'")
                                 exhausted = True
                                 break
-
-                        payload_cache_observations = [
-                            observation
-                            for observation in (
-                                get_issue_claim_cache_observation_from_payload(issue, authenticated_user)
-                                for issue in issues
-                            )
-                            if observation is not None
-                        ]
-                        record_issue_claim_cache_observations(payload_cache_observations)
 
                         cached_skips = get_cached_issue_claim_skips(issues, authenticated_user)
                         unresolved_candidates.extend(

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -117,6 +117,7 @@ DEFAULT_MAX_ISSUES = 5  # Default maximum number of issues to process per run
 DEFAULT_PARALLELISM = 1
 MAX_PARALLELISM = 4
 DEFAULT_ISSUE_SCAN_BATCH_SIZE = 25
+ISSUE_SCAN_PROGRESS_LOG_INTERVAL = 100
 GITHUB_API_MAX_PAGE_SIZE = 100
 GITHUB_SEARCH_MAX_RESULTS = 1000
 # GitHub validates GraphQL node cost against worst-case first values; 5 issues can exceed 500k here.
@@ -4851,6 +4852,45 @@ def get_issue_scan_batch_size(_remaining_limit: int, _available_slots: int) -> i
     return DEFAULT_ISSUE_SCAN_BATCH_SIZE
 
 
+def format_issue_scan_position(
+        offset: int,
+        current_offset: int,
+        priority_offset: int,
+        regular_offset: int,
+) -> str:
+    """Return a concise description of the current issue scan position."""
+    if offset == 0:
+        return f"priority offset {priority_offset}, regular offset {regular_offset}"
+    return f"offset {current_offset}"
+
+
+def log_issue_scan_start(label: str, offset: int) -> None:
+    """Log where an issue scan starts."""
+    if offset == 0:
+        position = "from the beginning with priority-first ordering"
+    else:
+        position = f"from offset {offset}"
+    print()
+    log_stage("issue-scan", f"Starting issue scan for label '{label}' {position}")
+
+
+def log_issue_scan_progress(
+        label: str,
+        scanned_count: int,
+        offset: int,
+        current_offset: int,
+        priority_offset: int,
+        regular_offset: int,
+) -> None:
+    """Log issue scan progress after another interval of candidates was inspected."""
+    position = format_issue_scan_position(offset, current_offset, priority_offset, regular_offset)
+    print()
+    log_stage(
+        "issue-scan",
+        f"Looked through {scanned_count} issue(s) for label '{label}' ({position})",
+    )
+
+
 def resolve_random_issue_scan_offset(label: str) -> int:
     """Choose a random searchable offset for an issue label."""
     issue_count = count_issues_with_label(label)
@@ -4892,6 +4932,7 @@ def process_issues_with_label(
 
     processed_count = 0
     scanned_count = 0
+    next_scan_progress_log_count = ISSUE_SCAN_PROGRESS_LOG_INTERVAL
     current_offset = offset
     priority_offset = 0
     regular_offset = 0
@@ -4900,6 +4941,8 @@ def process_issues_with_label(
     unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
     active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue] = {}
+
+    log_issue_scan_start(label, offset)
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=parallelism)
     try:
@@ -4955,6 +4998,16 @@ def process_issues_with_label(
                             for issue in issues
                         )
                         scanned_count += len(issues)
+                        while scanned_count >= next_scan_progress_log_count:
+                            log_issue_scan_progress(
+                                label,
+                                next_scan_progress_log_count,
+                                offset,
+                                current_offset,
+                                priority_offset,
+                                regular_offset,
+                            )
+                            next_scan_progress_log_count += ISSUE_SCAN_PROGRESS_LOG_INTERVAL
                         continue
                     else:
                         break

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -3377,7 +3377,7 @@ def get_work_queue_configs_from_environment(
             random_offset=(
                 random_offset_override
                 if random_offset_override is not None
-                else get_env_zero_one_bool("FORGE_RANDOM_WORK_OFFSET", True)
+                else get_env_zero_one_bool("FORGE_RANDOM_WORK_OFFSET", False)
             ),
         ),
     ]

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -325,14 +325,14 @@ def run_github_json_with_retries(
     raise RuntimeError("GitHub JSON command exhausted retries")
 
 
-def run_github_with_retries(
+def run_github_command_with_retries(
         gh_runner: Callable[..., subprocess.CompletedProcess],
         args: tuple[str, ...],
         *,
         quiet: bool = False,
         max_attempts: int = GITHUB_TRANSIENT_RETRY_ATTEMPTS,
 ) -> subprocess.CompletedProcess:
-    """Run a read-only gh command, retrying transient GitHub failures."""
+    """Run an idempotent gh command, retrying transient GitHub failures."""
     for attempt in range(1, max_attempts + 1):
         command_quiet = quiet or attempt < max_attempts
         try:
@@ -346,6 +346,22 @@ def run_github_with_retries(
             raise
 
     raise RuntimeError("GitHub command exhausted retries")
+
+
+def run_github_with_retries(
+        gh_runner: Callable[..., subprocess.CompletedProcess],
+        args: tuple[str, ...],
+        *,
+        quiet: bool = False,
+        max_attempts: int = GITHUB_TRANSIENT_RETRY_ATTEMPTS,
+) -> subprocess.CompletedProcess:
+    """Run a read-only gh command, retrying transient GitHub failures."""
+    return run_github_command_with_retries(
+        gh_runner,
+        args,
+        quiet=quiet,
+        max_attempts=max_attempts,
+    )
 
 
 def gh_json(*args: str) -> Any:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1160,6 +1160,32 @@ class IssueClaimCacheTests(unittest.TestCase):
                 forge_metadata.invalidate_issue_claim_cache_entry(1412, now=101.0)
                 self.assertEqual(forge_metadata.read_issue_claim_cache(now=101.0), {})
 
+    def test_clear_issue_caches_removes_claim_and_search_caches(self) -> None:
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root):
+                forge_metadata.record_issue_claim_cache_observations(
+                    [
+                        forge_metadata.IssueClaimCacheObservation(
+                            issue_number=1412,
+                            reason=forge_metadata.ISSUE_CLAIM_CACHE_REASON_BLOCKED,
+                            open_blockers=(99,),
+                        ),
+                    ],
+                    now=100.0,
+                )
+                forge_metadata._write_issue_search_cache_payload(
+                    forge_metadata._empty_issue_search_cache_payload(100.0),
+                    100.0,
+                )
+
+                self.assertTrue(os.path.exists(forge_metadata.get_issue_claim_cache_path()))
+                self.assertTrue(os.path.exists(forge_metadata.get_issue_search_cache_path()))
+
+                forge_metadata.clear_issue_caches()
+
+                self.assertFalse(os.path.exists(forge_metadata.get_issue_claim_cache_path()))
+                self.assertFalse(os.path.exists(forge_metadata.get_issue_search_cache_path()))
+
     def test_cached_own_assignment_is_not_returned_as_skip(self) -> None:
         issue = {
             "number": 1412,

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -879,6 +879,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "2",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "3",
             "FORGE_STRATEGY_NAME": "custom-strategy",
             "FORGE_WORK_LABEL": forge_metadata.LABEL_LIBRARY_NEW,
@@ -894,7 +895,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
                 (forge_metadata.LABEL_JAVA_RUN_FAIL, 2, None, False),
                 (forge_metadata.LABEL_NI_RUN_FAIL, 0, None, False),
                 (forge_metadata.LABEL_LIBRARY_UPDATE, 0, None, False),
-                (forge_metadata.LABEL_LIBRARY_NEW, 3, "custom-strategy", True),
+                (forge_metadata.LABEL_LIBRARY_NEW, 3, "custom-strategy", False),
             ],
         )
 
@@ -926,6 +927,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "0",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "1",
             "FORGE_RANDOM_WORK_OFFSET": "0",
         }
@@ -935,11 +937,27 @@ class WorkQueueSchedulerTests(unittest.TestCase):
 
         self.assertFalse(configs[-1].random_offset)
 
+    def test_random_work_offset_can_be_enabled_from_environment(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "1",
+            "FORGE_RANDOM_WORK_OFFSET": "1",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            configs = forge_metadata.get_work_queue_configs_from_environment()
+
+        self.assertTrue(configs[-1].random_offset)
+
     def test_random_work_offset_can_be_disabled_from_cli_override(self) -> None:
         env = {
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "0",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "1",
             "FORGE_RANDOM_WORK_OFFSET": "1",
         }
@@ -981,6 +999,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "1",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "0",
             "FORGE_REVIEW_LIMIT": "0",
             "FORGE_JAVA_RUN_STRATEGY_NAME": "java-run-strategy",
@@ -1018,6 +1037,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "0",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "1",
             "FORGE_REVIEW_LIMIT": "0",
             "FORGE_RANDOM_WORK_OFFSET": "1",
@@ -1059,6 +1079,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             "FORGE_JAVAC_WORK_LIMIT": "0",
             "FORGE_JAVA_RUN_WORK_LIMIT": "0",
             "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
             "FORGE_WORK_LIMIT": "0",
             "FORGE_REVIEW_LIMIT": "1",
             "FORGE_REVIEW_LABEL": forge_metadata.LABEL_LIBRARY_NEW,

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -590,6 +590,46 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         self.assertIn("no longer has label", stdout.getvalue())
 
+    def test_refresh_issue_payload_for_claim_skips_issue_assigned_to_other_user(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW]),
+            "state": "OPEN",
+            "assignees": [{"login": "other-user"}],
+        }
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue):
+                self.assertFalse(
+                    forge_metadata.refresh_issue_payload_for_claim(
+                        issue,
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                        "automation-user",
+                    )
+                )
+                cache = forge_metadata.read_issue_claim_cache()
+
+        self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_ASSIGNED)
+        self.assertEqual(cache[1412].assignees, ("other-user",))
+
+    def test_refresh_issue_payload_for_claim_allows_issue_assigned_to_authenticated_user(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW]),
+            "state": "OPEN",
+            "assignees": [{"login": "automation-user"}],
+        }
+
+        with patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue):
+            self.assertTrue(
+                forge_metadata.refresh_issue_payload_for_claim(
+                    issue,
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    "automation-user",
+                )
+            )
+
     def test_issue_scan_batch_size_returns_candidate_batch_size(self) -> None:
         self.assertEqual(
             forge_metadata.get_issue_scan_batch_size(1, 1),

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1399,6 +1399,52 @@ class IssueClaimCacheTests(unittest.TestCase):
             ],
         )
 
+    def test_process_loop_logs_scan_start_and_progress(self) -> None:
+        issues = [
+            {
+                "number": issue_number,
+                "title": f"Add support for org.example:lib{issue_number}:1.0.0",
+                "labels": [],
+                "assignees": [],
+            }
+            for issue_number in range(1, 251)
+        ]
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                    patch.object(
+                        forge_metadata,
+                        "get_prioritized_issues_with_label",
+                        return_value=(issues, 0, len(issues), True, True),
+                    ), \
+                    patch.object(
+                        forge_metadata,
+                        "claim_issue_for_processing",
+                        return_value=None,
+                    ), \
+                    patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                self.assertEqual(
+                    forge_metadata.process_issues_with_label(
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                        1,
+                        0,
+                        "/tmp/reachability",
+                        "/tmp/metrics",
+                        None,
+                        False,
+                        "automation-user",
+                        1,
+                    ),
+                    0,
+                )
+
+        output = stdout.getvalue()
+        self.assertIn("Starting issue scan for label 'library-new-request'", output)
+        self.assertIn("Looked through 100 issue(s) for label 'library-new-request'", output)
+        self.assertIn("Looked through 200 issue(s) for label 'library-new-request'", output)
+        self.assertNotIn("Looked through 300 issue(s)", output)
+
 
 class ProjectItemStatusTests(unittest.TestCase):
     def test_common_helper_fetches_project_item_and_status_with_one_graphql_call(self) -> None:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -447,6 +447,86 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertEqual(set(preflights), set(issue_numbers))
         self.assertLessEqual(forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE, 4)
 
+    def test_open_issues_blocked_by_issue_counts_use_blocking_edge(self) -> None:
+        blocking_nodes = [
+            {"number": issue_number, "closed": False}
+            for issue_number in range(1, 11)
+        ]
+        blocking_nodes.append({"number": 99, "closed": True})
+        response = {
+            "data": {
+                "repository": {
+                    "issue_1412": {
+                        "blocking": {
+                            "nodes": blocking_nodes,
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    },
+                },
+            },
+        }
+
+        with patch.object(forge_metadata, "gh_json", return_value=response) as gh_json:
+            counts = forge_metadata.get_open_issues_blocked_by_issue_counts([1412])
+
+        self.assertEqual(counts, {1412: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD})
+        gh_json.assert_called_once()
+        self.assertEqual(gh_json.call_args.kwargs, {"quiet": True})
+        self.assertIn("blocking(first: 100", gh_json.call_args.args[-1])
+        self.assertNotIn("blockedBy(first:", gh_json.call_args.args[-1])
+
+    def test_mark_issues_blocking_many_libraries_adds_priority_label_to_payload(self) -> None:
+        priority_issue = _search_issue(1412)
+        regular_issue = _search_issue(1413)
+
+        with patch.object(
+                forge_metadata,
+                "get_open_issues_blocked_by_issue_counts",
+                return_value={1412: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD, 1413: 9},
+        ), \
+                patch.object(forge_metadata, "add_issue_label") as add_issue_label, \
+                patch("sys.stdout", new_callable=io.StringIO):
+            forge_metadata.mark_issues_blocking_many_libraries_as_priority([
+                priority_issue,
+                regular_issue,
+            ])
+
+        add_issue_label.assert_called_once_with(1412, forge_metadata.LABEL_PRIORITY)
+        self.assertTrue(forge_metadata.issue_has_label(priority_issue, forge_metadata.LABEL_PRIORITY))
+        self.assertFalse(forge_metadata.issue_has_label(regular_issue, forge_metadata.LABEL_PRIORITY))
+
+    def test_prioritized_issue_fetch_marks_blocking_libraries_before_sorting(self) -> None:
+        regular_issue = _search_issue(1412)
+        priority_issue = _search_issue(1413)
+
+        with patch.object(
+                forge_metadata,
+                "get_issues_with_label",
+                return_value=[regular_issue, priority_issue],
+        ), \
+                patch.object(
+                    forge_metadata,
+                    "get_open_issues_blocked_by_issue_counts",
+                    return_value={
+                        1412: 0,
+                        1413: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
+                    },
+                ), \
+                patch.object(forge_metadata, "add_issue_label"), \
+                patch("sys.stdout", new_callable=io.StringIO):
+            issues, priority_offset, regular_offset, priority_exhausted, exhausted = (
+                forge_metadata.get_prioritized_issues_with_label(
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    2,
+                )
+            )
+
+        self.assertEqual([issue["number"] for issue in issues], [1413, 1412])
+        self.assertEqual(priority_offset, 0)
+        self.assertEqual(regular_offset, 2)
+        self.assertTrue(priority_exhausted)
+        self.assertFalse(exhausted)
+
     def test_issue_scan_batch_size_returns_candidate_batch_size(self) -> None:
         self.assertEqual(
             forge_metadata.get_issue_scan_batch_size(1, 1),
@@ -1534,6 +1614,26 @@ class IssueClaimLockTests(unittest.TestCase):
                         get_open_blocking_issues.assert_not_called()
                 finally:
                     claim_lock.release()
+
+    def test_try_claim_issue_marks_open_blockers_that_block_many_libraries(self) -> None:
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:lib:1.0.0",
+            "labels": [],
+            "assignees": [],
+        }
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[1392]), \
+                    patch.object(
+                        forge_metadata,
+                        "try_mark_issue_numbers_blocking_many_libraries_as_priority",
+                    ) as mark_priority, \
+                    patch.object(forge_metadata, "get_issue_assignees") as get_issue_assignees:
+                self.assertIsNone(forge_metadata.try_claim_issue(issue, "automation-user"))
+
+        mark_priority.assert_called_once_with([1392])
+        get_issue_assignees.assert_not_called()
 
     def test_try_claim_issue_refreshes_assignees_after_local_lock(self) -> None:
         issue = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -261,6 +261,38 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertEqual(run.call_count, 2)
         sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
 
+    def test_set_item_status_retries_transient_http_502(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr="non-200 OK status code: 502 Bad Gateway",
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch.object(
+                forge_metadata,
+                "get_cached_field_info",
+                return_value=("project-id", "field-id", {forge_metadata.STATUS_IN_PROGRESS: "option-id"}),
+        ), \
+                patch.object(
+                    forge_metadata.subprocess,
+                    "run",
+                    side_effect=[failed_process, successful_process],
+                ) as run, \
+                patch.object(common_git.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            forge_metadata.set_item_status("item-id", forge_metadata.STATUS_IN_PROGRESS)
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+        self.assertIn("GitHub API transient failure", stderr.getvalue())
+
     def test_preflight_fallback_does_not_continue_after_rate_limit(self) -> None:
         issue = {"number": 1412, "labels": []}
 
@@ -1530,6 +1562,24 @@ class IssueClaimLockTests(unittest.TestCase):
 
         set_item_status.assert_called_once_with("item-1", forge_metadata.STATUS_TODO)
         clear_issue_assignees.assert_called_once_with(1412)
+
+    def test_revert_issue_claim_clears_assignees_after_status_update_error(self) -> None:
+        status_error = subprocess.CalledProcessError(
+            1,
+            ["gh", "project", "item-edit"],
+            output="",
+            stderr="non-200 OK status code: 502 Bad Gateway",
+        )
+
+        with patch.object(forge_metadata, "set_item_status", side_effect=status_error), \
+                patch.object(forge_metadata, "clear_issue_assignees") as clear_issue_assignees, \
+                patch.object(forge_metadata, "get_item_status", return_value=forge_metadata.STATUS_TODO), \
+                patch.object(forge_metadata, "get_issue_assignees", return_value=[]), \
+                patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            forge_metadata.revert_issue_claim("item-1", 1412, "test")
+
+        clear_issue_assignees.assert_called_once_with(1412)
+        self.assertIn("could not set project item", stderr.getvalue())
 
 
 class IssueSearchCacheTests(unittest.TestCase):

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -591,7 +591,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
                 f"q=repo:{forge_metadata.REPO} is:issue is:open "
                 f'label:"{forge_metadata.LABEL_LIBRARY_NEW}" -label:"{forge_metadata.LABEL_NOT_FOR_NATIVE_IMAGE}"'
             ),
-            "-f", "sort=created",
+            "-f", "sort=updated",
             "-f", "order=desc",
             "-F", "per_page=100",
             "-F", "page=3",

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -527,6 +527,69 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertTrue(priority_exhausted)
         self.assertFalse(exhausted)
 
+    def test_refresh_issue_payload_for_claim_skips_closed_issue(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW]),
+            "state": "CLOSED",
+        }
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue):
+                self.assertFalse(
+                    forge_metadata.refresh_issue_payload_for_claim(
+                        issue,
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                    )
+                )
+                cache = forge_metadata.read_issue_claim_cache()
+
+        self.assertEqual(issue["state"], "CLOSED")
+        self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_CLOSED)
+
+    def test_refresh_issue_payload_for_claim_skips_human_intervention_label(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(
+                1412,
+                [forge_metadata.LABEL_LIBRARY_NEW, forge_metadata.LABEL_HUMAN_INTERVENTION],
+            ),
+            "state": "OPEN",
+        }
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue):
+                self.assertFalse(
+                    forge_metadata.refresh_issue_payload_for_claim(
+                        issue,
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                    )
+                )
+                cache = forge_metadata.read_issue_claim_cache()
+
+        self.assertTrue(forge_metadata.issue_has_label(issue, forge_metadata.LABEL_HUMAN_INTERVENTION))
+        self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION)
+
+    def test_refresh_issue_payload_for_claim_skips_removed_queue_label(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(1412, []),
+            "state": "OPEN",
+        }
+
+        with patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertFalse(
+                forge_metadata.refresh_issue_payload_for_claim(
+                    issue,
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                )
+            )
+
+        self.assertIn("no longer has label", stdout.getvalue())
+
     def test_issue_scan_batch_size_returns_candidate_batch_size(self) -> None:
         self.assertEqual(
             forge_metadata.get_issue_scan_batch_size(1, 1),
@@ -584,14 +647,14 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         get_issue_claim_preflights.assert_called_once_with([4, 3])
 
-    def test_payload_assignees_skip_without_preflight(self) -> None:
+    def test_payload_assignees_do_not_skip_without_fresh_claim_state(self) -> None:
         issue = {
             "number": 1412,
             "labels": [],
             "assignees": [{"login": "automation-user"}],
         }
 
-        self.assertTrue(
+        self.assertFalse(
             forge_metadata.should_skip_issue_from_preflight(issue, None)
         )
 
@@ -1624,6 +1687,7 @@ class IssueClaimLockTests(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[1392]), \
                     patch.object(
                         forge_metadata,
@@ -1635,6 +1699,31 @@ class IssueClaimLockTests(unittest.TestCase):
         mark_priority.assert_called_once_with([1392])
         get_issue_assignees.assert_not_called()
 
+    def test_try_claim_issue_refreshes_paused_issue_before_claim_checks(self) -> None:
+        issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
+        fresh_issue = {
+            **_search_issue(
+                1412,
+                [forge_metadata.LABEL_LIBRARY_NEW, forge_metadata.LABEL_HUMAN_INTERVENTION],
+            ),
+            "state": "OPEN",
+        }
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "get_issue_claim_payload", return_value=fresh_issue), \
+                    patch.object(forge_metadata, "get_open_blocking_issue_numbers") as get_blockers:
+                self.assertIsNone(
+                    forge_metadata.try_claim_issue(
+                        issue,
+                        "automation-user",
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                    )
+                )
+                cache = forge_metadata.read_issue_claim_cache()
+
+        get_blockers.assert_not_called()
+        self.assertEqual(cache[1412].reason, forge_metadata.ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION)
+
     def test_try_claim_issue_refreshes_assignees_after_local_lock(self) -> None:
         issue = {
             "number": 1412,
@@ -1644,6 +1733,7 @@ class IssueClaimLockTests(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
                     patch.object(forge_metadata, "get_issue_assignees", return_value=["other-user"]), \
                     patch.object(forge_metadata, "get_project_item_state") as get_project_item_state:
@@ -1662,6 +1752,7 @@ class IssueClaimLockTests(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
                     patch.object(forge_metadata, "get_issue_assignees", side_effect=[
                         ["automation-user"],
@@ -1688,6 +1779,7 @@ class IssueClaimLockTests(unittest.TestCase):
         issue = _search_issue(1412, [forge_metadata.LABEL_LARGE_LIBRARY_NEXT_PART])
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
                     patch.object(forge_metadata, "get_issue_assignees", side_effect=[[], ["automation-user"]]), \
                     patch.object(
@@ -1716,6 +1808,7 @@ class IssueClaimLockTests(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as lock_root:
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[]), \
                     patch.object(forge_metadata, "get_issue_assignees", side_effect=[[], ["automation-user"]]), \
                     patch.object(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1470,7 +1470,8 @@ class ProjectItemStatusTests(unittest.TestCase):
                 forge_metadata,
                 "get_issue_project_item_status",
                 return_value=("project-item", forge_metadata.STATUS_TODO),
-        ) as get_issue_project_item_status:
+        ) as get_issue_project_item_status, \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
             self.assertEqual(
                 forge_metadata.get_project_item_state(1412),
                 ("project-item", forge_metadata.STATUS_TODO),
@@ -1481,6 +1482,13 @@ class ProjectItemStatusTests(unittest.TestCase):
             forge_metadata.PROJECT_NUMBER,
             1412,
             forge_metadata.STATUS_FIELD_NAME,
+        )
+        self.assertIn(
+            (
+                "[project-item] Issue #1412 is linked to GitHub project item project-item "
+                f"in project {forge_metadata.PROJECT_NUMBER} with Status '{forge_metadata.STATUS_TODO}'"
+            ),
+            stdout.getvalue(),
         )
 
 

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -540,11 +540,12 @@ class IssueClaimPreflightTests(unittest.TestCase):
     def test_offset_issue_fetch_uses_search_page_instead_of_expanding_limit(self) -> None:
         page_items = [_search_issue(number) for number in range(200, 300)]
 
-        with patch.object(
-                forge_metadata,
-                "gh_json",
-                return_value={"items": page_items},
-        ) as gh_json:
+        with patch.dict(os.environ, {"FORGE_ISSUE_SEARCH_CACHE": "0"}), \
+                patch.object(
+                        forge_metadata,
+                        "gh_json",
+                        return_value={"items": page_items},
+                ) as gh_json:
             issues = forge_metadata.get_issues_with_label(
                 forge_metadata.LABEL_LIBRARY_NEW,
                 1,
@@ -1529,6 +1530,42 @@ class IssueClaimLockTests(unittest.TestCase):
 
         set_item_status.assert_called_once_with("item-1", forge_metadata.STATUS_TODO)
         clear_issue_assignees.assert_called_once_with(1412)
+
+
+class IssueSearchCacheTests(unittest.TestCase):
+    def test_search_page_cache_is_shared_by_label_queries(self) -> None:
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:cached:1.0.0",
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/issues/1412",
+            "labels": [{"name": forge_metadata.LABEL_LIBRARY_NEW}],
+            "assignees": [],
+        }
+
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata.time, "time", return_value=100.0), \
+                    patch.object(forge_metadata, "fetch_issue_search_page", return_value=[issue]) as fetch_page:
+                self.assertEqual(
+                    forge_metadata.get_issues_with_label(forge_metadata.LABEL_LIBRARY_NEW, 1),
+                    [issue],
+                )
+                self.assertEqual(
+                    forge_metadata.get_issues_with_label(forge_metadata.LABEL_LIBRARY_NEW, 1),
+                    [issue],
+                )
+
+        fetch_page.assert_called_once()
+
+    def test_search_count_cache_is_shared_by_random_offset_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as lock_root:
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata.time, "time", return_value=100.0), \
+                    patch.object(forge_metadata, "fetch_issue_search_count", return_value=42) as fetch_count:
+                self.assertEqual(forge_metadata.count_issues_with_label(forge_metadata.LABEL_LIBRARY_NEW), 42)
+                self.assertEqual(forge_metadata.count_issues_with_label(forge_metadata.LABEL_LIBRARY_NEW), 42)
+
+        fetch_count.assert_called_once()
 
 
 class EnvironmentValidationTests(unittest.TestCase):


### PR DESCRIPTION
### Summary
- add a shared local issue-search cache for Forge queue scans and random-offset counts
- guard cache updates with a local writer lock so concurrent local do-work processes reuse fetched pages
- reduce scan logging to one aggregate scanned-count line per queue

### Testing
- python3 -m unittest tests.test_forge_metadata.IssueSearchCacheTests tests.test_forge_metadata.IssueClaimCacheTests tests.test_forge_metadata.IssueClaimPreflightTests
- python3 -m py_compile forge_metadata.py tests/test_forge_metadata.py

Fixes #5811