### PR TITLE
Reject legacy test-only Native Image config in Forge

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -389,6 +389,18 @@ def write_add_new_library_support_metrics(run_metrics, metrics_json, is_benchmar
     log_stage("schema-validation", "Schema validated")
 
 
+def _should_create_failure_run_metrics(
+        workflow_status: str,
+        unittest_number: int,
+        scaffold_placeholder_quality_gate_failed: bool,
+) -> bool:
+    """Return True when normal coverage/metadata metrics must not be collected."""
+    return (
+        scaffold_placeholder_quality_gate_failed
+        or workflow_status == RUN_STATUS_FAILURE
+        or (unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS)
+    )
+
 
 def main(argv=None):
     (
@@ -600,7 +612,7 @@ def main(argv=None):
             elif not strategy_obj._commit_library_iteration():
                 workflow_status = RUN_STATUS_FAILURE
         else:
-            finalize_status, _ = strategy_obj._finalize_successful_iteration()
+            finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint_commit_hash)
             if finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS} and workflow_status == RUN_STATUS_CHUNK_READY:
                 workflow_status = RUN_STATUS_CHUNK_READY
             else:
@@ -614,21 +626,16 @@ def main(argv=None):
     else:
         log_stage("status", "Test generation failed")
 
+    create_failure_metrics = _should_create_failure_run_metrics(
+        workflow_status,
+        unittest_number,
+        scaffold_placeholder_quality_gate_failed,
+    )
     if scaffold_placeholder_quality_gate_failed:
         log_stage("status", "Generated tests failed scaffold placeholder quality gate")
-        run_metrics = create_failure_run_metrics_output(
-            package=package,
-            artifact=artifact,
-            library_version=library_version,
-            agent=agent,
-            model_name=model_name,
-            global_iterations=global_iterations,
-            strategy_name=strategy_name,
-            starting_commit=checkpoint_commit_hash,
-            ending_commit=ending_commit_hash,
-        )
     elif unittest_number == 0 and workflow_status != SUCCESS_WITH_INTERVENTION_STATUS:
         log_stage("status", "No valid unit test generated")
+    if create_failure_metrics:
         run_metrics = create_failure_run_metrics_output(
             package=package,
             artifact=artifact,

--- a/forge/ai_workflows/improve_library_coverage.py
+++ b/forge/ai_workflows/improve_library_coverage.py
@@ -972,7 +972,7 @@ def main(argv=None) -> int:
     workflow_status, iterations = run_result[0], run_result[1]
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
-        finalize_status, _ = strategy_obj._finalize_successful_iteration()
+        finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=checkpoint_commit)
         if finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS} and workflow_status == RUN_STATUS_CHUNK_READY:
             workflow_status = RUN_STATUS_CHUNK_READY
         else:

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -555,7 +555,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         if last_passing_candidate_commit is None:
             workflow_status = RUN_STATUS_FAILURE
         else:
-            finalize_status, _ = strategy_obj._finalize_successful_iteration()
+            finalize_status, _ = strategy_obj._finalize_successful_iteration(base_commit=commit_checkpoint)
             workflow_status = finalize_status
 
     if workflow_status not in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}:

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -432,7 +432,7 @@ class WorkflowStrategy(ABC):
         print(f"ERROR: checkMetadataFiles still fails after updating allowed-packages for {library}.", file=sys.stderr)
         return False
 
-    def _finalize_successful_iteration(self) -> tuple[str, str | None]:
+    def _finalize_successful_iteration(self, base_commit: str | None = None) -> tuple[str, str | None]:
         """Generate metadata, run follow-up Gradle tasks, and commit the iteration."""
         log_stage("generate-metadata", f"Running generateMetadata for {self.library}")
         self._run_command(f"./gradlew generateMetadata -Pcoordinates={self.library} --agentAllowedPackages=fromJar")
@@ -455,6 +455,7 @@ class WorkflowStrategy(ABC):
                 artifact=artifact,
                 library_version=library_version,
                 model_name=self.model_name,
+                base_commit=base_commit,
             ):
                 return RUN_STATUS_FAILURE, None
         log_stage("commit-iteration", f"Running commit iteration for {self.library}")

--- a/forge/tests/test_add_new_library_support.py
+++ b/forge/tests/test_add_new_library_support.py
@@ -1,0 +1,35 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import unittest
+
+from ai_workflows.add_new_library_support import _should_create_failure_run_metrics
+from ai_workflows.workflow_strategies.workflow_strategy import (
+    RUN_STATUS_CHUNK_READY,
+    RUN_STATUS_FAILURE,
+    RUN_STATUS_SUCCESS,
+    SUCCESS_WITH_INTERVENTION_STATUS,
+)
+
+
+class AddNewLibrarySupportTests(unittest.TestCase):
+    def test_failure_after_generated_tests_uses_failure_metrics(self) -> None:
+        self.assertTrue(_should_create_failure_run_metrics(RUN_STATUS_FAILURE, 1, False))
+
+    def test_successful_statuses_with_generated_tests_use_normal_metrics(self) -> None:
+        for status in (RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY, SUCCESS_WITH_INTERVENTION_STATUS):
+            with self.subTest(status=status):
+                self.assertFalse(_should_create_failure_run_metrics(status, 1, False))
+
+    def test_no_generated_tests_uses_failure_metrics_except_intervention_status(self) -> None:
+        self.assertTrue(_should_create_failure_run_metrics(RUN_STATUS_SUCCESS, 0, False))
+        self.assertFalse(_should_create_failure_run_metrics(SUCCESS_WITH_INTERVENTION_STATUS, 0, False))
+
+    def test_scaffold_placeholder_gate_uses_failure_metrics(self) -> None:
+        self.assertTrue(_should_create_failure_run_metrics(RUN_STATUS_SUCCESS, 1, True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -1,0 +1,158 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts.library_finalization import run_library_finalization
+
+
+def _git(repo_path: str, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_all(repo_path: str, message: str) -> str:
+    _git(repo_path, "add", "-A")
+    _git(repo_path, "-c", "user.name=Forge Test", "-c", "user.email=forge@example.com", "commit", "-m", message)
+    return _git(repo_path, "rev-parse", "HEAD")
+
+
+class LibraryFinalizationTests(unittest.TestCase):
+    def test_rejects_legacy_test_resource_native_image_config_after_split(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            _commit_all(repo_path, "base")
+            native_image_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(native_image_dir)
+            with open(os.path.join(native_image_dir, "proxy-config.json"), "w", encoding="utf-8") as file:
+                file.write("[]\n")
+
+            with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
+                    patch("utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix") as check_metadata, \
+                    patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks, \
+                    patch("sys.stderr", new_callable=io.StringIO) as stderr:
+                result = run_library_finalization(
+                    repo_path=repo_path,
+                    library="org.example:demo:1.0.0",
+                    group="org.example",
+                    artifact="demo",
+                    library_version="1.0.0",
+                )
+
+        self.assertFalse(result)
+        self.assertIn("proxy-config.json", stderr.getvalue())
+        self.assertIn("reachability-metadata.json", stderr.getvalue())
+        check_metadata.assert_not_called()
+        style_checks.assert_not_called()
+
+    def test_rejects_committed_legacy_test_resource_native_image_config_after_base_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(repo_path, "base")
+            native_image_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(native_image_dir)
+            with open(os.path.join(native_image_dir, "proxy-config.json"), "w", encoding="utf-8") as file:
+                file.write("[]\n")
+            _commit_all(repo_path, "generated legacy config")
+
+            with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
+                    patch("utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix") as check_metadata, \
+                    patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks, \
+                    patch("sys.stderr", new_callable=io.StringIO) as stderr:
+                result = run_library_finalization(
+                    repo_path=repo_path,
+                    library="org.example:demo:1.0.0",
+                    group="org.example",
+                    artifact="demo",
+                    library_version="1.0.0",
+                    base_commit=base,
+                )
+
+        self.assertFalse(result)
+        self.assertIn("proxy-config.json", stderr.getvalue())
+        self.assertIn("reachability-metadata.json", stderr.getvalue())
+        check_metadata.assert_not_called()
+        style_checks.assert_not_called()
+
+    def test_allows_pre_existing_legacy_test_resource_native_image_config(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            native_image_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(native_image_dir)
+            with open(os.path.join(native_image_dir, "proxy-config.json"), "w", encoding="utf-8") as file:
+                file.write("[]\n")
+            base = _commit_all(repo_path, "existing legacy config")
+
+            with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
+                    patch("utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix", return_value=True) as check_metadata, \
+                    patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True) as style_checks:
+                result = run_library_finalization(
+                    repo_path=repo_path,
+                    library="org.example:demo:1.0.0",
+                    group="org.example",
+                    artifact="demo",
+                    library_version="1.0.0",
+                    base_commit=base,
+                )
+
+        self.assertTrue(result)
+        check_metadata.assert_called_once()
+        style_checks.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -21,6 +21,7 @@ from utility_scripts.local_ci_verification import (
     run_local_ci_verification,
     _github_repo_slug_from_url,
     _graalvm_home_for_java_version,
+    _run_legacy_test_native_image_config_validation,
     _run_infrastructure_matrix_entries,
     _run_recorded_command,
     _run_recorded_command_without_new_docker_images,
@@ -285,6 +286,49 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(gates, ["check-metadata-files", "run-consecutive-tests"])
         self.assertNotIn("disable-docker-networking", gates)
         self.assertNotIn("restore-docker-networking", gates)
+
+    def test_legacy_test_native_image_config_validation_fails_changed_legacy_file(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as log_path:
+            _git(repo_path, "init")
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(repo_path, "base")
+            legacy_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(legacy_dir)
+            with open(os.path.join(legacy_dir, "reflect-config.json"), "w", encoding="utf-8") as file:
+                file.write("[]\n")
+
+            result = LocalCIVerificationResult(status="running", base_commit=base)
+            with patch(
+                    "utility_scripts.local_ci_verification.build_timestamped_task_log_path",
+                    return_value=os.path.join(log_path, "policy.log"),
+            ):
+                failed = _run_legacy_test_native_image_config_validation(
+                    repo_path,
+                    base,
+                    result,
+                    [
+                        "tests/src/org.example/demo/1.0.0/src/test/resources/"
+                        "META-INF/native-image/reflect-config.json",
+                    ],
+                )
+
+        self.assertIsNotNone(failed)
+        self.assertEqual(failed.gate, "legacy-test-native-image-config")
+        self.assertIn("reflect-config.json", result.commands[0].output_excerpt)
+        self.assertIn("reachability-metadata.json", result.commands[0].output_excerpt)
 
     def test_test_matrix_prepulls_docker_images_without_privileged_network_scripts(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 
@@ -22,6 +23,28 @@ from utility_scripts.metrics_writer import (
     execution_metrics_path,
     resolve_artifact_paths,
 )
+from utility_scripts.native_image_config_policy import (
+    find_legacy_test_native_image_config_files_for_coordinate,
+    is_legacy_test_native_image_config_path,
+)
+
+
+def _git(repo_path: str, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_all(repo_path: str, message: str) -> str:
+    _git(repo_path, "add", "-A")
+    _git(repo_path, "-c", "user.name=Forge Test", "-c", "user.email=forge@example.com", "commit", "-m", message)
+    return _git(repo_path, "rev-parse", "HEAD")
 
 
 def _minimal_run_metrics(library: str = "org.example:demo:1.0.0") -> dict:
@@ -368,6 +391,104 @@ class MetricsPathTests(unittest.TestCase):
                 )
 
             self.assertEqual(count_test_only_metadata_entries(temp_dir, "org.example", "demo", "1.0.0"), 3)
+
+    def test_count_test_only_metadata_entries_rejects_legacy_native_image_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _git(temp_dir, "init")
+            with open(os.path.join(temp_dir, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(temp_dir, "base")
+            test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(test_metadata_dir, "serialization-config.json"), "w", encoding="utf-8") as file:
+                json.dump([], file)
+            _commit_all(temp_dir, "generated legacy config")
+
+            with self.assertRaisesRegex(ValueError, "reachability-metadata.json"):
+                count_test_only_metadata_entries(temp_dir, "org.example", "demo", "1.0.0", base_commit=base)
+
+    def test_count_test_only_metadata_entries_grandfathers_existing_legacy_native_image_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _git(temp_dir, "init")
+            test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(test_metadata_dir, "serialization-config.json"), "w", encoding="utf-8") as file:
+                json.dump([], file)
+            base = _commit_all(temp_dir, "existing legacy config")
+
+            self.assertEqual(count_test_only_metadata_entries(
+                temp_dir,
+                "org.example",
+                "demo",
+                "1.0.0",
+                base_commit=base,
+            ), 0)
+
+    def test_native_image_config_policy_resolves_test_version_from_index(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            test_metadata_dir = os.path.join(
+                temp_dir,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(metadata_dir)
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(metadata_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "test-version": "1.0.0",
+                            "tested-versions": ["1.0.1"],
+                        }
+                    ],
+                    file,
+                )
+            with open(os.path.join(test_metadata_dir, "resource-config.json"), "w", encoding="utf-8") as file:
+                json.dump({"resources": {"includes": []}}, file)
+
+            self.assertTrue(is_legacy_test_native_image_config_path(
+                "tests/src/org.example/demo/1.0.0/src/test/resources/META-INF/native-image/resource-config.json"
+            ))
+            self.assertEqual(
+                find_legacy_test_native_image_config_files_for_coordinate(temp_dir, "org.example:demo:1.0.1"),
+                [
+                    "tests/src/org.example/demo/1.0.0/src/test/resources/META-INF/native-image/resource-config.json",
+                ],
+            )
 
     def test_create_run_metrics_includes_test_only_metadata_entries_only_when_positive(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -12,6 +12,11 @@ import sys
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import find_index_entry_for_version
 from utility_scripts.style_checks import run_style_fix_and_checks
+from utility_scripts.native_image_config_policy import (
+    find_changed_legacy_test_native_image_config_files_for_coordinate,
+    find_uncommitted_legacy_test_native_image_config_files_for_coordinate,
+    format_legacy_test_native_image_config_error,
+)
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.test_quality_checks import (
@@ -200,11 +205,22 @@ def run_library_finalization(
         library_version: str,
         log_prefix: str | None = None,
         model_name: str | None = None,
+        base_commit: str | None = None,
 ) -> bool:
     """Run the shared end-of-workflow finalization steps for one library."""
     del log_prefix
     log_stage("split-test-only-metadata", f"Running splitTestOnlyMetadata for {library}")
     if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):
+        return False
+    legacy_test_config_paths = set(
+        find_uncommitted_legacy_test_native_image_config_files_for_coordinate(repo_path, library)
+    )
+    if base_commit is not None:
+        legacy_test_config_paths.update(
+            find_changed_legacy_test_native_image_config_files_for_coordinate(repo_path, library, base_commit)
+        )
+    if legacy_test_config_paths:
+        print(format_legacy_test_native_image_config_error(sorted(legacy_test_config_paths)), file=sys.stderr)
         return False
     if not _run_check_metadata_files_with_allowed_packages_fix(
         repo_path=repo_path,

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -19,6 +19,11 @@ from pathlib import Path
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
+from utility_scripts.native_image_config_policy import (
+    find_changed_legacy_test_native_image_config_files,
+    format_legacy_test_native_image_config_error,
+    is_legacy_test_native_image_config_path,
+)
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
@@ -237,6 +242,9 @@ def _run_verification_once(
         result: LocalCIVerificationResult,
 ) -> CommandRecord | None:
     changed_files = changed_files_for_ci(repo_path, base_commit)
+    failed = _run_legacy_test_native_image_config_validation(repo_path, base_commit, result, changed_files)
+    if failed is not None:
+        return failed
 
     try:
         changed_metadata_matrix = _gradle_json_output(
@@ -300,6 +308,35 @@ def _run_verification_once(
             return failed
 
     return None
+
+
+def _run_legacy_test_native_image_config_validation(
+        repo_path: str,
+        base_commit: str,
+        result: LocalCIVerificationResult,
+        changed_files: list[str] | None = None,
+) -> CommandRecord | None:
+    legacy_paths = (
+        sorted(path for path in changed_files if is_legacy_test_native_image_config_path(path))
+        if changed_files is not None
+        else find_changed_legacy_test_native_image_config_files(repo_path, base_commit)
+    )
+    if not legacy_paths:
+        return None
+
+    output = format_legacy_test_native_image_config_error(legacy_paths) + "\n"
+    log_path = build_timestamped_task_log_path("local-ci", "legacy-test-native-image-config", "policy")
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(output)
+    record = CommandRecord(
+        gate="legacy-test-native-image-config",
+        command=["legacy-test-native-image-config-policy"],
+        returncode=1,
+        log_path=display_log_path(log_path),
+        output_excerpt=output[:MAX_OUTPUT_CHARS],
+    )
+    result.commands.append(record)
+    return record
 
 
 def _run_test_matrix_entries(

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -19,6 +19,10 @@ import utility_scripts.count_reachability_entries as reachability_metadata_count
 import utility_scripts.count_native_image_config_entries as legacy_metadata_count
 from utility_scripts.library_stats import load_library_stats_entry
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
+from utility_scripts.native_image_config_policy import (
+    find_changed_legacy_test_native_image_config_files_for_coordinate,
+    format_legacy_test_native_image_config_error,
+)
 from utility_scripts.source_context import resolve_test_source_layout
 from utility_scripts.strategy_loader import load_strategy_by_name
 from git_scripts.common_git import git_remote_exists
@@ -238,8 +242,23 @@ def count_metadata_entries(repo_path: str, package: str, artifact: str, library_
     return total
 
 
-def count_test_only_metadata_entries(repo_path: str, package: str, artifact: str, library_version: str) -> int:
+def count_test_only_metadata_entries(
+        repo_path: str,
+        package: str,
+        artifact: str,
+        library_version: str,
+        base_commit: str | None = None,
+) -> int:
     """Count test-only reachability metadata entries for a library version."""
+    coordinate = f"{package}:{artifact}:{library_version}"
+    legacy_test_config_paths = (
+        find_changed_legacy_test_native_image_config_files_for_coordinate(repo_path, coordinate, base_commit)
+        if base_commit is not None
+        else []
+    )
+    if legacy_test_config_paths:
+        raise ValueError(format_legacy_test_native_image_config_error(legacy_test_config_paths))
+
     test_version = _resolve_test_version_dir(repo_path, package, artifact, library_version)
     reach_json = os.path.join(
         repo_path,
@@ -293,6 +312,7 @@ def collect_and_print_metrics(
         agent,
         model_name: str | None,
         global_iterations: int,
+        starting_commit: str | None = None,
 ):
     """
     Compute metrics and print the same output produced previously.
@@ -326,7 +346,13 @@ def collect_and_print_metrics(
 
     # Calculating generated metadata entries
     total_entries = count_metadata_entries(repo_path, package, artifact, library_version)
-    test_only_metadata_entries = count_test_only_metadata_entries(repo_path, package, artifact, library_version)
+    test_only_metadata_entries = count_test_only_metadata_entries(
+        repo_path,
+        package,
+        artifact,
+        library_version,
+        base_commit=starting_commit,
+    )
 
     cached_tokens_suffix = ""
     if cached_input_tokens_used is not None:
@@ -471,7 +497,16 @@ def _is_test_source_file(file_name: str) -> bool:
     return file_name.endswith((".java", ".kt", ".scala", ".groovy"))
 
 
-def collect_base_metrics(repo_path, package, artifact, library_version, agent, model_name, global_iterations):
+def collect_base_metrics(
+        repo_path,
+        package,
+        artifact,
+        library_version,
+        agent,
+        model_name,
+        global_iterations,
+        starting_commit: str | None = None,
+):
     """Collect metrics and compute cost. Returns a flat dict of metric values."""
     metrics = collect_and_print_metrics(
         repo_path=repo_path,
@@ -481,6 +516,7 @@ def collect_base_metrics(repo_path, package, artifact, library_version, agent, m
         agent=agent,
         model_name=model_name,
         global_iterations=global_iterations,
+        starting_commit=starting_commit,
     )
     return metrics
 
@@ -503,7 +539,16 @@ def create_run_metrics_output_json(
     """
     Build a run_metrics dict using collected metrics.
     """
-    metrics = collect_base_metrics(repo_path, package, artifact, library_version, agent, model_name, global_iterations)
+    metrics = collect_base_metrics(
+        repo_path,
+        package,
+        artifact,
+        library_version,
+        agent,
+        model_name,
+        global_iterations,
+        starting_commit=starting_commit,
+    )
     test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, library_version, tests_root)
     agent_name = resolve_agent(strategy_name)
     stats = load_library_stats_snapshot(repo_path, package, artifact, library_version)
@@ -552,7 +597,16 @@ def create_javac_fix_run_metrics_output_json(
         post_generation_intervention: dict | None = None,
 ):
     """Build run metrics for fix_javac_fail workflow including previous-version metrics."""
-    metrics = collect_base_metrics(repo_path, package, artifact, new_library_version, agent, model_name, global_iterations)
+    metrics = collect_base_metrics(
+        repo_path,
+        package,
+        artifact,
+        new_library_version,
+        agent,
+        model_name,
+        global_iterations,
+        starting_commit=starting_commit,
+    )
     test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, new_library_version, tests_root)
 
     previous_coverage_percent, _ = collect_version_coverage_metrics(

--- a/forge/utility_scripts/native_image_config_policy.py
+++ b/forge/utility_scripts/native_image_config_policy.py
@@ -1,0 +1,160 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Policy checks for Native Image config files in generated test resources."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from utility_scripts.metadata_index import resolve_test_version
+
+LEGACY_TEST_NATIVE_IMAGE_CONFIG_FILENAMES = frozenset(
+    {
+        "reflect-config.json",
+        "resource-config.json",
+        "proxy-config.json",
+        "serialization-config.json",
+        "jni-config.json",
+        "predefined-classes-config.json",
+    }
+)
+TEST_NATIVE_IMAGE_RESOURCE_SEGMENT = "/src/test/resources/META-INF/native-image/"
+
+
+def format_legacy_test_native_image_config_error(paths: list[str]) -> str:
+    """Return the standard error shown when legacy test-resource config is found."""
+    joined_paths = "\n - ".join(paths)
+    return (
+        "ERROR: Legacy Native Image config files are not supported in generated test resources. "
+        "Move test-only metadata into reachability-metadata.json and remove:\n - "
+        f"{joined_paths}"
+    )
+
+
+def parse_coordinate_parts(coordinates: str) -> tuple[str, str, str]:
+    """Return group, artifact, version from Maven coordinates."""
+    parts = coordinates.split(":")
+    if len(parts) != 3:
+        raise ValueError(f"Expected Maven coordinates group:artifact:version, got {coordinates!r}")
+    return parts[0], parts[1], parts[2]
+
+
+def find_legacy_test_native_image_config_files_for_coordinate(repo_path: str, coordinates: str) -> list[str]:
+    """Return legacy Native Image config files under the resolved test resources for one coordinate."""
+    native_image_dir = os.path.join(repo_path, _coordinate_test_native_image_prefix(repo_path, coordinates))
+    if not os.path.isdir(native_image_dir):
+        return []
+
+    paths: list[str] = []
+    for root, _dirnames, filenames in os.walk(native_image_dir):
+        for filename in filenames:
+            if filename in LEGACY_TEST_NATIVE_IMAGE_CONFIG_FILENAMES:
+                paths.append(_repo_relative_path(repo_path, os.path.join(root, filename)))
+    return sorted(paths)
+
+
+def find_changed_legacy_test_native_image_config_files_for_coordinate(
+        repo_path: str,
+        coordinates: str,
+        base_commit: str,
+        head_commit: str = "HEAD",
+) -> list[str]:
+    """Return changed legacy test-resource Native Image config files for one coordinate."""
+    paths = find_changed_legacy_test_native_image_config_files(repo_path, base_commit, head_commit)
+    return _filter_coordinate_test_native_image_paths(repo_path, coordinates, paths)
+
+
+def find_changed_legacy_test_native_image_config_files(
+        repo_path: str,
+        base_commit: str,
+        head_commit: str = "HEAD",
+) -> list[str]:
+    """Return changed legacy Native Image config files under test resources."""
+    paths = _changed_files(repo_path, base_commit, head_commit)
+    return sorted(path for path in paths if is_legacy_test_native_image_config_path(path))
+
+
+def find_uncommitted_legacy_test_native_image_config_files_for_coordinate(repo_path: str, coordinates: str) -> list[str]:
+    """Return uncommitted legacy test-resource Native Image config files for one coordinate."""
+    paths = _uncommitted_files(repo_path)
+    legacy_paths = [path for path in paths if is_legacy_test_native_image_config_path(path)]
+    return _filter_coordinate_test_native_image_paths(repo_path, coordinates, legacy_paths)
+
+
+def is_legacy_test_native_image_config_path(path: str) -> bool:
+    """Return True when a repo-relative path is a legacy test-resource Native Image config file."""
+    normalized = path.replace("\\", "/")
+    return (
+        normalized.startswith("tests/src/")
+        and TEST_NATIVE_IMAGE_RESOURCE_SEGMENT in normalized
+        and os.path.basename(normalized) in LEGACY_TEST_NATIVE_IMAGE_CONFIG_FILENAMES
+    )
+
+
+def _coordinate_test_native_image_prefix(repo_path: str, coordinates: str) -> str:
+    group, artifact, version = parse_coordinate_parts(coordinates)
+    test_version = resolve_test_version(repo_path, group, artifact, version)
+    return (
+        f"tests/src/{group}/{artifact}/{test_version}/"
+        "src/test/resources/META-INF/native-image/"
+    )
+
+
+def _filter_coordinate_test_native_image_paths(repo_path: str, coordinates: str, paths: list[str]) -> list[str]:
+    prefix = _coordinate_test_native_image_prefix(repo_path, coordinates)
+    return sorted(path for path in paths if path.replace("\\", "/").startswith(prefix))
+
+
+def _changed_files(repo_path: str, base_commit: str, head_commit: str) -> list[str]:
+    diff_range = f"{base_commit}...{head_commit}"
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", diff_range],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMRT", base_commit, head_commit],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _uncommitted_files(repo_path: str) -> list[str]:
+    tracked_result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", "HEAD"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    untracked_result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return sorted({
+        line.strip()
+        for output in (tracked_result.stdout, untracked_result.stdout)
+        for line in output.splitlines()
+        if line.strip()
+    })
+
+
+def _repo_relative_path(repo_path: str, path: str) -> str:
+    return os.path.relpath(path, repo_path).replace(os.sep, "/")


### PR DESCRIPTION
## Summary

This fixes the Forge policy gap that let generated new-library PRs publish legacy Native Image config files from test resources. Forge now rejects changed test-resource `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, and `predefined-classes-config.json` under `tests/src/**/src/test/resources/META-INF/native-image/**` and points workers to move test-only metadata into `reachability-metadata.json` instead.

The guard is intentionally scoped to changed or uncommitted files for the active coordinate, so existing accepted historical test fixtures do not block unrelated Forge work.

## Root Cause

Forge/local CI accepted eight new-library PRs that added legacy Native Image config files under test resources. Required checks passed because native-image still consumes these files, but repository review policy expects generated test-only metadata to use supported `reachability-metadata.json`. That made this a Forge automation and metadata-format policy gap rather than a GraalVM runtime issue.

## GitHub Items Addressed

Original human-intervention PRs:

- #5726 `org.apache.pekko:pekko-protobuf-v3_2.13:1.1.5`
- #5659 `com.lihaoyi:os-lib_3:0.11.5-M8`
- #5640 `io.mockk:mockk-core-jvm:1.14.9`
- #5638 `io.mockk:mockk-agent-api-jvm:1.14.9`
- #5612 `org.eclipse.collections:eclipse-collections-api:11.1.0`
- #5583 `org.aesh:readline:2.6`
- #5563 `org.jetbrains.kotlin:kotlin-scripting-common:2.3.21`
- #5552 `args4j:args4j:2.0.26`

Those branches were repaired by converting the added legacy test-resource Native Image config into test-resource `reachability-metadata.json` and deleting the legacy files from the PR diffs. This PR adds the Forge guard to prevent recurrence.

## Validation

- `PYTHONPATH=$PWD/forge python3 -m unittest forge.tests.test_library_finalization forge.tests.test_local_ci_verification forge.tests.test_metrics_paths`
- `python3 -m py_compile forge/utility_scripts/native_image_config_policy.py forge/utility_scripts/library_finalization.py forge/utility_scripts/local_ci_verification.py forge/utility_scripts/metrics_writer.py forge/tests/test_library_finalization.py forge/tests/test_local_ci_verification.py forge/tests/test_metrics_paths.py`
- `git diff --check`
- Repaired branch validation: `./gradlew checkMetadataFiles test -Pcoordinates=<coordinate> --stacktrace` passed for all eight affected coordinates.
- Stats refresh validation: `./gradlew generateLibraryStats -Pcoordinates=<coordinate> --stacktrace` passed for all eight affected coordinates and no stats files changed after regeneration.
- Verified the eight repaired PR branch heads with `git ls-remote origin`.

## Remaining Human Action

The eight library PRs still need normal reviewer re-review because their review decision remains `CHANGES_REQUESTED` until GitHub records a fresh review.
