### PR TITLE
[GenAI] Add support for net.sf.ehcache:ehcache-core:2.4.4 using gpt-5.5

### DIFF
--- a/metadata/net.sf.ehcache/ehcache-core/2.4.4/reachability-metadata.json
+++ b/metadata/net.sf.ehcache/ehcache-core/2.4.4/reachability-metadata.json
@@ -1,0 +1,53 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.CacheManager"
+      },
+      "type": "org.slf4j.LoggerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.ElementValueComparatorConfiguration"
+      },
+      "type": "net.sf.ehcache.store.DefaultElementValueComparator",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.CopyStrategyConfiguration"
+      },
+      "type": "net.sf.ehcache.store.compound.ReadWriteSerializationCopyStrategy",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.SearchAttribute"
+      },
+      "type": "net.sf.ehcache.search.attribute.ValueObjectAttributeExtractor",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.SearchAttribute"
+      },
+      "type": "net.sf.ehcache.search.attribute.KeyObjectAttributeExtractor",
+      "allPublicConstructors": true
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.BeanHandler"
+      },
+      "type": "net.sf.ehcache.config.Configuration",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "net.sf.ehcache.config.BeanHandler"
+      },
+      "type": "net.sf.ehcache.config.CacheConfiguration",
+      "allPublicConstructors": true,
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/net.sf.ehcache/ehcache-core/index.json
+++ b/metadata/net.sf.ehcache/ehcache-core/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.4.4",
+    "source-code-url" : "https://repo1.maven.org/maven2/net/sf/ehcache/ehcache-core/$version$/ehcache-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/ehcache/ehcache2",
+    "test-code-url" : "https://github.com/ehcache/ehcache2/tree/ehcache-core-$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/net/sf/ehcache/ehcache-core/$version$/ehcache-core-$version$-javadoc.jar",
+    "description" : "Ehcache Core provides the core implementation of Ehcache 2, an embeddable Java cache for improving application performance and reducing backend load. It supplies cache management, configuration, eviction, persistence, and integration extension points that can be paired with other Ehcache modules for clustering, web, or framework support.",
+    "tested-versions" : [
+      "2.4.4"
+    ],
+    "allowed-packages" : [
+      "net.sf.ehcache"
+    ]
+  }
+]

--- a/stats/net.sf.ehcache/ehcache-core/2.4.4/execution-metrics.json
+++ b/stats/net.sf.ehcache/ehcache-core/2.4.4/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "add_new_library_support:2026-05-05": {
+    "timestamp": "2026-05-05T01:27:50.513656Z",
+    "library": "net.sf.ehcache:ehcache-core:2.4.4",
+    "starting_commit": "9627fd095028d473137aa1dea3cb1e2ed794fc6c",
+    "ending_commit": "ece5331e44845fec67e0dcaabbd8463b6698f578",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.4.4",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.194805,
+            "coveredCalls": 15,
+            "totalCalls": 77
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 0.189873,
+        "coveredCalls": 15,
+        "totalCalls": 79
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11114,
+          "missed": 70410,
+          "ratio": 0.136328,
+          "total": 81524
+        },
+        "line": {
+          "covered": 2847,
+          "missed": 15839,
+          "ratio": 0.15236,
+          "total": 18686
+        },
+        "method": {
+          "covered": 817,
+          "missed": 4359,
+          "ratio": 0.157844,
+          "total": 5176
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 144623,
+      "cached_input_tokens_used": 1093632,
+      "output_tokens_used": 18954,
+      "iterations": 5,
+      "cost_usd": 1.1154,
+      "generated_loc": 444,
+      "tested_library_loc": 2847,
+      "metadata_entries": 14,
+      "code_coverage_percent": 15.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java",
+      "metadata_file": "metadata/net.sf.ehcache/ehcache-core/2.4.4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.sf.ehcache/ehcache-core/2.4.4/stats.json
+++ b/stats/net.sf.ehcache/ehcache-core/2.4.4/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.4.4",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.194805,
+          "coveredCalls" : 15,
+          "totalCalls" : 77
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 0.189873,
+      "coveredCalls" : 15,
+      "totalCalls" : 79
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11114,
+        "missed" : 70410,
+        "ratio" : 0.136328,
+        "total" : 81524
+      },
+      "line" : {
+        "covered" : 2847,
+        "missed" : 15839,
+        "ratio" : 0.15236,
+        "total" : 18686
+      },
+      "method" : {
+        "covered" : 817,
+        "missed" : 4359,
+        "ratio" : 0.157844,
+        "total" : 5176
+      }
+    }
+  } ]
+}

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/.gitignore
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/build.gradle
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.sf.ehcache:ehcache-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/build.gradle
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/build.gradle
@@ -13,6 +13,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "net.sf.ehcache:ehcache-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 graalvmNative {

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/gradle.properties
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.sf.ehcache:ehcache-core:2.4.4
+library.version = 2.4.4
+metadata.dir = net.sf.ehcache/ehcache-core/2.4.4/

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/settings.gradle
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.sf.ehcache.ehcache-core_tests'

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
@@ -41,6 +41,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -210,6 +214,48 @@ public class Ehcache_coreTest {
             assertThat(createdByRefresh.getObjectValue()).isEqualTo("beta:generated:3");
             assertThat(backingCache.getKeys()).containsExactlyInAnyOrder("alpha", "beta");
         } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void explicitKeyLocksCoordinateConcurrentAccess() throws Exception {
+        CacheManager manager = newCacheManager("locking",
+                new CacheConfiguration("locks", 10)
+                        .eternal(true)
+                        .overflowToDisk(false));
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Cache cache = manager.getCache("locks");
+            cache.put(new Element("locked", "initial"));
+
+            cache.acquireWriteLockOnKey("locked");
+            try {
+                assertThat(cache.isWriteLockedByCurrentThread("locked")).isTrue();
+
+                Future<Boolean> blockedReader = executor.submit(() -> cache.tryReadLockOnKey("locked", 100L));
+                assertThat(blockedReader.get(1L, TimeUnit.SECONDS)).isFalse();
+            } finally {
+                cache.releaseWriteLockOnKey("locked");
+            }
+            assertThat(cache.isWriteLockedByCurrentThread("locked")).isFalse();
+
+            Future<Boolean> successfulWriter = executor.submit(() -> {
+                if (!cache.tryWriteLockOnKey("locked", 1_000L)) {
+                    return false;
+                }
+                try {
+                    cache.put(new Element("locked", "updated"));
+                    return true;
+                } finally {
+                    cache.releaseWriteLockOnKey("locked");
+                }
+            });
+            assertThat(successfulWriter.get(2L, TimeUnit.SECONDS)).isTrue();
+            assertThat(cache.get("locked").getObjectValue()).isEqualTo("updated");
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(2L, TimeUnit.SECONDS)).isTrue();
             manager.shutdown();
         }
     }

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
@@ -18,6 +18,8 @@ import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.CacheWriterConfiguration;
 import net.sf.ehcache.config.Configuration;
 import net.sf.ehcache.config.Searchable;
+import net.sf.ehcache.constructs.blocking.CacheEntryFactory;
+import net.sf.ehcache.constructs.blocking.SelfPopulatingCache;
 import net.sf.ehcache.event.CacheEventListener;
 import net.sf.ehcache.loader.CacheLoader;
 import net.sf.ehcache.management.ManagementService;
@@ -179,6 +181,40 @@ public class Ehcache_coreTest {
     }
 
     @Test
+    void selfPopulatingCacheCreatesAndRefreshesEntriesOnDemand() throws Exception {
+        CacheManager manager = newCacheManager("selfPopulating",
+                new CacheConfiguration("generatedValues", 10)
+                        .eternal(true)
+                        .overflowToDisk(false)
+                        .statistics(true));
+        try {
+            Cache backingCache = manager.getCache("generatedValues");
+            SequencedCacheEntryFactory factory = new SequencedCacheEntryFactory();
+            SelfPopulatingCache cache = new SelfPopulatingCache(backingCache, factory);
+
+            Element generated = cache.get("alpha");
+            assertThat(generated.getObjectValue()).isEqualTo("alpha:generated:1");
+            assertThat(backingCache.get("alpha").getObjectValue()).isEqualTo("alpha:generated:1");
+            assertThat(factory.created.get()).isEqualTo(1);
+
+            Element cached = cache.get("alpha");
+            assertThat(cached.getObjectValue()).isEqualTo("alpha:generated:1");
+            assertThat(factory.created.get()).isEqualTo(1);
+
+            Element refreshed = cache.refresh("alpha");
+            assertThat(refreshed.getObjectValue()).isEqualTo("alpha:generated:2");
+            assertThat(cache.get("alpha").getObjectValue()).isEqualTo("alpha:generated:2");
+            assertThat(factory.created.get()).isEqualTo(2);
+
+            Element createdByRefresh = cache.refresh("beta");
+            assertThat(createdByRefresh.getObjectValue()).isEqualTo("beta:generated:3");
+            assertThat(backingCache.getKeys()).containsExactlyInAnyOrder("alpha", "beta");
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     void xmlConfigurationInputStreamBuildsUsableCaches() throws Exception {
         String managerName = uniqueName("xml");
         String xml = """
@@ -267,6 +303,15 @@ public class Ehcache_coreTest {
 
     private static String uniqueName(String scenario) {
         return "ehcacheCore" + scenario + MANAGER_IDS.incrementAndGet();
+    }
+
+    private static final class SequencedCacheEntryFactory implements CacheEntryFactory {
+        private final AtomicInteger created = new AtomicInteger();
+
+        @Override
+        public Object createEntry(Object key) throws Exception {
+            return key + ":generated:" + created.incrementAndGet();
+        }
     }
 
     private static final class CountingCacheEventListener implements CacheEventListener {

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_sf_ehcache.ehcache_core;
+
+import org.junit.jupiter.api.Test;
+
+class Ehcache_coreTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/src/test/java/net_sf_ehcache/ehcache_core/Ehcache_coreTest.java
@@ -6,11 +6,413 @@
  */
 package net_sf_ehcache.ehcache_core;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheEntry;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.Statistics;
+import net.sf.ehcache.Status;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.CacheWriterConfiguration;
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.config.Searchable;
+import net.sf.ehcache.event.CacheEventListener;
+import net.sf.ehcache.loader.CacheLoader;
+import net.sf.ehcache.management.ManagementService;
+import net.sf.ehcache.search.Attribute;
+import net.sf.ehcache.search.Direction;
+import net.sf.ehcache.search.Query;
+import net.sf.ehcache.search.Result;
+import net.sf.ehcache.search.Results;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+import net.sf.ehcache.writer.CacheWriter;
 import org.junit.jupiter.api.Test;
 
-class Ehcache_coreTest {
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Ehcache_coreTest {
+    private static final AtomicInteger MANAGER_IDS = new AtomicInteger();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void programmaticCacheManagerSupportsCoreElementOperations() throws Exception {
+        CacheManager manager = newCacheManager("programmatic",
+                new CacheConfiguration("users", 10)
+                        .eternal(true)
+                        .overflowToDisk(false)
+                        .statistics(true));
+        try {
+            assertThat(manager.getStatus()).isEqualTo(Status.STATUS_ALIVE);
+            assertThat(manager.getCacheNames()).containsExactly("users");
+
+            manager.addCache("fromDefault");
+            assertThat(manager.cacheExists("fromDefault")).isTrue();
+            assertThat(manager.getCache("fromDefault").getCacheConfiguration().getMaxElementsInMemory()).isEqualTo(50);
+
+            Cache cache = manager.getCache("users");
+            cache.put(new Element("alice", "Alice"));
+            assertThat(cache.get("alice").getObjectValue()).isEqualTo("Alice");
+            assertThat(cache.isKeyInCache("alice")).isTrue();
+            assertThat(cache.isValueInCache("Alice")).isTrue();
+
+            Element existing = cache.putIfAbsent(new Element("alice", "Not stored"));
+            assertThat(existing.getObjectValue()).isEqualTo("Alice");
+            assertThat(cache.replace(new Element("alice", "Alice"), new Element("alice", "Bob"))).isTrue();
+            Element replaced = cache.replace(new Element("alice", "Carol"));
+            assertThat(replaced.getObjectValue()).isEqualTo("Bob");
+            assertThat(cache.removeElement(new Element("alice", "Carol"))).isTrue();
+            assertThat(cache.get("alice")).isNull();
+
+            cache.put(new Element("one", 1));
+            cache.put(new Element("two", 2));
+            assertThat(cache.getKeys()).containsExactlyInAnyOrder("one", "two");
+            manager.clearAll();
+            assertThat(cache.getSize()).isZero();
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void eventNotificationsEvictionExpiryAndStatisticsAreObservable() throws Exception {
+        CacheManager manager = newCacheManager("events",
+                new CacheConfiguration("events", 2)
+                        .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.FIFO)
+                        .eternal(false)
+                        .timeToLiveSeconds(1)
+                        .timeToIdleSeconds(0)
+                        .overflowToDisk(false)
+                        .statistics(true));
+        try {
+            Cache cache = manager.getCache("events");
+            CountingCacheEventListener listener = new CountingCacheEventListener();
+            cache.getCacheEventNotificationService().registerListener(listener);
+
+            cache.put(new Element("first", "one"));
+            cache.put(new Element("second", "two"));
+            cache.put(new Element("third", "three"));
+            assertThat(cache.getSize()).isEqualTo(2);
+            assertThat(cache.get("first")).isNull();
+            assertThat(listener.evicted.get()).isGreaterThanOrEqualTo(1);
+
+            cache.put(new Element("second", "updated"));
+            assertThat(cache.remove("second")).isTrue();
+            cache.removeAll();
+
+            cache.put(new Element("shortLived", "value"));
+            Thread.sleep(1_200L);
+            assertThat(cache.get("shortLived")).isNull();
+
+            Statistics statistics = cache.getStatistics();
+            assertThat(statistics.getCacheHits()).isGreaterThanOrEqualTo(0L);
+            assertThat(statistics.getCacheMisses()).isGreaterThanOrEqualTo(2L);
+            assertThat(statistics.getEvictionCount()).isGreaterThanOrEqualTo(1L);
+            assertThat(listener.put.get()).isGreaterThanOrEqualTo(4);
+            assertThat(listener.removed.get()).isEqualTo(1);
+            assertThat(listener.removeAll.get()).isEqualTo(1);
+            assertThat(listener.expired.get()).isGreaterThanOrEqualTo(1);
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void searchableCacheQueriesKeysValuesOrderingAndResultRanges() throws Exception {
+        Searchable searchable = new Searchable();
+        searchable.keys(true);
+        searchable.values(true);
+        CacheManager manager = newCacheManager("search",
+                new CacheConfiguration("scores", 10)
+                        .eternal(true)
+                        .overflowToDisk(false)
+                        .searchable(searchable)
+                        .statistics(true));
+        try {
+            Cache cache = manager.getCache("scores");
+            cache.put(new Element("alpha", 10));
+            cache.put(new Element("beta", 20));
+            cache.put(new Element("gamma", 30));
+            cache.put(new Element("delta", 40));
+
+            @SuppressWarnings("unchecked")
+            Attribute<String> keyAttribute = Query.KEY;
+            @SuppressWarnings("unchecked")
+            Attribute<Integer> valueAttribute = Query.VALUE;
+            Results results = cache.createQuery()
+                    .includeKeys()
+                    .includeValues()
+                    .addCriteria(valueAttribute.ge(20))
+                    .addOrderBy(keyAttribute, Direction.ASCENDING)
+                    .maxResults(2)
+                    .execute();
+            try {
+                assertThat(results.hasKeys()).isTrue();
+                assertThat(results.hasValues()).isTrue();
+                assertThat(results.size()).isEqualTo(2);
+
+                List<Result> rows = results.all();
+                assertThat(rows.get(0).getKey()).isEqualTo("beta");
+                assertThat(rows.get(0).getValue()).isEqualTo(20);
+                assertThat(rows.get(1).getKey()).isEqualTo("delta");
+                assertThat(rows.get(1).getValue()).isEqualTo(40);
+                assertThat(results.range(1, 1).get(0).getKey()).isEqualTo("delta");
+            } finally {
+                results.discard();
+            }
+
+            assertThat(cache.getStatistics().getAverageSearchTime()).isGreaterThanOrEqualTo(0L);
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void xmlConfigurationInputStreamBuildsUsableCaches() throws Exception {
+        String managerName = uniqueName("xml");
+        String xml = """
+                <ehcache name="%s" updateCheck="false" monitoring="off" dynamicConfig="true">
+                  <defaultCache maxElementsInMemory="10" eternal="false" timeToIdleSeconds="30"
+                                timeToLiveSeconds="30" overflowToDisk="false" />
+                  <cache name="xmlConfigured" maxElementsInMemory="3" eternal="true" overflowToDisk="false"
+                         statistics="true" memoryStoreEvictionPolicy="LFU" />
+                </ehcache>
+                """.formatted(managerName);
+
+        InputStream input = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+        CacheManager manager = new CacheManager(input);
+        try {
+            assertThat(manager.getName()).isEqualTo(managerName);
+            assertThat(manager.getCacheNames()).containsExactly("xmlConfigured");
+
+            Cache cache = manager.getCache("xmlConfigured");
+            assertThat(cache.getMemoryStoreEvictionPolicy().getName()).isEqualTo("LFU");
+            assertThat(cache.getCacheConfiguration().getMemoryStoreEvictionPolicy()).isEqualTo(MemoryStoreEvictionPolicy.LFU);
+            cache.put(new Element("xmlKey", "xmlValue"));
+            assertThat(cache.get("xmlKey").getObjectValue()).isEqualTo("xmlValue");
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void registeredLoadersWritersAndJmxManagementUsePublicExtensionPoints() throws Exception {
+        CacheManager manager = newCacheManager("extensions",
+                new CacheConfiguration("extensions", 20)
+                        .eternal(true)
+                        .overflowToDisk(false)
+                        .cacheWriter(new CacheWriterConfiguration()
+                                .writeMode(CacheWriterConfiguration.WriteMode.WRITE_THROUGH))
+                        .statistics(true));
+        ManagementService managementService = null;
+        try {
+            Cache cache = manager.getCache("extensions");
+            CountingCacheLoader loader = new CountingCacheLoader();
+            CountingCacheWriter writer = new CountingCacheWriter();
+            cache.registerCacheLoader(loader);
+            cache.registerCacheWriter(writer);
+
+            Element loaded = cache.getWithLoader("loaded", loader, "argument");
+            assertThat(loaded.getObjectValue()).isEqualTo("loaded:argument");
+            assertThat(loader.loadWithArgument.get()).isEqualTo(1);
+            assertThat(cache.get("loaded").getObjectValue()).isEqualTo("loaded:argument");
+
+            cache.putWithWriter(new Element("written", "value"));
+            assertThat(writer.writtenValues).containsEntry("written", "value");
+            assertThat(cache.removeWithWriter("written")).isTrue();
+            assertThat(writer.deletedKeys).containsEntry("written", "value");
+
+            MBeanServer mBeanServer = java.lang.management.ManagementFactory.getPlatformMBeanServer();
+            managementService = new ManagementService(manager, mBeanServer, true, true, true, true, true);
+            managementService.init();
+            ObjectName cacheManagerName = new ObjectName("net.sf.ehcache:type=CacheManager,name=" + manager.getName());
+            assertThat(mBeanServer.isRegistered(cacheManagerName)).isTrue();
+        } finally {
+            if (managementService != null) {
+                managementService.dispose();
+            }
+            manager.shutdown();
+        }
+    }
+
+    private static CacheManager newCacheManager(
+            String scenario, CacheConfiguration... cacheConfigurations) throws Exception {
+        Configuration configuration = new Configuration()
+                .name(uniqueName(scenario))
+                .updateCheck(false)
+                .monitoring(Configuration.Monitoring.OFF)
+                .dynamicConfig(true)
+                .defaultCache(new CacheConfiguration()
+                        .maxElementsInMemory(50)
+                        .eternal(false)
+                        .timeToLiveSeconds(300)
+                        .timeToIdleSeconds(300)
+                        .overflowToDisk(false));
+        for (CacheConfiguration cacheConfiguration : cacheConfigurations) {
+            configuration.cache(cacheConfiguration);
+        }
+        return new CacheManager(configuration);
+    }
+
+    private static String uniqueName(String scenario) {
+        return "ehcacheCore" + scenario + MANAGER_IDS.incrementAndGet();
+    }
+
+    private static final class CountingCacheEventListener implements CacheEventListener {
+        private final AtomicInteger put = new AtomicInteger();
+        private final AtomicInteger updated = new AtomicInteger();
+        private final AtomicInteger removed = new AtomicInteger();
+        private final AtomicInteger expired = new AtomicInteger();
+        private final AtomicInteger evicted = new AtomicInteger();
+        private final AtomicInteger removeAll = new AtomicInteger();
+
+        @Override
+        public void notifyElementRemoved(Ehcache cache, Element element) throws CacheException {
+            removed.incrementAndGet();
+        }
+
+        @Override
+        public void notifyElementPut(Ehcache cache, Element element) throws CacheException {
+            put.incrementAndGet();
+        }
+
+        @Override
+        public void notifyElementUpdated(Ehcache cache, Element element) throws CacheException {
+            updated.incrementAndGet();
+        }
+
+        @Override
+        public void notifyElementExpired(Ehcache cache, Element element) {
+            expired.incrementAndGet();
+        }
+
+        @Override
+        public void notifyElementEvicted(Ehcache cache, Element element) {
+            evicted.incrementAndGet();
+        }
+
+        @Override
+        public void notifyRemoveAll(Ehcache cache) {
+            removeAll.incrementAndGet();
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    private static final class CountingCacheLoader implements CacheLoader {
+        private final AtomicInteger loadWithArgument = new AtomicInteger();
+
+        @Override
+        public Object load(Object key) throws CacheException {
+            return key + ":loaded";
+        }
+
+        @Override
+        public Map<Object, Object> loadAll(Collection keys) {
+            Map<Object, Object> values = new HashMap<>();
+            for (Object key : keys) {
+                values.put(key, load(key));
+            }
+            return values;
+        }
+
+        @Override
+        public Object load(Object key, Object argument) {
+            loadWithArgument.incrementAndGet();
+            return key + ":" + argument;
+        }
+
+        @Override
+        public Map<Object, Object> loadAll(Collection keys, Object argument) {
+            Map<Object, Object> values = new HashMap<>();
+            for (Object key : keys) {
+                values.put(key, load(key, argument));
+            }
+            return values;
+        }
+
+        @Override
+        public String getName() {
+            return "counting";
+        }
+
+        @Override
+        public CacheLoader clone(Ehcache cache) throws CloneNotSupportedException {
+            return this;
+        }
+
+        @Override
+        public void init() {
+        }
+
+        @Override
+        public void dispose() throws CacheException {
+        }
+
+        @Override
+        public Status getStatus() {
+            return Status.STATUS_ALIVE;
+        }
+    }
+
+    private static final class CountingCacheWriter implements CacheWriter {
+        private final Map<Object, Object> writtenValues = new HashMap<>();
+        private final Map<Object, Object> deletedKeys = new HashMap<>();
+
+        @Override
+        public CacheWriter clone(Ehcache cache) throws CloneNotSupportedException {
+            return this;
+        }
+
+        @Override
+        public void init() {
+        }
+
+        @Override
+        public void dispose() throws CacheException {
+        }
+
+        @Override
+        public void write(Element element) throws CacheException {
+            writtenValues.put(element.getObjectKey(), element.getObjectValue());
+        }
+
+        @Override
+        public void writeAll(Collection<Element> elements) throws CacheException {
+            for (Element element : elements) {
+                write(element);
+            }
+        }
+
+        @Override
+        public void delete(CacheEntry entry) throws CacheException {
+            Element element = entry.getElement();
+            deletedKeys.put(entry.getKey(), element == null ? null : element.getObjectValue());
+        }
+
+        @Override
+        public void deleteAll(Collection<CacheEntry> entries) throws CacheException {
+            for (CacheEntry entry : entries) {
+                delete(entry);
+            }
+        }
     }
 }

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/user-code-filter.json
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "net.sf.ehcache.**"
+      "includeClasses" : "net.sf.ehcache.**"
+    },
+    {
+      "includeClasses" : "net_sf_ehcache.ehcache_core.**"
     }
   ]
 }

--- a/tests/src/net.sf.ehcache/ehcache-core/2.4.4/user-code-filter.json
+++ b/tests/src/net.sf.ehcache/ehcache-core/2.4.4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "net.sf.ehcache.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #2904

This PR introduces tests and metadata for net.sf.ehcache:ehcache-core:2.4.4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 144623
- Cached input tokens: 1093632
- Output tokens: 18954
- Metadata entries: 14
- Iterations: 5
- Library coverage percentage: 15.24
- Generated lines of code: 444
- Tested library lines of code: 2847

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cdc0e21cbe47d76ba1d54eab849ff3d7056b2171`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 15/79 covered calls (18.99%)
- Reflection: 15/77 covered calls (19.48%)
- Resources: 0/2 covered calls (0.00%)

Library coverage:
- Instruction: 11114/81524 (13.63%)
- Line: 2847/18686 (15.24%)
- Method: 817/5176 (15.78%)

### Local CI Verification

- Status: `success`
- Commands run: 19
- Fixup attempts: 1
