### PR TITLE
[GenAI] Mark org.sangria-graphql:sangria_3 as not for Native Image

### DIFF
--- a/metadata/org.sangria-graphql/sangria_3/index.json
+++ b/metadata/org.sangria-graphql/sangria_3/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published sangria_3 JAR contains only META-INF/MANIFEST.MF and no JVM class files; the JVM implementation classes are in sangria-core_3 and sangria-derivation_3.",
+    "replacement": "org.sangria-graphql:sangria-core_3:4.2.9 and org.sangria-graphql:sangria-derivation_3:4.2.9"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4967

This PR records `org.sangria-graphql:sangria_3` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published sangria_3 JAR contains only META-INF/MANIFEST.MF and no JVM class files; the JVM implementation classes are in sangria-core_3 and sangria-derivation_3.

Replacement guidance:
- org.sangria-graphql:sangria-core_3:4.2.9 and org.sangria-graphql:sangria-derivation_3:4.2.9

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `forge/shared-issue-search-cache`
- Forge commit hash: `1e38242c0a618fc217c5dd376934184c152e5e89`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
