### PR TITLE
[GenAI] Test fix for org.apache.thrift:libthrift:0.17.0 using gpt-5.5

### DIFF
--- a/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
+++ b/stats/org.apache.thrift/libthrift/0.17.0/execution-metrics.json
@@ -107,5 +107,114 @@
       "test_file": "tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java",
       "metadata_file": "metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json"
     }
+  },
+  "fix_java_run_fail:2026-05-05": {
+    "timestamp": "2026-05-05T07:35:38.766181Z",
+    "library": "org.apache.thrift:libthrift:0.17.0",
+    "starting_commit": "0d7f1ac496d758456ac5885710982fc775d89e05",
+    "ending_commit": "2155d32874ab927f183d3d7efbe04db076a3d83e",
+    "previous_library": "org.apache.thrift:libthrift:0.17.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 696,
+          "missed": 28584,
+          "ratio": 0.02377,
+          "total": 29280
+        },
+        "line": {
+          "covered": 182,
+          "missed": 6729,
+          "ratio": 0.026335,
+          "total": 6911
+        },
+        "method": {
+          "covered": 45,
+          "missed": 1590,
+          "ratio": 0.027523,
+          "total": 1635
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.17.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 696,
+          "missed": 28584,
+          "ratio": 0.02377,
+          "total": 29280
+        },
+        "line": {
+          "covered": 182,
+          "missed": 6729,
+          "ratio": 0.026335,
+          "total": 6911
+        },
+        "method": {
+          "covered": 45,
+          "missed": 1590,
+          "ratio": 0.027523,
+          "total": 1635
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 19905,
+      "cached_input_tokens_used": 61952,
+      "output_tokens_used": 784,
+      "iterations": 1,
+      "cost_usd": 0.0545,
+      "tested_library_loc": 182,
+      "metadata_entries": 31,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 31,
+      "previous_library_test_only_metadata_entries": 8,
+      "code_coverage_percent": 2.63,
+      "previous_library_coverage_percent": 2.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.thrift/libthrift/0.17.0/src/test/java/org_apache_thrift/libthrift/TSSLTransportFactoryTest.java",
+      "metadata_file": "metadata/org.apache.thrift/libthrift/0.17.0/reachability-metadata.json"
+    }
   }
 }

--- a/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
+++ b/tests/src/org.apache.thrift/libthrift/0.17.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.apache.thrift.**"
+    },
+    {
+      "includeClasses" : "org_apache_thrift.libthrift.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4262

This PR provides test fixes and new metadata for org.apache.thrift:libthrift:0.17.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 19905
- Cached input tokens: 61952
- Output tokens: 784
- Metadata entries: 31
- Test-only metadata entries: 8
- Iterations: 1
- Library coverage percentage: 2.63
- Previous library version metadata entries: 31
- Previous library version test-only metadata entries: 8
- Previous library version coverage percentage: 2.63

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

Same entry for both `org.apache.thrift:libthrift:0.17.0` and `org.apache.thrift:libthrift:0.17.0`.

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 12
- Fixup attempts: 0
