### PR TITLE
[GenAI] Add support for software.amazon.awssdk:annotations:2.34.0 using gpt-5.5

### DIFF
--- a/stats/software.amazon.awssdk/annotations/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/annotations/2.34.0/execution-metrics.json
@@ -32,5 +32,39 @@
       "test_file": "tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java",
       "metadata_file": "metadata/software.amazon.awssdk/annotations/2.34.0/reachability-metadata.json"
     }
+  },
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T23:00:16.935032Z",
+    "library": "software.amazon.awssdk:annotations:2.34.0",
+    "starting_commit": "7cd119e987c47e2994bef806fcfe9050bb7e9d70",
+    "ending_commit": "69261fdf5754bbe3de0fd046e2e27d13cfd4b0db",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.34.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 97269,
+      "cached_input_tokens_used": 863232,
+      "output_tokens_used": 13746,
+      "iterations": 3,
+      "cost_usd": 0.844,
+      "generated_loc": 594,
+      "tested_library_loc": 0,
+      "metadata_entries": 0,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java",
+      "metadata_file": "metadata/software.amazon.awssdk/annotations/2.34.0/reachability-metadata.json"
+    }
   }
 }

--- a/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
+++ b/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
@@ -42,6 +42,17 @@ public class AnnotationsTest {
     }
 
     @Test
+    void immutableAnnotationsCanDocumentLazilyComputedInternalState() {
+        LazyEndpointDescriptor descriptor = new LazyEndpointDescriptor("dynamodb", "us-east-1");
+
+        assertThat(descriptor.endpointUri()).isEqualTo("https://dynamodb.us-east-1.amazonaws.com");
+        assertThat(descriptor.endpointUri()).isEqualTo("https://dynamodb.us-east-1.amazonaws.com");
+        assertThat(descriptor.routingHeaders())
+                .containsExactly("host:dynamodb.us-east-1.amazonaws.com", "region:us-east-1");
+        assertThat(descriptor.cacheStatisticsForTests()).isEqualTo("endpoint-computations=1");
+    }
+
+    @Test
     void sdkAnnotationsCanDocumentRecordBasedConfigurationComponents() {
         AnnotatedClientConfiguration configuration = new AnnotatedClientConfiguration("s3", "us-west-2", 3);
 
@@ -360,6 +371,61 @@ public class AnnotationsTest {
         @ToBuilderIgnoreField({"cachedEndpoint", "computedRegion"})
         List<String> builderIgnoredFields() {
             return List.of("cachedEndpoint", "computedRegion");
+        }
+    }
+
+    @Immutable
+    @ThreadSafe
+    @SdkPublicApi
+    static final class LazyEndpointDescriptor {
+        @NotNull
+        private final String service;
+
+        @NotNull
+        private final String region;
+
+        @SdkInternalApi
+        private volatile String cachedEndpointHost;
+
+        @SdkInternalApi
+        private int endpointComputations;
+
+        @SdkPublicApi
+        LazyEndpointDescriptor(@NotNull String service, @NotNull String region) {
+            this.service = service;
+            this.region = region;
+        }
+
+        @NotNull
+        @SdkPublicApi
+        String endpointUri() {
+            return "https://" + endpointHost();
+        }
+
+        @SdkProtectedApi
+        List<String> routingHeaders() {
+            String host = endpointHost();
+            return List.of("host:" + host, "region:" + region);
+        }
+
+        @SdkTestInternalApi
+        synchronized String cacheStatisticsForTests() {
+            return "endpoint-computations=" + endpointComputations;
+        }
+
+        private String endpointHost() {
+            String host = cachedEndpointHost;
+            if (host == null) {
+                synchronized (this) {
+                    host = cachedEndpointHost;
+                    if (host == null) {
+                        host = service + "." + region + ".amazonaws.com";
+                        endpointComputations++;
+                        cachedEndpointHost = host;
+                    }
+                }
+            }
+            return host;
         }
     }
 

--- a/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
+++ b/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
@@ -76,6 +76,18 @@ public class AnnotationsTest {
     }
 
     @Test
+    void sdkAnnotationsCanDocumentGeneratedModeledEnumValues() {
+        ModeledEndpointStatus status = ModeledEndpointStatus.fromServiceValue("preview");
+
+        assertThat(status).isEqualTo(ModeledEndpointStatus.PREVIEW);
+        assertThat(status.serviceValue()).isEqualTo("preview");
+        assertThat(status.requiresReleaseReview()).isTrue();
+        assertThat(status.routingHeader()).isEqualTo("x-amz-endpoint-status:preview");
+        assertThat(ModeledEndpointStatus.fromServiceValue("available"))
+                .isEqualTo(ModeledEndpointStatus.AVAILABLE);
+    }
+
+    @Test
     void annotationsWithMembersCanBeImplementedWithoutReflection() {
         Generated generated = new Generated() {
             @Override
@@ -388,6 +400,57 @@ public class AnnotationsTest {
         @SdkTestInternalApi
         String describeForTests() {
             return operation + "#" + attempts;
+        }
+    }
+
+    @Generated(value = "smithy-enum-generator", comments = "exercise generated enum constants")
+    @SdkPublicApi
+    enum ModeledEndpointStatus {
+        @Generated("enum-constant-available")
+        @SdkPublicApi
+        AVAILABLE("available", false),
+
+        @Generated("enum-constant-preview")
+        @ReviewBeforeRelease("Preview enum value must be reviewed before public documentation is updated")
+        PREVIEW("preview", true);
+
+        @NotNull
+        @SdkPublicApi
+        private final String serviceValue;
+
+        @SdkInternalApi
+        private final boolean requiresReleaseReview;
+
+        @SdkInternalApi
+        ModeledEndpointStatus(String serviceValue, boolean requiresReleaseReview) {
+            this.serviceValue = serviceValue;
+            this.requiresReleaseReview = requiresReleaseReview;
+        }
+
+        @NotNull
+        @SdkPublicApi
+        String serviceValue() {
+            return serviceValue;
+        }
+
+        @SdkProtectedApi
+        boolean requiresReleaseReview() {
+            return requiresReleaseReview;
+        }
+
+        @Generated(value = "routing-header", comments = "derived from generated enum model")
+        String routingHeader() {
+            return "x-amz-endpoint-status:" + serviceValue;
+        }
+
+        @SdkPublicApi
+        static ModeledEndpointStatus fromServiceValue(@NotNull String serviceValue) {
+            for (ModeledEndpointStatus status : values()) {
+                if (status.serviceValue.equals(serviceValue)) {
+                    return status;
+                }
+            }
+            throw new IllegalArgumentException("Unknown endpoint status: " + serviceValue);
         }
     }
 

--- a/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
+++ b/tests/src/software.amazon.awssdk/annotations/2.34.0/src/test/java/software_amazon_awssdk/annotations/AnnotationsTest.java
@@ -8,7 +8,9 @@ package software_amazon_awssdk.annotations;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.annotations.Generated;
@@ -26,6 +28,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.annotations.ToBuilderIgnoreField;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnnotationsTest {
     @Test
@@ -226,6 +229,41 @@ public class AnnotationsTest {
         assertThat(fixture.rebuildToken()).isEqualTo("rebuild-annotations-contract");
     }
 
+    @Test
+    void annotatedComponentsKeepTheirNormalValidationSemantics() {
+        assertThatThrownBy(() -> new AnnotatedClientConfiguration("", "us-east-1", 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("service must not be blank");
+        assertThatThrownBy(() -> new AnnotatedClientConfiguration("s3", "", 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("region must not be blank");
+        assertThatThrownBy(() -> new AnnotatedClientConfiguration("s3", "us-east-1", -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxRetries must not be negative");
+    }
+
+    @Test
+    void sdkAnnotationsCanDocumentFluentBuildersAndIgnoredComputedState() {
+        AnnotatedRequestBuilder builder = new AnnotatedRequestBuilder()
+                .service("dynamodb")
+                .region("ap-south-1")
+                .operation("ListTables")
+                .putAttribute("tenant", "analytics")
+                .withCachedSigningRegion("ap-south-1-signing");
+
+        ServiceOperation operation = builder.build();
+
+        assertThat(builder.ignoredBuilderFields()).containsExactly("cachedSigningRegion", "attributes");
+        assertThat(operation.service()).isEqualTo("dynamodb");
+        assertThat(operation.region()).isEqualTo("ap-south-1");
+        assertThat(operation.operation()).isEqualTo("ListTables");
+        assertThat(operation.signingRegion()).isEqualTo("ap-south-1-signing");
+        assertThat(operation.attributes())
+                .hasSize(2)
+                .containsEntry("tenant", "analytics")
+                .containsEntry("endpoint", "dynamodb.ap-south-1.amazonaws.com");
+    }
+
     @NotNull
     @Generated("metadata-contract")
     @interface MetadataContract {
@@ -378,6 +416,101 @@ public class AnnotationsTest {
         String generatedDescription(String generator) {
             return generator + ":" + name;
         }
+    }
+
+    @Mutable
+    @NotThreadSafe
+    @SdkPublicApi
+    static final class AnnotatedRequestBuilder {
+        @NotNull
+        @SdkPublicApi
+        private String service;
+
+        @NotNull
+        @SdkPublicApi
+        private String region;
+
+        @NotNull
+        @SdkPublicApi
+        private String operation;
+
+        @SdkInternalApi
+        private String cachedSigningRegion;
+
+        private final Map<String, String> attributes = new LinkedHashMap<>();
+
+        @SdkPublicApi
+        AnnotatedRequestBuilder() {
+        }
+
+        @SdkPublicApi
+        AnnotatedRequestBuilder service(@NotNull String service) {
+            this.service = requireText(service, "service");
+            return this;
+        }
+
+        @SdkPublicApi
+        AnnotatedRequestBuilder region(@NotNull String region) {
+            this.region = requireText(region, "region");
+            return this;
+        }
+
+        @SdkPublicApi
+        AnnotatedRequestBuilder operation(@NotNull String operation) {
+            this.operation = requireText(operation, "operation");
+            return this;
+        }
+
+        @SdkPreviewApi
+        AnnotatedRequestBuilder putAttribute(@NotNull String name, @NotNull String value) {
+            attributes.put(requireText(name, "name"), requireText(value, "value"));
+            return this;
+        }
+
+        @SdkProtectedApi
+        AnnotatedRequestBuilder withCachedSigningRegion(@NotNull String signingRegion) {
+            this.cachedSigningRegion = requireText(signingRegion, "signingRegion");
+            return this;
+        }
+
+        @ToBuilderIgnoreField({"cachedSigningRegion", "attributes"})
+        List<String> ignoredBuilderFields() {
+            return List.of("cachedSigningRegion", "attributes");
+        }
+
+        @SdkPublicApi
+        ServiceOperation build() {
+            String resolvedService = requireText(service, "service");
+            String resolvedRegion = requireText(region, "region");
+            String resolvedOperation = requireText(operation, "operation");
+            String signingRegion = cachedSigningRegion == null ? resolvedRegion : cachedSigningRegion;
+            Map<String, String> resolvedAttributes = new LinkedHashMap<>(attributes);
+            resolvedAttributes.put("endpoint", resolvedService + "." + resolvedRegion + ".amazonaws.com");
+            return new ServiceOperation(
+                    resolvedService,
+                    resolvedRegion,
+                    resolvedOperation,
+                    signingRegion,
+                    Map.copyOf(resolvedAttributes));
+        }
+
+        private static String requireText(String value, String fieldName) {
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException(fieldName + " must not be blank");
+            }
+            return value;
+        }
+    }
+
+    @Immutable
+    @ThreadSafe
+    @SdkPublicApi
+    record ServiceOperation(
+            @NotNull String service,
+            @NotNull String region,
+            @NotNull String operation,
+            @SdkInternalApi String signingRegion,
+            @SdkProtectedApi Map<String, String> attributes) {
     }
 
     @SdkTestInternalApi

--- a/tests/src/software.amazon.awssdk/annotations/2.34.0/user-code-filter.json
+++ b/tests/src/software.amazon.awssdk/annotations/2.34.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "software.amazon.awssdk.annotations.**"
+    },
+    {
+      "includeClasses" : "software_amazon_awssdk.annotations.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4514

This PR introduces tests and metadata for software.amazon.awssdk:annotations:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 97269
- Cached input tokens: 863232
- Output tokens: 13746
- Metadata entries: 0
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 594
- Tested library lines of code: 0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `7cd119e987c47e2994bef806fcfe9050bb7e9d70`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: N/A
- Line: N/A
- Method: N/A

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
