### PR TITLE
[Automation] Generated metadata for io.netty:netty-codec-dns:4.1.79.Final

### DIFF
--- a/metadata/io.netty/netty-codec-dns/4.1.79.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-codec-dns/4.1.79.Final/reachability-metadata.json
@@ -2,6 +2,39 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+      "fields": [
+        {
+          "name": "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+      "fields": [
+        {
+          "name": "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.handler.codec.dns.TcpDnsResponseEncoder"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+      "fields": [
+        {
+          "name": "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition": {
         "typeReached": "io.netty.buffer.AbstractByteBufAllocator"
       },
       "type": "io.netty.buffer.AbstractByteBufAllocator",


### PR DESCRIPTION
Fixes: oracle/graalvm-reachability-metadata#4306

This PR provides new metadata needed for the io.netty:netty-codec-dns:4.1.79.Final, addressing Native Image run failures caused by changes in the updated library version.

- Metadata entries (previous `io.netty:netty-codec-dns:4.1.74.Final`): 37
- Metadata entries (new `io.netty:netty-codec-dns:4.1.79.Final`): 40
- Library coverage (previous): 56.21%
- Library coverage (new): 56.36%

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e482e7c4ab38a385142e4294b59445c8c11aa691`

### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-codec-dns:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-codec-dns:4.1.79.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-codec-dns:4.1.74.Final: 2942/4953 (59.40%)
- io.netty:netty-codec-dns:4.1.79.Final: 2942/4951 (59.42%)

**Line:**
- io.netty:netty-codec-dns:4.1.74.Final: 647/1151 (56.21%)
- io.netty:netty-codec-dns:4.1.79.Final: 647/1148 (56.36%)

**Method:**
- io.netty:netty-codec-dns:4.1.74.Final: 194/292 (66.44%)
- io.netty:netty-codec-dns:4.1.79.Final: 194/292 (66.44%)

### Local CI Verification

- Status: `success`
- Commands run: 19
- Fixup attempts: 0
