### PR TITLE
Add OpenTest4J assertion reflection metadata

### DIFF
--- a/metadata/org.opentest4j/opentest4j/1.2.0/reachability-metadata.json
+++ b/metadata/org.opentest4j/opentest4j/1.2.0/reachability-metadata.json
@@ -1,1 +1,17 @@
-{}
+{
+  "reflection": [
+    {
+      "type": "org.opentest4j.AssertionFailedError",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.opentest4j/opentest4j/1.2.0/src/test/java/org_opentest4j/opentest4j/Opentest4jTest.java
+++ b/tests/src/org.opentest4j/opentest4j/1.2.0/src/test/java/org_opentest4j/opentest4j/Opentest4jTest.java
@@ -19,6 +19,7 @@ import org.opentest4j.ValueWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Opentest4jTest {
 
@@ -165,6 +166,18 @@ public class Opentest4jTest {
         assertThat(error.getActual()).isSameAs(actual);
         assertThat(error.getExpected().getStringRepresentation()).isEqualTo("expected ten");
         assertThat(error.getActual().getStringRepresentation()).isEqualTo("actual twenty");
+    }
+
+    @Test
+    void assertjEqualityFailuresUseOpenTest4jAssertionFailedError() {
+        try {
+            assertThat("actual value").isEqualTo("expected value");
+            fail("AssertJ equality assertion should fail");
+        } catch (AssertionFailedError error) {
+            assertThat(error.getExpected().getValue()).isEqualTo("\"expected value\"");
+            assertThat(error.getActual().getValue()).isEqualTo("\"actual value\"");
+            assertThat(error.getMessage()).contains("expected value").contains("actual value");
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Add reflection metadata for org.opentest4j.AssertionFailedError(String, Object, Object).
- Add an OpenTest4J test that forces AssertJ's equality-failure path to create AssertionFailedError reflectively.

### Testing
- ./gradlew checkMetadataFiles -Pcoordinates=org.opentest4j:opentest4j:1.2.0 --stacktrace
- ./gradlew compileTestJava -Pcoordinates=org.opentest4j:opentest4j:1.2.0 --stacktrace
- ./gradlew javaTest -Pcoordinates=org.opentest4j:opentest4j:1.2.0 --stacktrace
- ./gradlew test -Pcoordinates=org.opentest4j:opentest4j:1.2.0 --stacktrace

Fixes #5859