### PR TITLE
[GenAI] Test fix for net.postgis:postgis-jdbc:2021.1.0 using gpt-5.5

### DIFF
--- a/.github/workflows/scripts/run-consecutive-tests.sh
+++ b/.github/workflows/scripts/run-consecutive-tests.sh
@@ -58,7 +58,9 @@ run_multiple_attempts() {
     if [ -n "${GVM_TCK_NATIVE_IMAGE_MODE:-}" ]; then
       native_image_mode_prefix="GVM_TCK_NATIVE_IMAGE_MODE=\"$GVM_TCK_NATIVE_IMAGE_MODE\" "
     fi
-    local cmd_str="${native_image_mode_prefix}GVM_TCK_LV=\"$VERSION\" ./gradlew clean $gradle_command -Pcoordinates=\"$TEST_COORDINATES\""
+    # Run each stage without the Gradle daemon so a prior stop-requested daemon
+    # cannot break the next stage in this consecutive verification loop.
+    local cmd_str="${native_image_mode_prefix}GVM_TCK_LV=\"$VERSION\" ./gradlew --no-daemon clean $gradle_command -Pcoordinates=\"$TEST_COORDINATES\""
     if [ $attempt -gt 0 ]; then
       echo "Re-running stage '$stage' (attempt $((attempt + 1))/$max_attempts)"
     fi

--- a/metadata/net.postgis/postgis-jdbc/2021.1.0/reachability-metadata.json
+++ b/metadata/net.postgis/postgis-jdbc/2021.1.0/reachability-metadata.json
@@ -1,0 +1,24 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "net.postgis.jdbc.DriverWrapper"
+      },
+      "type": "net.postgis.jdbc.DriverWrapper$TypesAdder80",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "net.postgis.jdbc.Version"
+      },
+      "glob": "net/postgis/jdbc/version.properties"
+    }
+  ]
+}

--- a/metadata/net.postgis/postgis-jdbc/index.json
+++ b/metadata/net.postgis/postgis-jdbc/index.json
@@ -14,5 +14,15 @@
       "examples",
       "org.postgis"
     ]
+  },
+  {
+    "metadata-version" : "2021.1.0",
+    "tested-versions" : [
+      "2021.1.0"
+    ],
+    "allowed-packages" : [
+      "examples",
+      "org.postgis"
+    ]
   }
 ]

--- a/metadata/net.postgis/postgis-jdbc/index.json
+++ b/metadata/net.postgis/postgis-jdbc/index.json
@@ -1,28 +1,34 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.5.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-sources.jar",
-    "repository-url" : "https://github.com/postgis/postgis-java",
-    "test-code-url" : "https://github.com/postgis/postgis-java/tree/postgis-java-aggregator-$version$/jdbc/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-javadoc.jar",
-    "description" : "PostGIS JDBC provides PostgreSQL JDBC driver extensions that register PostGIS geometry and geography data types with Java JDBC connections. It builds on postgis-geometry and the PostgreSQL JDBC driver so applications can read, write, parse, and serialize spatial values in PostGIS databases.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "2.5.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-sources.jar",
+    "repository-url": "https://github.com/postgis/postgis-java",
+    "test-code-url": "https://github.com/postgis/postgis-java/tree/postgis-java-aggregator-$version$/jdbc/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-javadoc.jar",
+    "description": "PostGIS JDBC provides PostgreSQL JDBC driver extensions that register PostGIS geometry and geography data types with Java JDBC connections. It builds on postgis-geometry and the PostgreSQL JDBC driver so applications can read, write, parse, and serialize spatial values in PostGIS databases.",
+    "tested-versions": [
       "2.5.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "examples",
       "org.postgis"
     ]
   },
   {
-    "metadata-version" : "2021.1.0",
-    "tested-versions" : [
+    "metadata-version": "2021.1.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-sources.jar",
+    "repository-url": "https://github.com/postgis/postgis-java",
+    "test-code-url": "https://github.com/postgis/postgis-java/tree/postgis-java-aggregator-$version$/postgis-jdbc/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/$version$/postgis-jdbc-$version$-javadoc.jar",
+    "description": "PostGIS JDBC provides PostgreSQL JDBC driver extensions that register PostGIS geometry and geography data types with Java JDBC connections. It builds on postgis-geometry and the PostgreSQL JDBC driver so applications can read, write, parse, and serialize spatial values in PostGIS databases.",
+    "tested-versions": [
       "2021.1.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "examples",
-      "org.postgis"
+      "org.postgis",
+      "net.postgis.jdbc"
     ]
   }
 ]

--- a/stats/net.postgis/postgis-jdbc/2021.1.0/execution-metrics.json
+++ b/stats/net.postgis/postgis-jdbc/2021.1.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-05": {
+    "timestamp": "2026-05-05T02:19:11.623606Z",
+    "library": "net.postgis:postgis-jdbc:2021.1.0",
+    "starting_commit": "5e3ad8bf8a9002ab17dffdd4542fe91434bb5a97",
+    "ending_commit": "c5733d6d0aa7e60679da5718111571abacabb7d2",
+    "previous_library": "net.postgis:postgis-jdbc:2.5.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2021.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 217,
+          "missed": 912,
+          "ratio": 0.192205,
+          "total": 1129
+        },
+        "line": {
+          "covered": 59,
+          "missed": 257,
+          "ratio": 0.186709,
+          "total": 316
+        },
+        "method": {
+          "covered": 12,
+          "missed": 83,
+          "ratio": 0.126316,
+          "total": 95
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 217,
+          "missed": 1239,
+          "ratio": 0.149038,
+          "total": 1456
+        },
+        "line": {
+          "covered": 59,
+          "missed": 347,
+          "ratio": 0.14532,
+          "total": 406
+        },
+        "method": {
+          "covered": 12,
+          "missed": 86,
+          "ratio": 0.122449,
+          "total": 98
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 21062,
+      "cached_input_tokens_used": 188928,
+      "output_tokens_used": 1504,
+      "iterations": 1,
+      "cost_usd": 0.1396,
+      "tested_library_loc": 59,
+      "metadata_entries": 3,
+      "previous_library_metadata_entries": 3,
+      "code_coverage_percent": 18.67,
+      "previous_library_coverage_percent": 14.53
+    },
+    "artifacts": {
+      "test_file": "tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java",
+      "metadata_file": "metadata/net.postgis/postgis-jdbc/2021.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/net.postgis/postgis-jdbc/2021.1.0/stats.json
+++ b/stats/net.postgis/postgis-jdbc/2021.1.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2021.1.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 217,
+        "missed" : 912,
+        "ratio" : 0.192205,
+        "total" : 1129
+      },
+      "line" : {
+        "covered" : 59,
+        "missed" : 257,
+        "ratio" : 0.186709,
+        "total" : 316
+      },
+      "method" : {
+        "covered" : 12,
+        "missed" : 83,
+        "ratio" : 0.126316,
+        "total" : 95
+      }
+    }
+  } ]
+}

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/.gitignore
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/build.gradle
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "net.postgis:postgis-jdbc:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/gradle.properties
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = net.postgis:postgis-jdbc:2021.1.0
+library.version = 2021.1.0
+metadata.dir = net.postgis/postgis-jdbc/2021.1.0/

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/settings.gradle
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'net.postgis.postgis-jdbc_tests'

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_postgis.postgis_jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Test;
+import org.postgis.DriverWrapper;
+
+public class DriverWrapperTest {
+
+    @Test
+    void constructorLoadsTypesAdderAndAcceptsPostgisJdbcUrls() throws SQLException {
+        DriverWrapper driver = new DriverWrapper();
+
+        assertThat(driver.acceptsURL("jdbc:postgresql_postGIS://localhost:5432/spatial")).isTrue();
+        assertThat(driver.acceptsURL("jdbc:postgresql://localhost:5432/spatial")).isFalse();
+        assertThat(driver.acceptsURL("jdbc:postgresql_postGISX://localhost:5432/spatial")).isFalse();
+    }
+
+    @Test
+    void staticTypeRegistrationLoadsTypesAdderBeforeUsingConnection() {
+        assertThatThrownBy(() -> DriverWrapper.addGISTypes80(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.SQLException;
 
+import net.postgis.jdbc.DriverWrapper;
 import org.junit.jupiter.api.Test;
-import org.postgis.DriverWrapper;
 
 public class DriverWrapperTest {
 

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_postgis.postgis_jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.postgis.Version;
+
+public class VersionTest {
+
+    @Test
+    void exposesVersionLoadedFromBundledPropertiesResource() {
+        assertThat(Version.VERSION).isNotBlank();
+        assertThat(Version.MAJOR).isGreaterThanOrEqualTo(0);
+        assertThat(Version.MINOR).isGreaterThanOrEqualTo(0);
+        assertThat(Version.MICRO).isNotBlank();
+
+        String expectedFullVersion = "PostGIS JDBC V" + Version.MAJOR + "." + Version.MINOR + "."
+                + Version.MICRO;
+        assertThat(Version.getFullVersion()).isEqualTo(expectedFullVersion);
+        assertThat(Version.VERSION)
+                .startsWith(Version.MAJOR + "." + Version.MINOR + ".");
+    }
+}

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
@@ -8,8 +8,8 @@ package net_postgis.postgis_jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.postgis.jdbc.Version;
 import org.junit.jupiter.api.Test;
-import org.postgis.Version;
 
 public class VersionTest {
 

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "examples.**"
+    },
+    {
+      "includeClasses" : "org.postgis.**"
+    },
+    {
+      "includeClasses" : "net_postgis.postgis_jdbc.**"
+    }
+  ]
+}

--- a/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
+++ b/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
@@ -4,10 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "examples.**"
-    },
-    {
-      "includeClasses" : "org.postgis.**"
+      "includeClasses" : "net.postgis.jdbc.**"
     },
     {
       "includeClasses" : "net_postgis.postgis_jdbc.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #5884

This PR provides test fixes and new metadata for net.postgis:postgis-jdbc:2021.1.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 21062
- Cached input tokens: 188928
- Output tokens: 1504
- Metadata entries: 3
- Iterations: 1
- Library coverage percentage: 18.67
- Previous library version metadata entries: 3
- Previous library version coverage percentage: 14.53

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2b0a0c5e9d3239e28fd7c1e3a81e592fc5c3ddea`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- net.postgis:postgis-jdbc:2.5.0: 3/3 covered calls (100.00%)
- net.postgis:postgis-jdbc:2021.1.0: 3/3 covered calls (100.00%)

**Reflection:**
- net.postgis:postgis-jdbc:2.5.0: 2/2 covered calls (100.00%)
- net.postgis:postgis-jdbc:2021.1.0: 2/2 covered calls (100.00%)

**Resources:**
- net.postgis:postgis-jdbc:2.5.0: 1/1 covered calls (100.00%)
- net.postgis:postgis-jdbc:2021.1.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- net.postgis:postgis-jdbc:2.5.0: 217/1456 (14.90%)
- net.postgis:postgis-jdbc:2021.1.0: 217/1129 (19.22%)

**Line:**
- net.postgis:postgis-jdbc:2.5.0: 59/406 (14.53%)
- net.postgis:postgis-jdbc:2021.1.0: 59/316 (18.67%)

**Method:**
- net.postgis:postgis-jdbc:2.5.0: 12/98 (12.24%)
- net.postgis:postgis-jdbc:2021.1.0: 12/95 (12.63%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/net.postgis/postgis-jdbc/2.5.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
index eeb5120b93..dcb682f650 100644
--- 1/tests/src/net.postgis/postgis-jdbc/2.5.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
+++ 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/DriverWrapperTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.SQLException;
 
+import net.postgis.jdbc.DriverWrapper;
 import org.junit.jupiter.api.Test;
-import org.postgis.DriverWrapper;
 
 public class DriverWrapperTest {
 
diff --git 1/tests/src/net.postgis/postgis-jdbc/2.5.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
index 5a7f4d01e0..0d255e8d33 100644
--- 1/tests/src/net.postgis/postgis-jdbc/2.5.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
+++ 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/src/test/java/net_postgis/postgis_jdbc/VersionTest.java
@@ -8,8 +8,8 @@ package net_postgis.postgis_jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.postgis.jdbc.Version;
 import org.junit.jupiter.api.Test;
-import org.postgis.Version;
 
 public class VersionTest {
 
diff --git 1/tests/src/net.postgis/postgis-jdbc/2.5.0/user-code-filter.json 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
index 4385238df3..5495f91e3e 100644
--- 1/tests/src/net.postgis/postgis-jdbc/2.5.0/user-code-filter.json
+++ 2/tests/src/net.postgis/postgis-jdbc/2021.1.0/user-code-filter.json
@@ -4,10 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "examples.**"
-    },
-    {
-      "includeClasses" : "org.postgis.**"
+      "includeClasses" : "net.postgis.jdbc.**"
     },
     {
       "includeClasses" : "net_postgis.postgis_jdbc.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 19
- Fixup attempts: 1
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `.github/workflows/scripts/run-consecutive-tests.sh`
