### PR TITLE
[GenAI] Test fix for org.apache.lucene:lucene-core:6.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.lucene/lucene-core/6.0.0/reachability-metadata.json
+++ b/metadata/org.apache.lucene/lucene-core/6.0.0/reachability-metadata.json
@@ -1,0 +1,312 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.HotSpotDiagnosticMXBean",
+      "methods" : [
+        {
+          "name" : "getVMOption",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.VMOption",
+      "methods" : [
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.VMOption$Origin",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "ATTACH_ON_DEMAND"
+        },
+        {
+          "name" : "CONFIG_FILE"
+        },
+        {
+          "name" : "DEFAULT"
+        },
+        {
+          "name" : "ENVIRON_VAR"
+        },
+        {
+          "name" : "ERGONOMIC"
+        },
+        {
+          "name" : "MANAGEMENT"
+        },
+        {
+          "name" : "OTHER"
+        },
+        {
+          "name" : "VM_CREATION"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "com.sun.management.internal.Flag",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.Object",
+            "boolean",
+            "boolean",
+            "com.sun.management.VMOption$Origin"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Boolean",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Long",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Number"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getPlatformMXBean",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$1"
+      },
+      "type" : "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$2$1"
+      },
+      "type" : "java.nio.DirectByteBuffer",
+      "methods" : [
+        {
+          "name" : "cleaner",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$2$1"
+      },
+      "type" : "java.nio.DirectByteBufferR"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.MMapDirectory$2$1"
+      },
+      "type" : "jdk.internal.ref.Cleaner",
+      "methods" : [
+        {
+          "name" : "clean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeFactory"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeFactory$DefaultAttributeFactory"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.AttributeImpl"
+      },
+      "type" : "org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl",
+      "fields" : [
+        {
+          "name" : "flags"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.NamedSPILoader"
+      },
+      "type" : "org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.MMapDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.NIOFSDirectory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.nio.file.Path",
+            "org.apache.lucene.store.LockFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.RAMDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.CommandLineUtil"
+      },
+      "type" : "org.apache.lucene.store.SimpleFSDirectory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.LockStressTest"
+      },
+      "type" : "org.apache.lucene.store.SimpleFSLockFactory",
+      "fields" : [
+        {
+          "name" : "INSTANCE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "org.apache.lucene.util.BytesRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.RamUsageEstimator"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.IOUtils"
+      },
+      "glob" : "META-INF/LICENSE.txt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.NamedSPILoader"
+      },
+      "glob" : "META-INF/services/org.apache.lucene.codecs.PostingsFormat"
+    }
+  ]
+}

--- a/metadata/org.apache.lucene/lucene-core/index.json
+++ b/metadata/org.apache.lucene/lucene-core/index.json
@@ -20,6 +20,15 @@
     ]
   },
   {
+    "metadata-version" : "6.0.0",
+    "tested-versions" : [
+      "6.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.lucene"
+    ]
+  },
+  {
     "metadata-version" : "5.3.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/lucene-solr",

--- a/metadata/org.apache.lucene/lucene-core/index.json
+++ b/metadata/org.apache.lucene/lucene-core/index.json
@@ -21,6 +21,11 @@
   },
   {
     "metadata-version" : "6.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/lucene-solr",
+    "test-code-url" : "https://github.com/apache/lucene-solr/tree/releases/lucene-solr/$version$/lucene/core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/lucene/lucene-core/$version$/lucene-core-$version$-javadoc.jar",
+    "description" : "Apache Lucene Core provides the core indexing, search, storage, and query APIs for the Lucene full-text search engine. It lets JVM applications create and query inverted indexes with analyzers, codecs, scoring, and low-level index management primitives.",
     "tested-versions" : [
       "6.0.0"
     ],

--- a/stats/org.apache.lucene/lucene-core/6.0.0/execution-metrics.json
+++ b/stats/org.apache.lucene/lucene-core/6.0.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-05": {
+    "timestamp": "2026-05-05T07:28:05.589071Z",
+    "library": "org.apache.lucene:lucene-core:6.0.0",
+    "starting_commit": "b2ad7ccf8e985e56fb4ddd7dafee861bc6e23ecd",
+    "ending_commit": "d9cdc70ac97043330ddd0b4de89acd3a3b7f4bde",
+    "previous_library": "org.apache.lucene:lucene-core:5.5.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 27,
+        "totalCalls": 27
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3797,
+          "missed": 276616,
+          "ratio": 0.013541,
+          "total": 280413
+        },
+        "line": {
+          "covered": 642,
+          "missed": 50787,
+          "ratio": 0.012483,
+          "total": 51429
+        },
+        "method": {
+          "covered": 157,
+          "missed": 8958,
+          "ratio": 0.017224,
+          "total": 9115
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "5.5.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 29,
+            "totalCalls": 29
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 31,
+        "totalCalls": 31
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4097,
+          "missed": 269593,
+          "ratio": 0.014969,
+          "total": 273690
+        },
+        "line": {
+          "covered": 670,
+          "missed": 49099,
+          "ratio": 0.013462,
+          "total": 49769
+        },
+        "method": {
+          "covered": 166,
+          "missed": 8913,
+          "ratio": 0.018284,
+          "total": 9079
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 24911,
+      "cached_input_tokens_used": 72192,
+      "output_tokens_used": 1451,
+      "iterations": 1,
+      "cost_usd": 0.0796,
+      "tested_library_loc": 642,
+      "metadata_entries": 60,
+      "test_only_metadata_entries": 11,
+      "previous_library_metadata_entries": 60,
+      "previous_library_test_only_metadata_entries": 11,
+      "code_coverage_percent": 1.25,
+      "previous_library_coverage_percent": 1.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java",
+      "metadata_file": "metadata/org.apache.lucene/lucene-core/6.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.lucene/lucene-core/6.0.0/stats.json
+++ b/stats/org.apache.lucene/lucene-core/6.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "6.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 25,
+          "totalCalls" : 25
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 27,
+      "totalCalls" : 27
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3797,
+        "missed" : 276616,
+        "ratio" : 0.013541,
+        "total" : 280413
+      },
+      "line" : {
+        "covered" : 642,
+        "missed" : 50787,
+        "ratio" : 0.012483,
+        "total" : 51429
+      },
+      "method" : {
+        "covered" : 157,
+        "missed" : 8958,
+        "ratio" : 0.017224,
+        "total" : 9115
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/.gitignore
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import org.gradle.api.tasks.testing.Test
+
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.lucene:lucene-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
@@ -31,4 +31,12 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        all {
+            buildArgs.addAll([
+                    '--add-opens=java.base/java.nio=ALL-UNNAMED',
+                    '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED'
+            ])
+        }
+    }
 }

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/gradle.properties
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.lucene:lucene-core:6.0.0
+library.version = 6.0.0
+metadata.dir = org.apache.lucene/lucene-core/6.0.0/

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/settings.gradle
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.lucene.lucene-core_tests'

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.lucene.util.Attribute;
+import org.apache.lucene.util.AttributeImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeImplTest {
+    @Test
+    void defaultReflectWithReflectsDeclaredInstanceFields() {
+        SingleAttributeImpl attribute = new SingleAttributeImpl();
+        attribute.setValues("sample", 12);
+
+        Map<String, Object> reflectedValues = new LinkedHashMap<>();
+        attribute.reflectWith((attributeClass, key, value) -> {
+            assertThat(attributeClass).isEqualTo(SingleAttribute.class);
+            reflectedValues.put(key, value);
+        });
+
+        assertThat(reflectedValues)
+                .containsEntry("term", "sample")
+                .containsEntry("position", 12)
+                .doesNotContainKey("STATIC_VALUE");
+    }
+
+    private interface SingleAttribute extends Attribute {
+        String term();
+
+        int position();
+    }
+
+    private static final class SingleAttributeImpl extends AttributeImpl implements SingleAttribute {
+        private static final String STATIC_VALUE = "ignored";
+
+        private String term;
+        private int position;
+
+        void setValues(String newTerm, int newPosition) {
+            term = newTerm;
+            position = newPosition;
+        }
+
+        @Override
+        public String term() {
+            return term;
+        }
+
+        @Override
+        public int position() {
+            return position;
+        }
+
+        @Override
+        public void clear() {
+            term = null;
+            position = 0;
+        }
+
+        @Override
+        public void copyTo(AttributeImpl target) {
+            SingleAttributeImpl other = (SingleAttributeImpl) target;
+            other.setValues(term, position);
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
@@ -11,13 +11,14 @@ import java.util.Map;
 
 import org.apache.lucene.util.Attribute;
 import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeImplTest {
     @Test
-    void defaultReflectWithReflectsDeclaredInstanceFields() {
+    void reflectWithReflectsAttributeValues() {
         SingleAttributeImpl attribute = new SingleAttributeImpl();
         attribute.setValues("sample", 12);
 
@@ -29,8 +30,7 @@ public class AttributeImplTest {
 
         assertThat(reflectedValues)
                 .containsEntry("term", "sample")
-                .containsEntry("position", 12)
-                .doesNotContainKey("STATIC_VALUE");
+                .containsEntry("position", 12);
     }
 
     private interface SingleAttribute extends Attribute {
@@ -40,8 +40,6 @@ public class AttributeImplTest {
     }
 
     private static final class SingleAttributeImpl extends AttributeImpl implements SingleAttribute {
-        private static final String STATIC_VALUE = "ignored";
-
         private String term;
         private int position;
 
@@ -64,6 +62,12 @@ public class AttributeImplTest {
         public void clear() {
             term = null;
             position = 0;
+        }
+
+        @Override
+        public void reflectWith(AttributeReflector reflector) {
+            reflector.reflect(SingleAttribute.class, "term", term());
+            reflector.reflect(SingleAttribute.class, "position", position());
         }
 
         @Override

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeSupportTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeSupportTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import org.apache.lucene.analysis.tokenattributes.FlagsAttribute;
+import org.apache.lucene.analysis.tokenattributes.FlagsAttributeImpl;
+import org.apache.lucene.util.AttributeFactory;
+import org.apache.lucene.util.AttributeImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeSupportTest {
+    @Test
+    void reflectsFieldsFromAttributeImplementation() {
+        FlagsAttributeImpl attribute = new FlagsAttributeImpl();
+        attribute.setFlags(7);
+
+        assertThat(attribute.reflectAsString(false)).contains("flags=7");
+    }
+
+    @Test
+    void createsAttributeImplementationFromDefaultFactory() {
+        AttributeFactory factory = AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY;
+        AttributeImpl attribute = factory.createAttributeInstance(FlagsAttribute.class);
+
+        assertThat(attribute).isInstanceOf(FlagsAttributeImpl.class);
+        assertThat(((FlagsAttribute) attribute).getFlags()).isZero();
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/CommandLineUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.util.CommandLineUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CommandLineUtilTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void loadsDirectoryImplementationFromSimpleAndFullyQualifiedNames() throws ClassNotFoundException {
+        Class<? extends Directory> simpleNameClass = CommandLineUtil.loadDirectoryClass("RAMDirectory");
+        Class<? extends Directory> fullyQualifiedClass =
+                CommandLineUtil.loadDirectoryClass("org.apache.lucene.store.MMapDirectory");
+
+        assertThat(simpleNameClass).isEqualTo(RAMDirectory.class);
+        assertThat(fullyQualifiedClass).isEqualTo(MMapDirectory.class);
+    }
+
+    @Test
+    void loadsFSDirectoryImplementationFromSimpleName() throws ClassNotFoundException {
+        Class<? extends FSDirectory> fsDirectoryClass = CommandLineUtil.loadFSDirectoryClass("SimpleFSDirectory");
+
+        assertThat(fsDirectoryClass).isEqualTo(SimpleFSDirectory.class);
+    }
+
+    @Test
+    void createsFSDirectoryByClassNameUsingPathConstructor() throws IOException {
+        Path directoryPath = temporaryDirectory;
+
+        FSDirectory directory = CommandLineUtil.newFSDirectory("NIOFSDirectory", directoryPath);
+        try {
+            assertThat(directory).isInstanceOf(NIOFSDirectory.class);
+            assertThat(directory.getDirectory()).isEqualTo(directoryPath.toRealPath());
+        } finally {
+            directory.close();
+        }
+    }
+
+    @Test
+    void reportsNonFSDirectoryClassNames() {
+        assertThatThrownBy(() -> CommandLineUtil.loadFSDirectoryClass("RAMDirectory"))
+                .isInstanceOf(ClassCastException.class);
+        assertThatThrownBy(() -> CommandLineUtil.newFSDirectory("RAMDirectory", temporaryDirectory))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RAMDirectory is not a FSDirectory implementation");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/IOUtilsAndNamedSPILoaderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.util.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IOUtilsAndNamedSPILoaderTest {
+    @Test
+    void readsClasspathResourceWithExplicitCharsetDecoder() throws Exception {
+        try (Reader reader = IOUtils.getDecodingReader(IOUtils.class, "/META-INF/LICENSE.txt", StandardCharsets.UTF_8)) {
+            char[] buffer = new char[192];
+            int read = reader.read(buffer);
+
+            assertThat(read).isPositive();
+            assertThat(new String(buffer, 0, read)).contains("Apache License");
+        }
+    }
+
+    @Test
+    void loadsBuiltInPostingsFormatsThroughNamedSpiLookup() {
+        PostingsFormat postingsFormat = PostingsFormat.forName("Lucene50");
+
+        assertThat(postingsFormat.getClass().getName())
+                .isEqualTo("org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat");
+        assertThat(PostingsFormat.availablePostingsFormats()).contains("Lucene50");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/LockStressTestTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockStressTest;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LockStressTestTest {
+    private static final int CLIENT_ID = 17;
+    private static final int STARTING_GUN = 43;
+    private static final int LOCKED = 1;
+    private static final int UNLOCKED = 0;
+
+    @TempDir
+    Path lockDirectory;
+
+    @Test
+    void instantiatesConfiguredLockFactoryAndCompletesSingleLockCycle() throws Exception {
+        try (LockVerificationServer server = LockVerificationServer.start()) {
+            LockStressTest.main(new String[] {
+                    Integer.toString(CLIENT_ID),
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    Integer.toString(server.port()),
+                    SimpleFSLockFactory.class.getName(),
+                    lockDirectory.toString(),
+                    "0",
+                    "1"
+            });
+
+            server.awaitCompletion();
+        }
+    }
+
+    @Test
+    void instantiatesConstructibleLockFactoryAndCompletesSingleLockCycle() throws Exception {
+        try (LockVerificationServer server = LockVerificationServer.start()) {
+            LockStressTest.main(new String[] {
+                    Integer.toString(CLIENT_ID),
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    Integer.toString(server.port()),
+                    ConstructibleFSLockFactory.class.getName(),
+                    lockDirectory.toString(),
+                    "0",
+                    "1"
+            });
+
+            server.awaitCompletion();
+        }
+    }
+
+    public static final class ConstructibleFSLockFactory extends FSLockFactory {
+        public ConstructibleFSLockFactory() {
+        }
+
+        @Override
+        protected Lock obtainFSLock(FSDirectory dir, String lockName) throws IOException {
+            return SimpleFSLockFactory.INSTANCE.obtainLock(dir, lockName);
+        }
+    }
+
+    private static final class LockVerificationServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final ExecutorService executorService;
+        private final Future<?> serverFuture;
+
+        private LockVerificationServer(
+                ServerSocket serverSocket,
+                ExecutorService executorService,
+                Future<?> serverFuture) {
+            this.serverSocket = serverSocket;
+            this.executorService = executorService;
+            this.serverFuture = serverFuture;
+        }
+
+        private static LockVerificationServer start() throws Exception {
+            ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+            ExecutorService executorService = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "lock-stress-test-verifier");
+                thread.setDaemon(true);
+                return thread;
+            });
+            Future<?> serverFuture = executorService.submit(() -> {
+                serveSingleClient(serverSocket);
+                return null;
+            });
+            return new LockVerificationServer(serverSocket, executorService, serverFuture);
+        }
+
+        private int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        private void awaitCompletion() throws Exception {
+            serverFuture.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+            executorService.shutdownNow();
+            assertThat(executorService.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        private static void serveSingleClient(ServerSocket serverSocket) throws Exception {
+            try (Socket socket = serverSocket.accept();
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream()) {
+                assertThat(inputStream.read()).isEqualTo(CLIENT_ID);
+                outputStream.write(STARTING_GUN);
+                outputStream.flush();
+
+                boolean locked = false;
+                int transitions = 0;
+                int command;
+                while ((command = inputStream.read()) >= 0) {
+                    if (command == LOCKED) {
+                        assertThat(locked).isFalse();
+                        locked = true;
+                    } else {
+                        assertThat(command).isEqualTo(UNLOCKED);
+                        assertThat(locked).isTrue();
+                        locked = false;
+                    }
+                    transitions++;
+                    outputStream.write(command);
+                    outputStream.flush();
+                }
+
+                assertThat(locked).isFalse();
+                assertThat(transitions).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/MMapDirectoryAnonymous1Anonymous1Test.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.io.IOException;
+import java.lang.reflect.InaccessibleObjectException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.RandomAccessInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MMapDirectoryAnonymous1Anonymous1Test {
+    private static final String INDEX_FILE_NAME = "mapped-input.bin";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void closingMappedInputUsesCleanerWhenUnmapIsEnabled() throws IOException {
+        byte[] content = new byte[] {10, 20, 30, 40, 50, 60, 70, 80};
+        Files.write(temporaryDirectory.resolve(INDEX_FILE_NAME), content);
+
+        MMapDirectory directory = new AlwaysUnmappingMMapDirectory(temporaryDirectory);
+        try {
+            IndexInput input = directory.openInput(INDEX_FILE_NAME, IOContext.DEFAULT);
+            try {
+                RandomAccessInput randomAccessInput = (RandomAccessInput) input;
+
+                assertThat(input.length()).isEqualTo(content.length);
+                assertThat(input.readByte()).isEqualTo(content[0]);
+                assertThat(randomAccessInput.readLong(0)).isEqualTo(0x0A141E28323C4650L);
+            } finally {
+                closeMappedInput(input);
+            }
+        } finally {
+            directory.close();
+        }
+    }
+
+    private static void closeMappedInput(IndexInput input) throws IOException {
+        try {
+            input.close();
+        } catch (IOException e) {
+            assertThat(e).hasMessageContaining("Unable to unmap the mapped buffer");
+            assertThat(e.getCause())
+                    .isInstanceOfAny(IllegalAccessException.class, NoSuchMethodException.class);
+        } catch (InaccessibleObjectException e) {
+            assertThat(e).hasMessageContaining("java.nio");
+        }
+    }
+
+    private static final class AlwaysUnmappingMMapDirectory extends MMapDirectory {
+        private AlwaysUnmappingMMapDirectory(Path path) throws IOException {
+            super(path);
+        }
+
+        @Override
+        public boolean getUseUnmap() {
+            return true;
+        }
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/RamUsageEstimatorTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/RamUsageEstimatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RamUsageEstimatorTest {
+    @Test
+    void initializesJvmMemoryConstants() {
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_REF).isIn(4, 8);
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_HEADER).isGreaterThanOrEqualTo(8);
+        assertThat(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER)
+                .isGreaterThan(RamUsageEstimator.NUM_BYTES_OBJECT_HEADER);
+        assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT).isPositive();
+        assertThat(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER % RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT).isZero();
+        if (RamUsageEstimator.COMPRESSED_REFS_ENABLED) {
+            assertThat(RamUsageEstimator.NUM_BYTES_OBJECT_REF).isEqualTo(RamUsageEstimator.NUM_BYTES_INT);
+        }
+    }
+
+    @Test
+    void estimatesShallowSizeForLuceneClassWithPrimitiveAndReferenceFields() {
+        BytesRef bytesRef = new BytesRef("dynamic-access");
+
+        long sizeFromClass = RamUsageEstimator.shallowSizeOfInstance(BytesRef.class);
+        long sizeFromObject = RamUsageEstimator.shallowSizeOf(bytesRef);
+
+        assertThat(sizeFromClass).isEqualTo(sizeFromObject);
+        assertThat(sizeFromClass).isGreaterThanOrEqualTo(RamUsageEstimator.NUM_BYTES_OBJECT_HEADER);
+        assertThat(sizeFromClass % RamUsageEstimator.NUM_BYTES_OBJECT_ALIGNMENT).isZero();
+    }
+
+    @Test
+    void estimatesArraySizesUsingPublicHelpers() {
+        byte[] bytes = new byte[] {1, 2, 3, 4};
+        int[] ints = new int[] {1, 2, 3};
+        Object[] references = new Object[] {new BytesRef("one"), new BytesRef("two")};
+
+        assertThat(RamUsageEstimator.sizeOf(bytes))
+                .isEqualTo(RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + bytes.length));
+        assertThat(RamUsageEstimator.sizeOf(ints))
+                .isEqualTo(RamUsageEstimator.alignObjectSize(
+                        RamUsageEstimator.NUM_BYTES_ARRAY_HEADER
+                                + (long) RamUsageEstimator.NUM_BYTES_INT * ints.length));
+        assertThat(RamUsageEstimator.shallowSizeOf(references))
+                .isEqualTo(RamUsageEstimator.shallowSizeOf(new Object[references.length]));
+    }
+
+    @Test
+    void reportsLongAndHumanReadableSizes() {
+        long uncachedLong = Long.MAX_VALUE;
+
+        assertThat(RamUsageEstimator.sizeOf(Long.valueOf(uncachedLong)))
+                .isEqualTo(RamUsageEstimator.shallowSizeOfInstance(Long.class));
+        assertThat(RamUsageEstimator.humanReadableUnits(RamUsageEstimator.ONE_KB)).isEqualTo("1 KB");
+        assertThat(RamUsageEstimator.humanReadableUnits(RamUsageEstimator.ONE_MB)).isEqualTo("1 MB");
+        assertThat(RamUsageEstimator.humanReadableUnits(512)).isEqualTo("512 bytes");
+    }
+
+    @Test
+    void rejectsArrayClassesForInstanceSizing() {
+        assertThatThrownBy(() -> RamUsageEstimator.shallowSizeOfInstance(byte[].class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("array classes");
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/SPIClassIteratorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import java.util.NoSuchElementException;
+
+import org.apache.lucene.util.SPIClassIterator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SPIClassIteratorTest {
+    @Test
+    void findsServiceDefinitionWithExplicitClassLoader() {
+        ClassLoader classLoader = SPIClassIteratorTest.class.getClassLoader();
+        SPIClassIterator<SPIClassIteratorService> iterator = SPIClassIterator.get(
+                SPIClassIteratorService.class,
+                classLoader);
+
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(SPIClassIteratorServiceImplementation.class);
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void findsServiceDefinitionWithSystemClassLoaderResources() {
+        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        SPIClassIterator<SPIClassIteratorSystemService> iterator = SPIClassIterator.get(
+                SPIClassIteratorSystemService.class,
+                classLoader);
+
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(SPIClassIteratorSystemServiceImplementation.class);
+        assertThat(iterator.hasNext()).isFalse();
+    }
+}
+
+interface SPIClassIteratorService {
+}
+
+class SPIClassIteratorServiceImplementation implements SPIClassIteratorService {
+}
+
+interface SPIClassIteratorSystemService {
+}
+
+class SPIClassIteratorSystemServiceImplementation implements SPIClassIteratorSystemService {
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/VirtualMethodTest.java
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/VirtualMethodTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_lucene.lucene_core;
+
+import org.apache.lucene.util.VirtualMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VirtualMethodTest {
+    private static final VirtualMethod<BaseDescription> DESCRIPTION_METHOD =
+            new VirtualMethod<>(BaseDescription.class, "describe");
+
+    @Test
+    void reportsOverrideDistanceAcrossInheritanceHierarchy() {
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(BaseDescription.class)).isZero();
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(DerivedDescription.class)).isEqualTo(1);
+        assertThat(DESCRIPTION_METHOD.getImplementationDistance(FurtherDerivedDescription.class)).isEqualTo(1);
+        assertThat(DESCRIPTION_METHOD.isOverriddenAsOf(FurtherDerivedDescription.class)).isTrue();
+    }
+
+    public static class BaseDescription {
+        public String describe() {
+            return "base";
+        }
+    }
+
+    public static class DerivedDescription extends BaseDescription {
+        @Override
+        public String describe() {
+            return "derived";
+        }
+    }
+
+    public static class FurtherDerivedDescription extends DerivedDescription {
+    }
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,70 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$BaseDescription",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$DerivedDescription",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.SPIClassIterator"
+      },
+      "type" : "org_apache_lucene.lucene_core.SPIClassIteratorServiceImplementation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.SPIClassIterator"
+      },
+      "type" : "org_apache_lucene.lucene_core.SPIClassIteratorSystemServiceImplementation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$BaseDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$DerivedDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.util.VirtualMethod"
+      },
+      "type" : "org_apache_lucene.lucene_core.VirtualMethodTest$FurtherDerivedDescription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.lucene.store.LockStressTest"
+      },
+      "type" : "org_apache_lucene.lucene_core.LockStressTestTest$ConstructibleFSLockFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorService
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorService
@@ -1,0 +1,3 @@
+# comments and surrounding whitespace are ignored by SPIClassIterator
+  org_apache_lucene.lucene_core.SPIClassIteratorServiceImplementation  
+

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorSystemService
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/resources/META-INF/services/org_apache_lucene.lucene_core.SPIClassIteratorSystemService
@@ -1,0 +1,1 @@
+org_apache_lucene.lucene_core.SPIClassIteratorSystemServiceImplementation

--- a/tests/src/org.apache.lucene/lucene-core/6.0.0/user-code-filter.json
+++ b/tests/src/org.apache.lucene/lucene-core/6.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.lucene.**"
+    },
+    {
+      "includeClasses" : "org_apache_lucene.lucene_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5851

This PR provides test fixes and new metadata for org.apache.lucene:lucene-core:6.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 24911
- Cached input tokens: 72192
- Output tokens: 1451
- Metadata entries: 60
- Test-only metadata entries: 11
- Iterations: 1
- Library coverage percentage: 1.25
- Previous library version metadata entries: 60
- Previous library version test-only metadata entries: 11
- Previous library version coverage percentage: 1.35

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.lucene:lucene-core:5.5.0: 31/31 covered calls (100.00%)
- org.apache.lucene:lucene-core:6.0.0: 27/27 covered calls (100.00%)

**Reflection:**
- org.apache.lucene:lucene-core:5.5.0: 29/29 covered calls (100.00%)
- org.apache.lucene:lucene-core:6.0.0: 25/25 covered calls (100.00%)

**Resources:**
- org.apache.lucene:lucene-core:5.5.0: 2/2 covered calls (100.00%)
- org.apache.lucene:lucene-core:6.0.0: 2/2 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.lucene:lucene-core:5.5.0: 4097/273690 (1.50%)
- org.apache.lucene:lucene-core:6.0.0: 3797/280413 (1.35%)

**Line:**
- org.apache.lucene:lucene-core:5.5.0: 670/49769 (1.35%)
- org.apache.lucene:lucene-core:6.0.0: 642/51429 (1.25%)

**Method:**
- org.apache.lucene:lucene-core:5.5.0: 166/9079 (1.83%)
- org.apache.lucene:lucene-core:6.0.0: 157/9115 (1.72%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.lucene/lucene-core/5.5.0/build.gradle 2/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
index f49a117f3d..db4ec0e388 100644
--- 1/tests/src/org.apache.lucene/lucene-core/5.5.0/build.gradle
+++ 2/tests/src/org.apache.lucene/lucene-core/6.0.0/build.gradle
@@ -31,4 +31,12 @@ graalvmNative {
             }
         }
     }
+    binaries {
+        all {
+            buildArgs.addAll([
+                    '--add-opens=java.base/java.nio=ALL-UNNAMED',
+                    '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED'
+            ])
+        }
+    }
 }
diff --git 1/tests/src/org.apache.lucene/lucene-core/5.5.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java 2/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
index 39f6f7ad27..64bc24a751 100644
--- 1/tests/src/org.apache.lucene/lucene-core/5.5.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
+++ 2/tests/src/org.apache.lucene/lucene-core/6.0.0/src/test/java/org_apache_lucene/lucene_core/AttributeImplTest.java
@@ -11,13 +11,14 @@ import java.util.Map;
 
 import org.apache.lucene.util.Attribute;
 import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeImplTest {
     @Test
-    void defaultReflectWithReflectsDeclaredInstanceFields() {
+    void reflectWithReflectsAttributeValues() {
         SingleAttributeImpl attribute = new SingleAttributeImpl();
         attribute.setValues("sample", 12);
 
@@ -29,8 +30,7 @@ public class AttributeImplTest {
 
         assertThat(reflectedValues)
                 .containsEntry("term", "sample")
-                .containsEntry("position", 12)
-                .doesNotContainKey("STATIC_VALUE");
+                .containsEntry("position", 12);
     }
 
     private interface SingleAttribute extends Attribute {
@@ -40,8 +40,6 @@ public class AttributeImplTest {
     }
 
     private static final class SingleAttributeImpl extends AttributeImpl implements SingleAttribute {
-        private static final String STATIC_VALUE = "ignored";
-
         private String term;
         private int position;
 
@@ -66,6 +64,12 @@ public class AttributeImplTest {
             position = 0;
         }
 
+        @Override
+        public void reflectWith(AttributeReflector reflector) {
+            reflector.reflect(SingleAttribute.class, "term", term());
+            reflector.reflect(SingleAttribute.class, "position", position());
+        }
+
         @Override
         public void copyTo(AttributeImpl target) {
             SingleAttributeImpl other = (SingleAttributeImpl) target;

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
