### PR TITLE
[GenAI] Test fix for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0 using gpt-5.5

### DIFF
--- a/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
+++ b/metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json
@@ -2,6 +2,15 @@
   "reflection" : [
     {
       "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector"
+      },
+      "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition",
+      "allDeclaredFields" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredConstructors" : true
+    },
+    {
+      "condition" : {
         "typeReached" : "com.fasterxml.jackson.jr.type.TypeResolver"
       },
       "type" : "com.fasterxml.jackson.jr.ob.impl.POJODefinition[]"
@@ -38,6 +47,18 @@
       "methods" : [
         {
           "name" : "getType",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.fasterxml.jackson.jr.ob.api.MapBuilder$Default"
+      },
+      "type" : "java.util.TreeMap",
+      "methods" : [
+        {
+          "name" : "<init>",
           "parameterTypes" : [ ]
         }
       ]

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/execution-metrics.json
@@ -85,5 +85,92 @@
       "test_file": "tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java",
       "metadata_file": "metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json"
     }
+  },
+  "fix_javac_fail:2026-05-05": {
+    "timestamp": "2026-05-05T02:26:47.999822Z",
+    "library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0",
+    "starting_commit": "2b0a0c5e9d3239e28fd7c1e3a81e592fc5c3ddea",
+    "ending_commit": "d034624030776964faf70c874b691e3c83cf07f8",
+    "previous_library": "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.21.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5565,
+          "missed": 8145,
+          "ratio": 0.405908,
+          "total": 13710
+        },
+        "method": {
+          "covered": 292,
+          "missed": 413,
+          "ratio": 0.414184,
+          "total": 705
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.21.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 21
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 21
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5565,
+          "missed": 8145,
+          "ratio": 0.405908,
+          "total": 13710
+        },
+        "method": {
+          "covered": 292,
+          "missed": 413,
+          "ratio": 0.414184,
+          "total": 705
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 879125,
+      "cached_input_tokens_used": 11328000,
+      "output_tokens_used": 97001,
+      "iterations": 19,
+      "cost_usd": 8.574,
+      "tested_library_loc": 0,
+      "metadata_entries": 13,
+      "test_only_metadata_entries": 129,
+      "previous_library_metadata_entries": 13,
+      "previous_library_test_only_metadata_entries": 129,
+      "code_coverage_percent": 40.59,
+      "previous_library_coverage_percent": 40.59
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java",
+      "metadata_file": "metadata/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/reachability-metadata.json"
+    }
   }
 }

--- a/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
+++ b/stats/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/stats.json
@@ -15,16 +15,16 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 5349,
-        "missed" : 8361,
-        "ratio" : 0.390153,
+        "covered" : 5565,
+        "missed" : 8145,
+        "ratio" : 0.405908,
         "total" : 13710
       },
       "line" : "N/A",
       "method" : {
-        "covered" : 286,
-        "missed" : 419,
-        "ratio" : 0.405674,
+        "covered" : 292,
+        "missed" : 413,
+        "ratio" : 0.414184,
         "total" : 705
       }
     }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -6,11 +6,14 @@
  */
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
-import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +27,36 @@ public class BeanConstructorsDynamicAccessTest {
     void resetConstructorCounters() {
         PublicDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
         PrivateDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        NestedBeanHolder.CONSTRUCTOR_CALLS.set(0);
+        NestedDefaultCtorBean.CONSTRUCTOR_CALLS.set(0);
+        NestedRecordHolder.CONSTRUCTOR_CALLS.set(0);
         RECORD_CTOR_CALLS.set(0);
     }
 
     @Test
-    void createsBeansDirectlyThroughPublicDefaultConstructors() throws Exception {
-        Constructor<PublicDefaultCtorBean> constructor = PublicDefaultCtorBean.class.getDeclaredConstructor();
+    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
+        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, """
+                {"name":"Ada"}
+                """);
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
+        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class, """
+                {"name":"Ada"}
+                """);
+
+        assertThat(bean.name).isEqualTo("Ada");
+        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsBeansThroughConstructorsDiscoveredByBeanIntrospection() throws Exception {
         AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PublicDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
+        BeanPropertyIntrospector.addNonRecordConstructors(PublicDefaultCtorBean.class, constructors);
 
         PublicDefaultCtorBean bean = (PublicDefaultCtorBean) constructors.createBean();
 
@@ -40,42 +65,21 @@ public class BeanConstructorsDynamicAccessTest {
     }
 
     @Test
-    void createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        Constructor<PrivateDefaultCtorBean> constructor = PrivateDefaultCtorBean.class.getDeclaredConstructor();
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(PrivateDefaultCtorBean.class);
-        constructors.addNoArgsConstructor(constructor);
-        constructors.forceAccess();
+    void createsNestedBeansThroughDefaultConstructorsWhenReadingProperties() throws Exception {
+        NestedBeanHolder bean = JSON.std.beanFrom(NestedBeanHolder.class, """
+                {"child":{"name":"Grace"}}
+                """);
 
-        PrivateDefaultCtorBean bean = (PrivateDefaultCtorBean) constructors.createBean();
-
-        assertThat(bean).isNotNull();
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsBeansThroughPublicDefaultConstructorsWhenReadingObjects() throws Exception {
-        PublicDefaultCtorBean bean = JSON.std.beanFrom(PublicDefaultCtorBean.class, "{\"name\":\"Ada\"}");
-
-        assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PublicDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
-    }
-
-    @Test
-    void createsRecordsDirectlyThroughCanonicalConstructors() throws Exception {
-        Constructor<RecordCtorBean> constructor = RecordCtorBean.class.getDeclaredConstructor(String.class, int.class);
-        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(RecordCtorBean.class);
-        constructors.addRecordConstructor(constructor);
-
-        RecordCtorBean bean = (RecordCtorBean) constructors.createRecordBean("Ada", 37);
-
-        assertThat(bean.name()).isEqualTo("Ada");
-        assertThat(bean.age()).isEqualTo(37);
-        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+        assertThat(bean.child.name).isEqualTo("Grace");
+        assertThat(NestedBeanHolder.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(NestedDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
     }
 
     @Test
     void createsRecordsThroughCanonicalConstructorsWhenReadingObjects() throws Exception {
-        RecordCtorBean bean = JSON.std.beanFrom(RecordCtorBean.class, "{\"name\":\"Ada\",\"age\":37}");
+        RecordCtorBean bean = JSON.std.beanFrom(RecordCtorBean.class, """
+                {"name":"Ada","age":37}
+                """);
 
         assertThat(bean.name()).isEqualTo("Ada");
         assertThat(bean.age()).isEqualTo(37);
@@ -83,12 +87,30 @@ public class BeanConstructorsDynamicAccessTest {
     }
 
     @Test
-    void createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced() throws Exception {
-        PrivateDefaultCtorBean bean = JSON_WITH_FORCE_ACCESS.beanFrom(PrivateDefaultCtorBean.class,
-                "{\"name\":\"Ada\"}");
+    void createsRecordsThroughConstructorsDiscoveredByBeanIntrospection() throws Exception {
+        Map<String, String> propertyNames = new LinkedHashMap<>();
+        AccessibleBeanConstructors constructors = new AccessibleBeanConstructors(RecordCtorBean.class);
+        constructors.addRecordConstructor(BeanPropertyIntrospector.derivePropertiesFromRecordConstructor(
+                RecordCtorBean.class, propertyNames, Function.identity()));
 
-        assertThat(bean.name).isEqualTo("Ada");
-        assertThat(PrivateDefaultCtorBean.CONSTRUCTOR_CALLS).hasValue(1);
+        RecordCtorBean bean = (RecordCtorBean) constructors.createRecordBean("Ada", 37);
+
+        assertThat(propertyNames).containsOnlyKeys("name", "age");
+        assertThat(bean.name()).isEqualTo("Ada");
+        assertThat(bean.age()).isEqualTo(37);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
+    }
+
+    @Test
+    void createsNestedRecordsThroughCanonicalConstructorsWhenReadingProperties() throws Exception {
+        NestedRecordHolder bean = JSON.std.beanFrom(NestedRecordHolder.class, """
+                {"child":{"name":"Grace","age":42}}
+                """);
+
+        assertThat(bean.child.name()).isEqualTo("Grace");
+        assertThat(bean.child.age()).isEqualTo(42);
+        assertThat(NestedRecordHolder.CONSTRUCTOR_CALLS).hasValue(1);
+        assertThat(RECORD_CTOR_CALLS).hasValue(1);
     }
 
     static final class AccessibleBeanConstructors extends BeanConstructors {
@@ -121,6 +143,36 @@ public class BeanConstructorsDynamicAccessTest {
         public String name;
 
         private PrivateDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class NestedBeanHolder {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public NestedDefaultCtorBean child;
+
+        public NestedBeanHolder() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class NestedDefaultCtorBean {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public String name;
+
+        public NestedDefaultCtorBean() {
+            CONSTRUCTOR_CALLS.incrementAndGet();
+        }
+    }
+
+    public static final class NestedRecordHolder {
+        private static final AtomicInteger CONSTRUCTOR_CALLS = new AtomicInteger();
+
+        public RecordCtorBean child;
+
+        public NestedRecordHolder() {
             CONSTRUCTOR_CALLS.incrementAndGet();
         }
     }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanConstructorsDynamicAccessTest.java
@@ -95,7 +95,7 @@ public class BeanConstructorsDynamicAccessTest {
 
         RecordCtorBean bean = (RecordCtorBean) constructors.createRecordBean("Ada", 37);
 
-        assertThat(propertyNames).containsOnlyKeys("name", "age");
+        assertThat(propertyNames.keySet()).containsExactlyInAnyOrder("name", "age");
         assertThat(bean.name()).isEqualTo("Ada");
         assertThat(bean.age()).isEqualTo(37);
         assertThat(RECORD_CTOR_CALLS).hasValue(1);

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyIntrospectorDynamicAccessTest.java
@@ -33,6 +33,8 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         BeanConstructors constructors = new BeanConstructors(IntrospectedBean.class);
         BeanPropertyIntrospector.addNonRecordConstructors(IntrospectedBean.class, constructors);
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER,
+                POJODefinition.class);
 
         IntrospectedBean objectBean = JSON_WITH_FORCE_ACCESS.beanFrom(IntrospectedBean.class,
                 "{\"name\":\"Ada\",\"active\":true,\"visible\":7}");
@@ -41,7 +43,9 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         assertThat(constructors).isNotNull();
         assertThat(definition.constructors()).isNotNull();
+        assertThat(libraryDefinition.constructors()).isNotNull();
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
         assertThat(objectBean.getName()).isEqualTo("Ada");
         assertThat(objectBean.isActive()).isTrue();
         assertThat(objectBean.visible).isEqualTo(7);
@@ -52,9 +56,15 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
     @Test
     void collectsDeclaredFieldsAndMethodsForSerialization() throws Exception {
         POJODefinition definition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER, IntrospectedBean.class);
+        POJODefinition libraryDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                POJODefinition.class);
+        POJODefinition beanConstructorsDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                BeanConstructors.class);
         String json = JSON_WITH_FORCE_ACCESS.asString(IntrospectedBean.create("Ada", true, 7));
 
         assertThat(propertyNames(definition)).containsExactlyInAnyOrder("active", "name", "visible");
+        assertThat(propertyNames(libraryDefinition)).contains("ignorableNames", "properties");
+        assertThat(beanConstructorsDefinition.getProperties()).isEmpty();
         assertThat(json).contains("\"name\":\"Ada\"", "\"active\":true", "\"visible\":7");
 
         POJODefinition.Prop visible = property(definition, "visible");
@@ -66,6 +76,25 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
         assertThat(name.setter).isNotNull();
         assertThat(active.isGetter).isNotNull();
         assertThat(active.setter).isNotNull();
+    }
+
+    @Test
+    void publicJsonApiIntrospectsBeanConstructorsFieldsAndMethods() throws Exception {
+        POJODefinition readDefinition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER,
+                PublicApiBean.class);
+        POJODefinition writeDefinition = INTROSPECTOR.pojoDefinitionForSerialization(JSON_WRITER,
+                PublicApiBean.class);
+        PublicApiBean bean = JSON.std.beanFrom(PublicApiBean.class,
+                "{\"id\":42,\"name\":\"Ada\",\"enabled\":true}");
+        String json = JSON.std.asString(bean);
+
+        assertThat(readDefinition.constructors()).isNotNull();
+        assertThat(propertyNames(readDefinition)).containsExactlyInAnyOrder("enabled", "id", "name");
+        assertThat(propertyNames(writeDefinition)).containsExactlyInAnyOrder("enabled", "id", "name");
+        assertThat(bean.id).isEqualTo(42);
+        assertThat(bean.getName()).isEqualTo("Ada");
+        assertThat(bean.isEnabled()).isTrue();
+        assertThat(json).contains("\"enabled\":true", "\"id\":42", "\"name\":\"Ada\"");
     }
 
     @Test
@@ -153,6 +182,31 @@ public class BeanPropertyIntrospectorDynamicAccessTest {
 
         public int getValue() {
             return value;
+        }
+    }
+
+    public static final class PublicApiBean {
+        public int id;
+        private String name;
+        private boolean enabled;
+
+        public PublicApiBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyReaderDynamicAccessTest.java
@@ -19,7 +19,7 @@ public class BeanPropertyReaderDynamicAccessTest {
 
     @Test
     void setsFieldBackedValuesThroughBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null, 0);
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
         reader.setValueFor(bean, new Object[]{3});
@@ -31,7 +31,7 @@ public class BeanPropertyReaderDynamicAccessTest {
     @Test
     void invokesSetterBackedValuesThroughBeanPropertyReader() throws Exception {
         BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class), 0);
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
         reader.setValueFor(bean, new Object[]{"Ada"});
@@ -42,7 +42,7 @@ public class BeanPropertyReaderDynamicAccessTest {
 
     @Test
     void reportsFieldBackedAssignmentFailuresFromBeanPropertyReader() throws Exception {
-        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null);
+        BeanPropertyReader reader = new BeanPropertyReader("x", FieldBackedReaderBean.class.getField("x"), null, 0);
         FieldBackedReaderBean bean = new FieldBackedReaderBean();
 
         assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{"not an int"}))
@@ -54,7 +54,7 @@ public class BeanPropertyReaderDynamicAccessTest {
     @Test
     void reportsSetterBackedInvocationFailuresFromBeanPropertyReader() throws Exception {
         BeanPropertyReader reader = new BeanPropertyReader("name", null,
-                PublicSetterBackedReaderBean.class.getMethod("setName", String.class));
+                PublicSetterBackedReaderBean.class.getMethod("setName", String.class), 0);
         PublicSetterBackedReaderBean bean = new PublicSetterBackedReaderBean();
 
         assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{13}))
@@ -63,6 +63,21 @@ public class BeanPropertyReaderDynamicAccessTest {
                         "Failed to set property 'name' (raw type java.lang.String) to value of type java.lang.Integer");
         assertThat(bean.getName()).isNull();
         assertThat(bean.getSetterCalls()).isZero();
+    }
+
+    @Test
+    void reportsExceptionsThrownBySetterMethodsFromBeanPropertyReader() throws Exception {
+        BeanPropertyReader reader = new BeanPropertyReader("name", null,
+                ThrowingSetterBackedReaderBean.class.getMethod("setName", String.class), 0);
+        ThrowingSetterBackedReaderBean bean = new ThrowingSetterBackedReaderBean();
+
+        assertThatThrownBy(() -> reader.setValueFor(bean, new Object[]{"denied"}))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining(
+                        "Failed to set property 'name' (raw type java.lang.String) to value of type java.lang.String")
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("Rejected name: denied");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
     @Test
@@ -98,6 +113,15 @@ public class BeanPropertyReaderDynamicAccessTest {
                 "{\"name\":\"Grace\"}");
 
         assertThat(bean.getName()).isEqualTo("Grace");
+        assertThat(bean.getSetterCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void populatesFieldAndSetterBackedPropertiesInOneRead() throws Exception {
+        MixedReaderBean bean = JSON.std.beanFrom(MixedReaderBean.class, "{\"id\":7,\"name\":\"Katherine\"}");
+
+        assertThat(bean.id).isEqualTo(7);
+        assertThat(bean.getName()).isEqualTo("Katherine");
         assertThat(bean.getSetterCalls()).isEqualTo(1);
     }
 
@@ -173,6 +197,44 @@ public class BeanPropertyReaderDynamicAccessTest {
             this.name = name;
             setterCalls++;
             return this;
+        }
+    }
+
+    public static final class MixedReaderBean {
+        public int id;
+        private String name;
+        private int setterCalls;
+
+        public MixedReaderBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            setterCalls++;
+        }
+    }
+
+    public static final class ThrowingSetterBackedReaderBean {
+        private int setterCalls;
+
+        public ThrowingSetterBackedReaderBean() {
+        }
+
+        public int getSetterCalls() {
+            return setterCalls;
+        }
+
+        public void setName(String name) {
+            setterCalls++;
+            throw new IllegalStateException("Rejected name: " + name);
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/BeanPropertyWriterDynamicAccessTest.java
@@ -11,10 +11,12 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.impl.BeanPropertyWriter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeanPropertyWriterDynamicAccessTest {
     private static final JSON JSON_WITH_FIELD_ACCESS = JSON.std
@@ -53,6 +55,16 @@ public class BeanPropertyWriterDynamicAccessTest {
     }
 
     @Test
+    void serializesFieldAndGetterBackedPropertiesFromSameBean() throws Exception {
+        MixedWriterBean bean = new MixedWriterBean("Grace");
+
+        String json = JSON.std.asString(bean);
+
+        assertThat(json).isEqualTo("{\"id\":5,\"name\":\"Grace\"}");
+        assertThat(bean.getterCalls).isEqualTo(1);
+    }
+
+    @Test
     void readsFieldBackedValuesThroughBeanPropertyWriter() throws Exception {
         Field field = FieldBackedWriterBean.class.getField("id");
         BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
@@ -74,6 +86,31 @@ public class BeanPropertyWriterDynamicAccessTest {
         assertThat(bean.getterCalls).isEqualTo(1);
     }
 
+    @Test
+    void reportsFieldAccessFailuresFromBeanPropertyWriter() throws Exception {
+        Field field = FieldBackedWriterBean.class.getField("id");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "id", field, null);
+
+        assertThatThrownBy(() -> writer.getValueFor(new GetterBackedWriterBean("Ada")))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to access property 'id'")
+                .hasMessageContaining("field " + FieldBackedWriterBean.class.getName() + ".id")
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void reportsGetterInvocationFailuresFromBeanPropertyWriter() throws Exception {
+        Method getter = ThrowingGetterBackedWriterBean.class.getMethod("getName");
+        BeanPropertyWriter writer = new BeanPropertyWriter(0, "name", null, getter);
+
+        assertThatThrownBy(() -> writer.getValueFor(new ThrowingGetterBackedWriterBean()))
+                .isInstanceOf(JSONObjectException.class)
+                .hasMessageContaining("Failed to access property 'name'")
+                .hasMessageContaining("method " + ThrowingGetterBackedWriterBean.class.getName() + ".getName()")
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("Cannot read name");
+    }
+
     public static final class FieldBackedWriterBean {
         public int id = 3;
     }
@@ -89,6 +126,27 @@ public class BeanPropertyWriterDynamicAccessTest {
         public String getName() {
             getterCalls++;
             return name;
+        }
+    }
+
+    public static final class MixedWriterBean {
+        public int id = 5;
+        private int getterCalls;
+        private final String name;
+
+        public MixedWriterBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            getterCalls++;
+            return name;
+        }
+    }
+
+    public static final class ThrowingGetterBackedWriterBean {
+        public String getName() {
+            throw new IllegalStateException("Cannot read name");
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/CollectionBuilderDynamicAccessTest.java
@@ -56,6 +56,30 @@ public class CollectionBuilderDynamicAccessTest {
     }
 
     @Test
+    void createsLibraryTypedArraysDirectlyForEveryCardinality() throws Exception {
+        CollectionBuilder builder = CollectionBuilder.defaultImpl();
+        Class<JSON> elementType = runtimeJsonType();
+        JSON alternate = JSON.builder().build();
+
+        JSON[] empty = builder.emptyArray(elementType);
+        JSON[] singleton = builder.singletonArray(elementType, JSON.std);
+        JSON[] multiple = builder.start()
+                .add(JSON.std)
+                .add(alternate)
+                .buildArray(elementType);
+
+        assertThat(empty).isEmpty();
+        assertThat(empty.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(singleton).hasSize(1);
+        assertThat(singleton[0]).isSameAs(JSON.std);
+        assertThat(singleton.getClass().getComponentType()).isSameAs(elementType);
+        assertThat(multiple).hasSize(2);
+        assertThat(multiple[0]).isSameAs(JSON.std);
+        assertThat(multiple[1]).isSameAs(alternate);
+        assertThat(multiple.getClass().getComponentType()).isSameAs(elementType);
+    }
+
+    @Test
     void readsEmptyTypedArraysThroughJsonApi() throws Exception {
         Class<String> elementType = runtimeStringType();
 
@@ -132,6 +156,17 @@ public class CollectionBuilderDynamicAccessTest {
     @SuppressWarnings("unchecked")
     private static Class<String> runtimeStringType() throws Exception {
         return (Class<String>) JSON.std.beanFrom(Class.class, '"' + String.class.getName() + '"');
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<JSON> runtimeJsonType() throws Exception {
+        String propertyName = "collection.builder.json.type." + System.nanoTime();
+        System.setProperty(propertyName, JSON.class.getName());
+        try {
+            return (Class<JSON>) JSON.std.beanFrom(Class.class, '"' + System.getProperty(propertyName) + '"');
+        } finally {
+            System.clearProperty(propertyName);
+        }
     }
 
     public static final class ArrayElement {

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/MapBuilderDefaultDynamicAccessTest.java
@@ -8,6 +8,7 @@ package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -77,6 +78,32 @@ public class MapBuilderDefaultDynamicAccessTest {
         assertThat(empty).isInstanceOf(ConstructorTrackingMap.class).isEmpty();
         assertThat(singleton).isInstanceOf(ConstructorTrackingMap.class).containsEntry("answer", 42);
         assertThat(ConstructorTrackingMap.CONSTRUCTOR_CALLS).hasValue(2);
+    }
+
+    @Test
+    void readsJsonObjectIntoConfiguredJdkMapImplementation() throws Exception {
+        JSON json = JSON.builder()
+                .mapBuilder(MapBuilder.defaultImpl().newBuilder(TreeMap.class))
+                .build();
+
+        Map<String, Object> counts = json.mapFrom("{\"beta\":2,\"alpha\":1}");
+
+        assertThat(counts).isExactlyInstanceOf(TreeMap.class);
+        assertThat(counts).containsEntry("alpha", 1).containsEntry("beta", 2);
+        assertThat(counts.keySet()).containsExactly("alpha", "beta");
+    }
+
+    @Test
+    void directBuilderFactoryMethodsInstantiateConfiguredJdkMapImplementation() throws Exception {
+        MapBuilder builder = MapBuilder.defaultImpl()
+                .newBuilder(TreeMap.class)
+                .newBuilder(JSON.Feature.READ_ONLY.mask());
+
+        Map<String, Object> empty = builder.emptyMap();
+        Map<String, Object> singleton = builder.singletonMap("answer", 42);
+
+        assertThat(empty).isExactlyInstanceOf(TreeMap.class).isEmpty();
+        assertThat(singleton).isExactlyInstanceOf(TreeMap.class).containsEntry("answer", 42);
     }
 
     @Test

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/RecordsHelpersDynamicAccessTest.java
@@ -29,15 +29,18 @@ public class RecordsHelpersDynamicAccessTest {
 
     @Test
     void findsCanonicalConstructorsForRecords() {
-        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(InventoryItem.class);
+        Class<?> recordType = inventoryItemClassSelectedAtRuntime();
+        Constructor<?> constructor = RecordsHelpers.findCanonicalConstructor(recordType);
 
         assertThat(constructor).isNotNull();
+        assertThat(constructor.getDeclaringClass()).isEqualTo(recordType);
         assertThat(constructor.getParameterTypes()).containsExactly(String.class, int.class, boolean.class);
     }
 
     @Test
     void derivesRecordPropertiesFromCanonicalConstructor() {
-        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER, InventoryItem.class);
+        POJODefinition definition = INTROSPECTOR.pojoDefinitionForDeserialization(JSON_READER,
+                inventoryItemClassSelectedAtRuntime());
 
         assertThat(propertyNames(definition)).containsExactly("id", "quantity", "available");
         assertThat(definition.constructors()).isNotNull();
@@ -45,10 +48,32 @@ public class RecordsHelpersDynamicAccessTest {
 
     @Test
     void deserializesRecordsThroughJsonApi() throws Exception {
-        InventoryItem item = JSON.std.beanFrom(InventoryItem.class,
+        Class<?> recordType = inventoryItemClassSelectedAtRuntime();
+        Object item = JSON.std.beanFrom(recordType,
                 "{\"id\":\"A-1\",\"quantity\":3,\"available\":true}");
 
-        assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+        if (recordType == InventoryItem.class) {
+            assertThat(item).isEqualTo(new InventoryItem("A-1", 3, true));
+        } else {
+            assertThat(item).isEqualTo(new AlternateInventoryItem("A-1", 3, true));
+        }
+    }
+
+    @Test
+    void deserializesRecordsWithVirtualBeanGettersThroughJsonApi() throws Exception {
+        Class<?> recordType = virtualGetterRecordClassSelectedAtRuntime();
+        Object record = JSON.std.beanFrom(recordType,
+                "{\"id\":\"A-1\",\"label\":\"ignored\"}");
+
+        if (recordType == RecordWithVirtualGetter.class) {
+            RecordWithVirtualGetter typedRecord = (RecordWithVirtualGetter) record;
+            assertThat(typedRecord).isEqualTo(new RecordWithVirtualGetter("A-1"));
+            assertThat(typedRecord.getLabel()).isEqualTo("label:A-1");
+        } else {
+            AlternateRecordWithVirtualGetter typedRecord = (AlternateRecordWithVirtualGetter) record;
+            assertThat(typedRecord).isEqualTo(new AlternateRecordWithVirtualGetter("A-1"));
+            assertThat(typedRecord.getLabel()).isEqualTo("label:A-1");
+        }
     }
 
     @Test
@@ -62,9 +87,34 @@ public class RecordsHelpersDynamicAccessTest {
         return definition.getProperties().stream().map(prop -> prop.name).toList();
     }
 
+    private static Class<?> inventoryItemClassSelectedAtRuntime() {
+        return Boolean.getBoolean("jackson.jr.records.use.alternate.inventory")
+                ? AlternateInventoryItem.class : InventoryItem.class;
+    }
+
+    private static Class<?> virtualGetterRecordClassSelectedAtRuntime() {
+        return Boolean.getBoolean("jackson.jr.records.use.alternate.virtual.getter")
+                ? AlternateRecordWithVirtualGetter.class : RecordWithVirtualGetter.class;
+    }
+
     public record InventoryItem(String id, int quantity, boolean available) {
         public InventoryItem(String id) {
             this(id, 0, false);
+        }
+    }
+
+    public record AlternateInventoryItem(String id, int quantity, boolean available) {
+    }
+
+    public record RecordWithVirtualGetter(String id) {
+        public String getLabel() {
+            return "label:" + id;
+        }
+    }
+
+    public record AlternateRecordWithVirtualGetter(String id) {
+        public String getLabel() {
+            return "label:" + id;
         }
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/SimpleValueReaderDynamicAccessTest.java
@@ -24,39 +24,39 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class SimpleValueReaderDynamicAccessTest {
     @Test
     void resolvesTopLevelClassesFromStringValues() throws Exception {
-        String className = loadableClassName();
+        String className = runtimeJdkClassName();
 
         Class<?> resolved = JSON.std.beanFrom(Class.class, '"' + className + '"');
 
-        assertThat(resolved).isEqualTo(LoadableType.class);
+        assertThat(resolved.getName()).isEqualTo(className);
     }
 
     @Test
     void resolvesClassTypedBeanPropertiesFromStringValues() throws Exception {
-        String className = loadableClassName();
+        String className = runtimeJdkClassName();
 
         TypeHolder holder = JSON.std.beanFrom(TypeHolder.class,
                 "{\"type\":\"" + className + "\"}");
 
-        assertThat(holder.type).isEqualTo(LoadableType.class);
+        assertThat(holder.type.getName()).isEqualTo(className);
     }
 
     @Test
     void resolvesClassesInsideTypedMapsAndLists() throws Exception {
-        String className = loadableClassName();
+        String className = runtimeJdkClassName();
 
         Map<String, Class> classesByName = JSON.std.mapOfFrom(Class.class,
                 "{\"primary\":\"" + className + "\"}");
         List<Class> classes = JSON.std.listOfFrom(Class.class,
                 "[\"" + className + "\"]");
 
-        assertThat(classesByName.get("primary")).isEqualTo(LoadableType.class);
-        assertThat(classes).singleElement().isEqualTo(LoadableType.class);
+        assertThat(classesByName.get("primary").getName()).isEqualTo(className);
+        assertThat(classes).singleElement().satisfies(type -> assertThat(type.getName()).isEqualTo(className));
     }
 
     @Test
     void readsClassNamesWithSimpleValueReader() throws Exception {
-        String className = loadableClassName();
+        String className = runtimeJdkClassName();
         SimpleValueReader reader = new SimpleValueReader(Class.class, SER_CLASS);
         JsonFactory jsonFactory = new JsonFactory();
 
@@ -64,7 +64,22 @@ public class SimpleValueReaderDynamicAccessTest {
             parser.nextToken();
             Object resolved = reader.read(null, parser);
 
-            assertThat(resolved).isEqualTo(LoadableType.class);
+            assertThat(resolved).isInstanceOf(Class.class);
+            assertThat(((Class<?>) resolved).getName()).isEqualTo(className);
+        }
+    }
+
+    @Test
+    void readsClassNamesFromTheStreamingEntryPoint() throws Exception {
+        String className = runtimeJdkClassName();
+        SimpleValueReader reader = new SimpleValueReader(Class.class, SER_CLASS);
+        JsonFactory jsonFactory = new JsonFactory();
+
+        try (JsonParser parser = jsonFactory.createParser('"' + className + '"')) {
+            Object resolved = reader.readNext(null, parser);
+
+            assertThat(resolved).isInstanceOf(Class.class);
+            assertThat(((Class<?>) resolved).getName()).isEqualTo(className);
         }
     }
 
@@ -77,16 +92,13 @@ public class SimpleValueReaderDynamicAccessTest {
                 .hasMessage("Failed to bind `java.lang.Class` from value '" + className + "'");
     }
 
-    private static String loadableClassName() {
+    private static String runtimeJdkClassName() {
         String propertyName = "simple.value.reader.class." + System.nanoTime();
-        System.setProperty(propertyName, LoadableType.class.getName());
+        System.setProperty(propertyName, String.join(".", "java", "util", "LinkedHashMap"));
         return System.getProperty(propertyName);
     }
 
     public static final class TypeHolder {
         public Class<?> type;
-    }
-
-    public static final class LoadableType {
     }
 }

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/src/test/java/com_fasterxml_jackson_jr/jackson_jr_objects/ValueReaderLocatorDynamicAccessTest.java
@@ -7,6 +7,7 @@
 package com_fasterxml_jackson_jr.jackson_jr_objects;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.jr.ob.api.MapBuilder;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.impl.BeanConstructors;
+import com.fasterxml.jackson.jr.ob.impl.BeanPropertyIntrospector;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueReaderLocator;
@@ -46,6 +48,27 @@ public class ValueReaderLocatorDynamicAccessTest {
         ValueReader reader = locator.findReader(Direction.class);
 
         assertThat(reader).isNotNull();
+    }
+
+    @Test
+    void createsEnumReadersFromDefinitionFields() {
+        ExposedValueReaderLocator locator = new ExposedValueReaderLocator(new EnumDefinitionModifier());
+
+        ValueReader reader = locator.enumReaderFor(Direction.class);
+
+        assertThat(reader.valueType()).isEqualTo(Direction.class);
+    }
+
+    @Test
+    void deserializesRecordPropertiesFromDefinitionOriginalNames() throws Exception {
+        JSON json = JSON.builder()
+                .register(new RecordDefinitionExtension())
+                .build();
+
+        RecordWithExternalNames item = json.beanFrom(RecordWithExternalNames.class,
+                "{\"item_id\":\"A-1\",\"stock_count\":3}");
+
+        assertThat(item).isEqualTo(new RecordWithExternalNames("A-1", 3));
     }
 
     @Test
@@ -82,10 +105,48 @@ public class ValueReaderLocatorDynamicAccessTest {
     public record InventoryItem(String id, int quantity, boolean available) {
     }
 
+    public record RecordWithExternalNames(String id, int quantity) {
+    }
+
+    private static POJODefinition.Prop recordProp(String externalName, String originalName) {
+        return new POJODefinition.Prop(externalName, originalName, null, null, null, null, null);
+    }
+
+    public static class ExposedValueReaderLocator extends ValueReaderLocator {
+        ExposedValueReaderLocator(ReaderWriterModifier modifier) {
+            super(null, modifier);
+        }
+
+        ValueReader enumReaderFor(Class<?> enumType) {
+            return enumReader(enumType);
+        }
+    }
+
     public static class EnumDefinitionExtension extends JacksonJrExtension {
         @Override
         protected void register(ExtensionContext ctxt) {
             ctxt.insertModifier(new EnumDefinitionModifier());
+        }
+    }
+
+    public static class RecordDefinitionExtension extends JacksonJrExtension {
+        @Override
+        protected void register(ExtensionContext ctxt) {
+            ctxt.insertModifier(new RecordDefinitionModifier());
+        }
+    }
+
+    public static class RecordDefinitionModifier extends ReaderWriterModifier {
+        @Override
+        public POJODefinition pojoDefinitionForDeserialization(JSONReader readContext, Class<?> pojoType) {
+            if (pojoType != RecordWithExternalNames.class) {
+                return null;
+            }
+            POJODefinition base = BeanPropertyIntrospector.instance()
+                    .pojoDefinitionForDeserialization(readContext, pojoType);
+            return base.withProperties(List.of(
+                    recordProp("item_id", "id"),
+                    recordProp("stock_count", "quantity")));
         }
     }
 

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-jupiter.xml
@@ -1,67 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Jupiter" tests="58" skipped="0" failures="0" errors="0" time="0.057" hostname="kung-fu-workstation" timestamp="2026-05-03T11:28:44">
+<testsuite name="JUnit Jupiter" tests="72" skipped="0" failures="0" errors="0" time="0.044" hostname="kung-fu-workstation" timestamp="2026-05-05T04:25:14">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.class-for-name-respects-class-loader" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-file-system-providers" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-resource-bundles" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
 <property name="os.name" value="Linux"/>
 <property name="os.version" value="6.17.0-22-generic"/>
 <property name="path.separator" value=":"/>
-<property name="simple.value.reader.class.216897410546714" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
-<property name="simple.value.reader.class.216897410685214" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
-<property name="simple.value.reader.class.216897410746261" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
-<property name="simple.value.reader.class.216897410820682" value="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest$LoadableType"/>
+<property name="simple.value.reader.class.364287998235647" value="java.util.LinkedHashMap"/>
+<property name="simple.value.reader.class.364287998321248" value="java.util.LinkedHashMap"/>
+<property name="simple.value.reader.class.364287998381428" value="java.util.LinkedHashMap"/>
+<property name="simple.value.reader.class.364287998452885" value="java.util.LinkedHashMap"/>
+<property name="simple.value.reader.class.364287999038221" value="java.util.LinkedHashMap"/>
 <property name="stderr.encoding" value="UTF-8"/>
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-9e70594d/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/5176-1be4a586/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>
 <property name="user.timezone" value="Europe/Zurich"/>
 </properties>
-<testcase name="readsSingletonTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<testcase name="deserializesRecordsWithVirtualBeanGettersThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:deserializesRecordsWithVirtualBeanGettersThroughJsonApi()]
+display-name: deserializesRecordsWithVirtualBeanGettersThroughJsonApi()
+]]></system-out>
+</testcase>
+<testcase name="readsSingletonTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsSingletonTypedArraysThroughJsonApi()]
 display-name: readsSingletonTypedArraysThroughJsonApi()
 ]]></system-out>
 </testcase>
-<testcase name="createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<testcase name="createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()]
 display-name: createsBeansThroughPublicDefaultConstructorsWhenReadingObjects()
@@ -79,19 +91,31 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: resolvesTopLevelClassesFromStringValues()
 ]]></system-out>
 </testcase>
+<testcase name="publicJsonApiIntrospectsBeanConstructorsFieldsAndMethods()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:publicJsonApiIntrospectsBeanConstructorsFieldsAndMethods()]
+display-name: publicJsonApiIntrospectsBeanConstructorsFieldsAndMethods()
+]]></system-out>
+</testcase>
 <testcase name="reportsUnresolvableClassNames()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:reportsUnresolvableClassNames()]
 display-name: reportsUnresolvableClassNames()
 ]]></system-out>
 </testcase>
-<testcase name="readsPojoTypedArraysThroughJsonApiForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<testcase name="readsPojoTypedArraysThroughJsonApiForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsPojoTypedArraysThroughJsonApiForEveryCardinality()]
 display-name: readsPojoTypedArraysThroughJsonApiForEveryCardinality()
 ]]></system-out>
 </testcase>
-<testcase name="populatesPublicSettersThroughDefaultJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.001">
+<testcase name="createsBeansThroughConstructorsDiscoveredByBeanIntrospection()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughConstructorsDiscoveredByBeanIntrospection()]
+display-name: createsBeansThroughConstructorsDiscoveredByBeanIntrospection()
+]]></system-out>
+</testcase>
+<testcase name="populatesPublicSettersThroughDefaultJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPublicSettersThroughDefaultJsonApi()]
 display-name: populatesPublicSettersThroughDefaultJsonApi()
@@ -103,19 +127,25 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: createsEmptyTypedArraysDirectly()
 ]]></system-out>
 </testcase>
+<testcase name="createsLibraryTypedArraysDirectlyForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0.003">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsLibraryTypedArraysDirectlyForEveryCardinality()]
+display-name: createsLibraryTypedArraysDirectlyForEveryCardinality()
+]]></system-out>
+</testcase>
 <testcase name="derivesRecordPropertiesFromCanonicalConstructor()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:derivesRecordPropertiesFromCanonicalConstructor()]
 display-name: derivesRecordPropertiesFromCanonicalConstructor()
 ]]></system-out>
 </testcase>
-<testcase name="createsMultiValueTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<testcase name="createsMultiValueTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0.003">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsMultiValueTypedArraysDirectly()]
 display-name: createsMultiValueTypedArraysDirectly()
 ]]></system-out>
 </testcase>
-<testcase name="directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.003">
+<testcase name="directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()]
 display-name: directBuilderFactoryMethodsInstantiateConfiguredMapImplementation()
@@ -127,19 +157,13 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: populatesPublicSetterBackedProperties()
 ]]></system-out>
 </testcase>
-<testcase name="createsRecordsDirectlyThroughCanonicalConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsDirectlyThroughCanonicalConstructors()]
-display-name: createsRecordsDirectlyThroughCanonicalConstructors()
-]]></system-out>
-</testcase>
 <testcase name="supportsFieldNamedGettersWhenEnabled()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:supportsFieldNamedGettersWhenEnabled()]
 display-name: supportsFieldNamedGettersWhenEnabled()
 ]]></system-out>
 </testcase>
-<testcase name="resolvesGenericArrayTypesFromBoundTypeVariables()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
+<testcase name="resolvesGenericArrayTypesFromBoundTypeVariables()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesGenericArrayTypesFromBoundTypeVariables()]
 display-name: resolvesGenericArrayTypesFromBoundTypeVariables()
@@ -151,7 +175,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: readsModifierProvidedEnumDefinitionsCaseInsensitively()
 ]]></system-out>
 </testcase>
-<testcase name="createsRecordsThroughCanonicalConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.004">
+<testcase name="createsRecordsThroughCanonicalConstructorsWhenReadingObjects()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsThroughCanonicalConstructorsWhenReadingObjects()]
 display-name: createsRecordsThroughCanonicalConstructorsWhenReadingObjects()
@@ -163,7 +187,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: readsFieldBackedValuesThroughBeanPropertyWriter()
 ]]></system-out>
 </testcase>
-<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
+<testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
 display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
@@ -181,7 +205,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: invokesSetterBackedValuesThroughBeanPropertyReader()
 ]]></system-out>
 </testcase>
-<testcase name="serializesRecordFieldsInDeclarationOrderThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0.001">
+<testcase name="serializesRecordFieldsInDeclarationOrderThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.RecordsHelpersDynamicAccessTest]/[method:serializesRecordFieldsInDeclarationOrderThroughJsonApi()]
 display-name: serializesRecordFieldsInDeclarationOrderThroughJsonApi()
@@ -199,7 +223,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: readsEmptyTypedArraysThroughJsonApi()
 ]]></system-out>
 </testcase>
-<testcase name="readsEmptyJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<testcase name="readsEmptyJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.007">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsEmptyJsonObjectIntoConfiguredMapImplementation()]
 display-name: readsEmptyJsonObjectIntoConfiguredMapImplementation()
@@ -223,7 +247,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: deserializesRecordsThroughJsonApi()
 ]]></system-out>
 </testcase>
-<testcase name="setsFieldBackedValuesThroughBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.002">
+<testcase name="setsFieldBackedValuesThroughBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:setsFieldBackedValuesThroughBeanPropertyReader()]
 display-name: setsFieldBackedValuesThroughBeanPropertyReader()
@@ -241,6 +265,12 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: populatesPublicFieldsThroughDefaultJsonApi()
 ]]></system-out>
 </testcase>
+<testcase name="reportsGetterInvocationFailuresFromBeanPropertyWriter()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:reportsGetterInvocationFailuresFromBeanPropertyWriter()]
+display-name: reportsGetterInvocationFailuresFromBeanPropertyWriter()
+]]></system-out>
+</testcase>
 <testcase name="readsMultiValueTypedArraysThroughJsonApi()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:readsMultiValueTypedArraysThroughJsonApi()]
@@ -253,7 +283,13 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: collectsDeclaredFieldsAndMethodsForSerialization()
 ]]></system-out>
 </testcase>
-<testcase name="createsBeansThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
+<testcase name="createsNestedRecordsThroughCanonicalConstructorsWhenReadingProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsNestedRecordsThroughCanonicalConstructorsWhenReadingProperties()]
+display-name: createsNestedRecordsThroughCanonicalConstructorsWhenReadingProperties()
+]]></system-out>
+</testcase>
+<testcase name="createsBeansThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0.006">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest]/[method:createsBeansThroughPublicDefaultConstructors()]
 display-name: createsBeansThroughPublicDefaultConstructors()
@@ -265,7 +301,7 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: resolvesClassesInsideTypedMapsAndLists()
 ]]></system-out>
 </testcase>
-<testcase name="readsEnumsFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<testcase name="readsEnumsFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:readsEnumsFromModifierProvidedDefinitions()]
 display-name: readsEnumsFromModifierProvidedDefinitions()
@@ -283,10 +319,22 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: populatesFieldBackedBeanProperties()
 ]]></system-out>
 </testcase>
+<testcase name="directBuilderFactoryMethodsInstantiateConfiguredJdkMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:directBuilderFactoryMethodsInstantiateConfiguredJdkMapImplementation()]
+display-name: directBuilderFactoryMethodsInstantiateConfiguredJdkMapImplementation()
+]]></system-out>
+</testcase>
 <testcase name="resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest]/[method:resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()]
 display-name: resolvesSyntheticGenericArrayTypesFromLibraryComponentTypes()
+]]></system-out>
+</testcase>
+<testcase name="deserializesRecordPropertiesFromDefinitionOriginalNames()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:deserializesRecordPropertiesFromDefinitionOriginalNames()]
+display-name: deserializesRecordPropertiesFromDefinitionOriginalNames()
 ]]></system-out>
 </testcase>
 <testcase name="resolvesGenericArrayTypesNestedInParameterizedTypes()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.TypeResolverDynamicAccessTest" time="0">
@@ -295,16 +343,22 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: resolvesGenericArrayTypesNestedInParameterizedTypes()
 ]]></system-out>
 </testcase>
-<testcase name="createsSingletonTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
+<testcase name="createsSingletonTypedArraysDirectly()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0.001">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest]/[method:createsSingletonTypedArraysDirectly()]
 display-name: createsSingletonTypedArraysDirectly()
 ]]></system-out>
 </testcase>
-<testcase name="createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.006">
+<testcase name="readsClassNamesFromTheStreamingEntryPoint()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()]
-display-name: createsBeansDirectlyThroughNonPublicDefaultConstructorsWhenAccessIsForced()
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest]/[method:readsClassNamesFromTheStreamingEntryPoint()]
+display-name: readsClassNamesFromTheStreamingEntryPoint()
+]]></system-out>
+</testcase>
+<testcase name="reportsFieldAccessFailuresFromBeanPropertyWriter()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:reportsFieldAccessFailuresFromBeanPropertyWriter()]
+display-name: reportsFieldAccessFailuresFromBeanPropertyWriter()
 ]]></system-out>
 </testcase>
 <testcase name="typedArrayReadsUseConfiguredCollectionBuilderForEveryCardinality()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.CollectionBuilderDynamicAccessTest" time="0">
@@ -319,10 +373,16 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: retainsConfiguredMapImplementationWhenRestartingABusyBuilder()
 ]]></system-out>
 </testcase>
-<testcase name="readsMultiEntryJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.01">
+<testcase name="readsMultiEntryJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsMultiEntryJsonObjectIntoConfiguredMapImplementation()]
 display-name: readsMultiEntryJsonObjectIntoConfiguredMapImplementation()
+]]></system-out>
+</testcase>
+<testcase name="readsJsonObjectIntoConfiguredJdkMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsJsonObjectIntoConfiguredJdkMapImplementation()]
+display-name: readsJsonObjectIntoConfiguredJdkMapImplementation()
 ]]></system-out>
 </testcase>
 <testcase name="readsClassNamesWithSimpleValueReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.SimpleValueReaderDynamicAccessTest" time="0">
@@ -331,7 +391,19 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: readsClassNamesWithSimpleValueReader()
 ]]></system-out>
 </testcase>
-<testcase name="readsSingletonJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0.002">
+<testcase name="createsEnumReadersFromDefinitionFields()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:createsEnumReadersFromDefinitionFields()]
+display-name: createsEnumReadersFromDefinitionFields()
+]]></system-out>
+</testcase>
+<testcase name="createsRecordsThroughConstructorsDiscoveredByBeanIntrospection()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsRecordsThroughConstructorsDiscoveredByBeanIntrospection()]
+display-name: createsRecordsThroughConstructorsDiscoveredByBeanIntrospection()
+]]></system-out>
+</testcase>
+<testcase name="readsSingletonJsonObjectIntoConfiguredMapImplementation()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.MapBuilderDefaultDynamicAccessTest]/[method:readsSingletonJsonObjectIntoConfiguredMapImplementation()]
 display-name: readsSingletonJsonObjectIntoConfiguredMapImplementation()
@@ -349,16 +421,16 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: resolvesClassTypedBeanPropertiesFromStringValues()
 ]]></system-out>
 </testcase>
-<testcase name="createsBeansDirectlyThroughPublicDefaultConstructors()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0.002">
-<system-out><![CDATA[
-unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsBeansDirectlyThroughPublicDefaultConstructors()]
-display-name: createsBeansDirectlyThroughPublicDefaultConstructors()
-]]></system-out>
-</testcase>
 <testcase name="invokesGetterBackedValuesThroughBeanPropertyWriter()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:invokesGetterBackedValuesThroughBeanPropertyWriter()]
 display-name: invokesGetterBackedValuesThroughBeanPropertyWriter()
+]]></system-out>
+</testcase>
+<testcase name="populatesFieldAndSetterBackedPropertiesInOneRead()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFieldAndSetterBackedPropertiesInOneRead()]
+display-name: populatesFieldAndSetterBackedPropertiesInOneRead()
 ]]></system-out>
 </testcase>
 <testcase name="createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanReaderDynamicAccessTest" time="0">
@@ -367,13 +439,25 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: createsBeansThroughNonPublicDefaultConstructorsWhenAccessIsForced()
 ]]></system-out>
 </testcase>
-<testcase name="collectsIntegerConstructorsForNumericScalarDeserialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0.001">
+<testcase name="collectsIntegerConstructorsForNumericScalarDeserialization()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyIntrospectorDynamicAccessTest]/[method:collectsIntegerConstructorsForNumericScalarDeserialization()]
 display-name: collectsIntegerConstructorsForNumericScalarDeserialization()
 ]]></system-out>
 </testcase>
-<testcase name="populatesPrivateSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.002">
+<testcase name="serializesFieldAndGetterBackedPropertiesFromSameBean()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyWriterDynamicAccessTest]/[method:serializesFieldAndGetterBackedPropertiesFromSameBean()]
+display-name: serializesFieldAndGetterBackedPropertiesFromSameBean()
+]]></system-out>
+</testcase>
+<testcase name="createsNestedBeansThroughDefaultConstructorsWhenReadingProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanConstructorsDynamicAccessTest]/[method:createsNestedBeansThroughDefaultConstructorsWhenReadingProperties()]
+display-name: createsNestedBeansThroughDefaultConstructorsWhenReadingProperties()
+]]></system-out>
+</testcase>
+<testcase name="populatesPrivateSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesPrivateSetterBackedProperties()]
 display-name: populatesPrivateSetterBackedProperties()
@@ -385,13 +469,19 @@ unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_obj
 display-name: collectsDeclaredConstructorsForDeserialization()
 ]]></system-out>
 </testcase>
-<testcase name="createsEnumReadersFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0">
+<testcase name="reportsExceptionsThrownBySetterMethodsFromBeanPropertyReader()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
+<system-out><![CDATA[
+unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:reportsExceptionsThrownBySetterMethodsFromBeanPropertyReader()]
+display-name: reportsExceptionsThrownBySetterMethodsFromBeanPropertyReader()
+]]></system-out>
+</testcase>
+<testcase name="createsEnumReadersFromModifierProvidedDefinitions()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest" time="0.002">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.ValueReaderLocatorDynamicAccessTest]/[method:createsEnumReadersFromModifierProvidedDefinitions()]
 display-name: createsEnumReadersFromModifierProvidedDefinitions()
 ]]></system-out>
 </testcase>
-<testcase name="populatesFluentSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0.001">
+<testcase name="populatesFluentSetterBackedProperties()" classname="com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest" time="0">
 <system-out><![CDATA[
 unique-id: [engine:junit-jupiter]/[class:com_fasterxml_jackson_jr.jackson_jr_objects.BeanPropertyReaderDynamicAccessTest]/[method:populatesFluentSetterBackedProperties()]
 display-name: populatesFluentSetterBackedProperties()

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/test-results-native/test/TEST-junit-vintage.xml
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-03T11:28:44">
+<testsuite name="JUnit Vintage" tests="0" skipped="0" failures="0" errors="0" time="0" hostname="kung-fu-workstation" timestamp="2026-05-05T04:25:14">
 <properties>
 <property name="file.encoding" value="UTF-8"/>
 <property name="file.separator" value="/"/>
 <property name="java.class.path" value=""/>
 <property name="java.class.version" value="69.0"/>
-<property name="java.endorsed.dirs" value=""/>
-<property name="java.ext.dirs" value=""/>
 <property name="java.io.tmpdir" value="/tmp"/>
 <property name="java.library.path" value="/usr/lib64:/lib64:/lib:/usr/lib"/>
 <property name="java.runtime.name" value="GraalVM Runtime Environment"/>
-<property name="java.runtime.version" value="25.0.3+9-LTS-jvmci-b01"/>
+<property name="java.runtime.version" value="25.0.2+10-LTS-jvmci-25.1-b17"/>
 <property name="java.specification.name" value="Java Platform API Specification"/>
 <property name="java.specification.vendor" value="Oracle Corporation"/>
 <property name="java.specification.version" value="25"/>
 <property name="java.vendor" value="Oracle Corporation"/>
 <property name="java.vendor.url" value="https://www.graalvm.org/"/>
-<property name="java.vendor.version" value="Oracle GraalVM 25.0.3+9.1"/>
-<property name="java.version" value="25.0.3"/>
-<property name="java.version.date" value="2026-04-21"/>
+<property name="java.vendor.version" value="Oracle GraalVM 25.1.0-dev+10.1"/>
+<property name="java.version" value="25.0.2"/>
+<property name="java.version.date" value="2026-01-20"/>
 <property name="java.vm.info" value="serial gc, compressed references"/>
 <property name="java.vm.name" value="Substrate VM"/>
 <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
 <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
 <property name="java.vm.specification.version" value="25"/>
 <property name="java.vm.vendor" value="Oracle Corporation"/>
-<property name="java.vm.version" value="25.0.3+9-LTS"/>
+<property name="java.vm.version" value="25.0.2+10-LTS"/>
 <property name="jdk.lang.Process.launchMechanism" value="FORK"/>
+<property name="jdk.module.path" value=""/>
 <property name="junit.jupiter.execution.timeout.default" value="60 s"/>
 <property name="junit.jupiter.execution.timeout.mode" value="enabled"/>
 <property name="junit.jupiter.execution.timeout.thread.mode.default" value="separate_thread"/>
 <property name="line.separator" value="
 "/>
 <property name="native.encoding" value="UTF-8"/>
+<property name="org.graalvm.nativeimage.future-defaults.class-for-name-respects-class-loader" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.complete-reflection-types" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-file-system-providers" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-resource-bundles" value="true"/>
+<property name="org.graalvm.nativeimage.future-defaults.run-time-initialize-security-providers" value="true"/>
 <property name="org.graalvm.nativeimage.imagecode" value="runtime"/>
 <property name="org.graalvm.nativeimage.kind" value="executable"/>
 <property name="os.arch" value="amd64"/>
@@ -43,9 +47,10 @@
 <property name="stdin.encoding" value="UTF-8"/>
 <property name="stdout.encoding" value="UTF-8"/>
 <property name="sun.arch.data.model" value="64"/>
+<property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
 <property name="sun.jnu.encoding" value="UTF-8"/>
 <property name="user.country" value="US"/>
-<property name="user.dir" value="/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/2564-9e70594d/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
+<property name="user.dir" value="/home/vjovanov/c/forge/forge10/graalvm-reachability-metadata/forge/local_repositories/forge_worktrees/5176-1be4a586/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0"/>
 <property name="user.home" value="/home/vjovanov"/>
 <property name="user.language" value="en"/>
 <property name="user.name" value="vjovanov"/>

--- a/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
+++ b/tests/src/com.fasterxml.jackson.jr/jackson-jr-objects/2.21.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "com.fasterxml.jackson.jr.**"
+    },
+    {
+      "includeClasses" : "com_fasterxml_jackson_jr.jackson_jr_objects.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #5176

This PR provides test fixes and new metadata for com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 879125
- Cached input tokens: 11328000
- Output tokens: 97001
- Metadata entries: 13
- Test-only metadata entries: 129
- Iterations: 19
- Library coverage percentage: 40.59
- Previous library version metadata entries: 13
- Previous library version test-only metadata entries: 129
- Previous library version coverage percentage: 40.59

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2b0a0c5e9d3239e28fd7c1e3a81e592fc5c3ddea`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0` and `com.fasterxml.jackson.jr:jackson-jr-objects:2.21.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 17
- Fixup attempts: 1
