### PR TITLE
[GenAI] Add support for org.threeten:threetenbp:1.7.0 using gpt-5.5

### DIFF
--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -774,6 +774,26 @@
     "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
   },
   {
+    "name": "library_update_dynamic_access_bulk_pi_gpt-5.5",
+    "description": "Library-update bulk dynamic-access strategy: runs only the optimistic full-report workflow against existing tests, without per-class refinement.",
+    "agent": "pi",
+    "workflow": "optimistic_dynamic_access",
+    "model": "oca/gpt-5.5",
+    "prompts": {
+      "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md"
+    },
+    "parameters": {
+      "max-optimistic-iterations": 3,
+      "max-test-iterations": 3,
+      "max-native-test-verification-iterations": 40,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": [],
+    "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
+  },
+  {
     "name": "library_update_optimistic_pi_gpt-5.5",
     "description": "Library-update composite strategy: bulk dynamic-access coverage in one broad pass first, then per-class iterative refinement of any stragglers. Mirrors the iterative library-update strategy but starts with a faster bulk pass.",
     "agent": "pi",

--- a/metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json
+++ b/metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json
@@ -1,16 +1,71 @@
 {
-  "resources": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.threeten.bp.zone.TzdbZoneRulesProvider"
+      "condition" : {
+        "typeReached" : "org.threeten.bp.chrono.Chronology"
       },
-      "glob": "org/threeten/bp/TZDB.dat"
+      "type" : "java.util.Locale",
+      "methods" : [
+        {
+          "name" : "getUnicodeLocaleType",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
     },
     {
-      "condition": {
-        "typeReached": "org.threeten.bp.format.DateTimeFormatterBuilder$ChronoPrinterParser"
+      "condition" : {
+        "typeReached" : "org.threeten.bp.zone.ZoneRulesInitializer$ServiceLoaderZoneRulesInitializer"
       },
-      "bundle": "org.threeten.bp.format.ChronologyText"
+      "type" : "org.threeten.bp.zone.TzdbZoneRulesProvider"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.format.DateTimeFormatterBuilder$ChronoPrinterParser"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.chrono.Chronology"
+      },
+      "glob" : "META-INF/services/org.threeten.bp.chrono.Chronology"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.zone.ZoneRulesInitializer$ServiceLoaderZoneRulesInitializer"
+      },
+      "glob" : "META-INF/services/org.threeten.bp.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.zone.TzdbZoneRulesProvider"
+      },
+      "glob" : "org/threeten/bp/TZDB.dat"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.format.DateTimeFormatterBuilder$ChronoPrinterParser"
+      },
+      "glob" : "org/threeten/bp/format/ChronologyText.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.format.DateTimeFormatterBuilder$ChronoPrinterParser"
+      },
+      "glob" : "org/threeten/bp/format/ChronologyText_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.threeten.bp.format.DateTimeFormatterBuilder$ChronoPrinterParser"
+      },
+      "glob" : "org/threeten/bp/format/ChronologyText_en_US.properties"
+    },
+    {
+      "bundle" : "org.threeten.bp.format.ChronologyText"
     }
   ]
 }

--- a/stats/org.threeten/threetenbp/1.7.0/execution-metrics.json
+++ b/stats/org.threeten/threetenbp/1.7.0/execution-metrics.json
@@ -63,5 +63,71 @@
       "test_file": "tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java",
       "metadata_file": "metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json"
     }
+  },
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T17:52:33.656770Z",
+    "library": "org.threeten:threetenbp:1.7.0",
+    "starting_commit": "6373813dc3645241de3a516e3e403db9b3f1c116",
+    "ending_commit": "669450ff79620ec2648cea578308d3799cc9ce79",
+    "strategy_name": "optimistic_dynamic_access_iterative_codex_gpt-5.5",
+    "agent": "codex",
+    "model": "gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.7.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7806,
+          "missed": 48423,
+          "ratio": 0.138825,
+          "total": 56229
+        },
+        "line": {
+          "covered": 1569,
+          "missed": 8984,
+          "ratio": 0.148678,
+          "total": 10553
+        },
+        "method": {
+          "covered": 352,
+          "missed": 1906,
+          "ratio": 0.15589,
+          "total": 2258
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 614238,
+      "cached_input_tokens_used": 532736,
+      "output_tokens_used": 7891,
+      "iterations": 1,
+      "cost_usd": 1.9374,
+      "generated_loc": 104,
+      "tested_library_loc": 1569,
+      "metadata_entries": 11,
+      "test_only_metadata_entries": 2,
+      "code_coverage_percent": 14.87
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/DateTimeFormatterBuilderInnerChronoPrinterParserTest.java",
+      "metadata_file": "metadata/org.threeten/threetenbp/1.7.0/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.threeten/threetenbp/1.7.0/stats.json
+++ b/stats/org.threeten/threetenbp/1.7.0/stats.json
@@ -20,21 +20,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 5812,
-        "missed" : 50417,
-        "ratio" : 0.103363,
+        "covered" : 7806,
+        "missed" : 48423,
+        "ratio" : 0.138825,
         "total" : 56229
       },
       "line" : {
-        "covered" : 1114,
-        "missed" : 9439,
-        "ratio" : 0.105562,
+        "covered" : 1569,
+        "missed" : 8984,
+        "ratio" : 0.148678,
         "total" : 10553
       },
       "method" : {
-        "covered" : 248,
-        "missed" : 2010,
-        "ratio" : 0.109832,
+        "covered" : 352,
+        "missed" : 1906,
+        "ratio" : 0.15589,
         "total" : 2258
       }
     }

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/ChronologyTest.java
@@ -12,6 +12,8 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.chrono.Chronology;
+import org.threeten.bp.chrono.IsoChronology;
+import org.threeten.bp.chrono.JapaneseChronology;
 import org.threeten.bp.chrono.ThaiBuddhistChronology;
 
 public class ChronologyTest {
@@ -24,5 +26,17 @@ public class ChronologyTest {
         assertThat(chronology).isSameAs(ThaiBuddhistChronology.INSTANCE);
         assertThat(chronology.getId()).isEqualTo("ThaiBuddhist");
         assertThat(chronology.getCalendarType()).isEqualTo("buddhist");
+    }
+
+    @Test
+    void ofLocaleResolvesIsoAndJapaneseCalendars() {
+        Locale japaneseLocale = Locale.forLanguageTag("ja-JP-u-ca-japanese");
+
+        Chronology isoChronology = Chronology.ofLocale(Locale.US);
+        Chronology japaneseChronology = Chronology.ofLocale(japaneseLocale);
+
+        assertThat(isoChronology).isSameAs(IsoChronology.INSTANCE);
+        assertThat(japaneseChronology).isSameAs(JapaneseChronology.INSTANCE);
+        assertThat(japaneseChronology.getCalendarType()).isEqualTo("japanese");
     }
 }

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/DateTimeFormatterBuilderInnerChronoPrinterParserTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/DateTimeFormatterBuilderInnerChronoPrinterParserTest.java
@@ -11,10 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
+import org.threeten.bp.chrono.Chronology;
+import org.threeten.bp.chrono.ThaiBuddhistChronology;
 import org.threeten.bp.chrono.ThaiBuddhistDate;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.format.TextStyle;
+import org.threeten.bp.temporal.TemporalQueries;
 
 public class DateTimeFormatterBuilderInnerChronoPrinterParserTest {
     @Test
@@ -26,5 +29,18 @@ public class DateTimeFormatterBuilderInnerChronoPrinterParserTest {
         String formatted = formatter.format(ThaiBuddhistDate.of(2567, 1, 1));
 
         assertThat(formatted).isEqualTo("Buddhist Calendar");
+    }
+
+    @Test
+    void appendChronologyIdFormatsAndParsesChronologyId() {
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendChronologyId()
+                .toFormatter(Locale.ENGLISH);
+
+        String formatted = formatter.format(ThaiBuddhistDate.of(2567, 1, 1));
+        Chronology parsed = formatter.parse("ThaiBuddhist", TemporalQueries.chronology());
+
+        assertThat(formatted).isEqualTo("ThaiBuddhist");
+        assertThat(parsed).isSameAs(ThaiBuddhistChronology.INSTANCE);
     }
 }

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/TzdbZoneRulesProviderTest.java
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/java/org_threeten/threetenbp/TzdbZoneRulesProviderTest.java
@@ -12,6 +12,8 @@ import java.util.NavigableMap;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.threeten.bp.Instant;
+import org.threeten.bp.ZoneOffset;
 import org.threeten.bp.zone.TzdbZoneRulesProvider;
 import org.threeten.bp.zone.ZoneRules;
 import org.threeten.bp.zone.ZoneRulesProvider;
@@ -31,6 +33,8 @@ public class TzdbZoneRulesProviderTest {
         assertThat(provider).isInstanceOf(ZoneRulesProvider.class);
         assertThat(zoneIds).contains("Europe/London", "America/New_York", "Asia/Tokyo");
         assertThat(londonRules.isFixedOffset()).isFalse();
+        assertThat(londonRules.getOffset(Instant.parse("2016-01-01T00:00:00Z"))).isEqualTo(ZoneOffset.UTC);
+        assertThat(londonRules.getOffset(Instant.parse("2016-07-01T00:00:00Z"))).isEqualTo(ZoneOffset.ofHours(1));
         assertThat(londonVersions).isNotEmpty();
     }
 }

--- a/tests/src/org.threeten/threetenbp/1.7.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.threeten/threetenbp/1.7.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_threeten.threetenbp.ChronologyTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_threeten.threetenbp.ChronologyTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
+++ b/tests/src/org.threeten/threetenbp/1.7.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.threeten.bp.**"
+    },
+    {
+      "includeClasses" : "org_threeten.threetenbp.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4648

This PR introduces tests and metadata for org.threeten:threetenbp:1.7.0, enabling support for this library.

Summary:
- Strategy: optimistic_dynamic_access_iterative_codex_gpt-5.5
- Agent: codex
- Model: gpt-5.5
- Input tokens: 614238
- Cached input tokens: 532736
- Output tokens: 7891
- Metadata entries: 11
- Test-only metadata entries: 2
- Iterations: 1
- Library coverage percentage: 14.87
- Generated lines of code: 104
- Tested library lines of code: 1569

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `6373813dc3645241de3a516e3e403db9b3f1c116`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 3/3 covered calls (100.00%)
- Reflection: 1/1 covered calls (100.00%)
- Resources: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 7806/56229 (13.88%)
- Line: 1569/10553 (14.87%)
- Method: 352/2258 (15.59%)

### Local CI Verification

- Status: `success`
- Commands run: 13
- Fixup attempts: 0
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `forge/strategies/predefined_strategies.json`
