### PR TITLE
[GenAI] Test fix for io.netty:netty-pkitesting:4.2.2.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-pkitesting/4.2.2.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-pkitesting/4.2.2.Final/reachability-metadata.json
@@ -1,0 +1,314 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.AsymmetricKey",
+      "methods" : [
+        {
+          "name" : "getParams",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.MessageDigestSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.interfaces.DSAPrivateKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.interfaces.DSAPublicKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.spec.DSAParameterSpec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder$Algorithm"
+      },
+      "type" : "java.security.spec.NamedParameterSpec",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "java.security.spec.NamedParameterSpec",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.DSA$SHA256withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.DSAKeyFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.DSAParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder$SecureRandomHolder"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.netty.pkitesting.CertificateBuilder"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.netty/netty-pkitesting/index.json
+++ b/metadata/io.netty/netty-pkitesting/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.2.2.Final",
+    "tested-versions" : [
+      "4.2.2.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.pkitesting"
+    ]
+  },
+  {
     "metadata-version" : "4.2.1.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-pkitesting/$version$/netty-pkitesting-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-pkitesting/index.json
+++ b/metadata/io.netty/netty-pkitesting/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.2.2.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-pkitesting/$version$/netty-pkitesting-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-pkitesting/$version$/netty-pkitesting-$version$-test-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-pkitesting/$version$/netty-pkitesting-$version$-javadoc.jar",
+    "description" : "Netty PKITesting provides test support utilities for building X.509 certificates, certificate bundles, and certificate revocation data. It is used by Netty's TLS and PKI-related tests to generate and serve certificate material without relying on external infrastructure.",
     "tested-versions" : [
       "4.2.2.Final"
     ],

--- a/stats/io.netty/netty-pkitesting/4.2.2.Final/execution-metrics.json
+++ b/stats/io.netty/netty-pkitesting/4.2.2.Final/execution-metrics.json
@@ -1,0 +1,100 @@
+{
+  "fix_java_run_fail:2026-05-05": {
+    "timestamp": "2026-05-05T02:55:16.319512Z",
+    "library": "io.netty:netty-pkitesting:4.2.2.Final",
+    "starting_commit": "f9efaa1811964f2e6097e5e01ca02f155b1a90ad",
+    "ending_commit": "1af5d4611fff9ecc90c28f04be95e519e7644fab",
+    "previous_library": "io.netty:netty-pkitesting:4.2.1.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.2.2.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 534,
+          "missed": 2406,
+          "ratio": 0.181633,
+          "total": 2940
+        },
+        "line": {
+          "covered": 85,
+          "missed": 488,
+          "ratio": 0.148342,
+          "total": 573
+        },
+        "method": {
+          "covered": 18,
+          "missed": 107,
+          "ratio": 0.144,
+          "total": 125
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.2.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 517,
+          "missed": 2423,
+          "ratio": 0.17585,
+          "total": 2940
+        },
+        "line": {
+          "covered": 80,
+          "missed": 493,
+          "ratio": 0.139616,
+          "total": 573
+        },
+        "method": {
+          "covered": 18,
+          "missed": 107,
+          "ratio": 0.144,
+          "total": 125
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 74512,
+      "cached_input_tokens_used": 815104,
+      "output_tokens_used": 13090,
+      "iterations": 3,
+      "cost_usd": 0.8003,
+      "tested_library_loc": 85,
+      "metadata_entries": 47,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 14.83,
+      "previous_library_coverage_percent": 13.96
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java",
+      "metadata_file": "metadata/io.netty/netty-pkitesting/4.2.2.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-pkitesting/4.2.2.Final/stats.json
+++ b/stats/io.netty/netty-pkitesting/4.2.2.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.2.2.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 534,
+        "missed" : 2406,
+        "ratio" : 0.181633,
+        "total" : 2940
+      },
+      "line" : {
+        "covered" : 85,
+        "missed" : 488,
+        "ratio" : 0.148342,
+        "total" : 573
+      },
+      "method" : {
+        "covered" : 18,
+        "missed" : 107,
+        "ratio" : 0.144,
+        "total" : 125
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/.gitignore
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/build.gradle
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-pkitesting:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/gradle.properties
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-pkitesting:4.2.2.Final
+library.version = 4.2.2.Final
+metadata.dir = io.netty/netty-pkitesting/4.2.2.Final/

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/settings.gradle
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-pkitesting_tests'

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_pkitesting;
+
+import io.netty.pkitesting.CertificateBuilder;
+import io.netty.pkitesting.X509Bundle;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import javax.security.auth.x500.X500Principal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CertificateBuilderTest {
+    @Test
+    void buildIssuedByReadsMlDsaParameterNameFromIssuerPublicKey() {
+        PublicKey issuerPublicKey = new MlDsaPublicKey();
+        X509Certificate issuerCertificate = new MinimalX509Certificate(issuerPublicKey);
+        X509Bundle issuerBundle = X509Bundle.fromCertificatePath(
+                new X509Certificate[] {issuerCertificate},
+                issuerCertificate,
+                new KeyPair(issuerPublicKey, new MinimalPrivateKey()));
+
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> new CertificateBuilder()
+                        .subject("CN=leaf")
+                        .publicKey(new MlDsaPublicKey())
+                        .buildIssuedBy(issuerBundle));
+
+        assertTrue(exception.getMessage().contains("Algorithm not supported: test-ml-dsa"));
+    }
+
+    public static final class MlDsaPublicKey implements PublicKey {
+        public MlDsaParameters getParams() {
+            return new MlDsaParameters();
+        }
+
+        @Override
+        public String getAlgorithm() {
+            return "ML-DSA";
+        }
+
+        @Override
+        public String getFormat() {
+            return "X.509";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new byte[0];
+        }
+    }
+
+    public static final class MlDsaParameters {
+        public String getName() {
+            return "test-ml-dsa";
+        }
+    }
+
+    private static final class MinimalPrivateKey implements PrivateKey {
+        @Override
+        public String getAlgorithm() {
+            return "ML-DSA";
+        }
+
+        @Override
+        public String getFormat() {
+            return "PKCS#8";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new byte[0];
+        }
+    }
+
+    private static final class MinimalX509Certificate extends X509Certificate {
+        private final PublicKey publicKey;
+        private final X500Principal principal = new X500Principal("CN=issuer");
+
+        MinimalX509Certificate(PublicKey publicKey) {
+            this.publicKey = publicKey;
+        }
+
+        @Override
+        public void checkValidity() {
+        }
+
+        @Override
+        public void checkValidity(Date date) {
+        }
+
+        @Override
+        public int getVersion() {
+            return 3;
+        }
+
+        @Override
+        public BigInteger getSerialNumber() {
+            return BigInteger.ONE;
+        }
+
+        @Override
+        public Principal getIssuerDN() {
+            return principal;
+        }
+
+        @Override
+        public Principal getSubjectDN() {
+            return principal;
+        }
+
+        @Override
+        public X500Principal getIssuerX500Principal() {
+            return principal;
+        }
+
+        @Override
+        public X500Principal getSubjectX500Principal() {
+            return principal;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return new Date(0L);
+        }
+
+        @Override
+        public Date getNotAfter() {
+            return new Date(Long.MAX_VALUE);
+        }
+
+        @Override
+        public byte[] getTBSCertificate() throws CertificateEncodingException {
+            return new byte[0];
+        }
+
+        @Override
+        public byte[] getSignature() {
+            return new byte[0];
+        }
+
+        @Override
+        public String getSigAlgName() {
+            return "ML-DSA";
+        }
+
+        @Override
+        public String getSigAlgOID() {
+            return "1.2.3.4";
+        }
+
+        @Override
+        public byte[] getSigAlgParams() {
+            return new byte[0];
+        }
+
+        @Override
+        public boolean[] getIssuerUniqueID() {
+            return null;
+        }
+
+        @Override
+        public boolean[] getSubjectUniqueID() {
+            return null;
+        }
+
+        @Override
+        public boolean[] getKeyUsage() {
+            return null;
+        }
+
+        @Override
+        public int getBasicConstraints() {
+            return -1;
+        }
+
+        @Override
+        public byte[] getEncoded() throws CertificateEncodingException {
+            return new byte[0];
+        }
+
+        @Override
+        public void verify(PublicKey key) {
+        }
+
+        @Override
+        public void verify(PublicKey key, String sigProvider) {
+        }
+
+        @Override
+        public String toString() {
+            return "MinimalX509Certificate";
+        }
+
+        @Override
+        public PublicKey getPublicKey() {
+            return publicKey;
+        }
+
+        @Override
+        public boolean hasUnsupportedCriticalExtension() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getCriticalExtensionOIDs() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return Set.of();
+        }
+
+        @Override
+        public byte[] getExtensionValue(String oid) {
+            return null;
+        }
+
+        @Override
+        public List<String> getExtendedKeyUsage() {
+            return null;
+        }
+
+        @Override
+        public Collection<List<?>> getSubjectAlternativeNames() {
+            return null;
+        }
+
+        @Override
+        public Collection<List<?>> getIssuerAlternativeNames() {
+            return null;
+        }
+    }
+}

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -23,10 +25,32 @@ import java.util.List;
 import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CertificateBuilderTest {
+    @Test
+    void buildIssuedByReadsMlDsaParameterNameFromJdkAsymmetricKey() throws Exception {
+        KeyPair issuerKeyPair = generateMlDsaKeyPair();
+        X509Certificate issuerCertificate = new MinimalX509Certificate(issuerKeyPair.getPublic());
+        X509Bundle issuerBundle = X509Bundle.fromCertificatePath(
+                new X509Certificate[] {issuerCertificate},
+                issuerCertificate,
+                issuerKeyPair);
+
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> new CertificateBuilder()
+                        .subject("CN=leaf")
+                        .publicKey(new MlDsaPublicKey())
+                        .buildIssuedBy(issuerBundle));
+
+        String message = String.valueOf(exception.getMessage());
+        assertFalse(message.contains("Cannot get algorithm name for ML-DSA key"));
+        assertFalse(message.contains("Don't know what signature algorithm is best"));
+    }
+
     @Test
     void buildIssuedByReadsMlDsaParameterNameFromIssuerPublicKey() {
         PublicKey issuerPublicKey = new MlDsaPublicKey();
@@ -36,14 +60,18 @@ public class CertificateBuilderTest {
                 issuerCertificate,
                 new KeyPair(issuerPublicKey, new MinimalPrivateKey()));
 
-        UnsupportedOperationException exception = assertThrows(
-                UnsupportedOperationException.class,
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
                 () -> new CertificateBuilder()
                         .subject("CN=leaf")
                         .publicKey(new MlDsaPublicKey())
                         .buildIssuedBy(issuerBundle));
 
-        assertTrue(exception.getMessage().contains("Algorithm not supported: test-ml-dsa"));
+        assertTrue(exception.getMessage().contains("Cannot get algorithm name for ML-DSA key"));
+    }
+
+    private static KeyPair generateMlDsaKeyPair() throws NoSuchAlgorithmException {
+        return KeyPairGenerator.getInstance("ML-DSA-44").generateKeyPair();
     }
 
     public static final class MlDsaPublicKey implements PublicKey {

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_netty.netty_pkitesting.CertificateBuilderTest"
+      },
+      "type" : "sun.security.provider.ML_DSA_Impls$KPG2",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_netty.netty_pkitesting.CertificateBuilderTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_netty.netty_pkitesting.CertificateBuilderTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-pkitesting/4.2.2.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-pkitesting/4.2.2.Final/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.netty.pkitesting.**"
+    },
+    {
+      "includeClasses" : "io_netty.netty_pkitesting.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5880

This PR provides test fixes and new metadata for io.netty:netty-pkitesting:4.2.2.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 74512
- Cached input tokens: 815104
- Output tokens: 13090
- Metadata entries: 47
- Test-only metadata entries: 6
- Iterations: 3
- Library coverage percentage: 14.83
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 13.96

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2b0a0c5e9d3239e28fd7c1e3a81e592fc5c3ddea`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-pkitesting:4.2.1.Final: 5/5 covered calls (100.00%)
- io.netty:netty-pkitesting:4.2.2.Final: 4/4 covered calls (100.00%)

**Reflection:**
- io.netty:netty-pkitesting:4.2.1.Final: 5/5 covered calls (100.00%)
- io.netty:netty-pkitesting:4.2.2.Final: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-pkitesting:4.2.1.Final: 517/2940 (17.59%)
- io.netty:netty-pkitesting:4.2.2.Final: 534/2940 (18.16%)

**Line:**
- io.netty:netty-pkitesting:4.2.1.Final: 80/573 (13.96%)
- io.netty:netty-pkitesting:4.2.2.Final: 85/573 (14.83%)

**Method:**
- io.netty:netty-pkitesting:4.2.1.Final: 18/125 (14.40%)
- io.netty:netty-pkitesting:4.2.2.Final: 18/125 (14.40%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.netty/netty-pkitesting/4.2.1.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java 2/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
index 30be37e5da..48bad52dc4 100644
--- 1/tests/src/io.netty/netty-pkitesting/4.2.1.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
+++ 2/tests/src/io.netty/netty-pkitesting/4.2.2.Final/src/test/java/io_netty/netty_pkitesting/CertificateBuilderTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -23,10 +25,32 @@ import java.util.List;
 import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CertificateBuilderTest {
+    @Test
+    void buildIssuedByReadsMlDsaParameterNameFromJdkAsymmetricKey() throws Exception {
+        KeyPair issuerKeyPair = generateMlDsaKeyPair();
+        X509Certificate issuerCertificate = new MinimalX509Certificate(issuerKeyPair.getPublic());
+        X509Bundle issuerBundle = X509Bundle.fromCertificatePath(
+                new X509Certificate[] {issuerCertificate},
+                issuerCertificate,
+                issuerKeyPair);
+
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> new CertificateBuilder()
+                        .subject("CN=leaf")
+                        .publicKey(new MlDsaPublicKey())
+                        .buildIssuedBy(issuerBundle));
+
+        String message = String.valueOf(exception.getMessage());
+        assertFalse(message.contains("Cannot get algorithm name for ML-DSA key"));
+        assertFalse(message.contains("Don't know what signature algorithm is best"));
+    }
+
     @Test
     void buildIssuedByReadsMlDsaParameterNameFromIssuerPublicKey() {
         PublicKey issuerPublicKey = new MlDsaPublicKey();
@@ -36,14 +60,18 @@ public class CertificateBuilderTest {
                 issuerCertificate,
                 new KeyPair(issuerPublicKey, new MinimalPrivateKey()));
 
-        UnsupportedOperationException exception = assertThrows(
-                UnsupportedOperationException.class,
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
                 () -> new CertificateBuilder()
                         .subject("CN=leaf")
                         .publicKey(new MlDsaPublicKey())
                         .buildIssuedBy(issuerBundle));
 
-        assertTrue(exception.getMessage().contains("Algorithm not supported: test-ml-dsa"));
+        assertTrue(exception.getMessage().contains("Cannot get algorithm name for ML-DSA key"));
+    }
+
+    private static KeyPair generateMlDsaKeyPair() throws NoSuchAlgorithmException {
+        return KeyPairGenerator.getInstance("ML-DSA-44").generateKeyPair();
     }
 
     public static final class MlDsaPublicKey implements PublicKey {

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
