### PR TITLE
[GenAI] Improve coverage for com.h2database:h2:2.2.224 using gpt-5.5

### DIFF
--- a/metadata/com.h2database/h2/2.1.210/reachability-metadata.json
+++ b/metadata/com.h2database/h2/2.1.210/reachability-metadata.json
@@ -201,6 +201,13 @@
     },
     {
       "condition": {
+        "typeReached": "org.h2.util.JdbcUtils"
+      },
+      "type": "java.sql.DatabaseMetaData",
+      "allDeclaredMethods": true
+    },
+    {
+      "condition": {
         "typeReached": "org.h2.util.MathUtils"
       },
       "type": "sun.security.provider.SHA",

--- a/stats/com.h2database/h2/2.1.210/stats.json
+++ b/stats/com.h2database/h2/2.1.210/stats.json
@@ -38,5 +38,44 @@
         "total" : 11943
       }
     }
+  }, {
+    "version" : "2.2.224",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.204082,
+          "coveredCalls" : 20,
+          "totalCalls" : 98
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 0.196078,
+      "coveredCalls" : 20,
+      "totalCalls" : 102
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 56802,
+        "missed" : 312339,
+        "ratio" : 0.153876,
+        "total" : 369141
+      },
+      "line" : {
+        "covered" : 13324,
+        "missed" : 69344,
+        "ratio" : 0.161175,
+        "total" : 82668
+      },
+      "method" : {
+        "covered" : 2876,
+        "missed" : 9471,
+        "ratio" : 0.232931,
+        "total" : 12347
+      }
+    }
   } ]
 }

--- a/stats/com.h2database/h2/2.2.224/execution-metrics.json
+++ b/stats/com.h2database/h2/2.2.224/execution-metrics.json
@@ -1,0 +1,67 @@
+{
+  "improve_library_coverage:2026-05-05": {
+    "timestamp": "2026-05-05T01:12:32.437300Z",
+    "library": "com.h2database:h2:2.2.224",
+    "starting_commit": "4108c4ccfeef373e340b59e0ea544336658b3a55",
+    "ending_commit": "34607203d404d39f9ab5076b50bb5f5473cca341",
+    "strategy_name": "library_update_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.224",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.204082,
+            "coveredCalls": 20,
+            "totalCalls": 98
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 0.196078,
+        "coveredCalls": 20,
+        "totalCalls": 102
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 56802,
+          "missed": 312339,
+          "ratio": 0.153876,
+          "total": 369141
+        },
+        "line": {
+          "covered": 13324,
+          "missed": 69344,
+          "ratio": 0.161175,
+          "total": 82668
+        },
+        "method": {
+          "covered": 2876,
+          "missed": 9471,
+          "ratio": 0.232931,
+          "total": 12347
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 41644,
+      "cached_input_tokens_used": 557056,
+      "output_tokens_used": 11168,
+      "iterations": 1,
+      "cost_usd": 0.6135,
+      "generated_loc": 236,
+      "tested_library_loc": 13324,
+      "metadata_entries": 41,
+      "code_coverage_percent": 16.12
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.h2database/h2/2.1.210/src/test/java/h2/H2Test.java",
+      "metadata_file": "metadata/com.h2database/h2/2.1.210/reachability-metadata.json"
+    }
+  }
+}

--- a/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/H2Test.java
+++ b/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/H2Test.java
@@ -7,6 +7,7 @@
 package h2;
 
 import org.h2.api.Interval;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -30,7 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Moritz Halbritter
  */
-class H2Test {
+public class H2Test {
+    @BeforeAll
+    static void configureJavaObjectSerializerProperty() {
+        System.setProperty("h2.javaObjectSerializer", JdbcUtilsTest.TestJavaObjectSerializer.class.getName());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"jdbc:h2:./data/test", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"})
     void test(String url) throws Exception {

--- a/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/H2Test.java
+++ b/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/H2Test.java
@@ -8,10 +8,15 @@ package h2;
 
 import org.h2.api.Interval;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -24,7 +29,9 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.util.Comparator;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,9 +39,27 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Moritz Halbritter
  */
 public class H2Test {
+    private static final Path FILE_DATABASE_DIRECTORY = Paths.get("data");
+
     @BeforeAll
     static void configureJavaObjectSerializerProperty() {
         System.setProperty("h2.javaObjectSerializer", JdbcUtilsTest.TestJavaObjectSerializer.class.getName());
+    }
+
+    @BeforeEach
+    void cleanupFileBackedDatabase() throws IOException {
+        if (!Files.exists(FILE_DATABASE_DIRECTORY)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(FILE_DATABASE_DIRECTORY)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to delete " + path, e);
+                }
+            });
+        }
     }
 
     @ParameterizedTest

--- a/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/JdbcUtilsTest.java
+++ b/tests/src/com.h2database/h2/2.1.210/src/test/java/h2/JdbcUtilsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package h2;
+
+import org.h2.api.JavaObjectSerializer;
+import org.h2.util.JdbcUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JdbcUtilsTest {
+    private static final String SERIALIZER_PROPERTY = "h2.javaObjectSerializer";
+    private static final String TEST_SERIALIZER_CLASS = TestJavaObjectSerializer.class.getName();
+
+    @BeforeAll
+    static void configureJavaObjectSerializerProperty() {
+        System.setProperty(SERIALIZER_PROPERTY, TEST_SERIALIZER_CLASS);
+    }
+
+    @Test
+    void initializesConfiguredJavaObjectSerializerWithDefaultConstructor() {
+        assertThat(JdbcUtils.serializer).isInstanceOf(TestJavaObjectSerializer.class);
+    }
+
+    @Test
+    void loadsUserClassWithDefaultClassLoader() {
+        assertThat(JdbcUtils.loadUserClass("java.lang.String")).isSameAs(String.class);
+    }
+
+    @Test
+    void createsJdbcDriverWithDefaultConstructor() {
+        assertThatThrownBy(() -> JdbcUtils.getConnection(
+                "org.h2.Driver", "jdbc:jdbc-utils-driver:mem", "sa", ""))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("not suitable");
+    }
+
+    @Test
+    void createsJndiContextWithDefaultConstructor() {
+        assertThatThrownBy(() -> JdbcUtils.getConnection(
+                "javax.naming.InitialContext", "java:comp/env/jdbc/missing", null, null))
+                .isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void readsDatabaseMetaDataByInvokingNoArgumentMethods() throws SQLException {
+        try (Connection connection = JdbcUtils.getConnection(
+                "org.h2.Driver", "jdbc:h2:mem:jdbc-utils-metadata", "sa", "");
+                ResultSet resultSet = JdbcUtils.getMetaResultSet(connection, "@info")) {
+            assertThat(containsMetadataEntry(resultSet, "meta.getDatabaseProductName", "H2")).isTrue();
+        }
+    }
+
+    @Test
+    void serializesJavaObjectWithDefaultObjectStreams() {
+        JavaObjectSerializer previousSerializer = JdbcUtils.serializer;
+        try {
+            JdbcUtils.serializer = null;
+
+            byte[] bytes = JdbcUtils.serialize(new SamplePayload("sample"), null);
+            Object deserialized = JdbcUtils.deserialize(bytes, null);
+
+            assertThat(deserialized).isEqualTo(new SamplePayload("sample"));
+        } finally {
+            JdbcUtils.serializer = previousSerializer;
+        }
+    }
+
+    private static boolean containsMetadataEntry(ResultSet resultSet, String expectedKey, String expectedValue)
+            throws SQLException {
+        while (resultSet.next()) {
+            if (expectedKey.equals(resultSet.getString("KEY")) && expectedValue.equals(resultSet.getString("VALUE"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static final class TestJavaObjectSerializer implements JavaObjectSerializer {
+        public TestJavaObjectSerializer() {
+        }
+
+        @Override
+        public byte[] serialize(Object obj) throws Exception {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+                objectOutput.writeObject(obj);
+            }
+            return output.toByteArray();
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) throws Exception {
+            try (ObjectInputStream objectInput = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+                return objectInput.readObject();
+            }
+        }
+    }
+
+    private record SamplePayload(String value) implements Serializable {
+    }
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #452

This PR improves dynamic-access coverage for com.h2database:h2:2.2.224 by generating additional tests.

Summary:
- Strategy: library_update_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 41644
- Cached input tokens: 557056
- Output tokens: 11168
- Metadata entries (before): 39
- Metadata entries (after): 41
- Iterations: 1
- Library coverage percentage: 16.12
- Generated lines of code: 236
- Tested library lines of code: 13324

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2b0a0c5e9d3239e28fd7c1e3a81e592fc5c3ddea`



### Stats comparison for `com.h2database:h2:2.2.224`

#### Dynamic access coverage

- Before (com.h2database:h2:2.2.224): 11/101 covered calls (10.89%)
- After (com.h2database:h2:2.2.224): 20/102 covered calls (19.61%)

**Reflection:**
- Before (com.h2database:h2:2.2.224): 11/97 covered calls (11.34%)
- After (com.h2database:h2:2.2.224): 20/98 covered calls (20.41%)

**Resources:**
- Before (com.h2database:h2:2.2.224): 0/4 covered calls (0.00%)
- After (com.h2database:h2:2.2.224): 0/4 covered calls (0.00%)

#### Library coverage

**Instruction:**
- Before (com.h2database:h2:2.2.224): 49743/360049 (13.82%)
- After (com.h2database:h2:2.2.224): 56802/369141 (15.39%)

**Line:**
- Before (com.h2database:h2:2.2.224): 11573/80614 (14.36%)
- After (com.h2database:h2:2.2.224): 13324/82668 (16.12%)

**Method:**
- Before (com.h2database:h2:2.2.224): 2412/11943 (20.20%)
- After (com.h2database:h2:2.2.224): 2876/12347 (23.29%)

### Local CI Verification

- Status: `success`
- Commands run: 17
- Fixup attempts: 1
