### PR TITLE
Use native trace when JVM-agent metadata fails

### DIFF
--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -226,10 +226,10 @@ labels after publishing the part PR.
   `native_trace_collect` intervention.
 - [Native test verification gate](native-test-verification.md) —
   reusable component that asserts `./gradlew nativeTest` passes for a
-  coordinate by running JVM-agent metadata collection first, using native
-  tracing only as fallback, and routing final recovery to Codex. Used as the
-  per-class gate in the dynamic-access workflow and the terminal gate in the
-  fix-native-run workflow.
+  coordinate by trying JVM-agent metadata collection first, using native
+  tracing when that path fails or when native testing still fails, and routing
+  final recovery to Codex. Used as the per-class gate in the dynamic-access
+  workflow and the terminal gate in the fix-native-run workflow.
 - [Java compilation / runtime failure fix workflow](fix-java-run-fail.md)
   — version-bump fix workflow shared by `fix_javac_fail` and
   `fix_java_run_fail`. Strategies in this family route through the

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -13,13 +13,16 @@
 The verification gate ensures that the test binary passes on Native Image
 for a given coordinate. The ordered recovery contract is:
 
-1. Run the normal JVM `native-image-agent` path first via
+1. Try the normal JVM `native-image-agent` path first via
    `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
-   This is the primary metadata source and must not be skipped.
-2. Run the regular coordinate validation (`./gradlew test -Pcoordinates=<g:a:v>`).
-   If the native tests pass, return `PASSED`.
-3. If native testing still fails after JVM-agent metadata was generated, use
-   native tracing as a fallback. Each fallback cycle invokes
+   This is the primary metadata source and must not be skipped. If this path
+   fails, continue with native tracing instead of routing directly to Codex.
+2. If JVM-agent metadata was generated, run the regular coordinate validation
+   (`./gradlew test -Pcoordinates=<g:a:v>`). If the native tests pass, return
+   `PASSED`.
+3. If native testing still fails after JVM-agent metadata was generated, or if
+   the JVM-agent metadata path failed, use native tracing as a fallback. Each
+   fallback cycle invokes
    `./gradlew runNativeTraceImage`; the trace binary is built with
    `-H:+MetadataTracingSupport`, `--exact-reachability-metadata`, and
    `-H:MissingRegistrationReportingMode=Exit`.
@@ -82,11 +85,11 @@ branch to its checkpoint.
 flowchart TD
     Start([invoke gate]) --> Init[reset output_dir + runs_dir<br/>config_dirs = []<br/>i = 0]
     Init --> Agent[gradlew generateMetadata<br/>--agentAllowedPackages=fromJar]
-    Agent -- fail --> Codex[run_codex_metadata_fix]
+    Agent -- fail --> Outer{i &lt; max-native-test-verification-iterations?}
     Agent -- pass --> Test[gradlew test<br/>-Pcoordinates=&lt;g:a:v&gt;]
     Test -- pass --> PassAgent([return PASSED])
     Test -- fails before nativeTest --> Codex
-    Test -- nativeTest fails --> Outer{i &lt; max-native-test-verification-iterations?}
+    Test -- nativeTest fails --> Outer
     Outer -- no --> Codex
     Outer -- yes --> Run[gradlew runNativeTraceImage<br/>-PtraceMetadataPath=runs/cycle-i<br/>-PtraceMetadataConditionPackages=&lt;packages&gt;<br/>-PmetadataConfigDirs=&lt;config_dirs&gt;]
     Run --> Route{binary exit code}
@@ -108,14 +111,15 @@ Gate semantics:
   `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
   The JVM agent observes the test suite on HotSpot and writes the normal
   repository metadata. Native tracing must not run before this step. If
-  metadata generation fails, the gate routes to codex with the generation
-  log and does not attempt native tracing.
+  metadata generation fails, the gate logs the failure and starts native
+  tracing with no accepted trace dirs.
 - **Native test run second.** After JVM-agent metadata is generated, the
   gate runs `./gradlew test -Pcoordinates=<g:a:v>`. A pass returns
   `PASSED` without invoking native tracing. A failure before `nativeTest`
   is treated as a code/test problem and is routed to codex.
-- **Native tracing is fallback.** The trace loop starts only after
-  JVM-agent metadata exists and native testing still fails.
+- **Native tracing is fallback.** The trace loop starts after JVM-agent
+  metadata generation fails, or after JVM-agent metadata exists and native
+  testing still fails.
 - **One Gradle invocation per trace cycle.** The cycle runs only
   `./gradlew runNativeTraceImage -Pcoordinates=<g:a:v>
   -PtraceMetadataPath=<runs_dir>/cycle-<i>
@@ -186,7 +190,8 @@ def verify_native_test_passes(
 The module composes existing helpers and owns no domain logic of its own:
 
 - `./gradlew generateMetadata -Pcoordinates=...
-  --agentAllowedPackages=fromJar` — primary JVM-agent metadata collection.
+  --agentAllowedPackages=fromJar` — primary JVM-agent metadata collection,
+  attempted before the trace loop.
 - `./gradlew test -Pcoordinates=...` — normal coordinate validation after
   JVM-agent metadata is available.
 - `./gradlew runNativeTraceImage -Pcoordinates=...
@@ -229,8 +234,8 @@ A `verify_native_test_passes(...)` invocation is correct iff:
 2. Before any native-trace cycle starts, the gate invokes
    `./gradlew generateMetadata -Pcoordinates=...
    --agentAllowedPackages=fromJar`.
-3. If JVM-agent metadata generation fails, the gate invokes codex with
-   the generation log and does not start native tracing.
+3. If JVM-agent metadata generation fails, the gate starts native tracing
+   with no accepted trace dirs.
 4. After successful JVM-agent metadata generation, the gate invokes
    `./gradlew test -Pcoordinates=...`. If the coordinate passes, return
    `PASSED` without native tracing.

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -514,8 +514,38 @@ class GateRoutingTests(unittest.TestCase):
         self.assertIn("codex-repro-metadata-gap-exhausted", trace_path)
         self.assertNotIn(trace_path, config_dirs)
 
-    def test_routes_to_codex_when_generate_metadata_fails(self) -> None:
-        fake, calls = self._fake_run_factory([], generate_metadata_rc=1)
+    def test_falls_back_to_native_trace_when_generate_metadata_fails(self) -> None:
+        fake, calls = self._fake_run_factory(
+            [0],
+            generate_metadata_rc=1,
+            log_text=(
+                "FAILURE: Build failed with an exception.\n"
+                "Caused by: java.lang.InternalError: platform encoding not initialized\n"
+            ),
+        )
+        output = io.StringIO()
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock, redirect_stdout(output):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        codex_mock.assert_not_called()
+        self.assertTrue(any("generateMetadata" in c for c in calls))
+        self.assertFalse(any("test" in c for c in calls))
+        self.assertTrue(any("runNativeTraceImage" in c for c in calls))
+        self.assertIn(
+            "generateMetadata failure reason: Caused by: java.lang.InternalError: platform encoding not initialized",
+            output.getvalue(),
+        )
+
+    def test_routes_to_codex_after_native_trace_failure_when_generate_metadata_fails(self) -> None:
+        fake, calls = self._fake_run_factory([1], generate_metadata_rc=1)
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_codex_metadata_fix",
             return_value=(0, "/tmp/codex.log", False),
@@ -528,7 +558,7 @@ class GateRoutingTests(unittest.TestCase):
             )
         self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         codex_mock.assert_called_once()
-        self.assertFalse(any("runNativeTraceImage" in c for c in calls))
+        self.assertTrue(any("runNativeTraceImage" in c for c in calls))
 
     def test_routes_to_codex_when_test_fails_before_native_test(self) -> None:
         fake, calls = self._fake_run_factory([], test_rc=1, test_failed_task="compileTestJava")

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -5,11 +5,12 @@
 
 """Native test verification gate.
 
-The gate first runs the normal JVM ``native-image-agent`` metadata collection
-(``generateMetadata``), then validates the coordinate with ``./gradlew test``.
-Native tracing is only a fallback when native testing still fails after that
-metadata exists. Codex is the terminal repair path when the fallback cannot
-converge. Pi is not invoked.
+The gate first tries the normal JVM ``native-image-agent`` metadata collection
+(``generateMetadata``). If that succeeds, it validates the coordinate with
+``./gradlew test``. Native tracing is the fallback when JVM-agent metadata
+generation fails or when native testing still fails after that metadata exists.
+Codex is the terminal repair path when the fallback cannot converge. Pi is not
+invoked.
 
 See ``forge/docs/native-test-verification.md`` for the full contract.
 """
@@ -90,7 +91,7 @@ def verify_native_test_passes(
         max_iterations: int = 100,
         cycle_timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
 ) -> NativeTestVerificationResult:
-    """Run JVM-agent metadata first, then trace only as native-test fallback.
+    """Try JVM-agent metadata first, then use native tracing as fallback.
 
     See ``forge/docs/native-test-verification.md`` for the full contract.
     """
@@ -166,34 +167,34 @@ def verify_native_test_passes(
     )
     last_log_path = generate_metadata_log_path
     if generate_metadata_rc != 0:
-        return _route_to_codex(
-            stage="generateMetadata",
-            reason=f"generateMetadata failed (exit={generate_metadata_rc})",
-            reproduction_command=_generate_metadata_command(coordinate),
-            iterations_used=0,
+        failure_reason = _summarize_gradle_failure_reason(generate_metadata_log_path)
+        log_stage(
+            _GATE_STAGE,
+            f"generateMetadata failed (exit={generate_metadata_rc}); starting native trace fallback",
         )
-
-    test_log_path = _gate_log_path(coordinate, 0, "test")
-    test_rc, failed_task = _run_coordinate_test(
-        reachability_repo_path=reachability_repo_path,
-        coordinate=coordinate,
-        log_path=test_log_path,
-        timeout_seconds=cycle_timeout_seconds,
-    )
-    last_log_path = test_log_path
-    if test_rc == 0:
-        log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
-        return _make_result(STATUS_PASSED, 0)
-    if failed_task != "nativeTest":
-        failed_task_display = failed_task or "unknown"
-        return _route_to_codex(
-            stage="test",
-            reason=f"test failed before native trace fallback (failed_task={failed_task_display}, exit={test_rc})",
-            reproduction_command=_coordinate_test_command(coordinate),
-            iterations_used=0,
+        log_stage(_GATE_STAGE, f"generateMetadata failure reason: {failure_reason}", indent_level=1)
+    else:
+        test_log_path = _gate_log_path(coordinate, 0, "test")
+        test_rc, failed_task = _run_coordinate_test(
+            reachability_repo_path=reachability_repo_path,
+            coordinate=coordinate,
+            log_path=test_log_path,
+            timeout_seconds=cycle_timeout_seconds,
         )
+        last_log_path = test_log_path
+        if test_rc == 0:
+            log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
+            return _make_result(STATUS_PASSED, 0)
+        if failed_task != "nativeTest":
+            failed_task_display = failed_task or "unknown"
+            return _route_to_codex(
+                stage="test",
+                reason=f"test failed before native trace fallback (failed_task={failed_task_display}, exit={test_rc})",
+                reproduction_command=_coordinate_test_command(coordinate),
+                iterations_used=0,
+            )
 
-    log_stage(_GATE_STAGE, "nativeTest still fails after JVM-agent metadata; starting native trace fallback")
+        log_stage(_GATE_STAGE, "nativeTest still fails after JVM-agent metadata; starting native trace fallback")
 
     for cycle in range(max_iterations):
         log_stage(_GATE_STAGE, f"cycle {cycle + 1}/{max_iterations}")
@@ -313,10 +314,6 @@ def verify_native_test_passes(
     )
 
 
-def _generate_metadata_command(coordinate: str) -> str:
-    return f"./gradlew generateMetadata -Pcoordinates={coordinate} --agentAllowedPackages=fromJar"
-
-
 def _coordinate_test_command(coordinate: str) -> str:
     return f"./gradlew test -Pcoordinates={coordinate}"
 
@@ -397,6 +394,63 @@ def _parse_first_failed_task(log_path: str) -> str | None:
         return None
     match = _FAILED_TASK_PATTERN.search(content)
     return match.group(1) if match else None
+
+
+def _summarize_gradle_failure_reason(log_path: str) -> str:
+    """Extract a short, human-readable Gradle failure reason from a log."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+            lines = [line.strip() for line in handle.readlines()]
+    except OSError as exc:
+        return f"unable to read log: {exc}"
+
+    non_empty_lines = [line for line in lines if line]
+    if not non_empty_lines:
+        return "log is empty"
+
+    priority_patterns = [
+        "Could not find agent library",
+        "platform encoding not initialized",
+        "FATAL ERROR in native method",
+        "Error occurred during initialization of VM",
+        "MissingReflectionRegistrationError",
+        "MissingResourceRegistrationError",
+        "MissingSerializationRegistrationError",
+        "MissingJNIRegistrationError",
+        "MissingProxyRegistrationError",
+        "Caused by:",
+        "Execution failed for task",
+        "Cannot generate metadata",
+        "finished with non-zero exit value",
+    ]
+    for pattern in priority_patterns:
+        for line in non_empty_lines:
+            if pattern in line:
+                return _trim_failure_reason(line)
+
+    failed_task = _FAILED_TASK_PATTERN.search("\n".join(non_empty_lines))
+    if failed_task:
+        return f"task {failed_task.group(1)} failed"
+
+    for line in non_empty_lines:
+        if line.startswith("ERROR:") or line.startswith("error:"):
+            return _trim_failure_reason(line)
+
+    fallback_lines = [
+        line for line in non_empty_lines
+        if not line.startswith("BUILD SUCCESSFUL")
+        and not line.startswith("Deprecated Gradle features were used")
+    ]
+    if fallback_lines:
+        return _trim_failure_reason(fallback_lines[-1])
+    return f"no specific failure reason found in {display_log_path(log_path)}"
+
+
+def _trim_failure_reason(reason: str, max_length: int = 240) -> str:
+    """Keep failure summaries compact enough for one log line."""
+    if len(reason) <= max_length:
+        return reason
+    return reason[:max_length - 3].rstrip() + "..."
 
 
 def _run_native_trace_image_command(


### PR DESCRIPTION
## Summary
- route `generateMetadata` failures through the native-trace fallback instead of directly to Codex
- print a compact failure reason from the `generateMetadata` log before starting native tracing
- update the native-test verification contract and regression tests

## Testing
- `python3 -m unittest tests.test_native_test_verification`

Fixes #5910