### PR TITLE
Run new library compatibility checks daily

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -2,7 +2,7 @@ name: "Verify compatibility with latest library versions"
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -39,7 +39,7 @@ Workflows testing metadata using [ci.json](../ci.json):
   - Triggers: PRs to master that change exploded stats files under [stats/](../stats/), [stats/schemas/library-stats-schema-v1.0.2.json](../stats/schemas/library-stats-schema-v1.0.2.json), or mirrored files under [metadata/](../metadata/).
   - Uses: [`validateLibraryStats`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to enforce schema compliance and normalized sorting.
 - Verify new library version compatibility ([.github/workflows/verify-new-library-version-compatibility.yml](../.github/workflows/verify-new-library-version-compatibility.yml))
-  - Triggers: every 4 hours and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
+  - Triggers: daily and manual ([`workflow_dispatch`](../.github/workflows/verify-new-library-version-compatibility.yml)).
   - Uses: [`fetchExistingLibrariesWithNewerVersions`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) plus [`generateNewLibraryVersionCompatibilityMatrix`](../tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle) to build a [`ci.json`](../ci.json)-driven matrix. The matrix generator limits the number of libraries per run, limits each library to at most 30 newer versions per run before expanding across the configured GraalVM JDK/OS combinations, records tested versions only after they pass on every required environment, and creates a single aggregated failure issue per failed library version while preserving the prior failure issue format with added OS and JDK lines.
 
 Workflows for style and security:

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -60,7 +60,7 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [CI.md](CI.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
-- Schedule-driven: full metadata sweep, new-library-version compatibility (every 4 hours), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
+- Schedule-driven: full metadata sweep, new-library-version compatibility (daily), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 


### PR DESCRIPTION
## Summary
- Change verify-new-library-version-compatibility from every four hours to once daily.
- Update CI documentation to describe the new daily cadence.

## Testing
- git diff --check

Draft PR: do not merge before Thursday, May 7, 2026.

Fixes #5915