### PR TITLE
Isolate Forge Gradle user homes per worktree

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -33,6 +33,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
 from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts import metrics_writer
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.large_library_progress import resolve_workflow_progress_state
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
@@ -276,6 +277,7 @@ def run_scaffold(library: str) -> bool:
     scaffold_proc = subprocess.run(
         f"./gradlew scaffold --coordinates={library} --rerun-tasks",
         shell=True,
+        env=gradle_command_environment(os.getcwd()),
         capture_output=True,
         text=True
     )

--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -10,6 +10,7 @@ import sys
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.source_context import populate_artifact_urls
@@ -62,6 +63,7 @@ def run_fix_test_native_image_run(
             f"-PnewLibraryVersion={new_version}",
         ],
         cwd=reachability_metadata_path,
+        env=gradle_command_environment(reachability_metadata_path),
     )
 
 
@@ -77,6 +79,7 @@ def run_gradle_test(
             f"-Pcoordinates={coordinates}",
         ],
         cwd=reachability_metadata_path,
+        env=gradle_command_environment(reachability_metadata_path),
     )
 
 

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -21,6 +21,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import (
 from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
@@ -228,9 +229,10 @@ def copy_and_prepare_project_dir(
 
 def run_gradle_task(task: str, coordinates: str) -> None:
     """Run a Gradle task for the provided dependency coordinates."""
-    require_complete_reachability_repo(os.getcwd())
+    repo_path = os.getcwd()
+    require_complete_reachability_repo(repo_path)
     command = f"./gradlew {task} -Pcoordinates={coordinates}"
-    subprocess.run(command, shell=True, check=True)
+    subprocess.run(command, shell=True, env=gradle_command_environment(repo_path), check=True)
 
 
 def update_metadata_index_json(config, group, artifact, updated_library_version):

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -235,7 +235,12 @@ def run_gradle_task(task: str, coordinates: str) -> None:
     subprocess.run(command, shell=True, env=gradle_command_environment(repo_path), check=True)
 
 
-def update_metadata_index_json(config, group, artifact, updated_library_version):
+def update_metadata_index_json(
+        config: JavaFailWorkflowConfig,
+        group: str,
+        artifact: str,
+        updated_library_version: str,
+) -> None:
     """Update metadata index.json for the target library version."""
     new_version_coordinates = f"{group}:{artifact}:{updated_library_version}"
     run_gradle_task(config.metadata_index_task, new_version_coordinates)
@@ -277,6 +282,90 @@ def create_project_prep_checkpoint(config: JavaFailWorkflowConfig, group, artifa
         check=True,
     )
     return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def commit_last_passing_candidate(
+        reachability_repo_path: str,
+        group: str,
+        artifact: str,
+        updated_library_version: str,
+) -> str | None:
+    """Commit the generated candidate that already passed the workflow test loop."""
+    candidate_paths: list[str] = [
+        os.path.join("tests", "src", group, artifact, updated_library_version),
+        os.path.join("metadata", group, artifact),
+    ]
+    add_result = subprocess.run(
+        ["git", "add", "-A", "--", *candidate_paths],
+        cwd=reachability_repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if add_result.returncode != 0:
+        print("ERROR: Failed to stage last passing candidate.", file=sys.stderr)
+        print(add_result.stdout)
+        return None
+
+    diff_result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", *candidate_paths],
+        cwd=reachability_repo_path,
+        check=False,
+    )
+    if diff_result.returncode == 0:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=reachability_repo_path,
+            text=True,
+        ).strip()
+    if diff_result.returncode != 1:
+        print("ERROR: Failed to inspect staged last passing candidate.", file=sys.stderr)
+        return None
+
+    commit_result = subprocess.run(
+        ["git", "commit", "-m", f"Preserve last passing candidate for {group}:{artifact}:{updated_library_version}"],
+        cwd=reachability_repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if commit_result.returncode != 0:
+        print("ERROR: Failed to commit last passing candidate.", file=sys.stderr)
+        print(commit_result.stdout)
+        return None
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=reachability_repo_path,
+        text=True,
+    ).strip()
+
+
+def reset_failed_java_fix_worktree(
+        reachability_repo_path: str,
+        commit_checkpoint: str,
+        last_passing_candidate_commit: str | None,
+        tests_dir: str,
+        metadata_dir: str,
+        tests_dir_preexisted: bool,
+        metadata_dir_preexisted: bool,
+) -> str:
+    """Reset failed workflow output while keeping a passing candidate when one exists."""
+    reset_target = last_passing_candidate_commit or commit_checkpoint
+    if last_passing_candidate_commit is not None:
+        print(f"[Test fixing failed; preserving last passing candidate at {last_passing_candidate_commit}.]")
+    subprocess.run(["git", "reset", "--hard", reset_target], cwd=reachability_repo_path, check=True)
+    if last_passing_candidate_commit is None:
+        if not tests_dir_preexisted:
+            shutil.rmtree(tests_dir, ignore_errors=True)
+        if not metadata_dir_preexisted:
+            shutil.rmtree(metadata_dir, ignore_errors=True)
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=reachability_repo_path,
+        text=True,
+    ).strip()
 
 
 def init_agent(
@@ -448,18 +537,31 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         agent=agent,
     )
 
+    last_passing_candidate_commit = None
     if workflow_status == RUN_STATUS_SUCCESS:
-        finalize_status, _ = strategy_obj._finalize_successful_iteration()
-        workflow_status = finalize_status
+        last_passing_candidate_commit = commit_last_passing_candidate(
+            reachability_repo_path,
+            group,
+            artifact,
+            updated_library_version,
+        )
+        if last_passing_candidate_commit is None:
+            workflow_status = RUN_STATUS_FAILURE
+        else:
+            finalize_status, _ = strategy_obj._finalize_successful_iteration()
+            workflow_status = finalize_status
 
     if workflow_status not in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}:
         print("[Test fixing failed.]")
-        subprocess.run(["git", "reset", "--hard", commit_checkpoint], check=True)
-        ending_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-        if not tests_dir_preexisted:
-            shutil.rmtree(tests_dir, ignore_errors=True)
-        if not metadata_dir_preexisted:
-            shutil.rmtree(metadata_dir, ignore_errors=True)
+        ending_commit = reset_failed_java_fix_worktree(
+            reachability_repo_path=reachability_repo_path,
+            commit_checkpoint=commit_checkpoint,
+            last_passing_candidate_commit=last_passing_candidate_commit,
+            tests_dir=tests_dir,
+            metadata_dir=metadata_dir,
+            tests_dir_preexisted=tests_dir_preexisted,
+            metadata_dir_preexisted=metadata_dir_preexisted,
+        )
         run_metrics = create_failure_run_metrics_output(
             package=group,
             artifact=artifact,

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -19,6 +19,7 @@ from ai_workflows.fix_post_generation_pi import (
     run_pi_post_generation_fix,
 )
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -136,25 +137,30 @@ class WorkflowStrategy(ABC):
     @staticmethod
     def _run_command(cmd: str) -> str:
         """Execute a shell command and return its combined stdout/stderr."""
+        env = None
         if cmd.startswith("./gradlew"):
-            require_complete_reachability_repo(os.getcwd())
-        result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            repo_path = os.getcwd()
+            require_complete_reachability_repo(repo_path)
+            env = gradle_command_environment(repo_path)
+        result = subprocess.run(cmd, shell=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         return result.stdout
 
     def _run_command_with_env(self, cmd: str, env: dict[str, str] | None = None) -> str:
         """Execute a shell command with optional environment overrides."""
+        repo_path = getattr(self, "reachability_repo_path", os.getcwd())
         if cmd.startswith("./gradlew test "):
             return run_gradle_test_command(
                 cmd,
-                getattr(self, "reachability_repo_path", os.getcwd()),
+                repo_path,
                 library=getattr(self, "library", None),
                 env=env,
             )
+        command_env = gradle_command_environment(repo_path, env) if cmd.startswith("./gradlew") else env
         result = subprocess.run(
             cmd,
             shell=True,
-            cwd=getattr(self, "reachability_repo_path", None),
-            env=env,
+            cwd=repo_path,
+            env=command_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -262,6 +268,7 @@ class WorkflowStrategy(ABC):
         return subprocess.run(
             command,
             cwd=self.reachability_repo_path,
+            env=gradle_command_environment(self.reachability_repo_path),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -1,0 +1,56 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts.gradle_environment import (
+    FORGE_GRADLE_USER_HOME_ENV,
+    gradle_command_environment,
+    gradle_user_home_for_repo,
+)
+
+
+class GradleEnvironmentTests(unittest.TestCase):
+    def test_uses_temp_gradle_home_scoped_by_repo_path(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            with patch.dict(os.environ, {}, clear=True):
+                gradle_home = gradle_user_home_for_repo(repo_path)
+                equivalent_gradle_home = gradle_user_home_for_repo(os.path.join(repo_path, "."))
+
+            self.assertTrue(os.path.isabs(gradle_home))
+            self.assertEqual(os.path.dirname(os.path.dirname(gradle_home)), tempfile.gettempdir())
+            self.assertEqual(os.path.basename(os.path.dirname(gradle_home)), "metadata-forge-gradle")
+            self.assertEqual(gradle_home, equivalent_gradle_home)
+
+    def test_command_environment_preserves_base_env_and_sets_gradle_user_home(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            with patch.dict(os.environ, {}, clear=True):
+                env = gradle_command_environment(repo_path, {"JAVA_HOME": "/jdk"})
+                expected_gradle_user_home = gradle_user_home_for_repo(repo_path)
+
+            self.assertEqual(env["JAVA_HOME"], "/jdk")
+            self.assertEqual(env["GRADLE_USER_HOME"], expected_gradle_user_home)
+            self.assertTrue(os.path.isdir(env["GRADLE_USER_HOME"]))
+
+    def test_explicit_gradle_home_override_is_honored(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_home:
+            with patch.dict(os.environ, {FORGE_GRADLE_USER_HOME_ENV: gradle_home}, clear=True):
+                env = gradle_command_environment(repo_path)
+
+            self.assertEqual(env["GRADLE_USER_HOME"], gradle_home)
+
+    def test_base_env_gradle_home_override_is_honored(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_home:
+            with patch.dict(os.environ, {}, clear=True):
+                env = gradle_command_environment(repo_path, {FORGE_GRADLE_USER_HOME_ENV: gradle_home})
+
+            self.assertEqual(env["GRADLE_USER_HOME"], gradle_home)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -51,6 +51,38 @@ class GradleEnvironmentTests(unittest.TestCase):
 
             self.assertEqual(env["GRADLE_USER_HOME"], gradle_home)
 
+    def test_graalvm_home_with_native_image_drives_java_home(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as graalvm_home:
+            os.makedirs(os.path.join(graalvm_home, "bin"))
+            native_image_path = os.path.join(graalvm_home, "bin", "native-image")
+            with open(native_image_path, "w", encoding="utf-8"):
+                pass
+
+            with patch.dict(os.environ, {}, clear=True):
+                env = gradle_command_environment(
+                    repo_path,
+                    {
+                        "GRAALVM_HOME": graalvm_home,
+                        "JAVA_HOME": "/plain-jdk",
+                    },
+                )
+
+            self.assertEqual(env["GRAALVM_HOME"], graalvm_home)
+            self.assertEqual(env["JAVA_HOME"], graalvm_home)
+
+    def test_java_home_with_native_image_backfills_graalvm_home(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as java_home:
+            os.makedirs(os.path.join(java_home, "bin"))
+            native_image_path = os.path.join(java_home, "bin", "native-image")
+            with open(native_image_path, "w", encoding="utf-8"):
+                pass
+
+            with patch.dict(os.environ, {}, clear=True):
+                env = gradle_command_environment(repo_path, {"JAVA_HOME": java_home})
+
+            self.assertEqual(env["GRAALVM_HOME"], java_home)
+            self.assertEqual(env["JAVA_HOME"], java_home)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/forge/tests/test_java_fail_workflow.py
+++ b/forge/tests/test_java_fail_workflow.py
@@ -9,7 +9,12 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from ai_workflows.java_fail_workflow import JAVAC_CONFIG, copy_and_prepare_project_dir, create_project_prep_checkpoint
+from ai_workflows.java_fail_workflow import (
+    JAVAC_CONFIG,
+    copy_and_prepare_project_dir,
+    create_project_prep_checkpoint,
+    reset_failed_java_fix_worktree,
+)
 
 
 class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
@@ -61,3 +66,47 @@ class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
         self.assertEqual(run.call_count, 3)
         self.assertEqual(run.call_args_list[2].args[0], ["git", "diff", "--cached", "--quiet"])
         check_output.assert_called_once_with(["git", "rev-parse", "HEAD"], text=True)
+
+    def test_failed_workflow_reset_preserves_last_passing_candidate(self) -> None:
+        with patch("ai_workflows.java_fail_workflow.subprocess.run") as run, \
+                patch(
+                    "ai_workflows.java_fail_workflow.subprocess.check_output",
+                    return_value="candidate\n",
+                ) as check_output, \
+                patch("ai_workflows.java_fail_workflow.shutil.rmtree") as rmtree:
+            ending_commit = reset_failed_java_fix_worktree(
+                reachability_repo_path="/repo",
+                commit_checkpoint="prep",
+                last_passing_candidate_commit="candidate",
+                tests_dir="/repo/tests/src/org.example/demo/2.0.0",
+                metadata_dir="/repo/metadata/org.example/demo/2.0.0",
+                tests_dir_preexisted=False,
+                metadata_dir_preexisted=False,
+            )
+
+        self.assertEqual(ending_commit, "candidate")
+        run.assert_called_once_with(["git", "reset", "--hard", "candidate"], cwd="/repo", check=True)
+        check_output.assert_called_once_with(["git", "rev-parse", "HEAD"], cwd="/repo", text=True)
+        rmtree.assert_not_called()
+
+    def test_failed_workflow_reset_cleans_scaffold_when_no_candidate_passed(self) -> None:
+        with patch("ai_workflows.java_fail_workflow.subprocess.run") as run, \
+                patch(
+                    "ai_workflows.java_fail_workflow.subprocess.check_output",
+                    return_value="prep\n",
+                ), \
+                patch("ai_workflows.java_fail_workflow.shutil.rmtree") as rmtree:
+            ending_commit = reset_failed_java_fix_worktree(
+                reachability_repo_path="/repo",
+                commit_checkpoint="prep",
+                last_passing_candidate_commit=None,
+                tests_dir="/repo/tests/src/org.example/demo/2.0.0",
+                metadata_dir="/repo/metadata/org.example/demo/2.0.0",
+                tests_dir_preexisted=False,
+                metadata_dir_preexisted=False,
+            )
+
+        self.assertEqual(ending_commit, "prep")
+        run.assert_called_once_with(["git", "reset", "--hard", "prep"], cwd="/repo", check=True)
+        rmtree.assert_any_call("/repo/tests/src/org.example/demo/2.0.0", ignore_errors=True)
+        rmtree.assert_any_call("/repo/metadata/org.example/demo/2.0.0", ignore_errors=True)

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -1,0 +1,35 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+
+FORGE_GRADLE_USER_HOME_ENV = "FORGE_GRADLE_USER_HOME"
+_GRADLE_USER_HOME_ROOT = "metadata-forge-gradle"
+
+
+def gradle_user_home_for_repo(repo_path: str) -> str:
+    """Return the isolated Gradle user home for a reachability-metadata worktree."""
+    return _resolve_gradle_user_home(repo_path, os.environ.get(FORGE_GRADLE_USER_HOME_ENV))
+
+
+def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return an environment that keeps Gradle daemons scoped to one worktree."""
+    env = dict(os.environ if base_env is None else base_env)
+    gradle_user_home = _resolve_gradle_user_home(repo_path, env.get(FORGE_GRADLE_USER_HOME_ENV))
+    os.makedirs(gradle_user_home, exist_ok=True)
+    env["GRADLE_USER_HOME"] = gradle_user_home
+    return env
+
+
+def _resolve_gradle_user_home(repo_path: str, override: str | None) -> str:
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+
+    repo_id = hashlib.sha256(os.path.realpath(repo_path).encode("utf-8")).hexdigest()[:16]
+    return os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT, repo_id)

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -21,10 +21,27 @@ def gradle_user_home_for_repo(repo_path: str) -> str:
 def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None = None) -> dict[str, str]:
     """Return an environment that keeps Gradle daemons scoped to one worktree."""
     env = dict(os.environ if base_env is None else base_env)
+    _align_graalvm_java_home(env)
     gradle_user_home = _resolve_gradle_user_home(repo_path, env.get(FORGE_GRADLE_USER_HOME_ENV))
     os.makedirs(gradle_user_home, exist_ok=True)
     env["GRADLE_USER_HOME"] = gradle_user_home
     return env
+
+
+def _align_graalvm_java_home(env: dict[str, str]) -> None:
+    graalvm_home = env.get("GRAALVM_HOME")
+    java_home = env.get("JAVA_HOME")
+    if graalvm_home and _has_native_image(graalvm_home):
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+        return
+    if java_home and _has_native_image(java_home):
+        env["GRAALVM_HOME"] = java_home
+        env["JAVA_HOME"] = java_home
+
+
+def _has_native_image(home: str) -> bool:
+    return os.path.isfile(os.path.join(home, "bin", "native-image"))
 
 
 def _resolve_gradle_user_home(repo_path: str, override: str | None) -> str:

--- a/forge/utility_scripts/gradle_test_runner.py
+++ b/forge/utility_scripts/gradle_test_runner.py
@@ -16,6 +16,7 @@ import time
 
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 
 
@@ -55,11 +56,12 @@ def run_gradle_test_command(
     )
 
     start_time = time.monotonic()
+    command_env = gradle_command_environment(working_dir, env)
     with open(log_path, "w", encoding="utf-8") as log_file:
         process = subprocess.Popen(
             test_cmd,
             cwd=working_dir,
-            env=env,
+            env=command_env,
             shell=True,
             stdout=log_file,
             stderr=subprocess.STDOUT,

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.style_checks import run_style_fix_and_checks
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
@@ -20,6 +21,7 @@ def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> subpr
     return subprocess.run(
         command,
         cwd=repo_path,
+        env=gradle_command_environment(repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -16,6 +16,7 @@ import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
@@ -748,6 +749,7 @@ def _run_recorded_command(
     display_env = dict(env or {})
     command_env.update(display_env)
     _remove_gradle_java_home_overrides(command_env)
+    command_env = gradle_command_environment(repo_path, command_env)
     log_path = build_timestamped_task_log_path("local-ci", gate, Path(command[0]).name)
     sudo_reason = _sudo_usage_reason(repo_path, command)
     if sudo_reason:

--- a/forge/utility_scripts/native_metadata_exploration.py
+++ b/forge/utility_scripts/native_metadata_exploration.py
@@ -31,6 +31,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any
 
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import (
@@ -232,6 +233,7 @@ def _run_gradle(cmd: list[str], cwd: str, log_path: str, timeout_seconds: int) -
             result = subprocess.run(
                 cmd,
                 cwd=cwd,
+                env=gradle_command_environment(cwd),
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 check=False,

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -26,6 +26,7 @@ import subprocess
 from dataclasses import dataclass, field
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import (
@@ -375,6 +376,7 @@ def _run_logged_gradle_command(
             return subprocess.run(
                 cmd,
                 cwd=reachability_repo_path,
+                env=gradle_command_environment(reachability_repo_path),
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 check=False,
@@ -510,6 +512,7 @@ def _run_native_trace_image(
             result = subprocess.run(
                 cmd,
                 cwd=reachability_repo_path,
+                env=gradle_command_environment(reachability_repo_path),
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 check=False,
@@ -780,6 +783,7 @@ def _merge_into_output(
         result = subprocess.run(
             cmd,
             cwd=reachability_repo_path,
+            env=gradle_command_environment(reachability_repo_path),
             check=False,
             timeout=_MERGE_TIMEOUT_SECONDS,
         )

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from email.message import Message
 from typing import Any
 
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import is_not_for_native_image_entry
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
@@ -146,6 +147,7 @@ def populate_artifact_urls(reachability_repo_path: str, coordinate: str, agent_c
     result = subprocess.run(
         command,
         cwd=reachability_repo_path,
+        env=gradle_command_environment(reachability_repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -180,6 +182,7 @@ def discover_artifact_metadata(
     result = subprocess.run(
         command,
         cwd=reachability_repo_path,
+        env=gradle_command_environment(reachability_repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/forge/utility_scripts/style_checks.py
+++ b/forge/utility_scripts/style_checks.py
@@ -6,6 +6,7 @@
 import subprocess
 import sys
 
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.pi_logs import build_pi_log_path
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.task_logs import display_log_path
@@ -22,6 +23,7 @@ def _run_gradle_task(repo_path: str, command: list[str]) -> bool:
     result = subprocess.run(
         command,
         cwd=repo_path,
+        env=gradle_command_environment(repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -40,6 +42,7 @@ def _run_checkstyle(repo_path: str, coordinate_arg: str) -> subprocess.Completed
     return subprocess.run(
         ["./gradlew", "checkstyle", coordinate_arg],
         cwd=repo_path,
+        env=gradle_command_environment(repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -53,6 +56,7 @@ def _run_test(repo_path: str, coordinate_arg: str) -> subprocess.CompletedProces
     return subprocess.run(
         ["./gradlew", "test", coordinate_arg],
         cwd=repo_path,
+        env=gradle_command_environment(repo_path),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
@@ -81,7 +82,7 @@ def run_gradle_test_with_graalvm(repo_path: str, library: str, graalvm_home: str
     return subprocess.run(
         ["./gradlew", "test", f"-Pcoordinates={library}"],
         cwd=repo_path,
-        env=build_graalvm_environment(graalvm_home),
+        env=gradle_command_environment(repo_path, build_graalvm_environment(graalvm_home)),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,


### PR DESCRIPTION
### Summary

- Add a shared Forge helper that assigns a temporary GRADLE_USER_HOME scoped by reachability-metadata worktree path.
- Apply the isolated Gradle environment to Forge-managed Gradle invocations across workflow setup, test execution, local CI, source context, style checks, native verification, and finalization.
- Add unit tests for default temp directory selection and FORGE_GRADLE_USER_HOME overrides.

### Testing

- python3 -m unittest discover tests
- git diff --check

Fixes #5912