### PR TITLE
[GenAI] Add support for org.aesh:aesh:2.8.2 using gpt-5.5

### DIFF
--- a/metadata/org.aesh/aesh/2.8.2/reachability-metadata.json
+++ b/metadata/org.aesh/aesh/2.8.2/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedOptionBuilder"
+      },
+      "type" : "org.aesh.command.impl.parser.AeshOptionParser",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedOptionBuilder"
+      },
+      "type" : "org.aesh.command.impl.completer.BooleanOptionCompleter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.aesh/aesh/index.json
+++ b/metadata/org.aesh/aesh/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.8.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/aesh/aesh/$version$/aesh-$version$-sources.jar",
+    "repository-url" : "https://github.com/aeshell/aesh",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/aesh/aesh/$version$/aesh-$version$-tests.jar",
+    "documentation-url" : "https://github.com/aeshell/aesh/tree/$version$/docs",
+    "description" : "Aesh is a Java library for building command-line interfaces and interactive shells. It provides command parsing, completion, history, terminal input handling, and related console utilities.",
+    "tested-versions" : [
+      "2.8.2"
+    ],
+    "allowed-packages" : [
+      "org.aesh"
+    ]
+  }
+]

--- a/stats/org.aesh/aesh/2.8.2/execution-metrics.json
+++ b/stats/org.aesh/aesh/2.8.2/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-05-04": {
+    "timestamp": "2026-05-04T23:37:31.176233Z",
+    "library": "org.aesh:aesh:2.8.2",
+    "starting_commit": "d22d625262503817e9446e3bca9b203bf044c773",
+    "ending_commit": "60b4a0669baa1ddc41e095f310fef4f87362fd04",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.8.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.314286,
+            "coveredCalls": 11,
+            "totalCalls": 35
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.305556,
+        "coveredCalls": 11,
+        "totalCalls": 36
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7592,
+          "missed": 23440,
+          "ratio": 0.244651,
+          "total": 31032
+        },
+        "line": {
+          "covered": 1723,
+          "missed": 5006,
+          "ratio": 0.256056,
+          "total": 6729
+        },
+        "method": {
+          "covered": 448,
+          "missed": 1117,
+          "ratio": 0.286262,
+          "total": 1565
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 206982,
+      "cached_input_tokens_used": 2203648,
+      "output_tokens_used": 20089,
+      "iterations": 4,
+      "cost_usd": 1.7045,
+      "generated_loc": 363,
+      "tested_library_loc": 1723,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 18,
+      "code_coverage_percent": 25.61
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java",
+      "metadata_file": "metadata/org.aesh/aesh/2.8.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.aesh/aesh/2.8.2/stats.json
+++ b/stats/org.aesh/aesh/2.8.2/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.8.2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.314286,
+          "coveredCalls" : 11,
+          "totalCalls" : 35
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.305556,
+      "coveredCalls" : 11,
+      "totalCalls" : 36
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7592,
+        "missed" : 23440,
+        "ratio" : 0.244651,
+        "total" : 31032
+      },
+      "line" : {
+        "covered" : 1723,
+        "missed" : 5006,
+        "ratio" : 0.256056,
+        "total" : 6729
+      },
+      "method" : {
+        "covered" : 448,
+        "missed" : 1117,
+        "ratio" : 0.286262,
+        "total" : 1565
+      }
+    }
+  } ]
+}

--- a/tests/src/org.aesh/aesh/2.8.2/.gitignore
+++ b/tests/src/org.aesh/aesh/2.8.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.aesh/aesh/2.8.2/build.gradle
+++ b/tests/src/org.aesh/aesh/2.8.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.aesh:aesh:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.aesh/aesh/2.8.2/gradle.properties
+++ b/tests/src/org.aesh/aesh/2.8.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.aesh:aesh:2.8.2
+library.version = 2.8.2
+metadata.dir = org.aesh/aesh/2.8.2/

--- a/tests/src/org.aesh/aesh/2.8.2/settings.gradle
+++ b/tests/src/org.aesh/aesh/2.8.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.aesh.aesh_tests'

--- a/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
+++ b/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.aesh.command.AeshCommandRuntimeBuilder;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
 import org.aesh.command.CommandRuntime;
 import org.aesh.command.GroupCommandDefinition;
@@ -37,6 +38,9 @@ import org.aesh.command.option.Arguments;
 import org.aesh.command.option.Option;
 import org.aesh.command.option.OptionList;
 import org.aesh.command.registry.CommandRegistry;
+import org.aesh.command.result.ResultHandler;
+import org.aesh.command.validator.CommandValidator;
+import org.aesh.command.validator.CommandValidatorException;
 import org.aesh.command.validator.OptionValidator;
 import org.aesh.command.validator.OptionValidatorException;
 import org.aesh.command.validator.ValidatorInvocation;
@@ -57,11 +61,17 @@ import org.junit.jupiter.api.io.TempDir;
 public class AeshTest {
     private static RecipeExecution lastRecipeExecution;
     private static String lastAdminExecution;
+    private static String lastValidatedTask;
+    private static String lastTaskExecution;
+    private static String lastResultHandlerEvent;
 
     @BeforeEach
     void resetCapturedExecutions() {
         lastRecipeExecution = null;
         lastAdminExecution = null;
+        lastValidatedTask = null;
+        lastTaskExecution = null;
+        lastResultHandlerEvent = null;
     }
 
     @Test
@@ -131,6 +141,29 @@ public class AeshTest {
         assertThat(lastAdminExecution).isEqualTo("status:production");
         assertThat(runtime.getCommandRegistry().getAllCommandNames()).contains("admin");
         assertThat(runtime.commandInfo("admin")).contains("Administrative commands").contains("status");
+    }
+
+    @Test
+    void commandValidatorAndResultHandlerObserveCommandOutcomes() throws Exception {
+        CommandRuntime<CommandInvocation> runtime = runtimeFor(ValidatedTaskCommand.class);
+
+        CommandResult result = runtime.executeCommand("task --name deploy");
+
+        assertThat(result).isEqualTo(CommandResult.SUCCESS);
+        assertThat(lastValidatedTask).isEqualTo("deploy");
+        assertThat(lastTaskExecution).isEqualTo("deploy");
+        assertThat(lastResultHandlerEvent).isEqualTo("success");
+
+        lastValidatedTask = null;
+        lastTaskExecution = null;
+        lastResultHandlerEvent = null;
+
+        assertThatThrownBy(() -> runtime.executeCommand("task --name forbidden"))
+                .isInstanceOf(CommandValidatorException.class)
+                .hasMessageContaining("forbidden");
+        assertThat(lastValidatedTask).isEqualTo("forbidden");
+        assertThat(lastTaskExecution).isNull();
+        assertThat(lastResultHandlerEvent).isEqualTo("validation:CommandValidatorException");
     }
 
     @Test
@@ -297,6 +330,54 @@ public class AeshTest {
         public CommandResult execute(CommandInvocation commandInvocation) {
             lastAdminExecution = "status:" + name;
             return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(
+            name = "task",
+            description = "Runs a validated task",
+            validator = TaskCommandValidator.class,
+            resultHandler = TaskResultHandler.class)
+    public static class ValidatedTaskCommand implements Command<CommandInvocation> {
+        @Option(name = "name", required = true, description = "Task name")
+        private String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) {
+            lastTaskExecution = name;
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    public static class TaskCommandValidator implements CommandValidator<ValidatedTaskCommand, CommandInvocation> {
+        @Override
+        public void validate(ValidatedTaskCommand command) throws CommandValidatorException {
+            lastValidatedTask = command.name;
+            if ("forbidden".equals(command.name)) {
+                throw new CommandValidatorException("forbidden task names are rejected");
+            }
+        }
+    }
+
+    public static class TaskResultHandler implements ResultHandler {
+        @Override
+        public void onSuccess() {
+            lastResultHandlerEvent = "success";
+        }
+
+        @Override
+        public void onFailure(CommandResult commandResult) {
+            lastResultHandlerEvent = "failure:" + commandResult.getResultValue();
+        }
+
+        @Override
+        public void onValidationFailure(CommandResult commandResult, Exception exception) {
+            lastResultHandlerEvent = "validation:" + exception.getClass().getSimpleName();
+        }
+
+        @Override
+        public void onExecutionFailure(CommandResult commandResult, CommandException exception) {
+            lastResultHandlerEvent = "execution:" + exception.getClass().getSimpleName();
         }
     }
 

--- a/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
+++ b/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_aesh.aesh;
+
+import org.junit.jupiter.api.Test;
+
+class AeshTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
+++ b/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
@@ -28,6 +28,8 @@ import org.aesh.command.completer.CompleterInvocation;
 import org.aesh.command.completer.OptionCompleter;
 import org.aesh.command.converter.Converter;
 import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.export.ExportManager;
+import org.aesh.command.export.ExportPreProcessor;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.operator.OperatorType;
@@ -153,6 +155,29 @@ public class AeshTest {
 
         ParsedLine invalidLine = new LineParser().parseLine("recipe \"unterminated");
         assertThat(invalidLine.status()).isEqualTo(ParserStatus.UNCLOSED_QUOTE);
+    }
+
+    @Test
+    void exportManagerExpandsVariablesAndProvidesCompletionNames(@TempDir Path tempDir) {
+        ExportManager manager = new ExportManager(tempDir.resolve("exports").toFile());
+
+        assertThat(manager.addVariable("export BASE=/opt/aesh")).isNull();
+        assertThat(manager.addVariable("export BIN=$BASE/bin")).isNull();
+        assertThat(manager.addVariable("export MODE=fast")).isNull();
+
+        assertThat(manager.keys()).containsExactlyInAnyOrder("BASE", "BIN", "MODE");
+        assertThat(manager.getValue("BIN")).isEqualTo("/opt/aesh/bin");
+        assertThat(manager.getValue("run-${BIN}:$MODE")).isEqualTo("run-/opt/aesh/bin:fast");
+        assertThat(manager.getValueIgnoreCase("mode")).isEqualTo("fast");
+        assertThat(manager.findAllMatchingKeys("$B")).containsExactlyInAnyOrder("$BASE", "$BIN");
+        assertThat(manager.getAllNamesWithEquals()).contains("BASE=", "BIN=", "MODE=");
+        assertThat(manager.listAllVariables())
+                .contains("BASE=/opt/aesh")
+                .contains("BIN=/opt/aesh/bin")
+                .contains("MODE=fast");
+
+        ExportPreProcessor preProcessor = new ExportPreProcessor(manager);
+        assertThat(preProcessor.apply("$BIN/tool --mode=$MODE")).contains("/opt/aesh/bin/tool --mode=fast");
     }
 
     @Test

--- a/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
+++ b/tests/src/org.aesh/aesh/2.8.2/src/test/java/org_aesh/aesh/AeshTest.java
@@ -6,11 +6,312 @@
  */
 package org_aesh.aesh;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class AeshTest {
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.aesh.command.AeshCommandRuntimeBuilder;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandResult;
+import org.aesh.command.CommandRuntime;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.command.completer.OptionCompleter;
+import org.aesh.command.converter.Converter;
+import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.operator.OperatorType;
+import org.aesh.command.option.Arguments;
+import org.aesh.command.option.Option;
+import org.aesh.command.option.OptionList;
+import org.aesh.command.registry.CommandRegistry;
+import org.aesh.command.validator.OptionValidator;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.command.validator.ValidatorInvocation;
+import org.aesh.complete.AeshCompleteOperation;
+import org.aesh.io.FileResource;
+import org.aesh.io.Resource;
+import org.aesh.io.filter.AllResourceFilter;
+import org.aesh.io.filter.DirectoryResourceFilter;
+import org.aesh.io.filter.NoDotNamesFilter;
+import org.aesh.parser.LineParser;
+import org.aesh.parser.ParsedLine;
+import org.aesh.parser.ParserStatus;
+import org.aesh.readline.terminal.formatting.TerminalString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class AeshTest {
+    private static RecipeExecution lastRecipeExecution;
+    private static String lastAdminExecution;
+
+    @BeforeEach
+    void resetCapturedExecutions() {
+        lastRecipeExecution = null;
+        lastAdminExecution = null;
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void annotatedCommandParsesOptionsArgumentsListsConvertersAndValidators() throws Exception {
+        CommandRuntime<CommandInvocation> runtime = runtimeFor(RecipeCommand.class);
+
+        CommandResult result = runtime.executeCommand(
+                "recipe --count 3x2 --mode fast --tag dinner,quick --tag vegan --verbose flour sugar");
+
+        assertThat(result).isEqualTo(CommandResult.SUCCESS);
+        assertThat(lastRecipeExecution.count()).isEqualTo(6);
+        assertThat(lastRecipeExecution.mode()).isEqualTo("fast");
+        assertThat(lastRecipeExecution.verbose()).isTrue();
+        assertThat(lastRecipeExecution.tags()).containsExactly("dinner", "quick", "vegan");
+        assertThat(lastRecipeExecution.ingredients()).containsExactly("flour", "sugar");
+    }
+
+    @Test
+    void aliasesDefaultsAndValidationAreAppliedByTheCommandRuntime() throws Exception {
+        CommandRuntime<CommandInvocation> runtime = runtimeFor(RecipeCommand.class);
+
+        CommandResult result = runtime.executeCommand("cook --tag quick oats");
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(lastRecipeExecution.count()).isEqualTo(1);
+        assertThat(lastRecipeExecution.mode()).isEqualTo("slow");
+        assertThat(lastRecipeExecution.verbose()).isFalse();
+        assertThat(lastRecipeExecution.tags()).containsExactly("quick");
+        assertThat(lastRecipeExecution.ingredients()).containsExactly("oats");
+        assertThat(runtime.commandInfo("recipe"))
+                .contains("Builds a recipe")
+                .contains("--count")
+                .contains("--mode");
+
+        assertThatThrownBy(() -> runtime.executeCommand("recipe --count 0 flour"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(OptionValidatorException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void completionUsesRegisteredCommandsOptionsAndCustomOptionCompleters() throws Exception {
+        CommandRuntime<CommandInvocation> runtime = runtimeFor(RecipeCommand.class);
+
+        AeshCompleteOperation commandCompletion = new AeshCompleteOperation("rec", "rec".length());
+        runtime.complete(commandCompletion);
+        assertThat(candidateCharacters(commandCompletion)).contains("recipe");
+
+        String optionInput = "recipe --co";
+        AeshCompleteOperation optionCompletion = new AeshCompleteOperation(optionInput, optionInput.length());
+        runtime.complete(optionCompletion);
+        assertThat(candidateCharacters(optionCompletion)).contains("--count=");
+
+        String valueInput = "recipe --mode f";
+        AeshCompleteOperation valueCompletion = new AeshCompleteOperation(valueInput, valueInput.length());
+        runtime.complete(valueCompletion);
+        assertThat(candidateCharacters(valueCompletion)).contains("fast");
+    }
+
+    @Test
+    void groupCommandDispatchesToAnnotatedChildCommands() throws Exception {
+        CommandRuntime<CommandInvocation> runtime = runtimeFor(AdminCommand.class);
+
+        CommandResult result = runtime.executeCommand("admin status --name production");
+
+        assertThat(result).isEqualTo(CommandResult.SUCCESS);
+        assertThat(lastAdminExecution).isEqualTo("status:production");
+        assertThat(runtime.getCommandRegistry().getAllCommandNames()).contains("admin");
+        assertThat(runtime.commandInfo("admin")).contains("Administrative commands").contains("status");
+    }
+
+    @Test
+    void lineParserHandlesQuotingCursorSelectionAndOperators() {
+        ParsedLine parsedLine = new LineParser().parseLine("recipe --mode \"very fast\" ingredient", 18);
+
+        assertThat(parsedLine.status()).isEqualTo(ParserStatus.OK);
+        assertThat(parsedLine.words()).extracting(word -> word.word())
+                .containsExactly("recipe", "--mode", "very fast", "ingredient");
+        assertThat(parsedLine.selectedWord().word()).isEqualTo("very fast");
+        assertThat(parsedLine.wordCursor()).isPositive();
+
+        List<ParsedLine> pipeline = new LineParser()
+                .input("recipe flour\\ sugar | admin status")
+                .operators(EnumSet.of(OperatorType.PIPE))
+                .parseWithOperators();
+        assertThat(pipeline).hasSize(2);
+        assertThat(pipeline.get(0).operator()).isEqualTo(OperatorType.PIPE);
+        assertThat(pipeline.get(0).words()).extracting(word -> word.word()).containsExactly("recipe", "flour sugar");
+        assertThat(pipeline.get(1).operator()).isEqualTo(OperatorType.NONE);
+        assertThat(pipeline.get(1).words()).extracting(word -> word.word()).containsExactly("admin", "status");
+
+        ParsedLine invalidLine = new LineParser().parseLine("recipe \"unterminated");
+        assertThat(invalidLine.status()).isEqualTo(ParserStatus.UNCLOSED_QUOTE);
+    }
+
+    @Test
+    void fileResourcesReadWriteListFilterAndCopy(@TempDir Path tempDir) throws Exception {
+        Path visibleDirectory = Files.createDirectory(tempDir.resolve("visible"));
+        Path hiddenDirectory = Files.createDirectory(tempDir.resolve(".hidden"));
+        Path sourceFile = tempDir.resolve("source.txt");
+        Files.writeString(sourceFile, "aesh resource", StandardCharsets.UTF_8);
+        Files.writeString(visibleDirectory.resolve("nested.txt"), "nested", StandardCharsets.UTF_8);
+        Files.writeString(hiddenDirectory.resolve("secret.txt"), "secret", StandardCharsets.UTF_8);
+
+        Resource root = new FileResource(tempDir);
+        Resource source = new FileResource(sourceFile);
+        Resource target = new FileResource(tempDir.resolve("target.txt"));
+
+        assertThat(root.exists()).isTrue();
+        assertThat(root.isDirectory()).isTrue();
+        assertThat(source.isLeaf()).isTrue();
+        assertThat(resourceNames(root.list(new AllResourceFilter())))
+                .contains("visible", ".hidden", "source.txt");
+        assertThat(resourceNames(root.list(new DirectoryResourceFilter())))
+                .contains("visible", ".hidden")
+                .doesNotContain("source.txt");
+        assertThat(resourceNames(root.list(new NoDotNamesFilter())))
+                .contains("visible", "source.txt")
+                .doesNotContain(".hidden");
+
+        source.copy(target);
+        try (InputStream inputStream = target.read()) {
+            assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("aesh resource");
+        }
+
+        Resource created = root.newInstance(tempDir.resolve("created.txt").toString());
+        try (OutputStream outputStream = created.write(false)) {
+            outputStream.write("created".getBytes(StandardCharsets.UTF_8));
+        }
+        assertThat(Files.readString(tempDir.resolve("created.txt"), StandardCharsets.UTF_8)).isEqualTo("created");
+    }
+
+    private static CommandRuntime<CommandInvocation> runtimeFor(Class<? extends Command> command) throws Exception {
+        CommandRegistry<CommandInvocation> registry = AeshCommandRegistryBuilder.<CommandInvocation>builder()
+                .command(command)
+                .create();
+        return AeshCommandRuntimeBuilder.<CommandInvocation>builder()
+                .commandRegistry(registry)
+                .build();
+    }
+
+    private static List<String> candidateCharacters(AeshCompleteOperation operation) {
+        return operation.getCompletionCandidates().stream()
+                .map(TerminalString::getCharacters)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> resourceNames(List<Resource> resources) {
+        return resources.stream()
+                .map(Resource::getName)
+                .collect(Collectors.toList());
+    }
+
+    @CommandDefinition(
+            name = "recipe",
+            aliases = {"cook"},
+            description = "Builds a recipe from command line ingredients",
+            generateHelp = true)
+    public static class RecipeCommand implements Command<CommandInvocation> {
+        @Option(
+                name = "count",
+                shortName = 'c',
+                description = "Number of batches",
+                defaultValue = {"1"},
+                converter = MultiplierConverter.class,
+                validator = PositiveIntegerValidator.class)
+        private Integer count;
+
+        @Option(
+                name = "mode",
+                description = "Preparation mode",
+                defaultValue = {"slow"},
+                completer = ModeCompleter.class)
+        private String mode;
+
+        @Option(name = "verbose", shortName = 'v', description = "Enable verbose output", hasValue = false)
+        private boolean verbose;
+
+        @OptionList(name = "tag", shortName = 't', description = "Recipe tags", valueSeparator = ',')
+        private List<String> tags;
+
+        @Arguments(description = "Ingredients")
+        private List<String> ingredients;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) {
+            lastRecipeExecution = new RecipeExecution(count, mode, verbose, tags, ingredients);
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @GroupCommandDefinition(
+            name = "admin",
+            description = "Administrative commands",
+            groupCommands = {AdminStatusCommand.class})
+    public static class AdminCommand implements Command<CommandInvocation> {
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) {
+            lastAdminExecution = "admin";
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    @CommandDefinition(name = "status", description = "Shows status for a named environment")
+    public static class AdminStatusCommand implements Command<CommandInvocation> {
+        @Option(name = "name", required = true, description = "Environment name")
+        private String name;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) {
+            lastAdminExecution = "status:" + name;
+            return CommandResult.SUCCESS;
+        }
+    }
+
+    public static class MultiplierConverter implements Converter<Integer, ConverterInvocation> {
+        @Override
+        public Integer convert(ConverterInvocation invocation) throws OptionValidatorException {
+            String input = invocation.getInput();
+            if (input.contains("x")) {
+                String[] factors = input.split("x", -1);
+                int product = 1;
+                for (String factor : factors) {
+                    product *= Integer.parseInt(factor);
+                }
+                return product;
+            }
+            return Integer.valueOf(input);
+        }
+    }
+
+    public static class PositiveIntegerValidator implements OptionValidator<ValidatorInvocation<Integer, RecipeCommand>> {
+        @Override
+        public void validate(ValidatorInvocation<Integer, RecipeCommand> invocation) throws OptionValidatorException {
+            if (invocation.getValue() == null || invocation.getValue() <= 0) {
+                throw new OptionValidatorException("count must be positive");
+            }
+        }
+    }
+
+    public static class ModeCompleter implements OptionCompleter<CompleterInvocation> {
+        @Override
+        public void complete(CompleterInvocation invocation) {
+            invocation.setCompleterValues(List.of("fast", "slow", "balanced"));
+        }
+    }
+
+    private record RecipeExecution(
+            Integer count,
+            String mode,
+            boolean verbose,
+            List<String> tags,
+            List<String> ingredients) {
     }
 }

--- a/tests/src/org.aesh/aesh/2.8.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.aesh/aesh/2.8.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,112 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedOptionBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$MultiplierConverter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedOptionBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$PositiveIntegerValidator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedOptionBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$ModeCompleter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.container.AeshCommandContainerBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$RecipeCommand",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.container.AeshCommandContainerBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$AdminCommand",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.container.AeshCommandContainerBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$AdminStatusCommand",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.container.AeshCommandContainerBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$ValidatedTaskCommand",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedCommandBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$TaskCommandValidator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.aesh.command.impl.internal.ProcessedCommandBuilder"
+      },
+      "type" : "org_aesh.aesh.AeshTest$TaskResultHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.aesh/aesh/2.8.2/user-code-filter.json
+++ b/tests/src/org.aesh/aesh/2.8.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.aesh.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3756

This PR introduces tests and metadata for org.aesh:aesh:2.8.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 206982
- Cached input tokens: 2203648
- Output tokens: 20089
- Metadata entries: 4
- Test-only metadata entries: 18
- Iterations: 4
- Library coverage percentage: 25.61
- Generated lines of code: 363
- Tested library lines of code: 1723

### Metadata/dynamic-access evidence

- Covered dynamic-access calls: 11
- Metadata entries: 4
- These counts are different dimensions: covered dynamic-access calls count observed call sites, while metadata entries count generated reachability-config items. A single metadata entry can cover multiple observed call sites when they require the same reachability rule.

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `forge/shared-issue-search-cache`
- Forge commit hash: `21ea63bcf6cd21dc2893a5675c11b45a73f0f53e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 11/36 covered calls (30.56%)
- Reflection: 11/35 covered calls (31.43%)
- Resources: 0/1 covered calls (0.00%)

Library coverage:
- Instruction: 7592/31032 (24.47%)
- Line: 1723/6729 (25.61%)
- Method: 448/1565 (28.63%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
