### PR TITLE
[GenAI] Test fix for org.seleniumhq.selenium:selenium-api:4.1.2 using gpt-5.5

### DIFF
--- a/metadata/org.seleniumhq.selenium/selenium-api/4.1.2/reachability-metadata.json
+++ b/metadata/org.seleniumhq.selenium/selenium-api/4.1.2/reachability-metadata.json
@@ -1,0 +1,70 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.interactions.KeyInput"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.interactions.KeyInput"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.Cookie"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.Cookie"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.Cookie"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.logging.SessionLogs"
+      },
+      "type": "java.util.Collections$UnmodifiableMap",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.openqa.selenium.BuildInfo"
+      },
+      "glob": "META-INF/selenium-build.properties"
+    }
+  ]
+}

--- a/metadata/org.seleniumhq.selenium/selenium-api/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.2",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/$version$/selenium-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/SeleniumHQ/selenium",
+    "test-code-url" : "https://github.com/SeleniumHQ/selenium/tree/selenium-$version$-java/java/test/org/openqa/selenium",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/$version$/selenium-api-$version$-javadoc.jar",
+    "description" : "Selenium API provides the core Java interfaces and exceptions used by Selenium WebDriver to automate browsers. It defines browser automation contracts such as WebDriver, WebElement, By, capabilities, and related support types that client libraries and drivers implement.",
     "tested-versions" : [
       "4.1.2"
     ],

--- a/metadata/org.seleniumhq.selenium/selenium-api/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.2",
+    "tested-versions" : [
+      "4.1.2"
+    ],
+    "allowed-packages" : [
+      "org.openqa.selenium"
+    ]
+  },
+  {
     "metadata-version" : "4.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-api/$version$/selenium-api-$version$-sources.jar",
     "repository-url" : "https://github.com/SeleniumHQ/selenium",

--- a/stats/org.seleniumhq.selenium/selenium-api/4.1.2/execution-metrics.json
+++ b/stats/org.seleniumhq.selenium/selenium-api/4.1.2/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-05": {
+    "timestamp": "2026-05-05T07:42:58.704991Z",
+    "library": "org.seleniumhq.selenium:selenium-api:4.1.2",
+    "starting_commit": "afbd1754d92c53c41ea92bd371802a0fab330844",
+    "ending_commit": "98b8f9b910941bcb80b4998b22b01c244c094686",
+    "previous_library": "org.seleniumhq.selenium:selenium-api:4.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5273,
+          "missed": 9455,
+          "ratio": 0.358026,
+          "total": 14728
+        },
+        "line": {
+          "covered": 954,
+          "missed": 2045,
+          "ratio": 0.318106,
+          "total": 2999
+        },
+        "method": {
+          "covered": 321,
+          "missed": 629,
+          "ratio": 0.337895,
+          "total": 950
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5226,
+          "missed": 9390,
+          "ratio": 0.357553,
+          "total": 14616
+        },
+        "line": {
+          "covered": 949,
+          "missed": 2045,
+          "ratio": 0.316967,
+          "total": 2994
+        },
+        "method": {
+          "covered": 318,
+          "missed": 623,
+          "ratio": 0.337938,
+          "total": 941
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 13552,
+      "cached_input_tokens_used": 124416,
+      "output_tokens_used": 1167,
+      "iterations": 1,
+      "cost_usd": 0.0972,
+      "tested_library_loc": 954,
+      "metadata_entries": 10,
+      "previous_library_metadata_entries": 8,
+      "code_coverage_percent": 31.81,
+      "previous_library_coverage_percent": 31.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java",
+      "metadata_file": "metadata/org.seleniumhq.selenium/selenium-api/4.1.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.seleniumhq.selenium/selenium-api/4.1.2/stats.json
+++ b/stats/org.seleniumhq.selenium/selenium-api/4.1.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5273,
+        "missed" : 9455,
+        "ratio" : 0.358026,
+        "total" : 14728
+      },
+      "line" : {
+        "covered" : 954,
+        "missed" : 2045,
+        "ratio" : 0.318106,
+        "total" : 2999
+      },
+      "method" : {
+        "covered" : 321,
+        "missed" : 629,
+        "ratio" : 0.337895,
+        "total" : 950
+      }
+    }
+  } ]
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/.gitignore
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/build.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.seleniumhq.selenium:selenium-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/gradle.properties
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.seleniumhq.selenium:selenium-api:4.1.2
+library.version = 4.1.2
+metadata.dir = org.seleniumhq.selenium/selenium-api/4.1.2/

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/settings.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.seleniumhq.selenium.selenium-api_tests'

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_seleniumhq_selenium.selenium_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.DeviceRotation;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.KeyInput;
+import org.openqa.selenium.interactions.PointerInput;
+import org.openqa.selenium.interactions.Sequence;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogLevelMapping;
+import org.openqa.selenium.logging.LoggingPreferences;
+import org.openqa.selenium.logging.SessionLogs;
+import org.openqa.selenium.mobile.NetworkConnection.ConnectionType;
+
+public class Selenium_apiTest {
+    @Test
+    void capabilitiesMergeSpecialCasesAndExposeStableViews() {
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "firefox");
+        capabilities.setCapability("javascriptEnabled", true);
+        capabilities.setCapability("platform", "linux");
+        capabilities.setCapability("unexpectedAlertBehaviour", "accept");
+        capabilities.setCapability("temporary", "value");
+        capabilities.setCapability("temporary", (Object) null);
+
+        Map<String, Object> loggingMap = new LinkedHashMap<String, Object>();
+        loggingMap.put("browser", "DEBUG");
+        capabilities.setCapability("loggingPrefs", loggingMap);
+
+        ImmutableCapabilities extraCapabilities = new ImmutableCapabilities(
+                "browserVersion", "4.0.0",
+                "custom:option", 42);
+        MutableCapabilities merged = capabilities.merge(extraCapabilities);
+
+        assertThat(merged).isNotSameAs(capabilities);
+        assertThat(capabilities.getCapability("custom:option")).isNull();
+        assertThat(merged.getBrowserName()).isEqualTo("firefox");
+        assertThat(merged.is("javascriptEnabled")).isTrue();
+        assertThat(merged.getBrowserVersion()).isEqualTo("4.0.0");
+        assertThat(merged.getPlatformName()).isEqualTo(Platform.LINUX);
+        assertThat(merged.getCapability("unhandledPromptBehavior")).isEqualTo("accept");
+        assertThat(merged.getCapability("temporary")).isNull();
+        assertThat(merged.getCapabilityNames())
+                .contains("browserName", "javascriptEnabled", "platform", "loggingPrefs", "browserVersion", "custom:option")
+                .doesNotContain("temporary");
+        assertThat(merged.asMap()).containsEntry("custom:option", 42);
+        assertThatThrownBy(() -> merged.asMap().put("newCapability", true))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        LoggingPreferences loggingPreferences = (LoggingPreferences) merged.getCapability("loggingPrefs");
+        assertThat(loggingPreferences.getLevel("browser")).isEqualTo(Level.FINE);
+        assertThat(ImmutableCapabilities.copyOf(merged)).isEqualTo(merged);
+    }
+
+    @Test
+    void proxySupportsManualPacAutodetectAndCapabilitiesExtraction() {
+        Proxy manualProxy = new Proxy()
+                .setHttpProxy("proxy.example.test:8080")
+                .setSslProxy("secure.example.test:8443")
+                .setNoProxy("localhost, 127.0.0.1")
+                .setSocksProxy("socks.example.test:1080")
+                .setSocksVersion(5)
+                .setSocksUsername("user")
+                .setSocksPassword("secret");
+
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("proxy", manualProxy);
+
+        Proxy extractedProxy = Proxy.extractFrom(capabilities);
+        Map<String, Object> proxyJson = extractedProxy.toJson();
+
+        assertThat(extractedProxy).isSameAs(manualProxy);
+        assertThat(extractedProxy.getProxyType()).isEqualTo(Proxy.ProxyType.MANUAL);
+        assertThat(proxyJson)
+                .containsEntry("proxyType", "MANUAL")
+                .containsEntry("httpProxy", "proxy.example.test:8080")
+                .containsEntry("sslProxy", "secure.example.test:8443")
+                .containsEntry("socksProxy", "socks.example.test:1080")
+                .containsEntry("socksVersion", 5)
+                .containsEntry("socksUsername", "user")
+                .containsEntry("socksPassword", "secret");
+        assertThat(proxyJson.get("noProxy")).isEqualTo(Arrays.asList("localhost", "127.0.0.1"));
+
+        Map<String, Object> wireProxy = new LinkedHashMap<String, Object>();
+        wireProxy.put("proxyType", "pac");
+        wireProxy.put("proxyAutoconfigUrl", "https://proxy.example.test/proxy.pac");
+        Proxy pacProxy = new Proxy(wireProxy);
+        assertThat(pacProxy.getProxyType()).isEqualTo(Proxy.ProxyType.PAC);
+        assertThat(pacProxy.getProxyAutoconfigUrl()).isEqualTo("https://proxy.example.test/proxy.pac");
+
+        Proxy autodetectProxy = new Proxy().setAutodetect(true);
+        assertThat(autodetectProxy.isAutodetect()).isTrue();
+        assertThat(autodetectProxy.getProxyType()).isEqualTo(Proxy.ProxyType.AUTODETECT);
+        assertThat(autodetectProxy.toJson()).containsEntry("autodetect", true);
+    }
+
+    @Test
+    void cookiesValidateNormalizeAndRenderToWireFormat() {
+        Date expiryWithMillis = new Date(1_700_000_000_999L);
+        Cookie cookie = new Cookie.Builder("session", "abc123")
+                .domain("example.test:443")
+                .path("/app")
+                .expiresOn(expiryWithMillis)
+                .isSecure(true)
+                .isHttpOnly(true)
+                .build();
+
+        cookie.validate();
+
+        assertThat(cookie.getName()).isEqualTo("session");
+        assertThat(cookie.getValue()).isEqualTo("abc123");
+        assertThat(cookie.getDomain()).isEqualTo("example.test");
+        assertThat(cookie.getPath()).isEqualTo("/app");
+        assertThat(cookie.getExpiry()).isEqualTo(new Date(1_700_000_000_000L));
+        assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.toJson())
+                .containsEntry("name", "session")
+                .containsEntry("value", "abc123")
+                .containsEntry("domain", "example.test")
+                .containsEntry("path", "/app")
+                .containsEntry("secure", true)
+                .containsEntry("httpOnly", true)
+                .containsEntry("expiry", new Date(1_700_000_000_000L));
+        assertThat(cookie.toString())
+                .contains("session=abc123")
+                .contains("; path=/app")
+                .contains("; domain=example.test")
+                .contains(";secure;");
+        assertThat(cookie).isEqualTo(new Cookie("session", "abc123"));
+
+        assertThatThrownBy(() -> new Cookie("bad;name", "value").validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cookie names cannot contain");
+        assertThatThrownBy(() -> new Cookie("", "value").validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Required attributes");
+    }
+
+    @Test
+    void geometryPlatformAndRotationValueObjectsAreUsableWithoutADriver() {
+        Dimension size = new Dimension(640, 480);
+        Point origin = new Point(10, 20);
+        Rectangle rectangle = new Rectangle(origin, size);
+
+        assertThat(size.getWidth()).isEqualTo(640);
+        assertThat(size.getHeight()).isEqualTo(480);
+        assertThat(origin.moveBy(5, -10)).isEqualTo(new Point(15, 10));
+        assertThat(rectangle.getPoint()).isEqualTo(origin);
+        assertThat(rectangle.getDimension()).isEqualTo(size);
+
+        rectangle.setX(30);
+        rectangle.setY(40);
+        rectangle.setWidth(800);
+        rectangle.setHeight(600);
+
+        assertThat(rectangle).isEqualTo(new Rectangle(30, 40, 600, 800));
+        assertThat(rectangle.getPoint()).isEqualTo(new Point(30, 40));
+        assertThat(rectangle.getDimension()).isEqualTo(new Dimension(800, 600));
+
+        DeviceRotation rotation = new DeviceRotation(1, 2, 3);
+        assertThat(rotation.parameters())
+                .containsEntry("x", 1)
+                .containsEntry("y", 2)
+                .containsEntry("z", 3);
+        Map<String, Number> rotationParameters = new LinkedHashMap<String, Number>();
+        rotationParameters.put("x", 1);
+        rotationParameters.put("y", 2);
+        rotationParameters.put("z", 3);
+        assertThat(new DeviceRotation(rotationParameters)).isEqualTo(rotation);
+
+        assertThat(Platform.fromString("linux")).isEqualTo(Platform.LINUX);
+        assertThat(Platform.LINUX.is(Platform.UNIX)).isTrue();
+        assertThat(Platform.WIN10.is(Platform.WINDOWS)).isTrue();
+        assertThat(Platform.extractFromSysProperty("Mac OS X", "10.14")).isEqualTo(Platform.MAC);
+        assertThat(Platform.extractFromSysProperty("macOS 10.14", "10.14")).isEqualTo(Platform.MOJAVE);
+    }
+
+    @Test
+    void outputTypesAndKeyboardKeysUseWireCompatibleRepresentations() {
+        byte[] pngHeader = new byte[] {(byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
+        String base64 = OutputType.BASE64.convertFromPngBytes(pngHeader);
+
+        assertThat(base64).isEqualTo("iVBORw0KGgo=");
+        assertThat(OutputType.BASE64.convertFromBase64Png(base64)).isEqualTo(base64);
+        assertThat(OutputType.BYTES.convertFromBase64Png(base64)).containsExactly(pngHeader);
+        assertThat(OutputType.BYTES.convertFromPngBytes(pngHeader)).isSameAs(pngHeader);
+        assertThat(OutputType.BASE64.toString()).isEqualTo("OutputType.BASE64");
+        assertThat(OutputType.BYTES.toString()).isEqualTo("OutputType.BYTES");
+
+        assertThat((CharSequence) Keys.ENTER).hasToString("\uE007");
+        assertThat((CharSequence) Keys.ENTER).hasSize(1);
+        assertThat(Keys.ENTER.charAt(0)).isEqualTo('\uE007');
+        assertThat((Object) Keys.getKeyFromUnicode('\uE007')).isEqualTo(Keys.ENTER);
+        assertThat(Keys.chord(Keys.CONTROL, "a"))
+                .isEqualTo(Keys.CONTROL.toString() + "a" + Keys.NULL.toString());
+        assertThat(Keys.chord(Arrays.<CharSequence>asList(Keys.SHIFT, "abc")))
+                .isEqualTo(Keys.SHIFT.toString() + "abc" + Keys.NULL.toString());
+    }
+
+    @Test
+    void locatorsProvideIdentityNullValidationAndHelpfulMisses() {
+        By id = By.id("login");
+        By sameId = By.id("login");
+        By css = By.cssSelector("button.primary");
+
+        assertThat(id).isEqualTo(sameId);
+        assertThat(id.hashCode()).isEqualTo(sameId.hashCode());
+        assertThat(id).hasToString("By.id: login");
+        assertThat(css).hasToString("By.cssSelector: button.primary");
+        assertThat(By.name("username")).hasToString("By.name: username");
+        assertThat(By.className("field")).hasToString("By.className: field");
+        assertThat(By.xpath("//button")).hasToString("By.xpath: //button");
+        assertThat(By.linkText("Sign in")).hasToString("By.linkText: Sign in");
+        assertThat(By.partialLinkText("Sign")).hasToString("By.partialLinkText: Sign");
+        assertThat(By.tagName("button")).hasToString("By.tagName: button");
+
+        assertThatThrownBy(() -> By.id(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("id is null");
+        assertThatThrownBy(() -> By.cssSelector(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("selector is null");
+        assertThatThrownBy(() -> locatorReturningNoElements().findElement(null))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("Cannot locate an element using")
+                .hasMessageContaining("empty context");
+    }
+
+    @Test
+    void loggingEntriesPreferencesAndLevelMappingsPreserveEvents() {
+        LoggingPreferences basePreferences = new LoggingPreferences();
+        basePreferences.enable("browser", Level.FINE);
+        LoggingPreferences extraPreferences = new LoggingPreferences();
+        extraPreferences.enable("driver", Level.WARNING);
+
+        LoggingPreferences mergedPreferences = basePreferences.addPreferences(extraPreferences);
+
+        assertThat(mergedPreferences).isSameAs(basePreferences);
+        assertThat(basePreferences.getEnabledLogTypes()).containsExactlyInAnyOrder("browser", "driver");
+        assertThat(basePreferences.getLevel("browser")).isEqualTo(Level.FINE);
+        assertThat(basePreferences.getLevel("server")).isEqualTo(Level.OFF);
+        assertThat(basePreferences.toJson())
+                .containsEntry("browser", "DEBUG")
+                .containsEntry("driver", "WARNING");
+        assertThat(LogLevelMapping.toLevel("DEBUG")).isEqualTo(Level.FINE);
+        assertThat(LogLevelMapping.getName(Level.CONFIG)).isEqualTo("DEBUG");
+        assertThat(LogLevelMapping.normalize(Level.SEVERE)).isEqualTo(Level.SEVERE);
+
+        LogEntry warning = new LogEntry(Level.WARNING, 101L, "slow script");
+        LogEntry info = new LogEntry(Level.INFO, 102L, "page loaded");
+        LogEntries entries = new LogEntries(Arrays.asList(warning, info));
+
+        assertThat(entries.getAll()).containsExactly(warning, info);
+        assertThat(entries)
+                .filteredOn(entry -> entry.getLevel().equals(Level.WARNING))
+                .containsExactly(warning);
+        assertThat(entries.toJson()).containsExactly(warning, info);
+        assertThat(warning.toJson())
+                .containsEntry("level", Level.WARNING)
+                .containsEntry("timestamp", 101L)
+                .containsEntry("message", "slow script");
+        assertThat(warning.toString()).contains("[WARNING] slow script");
+        assertThatThrownBy(() -> entries.getAll().add(new LogEntry(Level.SEVERE, 103L, "failure")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void sessionLogsAggregateEntriesFromWireJsonByLogType() {
+        Map<String, Object> browserEvent = new LinkedHashMap<String, Object>();
+        browserEvent.put("level", "INFO");
+        browserEvent.put("timestamp", 201L);
+        browserEvent.put("message", "dom ready");
+        Map<String, Object> driverEvent = new LinkedHashMap<String, Object>();
+        driverEvent.put("level", "SEVERE");
+        driverEvent.put("timestamp", 202L);
+        driverEvent.put("message", "navigation failed");
+        Map<String, Object> wireLogs = new LinkedHashMap<String, Object>();
+        wireLogs.put("browser", Collections.singletonList(browserEvent));
+        wireLogs.put("driver", Collections.singletonList(driverEvent));
+
+        SessionLogs sessionLogs = SessionLogs.fromJSON(wireLogs);
+
+        LogEntry browserLog = sessionLogs.getLogs("browser").getAll().get(0);
+        assertThat(browserLog.getLevel()).isEqualTo(Level.INFO);
+        assertThat(browserLog.getTimestamp()).isEqualTo(201L);
+        assertThat(browserLog.getMessage()).isEqualTo("dom ready");
+        assertThat(sessionLogs.getLogs("driver").getAll().get(0).getLevel()).isEqualTo(Level.SEVERE);
+        assertThat(sessionLogs.getLogTypes()).containsExactlyInAnyOrder("browser", "driver");
+        assertThat(sessionLogs.getLogs("server").getAll()).isEmpty();
+        assertThat(sessionLogs.toJson()).containsKeys("browser", "driver");
+        assertThat(sessionLogs.toJson().get("browser").getAll()).containsExactly(browserLog);
+        assertThatThrownBy(() -> sessionLogs.getAll().put("server", new LogEntries(Collections.emptyList())))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        SessionLogs manuallyBuiltLogs = new SessionLogs();
+        manuallyBuiltLogs.addLog("browser", sessionLogs.getLogs("browser"));
+        assertThat(manuallyBuiltLogs.getAll()).containsOnlyKeys("browser");
+        assertThat(manuallyBuiltLogs.getLogs("browser").getAll()).containsExactly(browserLog);
+    }
+
+    @Test
+    void interactionsEncodeKeyboardPointerSequencesAndValidateArguments() {
+        KeyInput keyboard = new KeyInput("keyboard");
+        Sequence keySequence = new Sequence(keyboard, 1)
+                .addAction(keyboard.createKeyDown('A'))
+                .addAction(keyboard.createKeyUp('A'));
+
+        Map<String, Object> encodedKeys = keySequence.encode();
+        List<?> keyActions = (List<?>) encodedKeys.get("actions");
+
+        assertThat(encodedKeys)
+                .containsEntry("type", "key")
+                .containsEntry("id", "keyboard");
+        assertThat(keyActions).hasSize(3);
+        assertThat(asStringObjectMap(keyActions.get(0))).containsEntry("type", "pause").containsEntry("duration", 0L);
+        assertThat(asStringObjectMap(keyActions.get(1))).containsEntry("type", "keyDown").containsEntry("value", "A");
+        assertThat(asStringObjectMap(keyActions.get(2))).containsEntry("type", "keyUp").containsEntry("value", "A");
+
+        PointerInput mouse = new PointerInput(PointerInput.Kind.MOUSE, "mouse");
+        Sequence pointerSequence = new Sequence(mouse, 0)
+                .addAction(mouse.createPointerMove(Duration.ofMillis(250), PointerInput.Origin.viewport(), 10, 20))
+                .addAction(mouse.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
+                .addAction(mouse.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+
+        Map<String, Object> encodedPointer = pointerSequence.toJson();
+        Map<String, Object> pointerParameters = asStringObjectMap(encodedPointer.get("parameters"));
+        List<?> pointerActions = (List<?>) encodedPointer.get("actions");
+
+        assertThat(encodedPointer).containsEntry("type", "pointer").containsEntry("id", "mouse");
+        assertThat(pointerParameters).containsEntry("pointerType", "mouse");
+        assertThat(pointerActions).hasSize(3);
+        assertThat(asStringObjectMap(pointerActions.get(0)))
+                .containsEntry("type", "pointerMove")
+                .containsEntry("duration", 250L)
+                .containsEntry("origin", "viewport")
+                .containsEntry("x", 10)
+                .containsEntry("y", 20);
+        assertThat(asStringObjectMap(pointerActions.get(1)))
+                .containsEntry("type", "pointerDown")
+                .containsEntry("button", 0);
+        assertThat(asStringObjectMap(pointerActions.get(2)))
+                .containsEntry("type", "pointerUp")
+                .containsEntry("button", 0);
+
+        assertThatThrownBy(() -> mouse.createPointerMove(Duration.ofMillis(-1), PointerInput.Origin.pointer(), 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Duration must be set to 0 or more");
+        assertThatThrownBy(() -> new Sequence(keyboard, 0).addAction(mouse.createPointerDown(0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("wrong kind of input device");
+    }
+
+    @Test
+    void mobileConnectionTypesExposeStateAndWireMask() {
+        ConnectionType wifiAndData = new ConnectionType(true, true, false);
+
+        assertThat(wifiAndData.isWifiEnabled()).isTrue();
+        assertThat(wifiAndData.isDataEnabled()).isTrue();
+        assertThat(wifiAndData.isAirplaneMode()).isFalse();
+        assertThat(wifiAndData).isEqualTo(ConnectionType.ALL);
+        assertThat(wifiAndData.hashCode()).isEqualTo(ConnectionType.ALL.hashCode());
+        assertThat(wifiAndData.toJson()).isEqualTo(ConnectionType.ALL.toJson());
+        assertThat(wifiAndData).hasToString(ConnectionType.ALL.toString());
+
+        ConnectionType airplaneMode = new ConnectionType(ConnectionType.AIRPLANE_MODE.toJson());
+        assertThat(airplaneMode.isAirplaneMode()).isTrue();
+        assertThat(airplaneMode.isWifiEnabled()).isFalse();
+        assertThat(airplaneMode.isDataEnabled()).isFalse();
+        assertThat(airplaneMode).isEqualTo(ConnectionType.AIRPLANE_MODE);
+
+        ConnectionType noConnection = new ConnectionType(-1);
+        assertThat(noConnection).isEqualTo(ConnectionType.NONE);
+        assertThat(noConnection.toJson()).isZero();
+    }
+
+    @Test
+    void webdriverExceptionsIncludeAdditionalContextAndAlertPayload() {
+        WebDriverException exception = new WebDriverException("browser failed");
+        exception.addInfo(WebDriverException.DRIVER_INFO, "fake-driver 1.0");
+        exception.addInfo(WebDriverException.SESSION_ID, "session-123");
+
+        assertThat(exception.getMessage())
+                .contains("browser failed")
+                .contains("Driver info: fake-driver 1.0")
+                .contains("Session ID: session-123");
+        assertThat(exception.getAdditionalInformation())
+                .contains("Driver info: fake-driver 1.0")
+                .contains("Session ID: session-123");
+        assertThat(exception.getSupportUrl()).isNull();
+        assertThat(exception.getBuildInformation()).isNotNull();
+
+        UnhandledAlertException alertException = new UnhandledAlertException("modal dialog", "Delete item?");
+        assertThat(alertException.getAlertText()).isEqualTo("Delete item?");
+        assertThat(alertException.getAlert()).containsEntry("text", "Delete item?");
+        assertThat(alertException.getMessage()).contains("modal dialog: Delete item?");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asStringObjectMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    private static By locatorReturningNoElements() {
+        return new By() {
+            @Override
+            public List<WebElement> findElements(SearchContext context) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public String toString() {
+                return "empty context";
+            }
+        };
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
@@ -379,7 +379,7 @@ public class Selenium_apiTest {
 
         assertThatThrownBy(() -> mouse.createPointerMove(Duration.ofMillis(-1), PointerInput.Origin.pointer(), 0, 0))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Duration must be set to 0 or more");
+                .hasMessageContaining("Duration must be 0 or greater");
         assertThatThrownBy(() -> new Sequence(keyboard, 0).addAction(mouse.createPointerDown(0)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("wrong kind of input device");

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.openqa.selenium.**"
+    }
+  ]
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
+++ b/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.openqa.selenium.**"
+    },
+    {
+      "includeClasses" : "org_seleniumhq_selenium.selenium_api.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4267

This PR provides test fixes and new metadata for org.seleniumhq.selenium:selenium-api:4.1.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 13552
- Cached input tokens: 124416
- Output tokens: 1167
- Metadata entries: 10
- Iterations: 1
- Library coverage percentage: 31.81
- Previous library version metadata entries: 8
- Previous library version coverage percentage: 31.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.seleniumhq.selenium:selenium-api:4.0.0: 0/0 covered calls (100.00%)
- org.seleniumhq.selenium:selenium-api:4.1.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.seleniumhq.selenium:selenium-api:4.0.0: 5226/14616 (35.76%)
- org.seleniumhq.selenium:selenium-api:4.1.2: 5273/14728 (35.80%)

**Line:**
- org.seleniumhq.selenium:selenium-api:4.0.0: 949/2994 (31.70%)
- org.seleniumhq.selenium:selenium-api:4.1.2: 954/2999 (31.81%)

**Method:**
- org.seleniumhq.selenium:selenium-api:4.0.0: 318/941 (33.79%)
- org.seleniumhq.selenium:selenium-api:4.1.2: 321/950 (33.79%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.seleniumhq.selenium/selenium-api/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java 2/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
index 9a058e2205..f3088c5b12 100644
--- 1/tests/src/org.seleniumhq.selenium/selenium-api/4.0.0/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
+++ 2/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/src/test/java/org_seleniumhq_selenium/selenium_api/Selenium_apiTest.java
@@ -379,7 +379,7 @@ public class Selenium_apiTest {
 
         assertThatThrownBy(() -> mouse.createPointerMove(Duration.ofMillis(-1), PointerInput.Origin.pointer(), 0, 0))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Duration must be set to 0 or more");
+                .hasMessageContaining("Duration must be 0 or greater");
         assertThatThrownBy(() -> new Sequence(keyboard, 0).addAction(mouse.createPointerDown(0)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("wrong kind of input device");
diff --git 1/tests/src/org.seleniumhq.selenium/selenium-api/4.0.0/user-code-filter.json 2/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
index d758d2070f..fe7145ef86 100644
--- 1/tests/src/org.seleniumhq.selenium/selenium-api/4.0.0/user-code-filter.json
+++ 2/tests/src/org.seleniumhq.selenium/selenium-api/4.1.2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.openqa.selenium.**"
+    },
+    {
+      "includeClasses" : "org_seleniumhq_selenium.selenium_api.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
