### PR TITLE
Fix .log ignore rule for artifact directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ nb-configuration.xml
 
 # Log file
 *.log
+!*.log/
 
 # BlueJ files
 *.ctxt


### PR DESCRIPTION
Closes #5920

## What does this PR do?

Updates the repository `.gitignore` so `*.log` continues to ignore log files but no longer hides directories whose names end in `.log`.

This fixes artifact coordinates such as `org.osgi:org.osgi.service.log:1.3.0`, where generated files under `metadata/org.osgi/org.osgi.service.log/`, `tests/src/org.osgi/org.osgi.service.log/`, and `stats/org.osgi/org.osgi.service.log/` were ignored because the artifact directory matched `*.log`.

Validation run:
- `git check-ignore -v metadata/org.osgi/org.osgi.service.log/1.3.0/reachability-metadata.json tests/src/org.osgi/org.osgi.service.log/1.3.0/src/test/java/org_osgi/org_osgi_service_log/Org_osgi_service_logTest.java stats/org.osgi/org.osgi.service.log/1.3.0/stats.json` returned no ignored matches.
- `git check-ignore -v human-intervention-logs/org.osgi:org.osgi.service.log:1.3.0/gradle-test/example.log` still reports the `*.log` ignore rule.

No Gradle validation was run because this is an ignore-rule-only change.

## Code sections where the PR accesses files, network, docker or some external service

- `.gitignore` only; no runtime file, network, docker, or external service access.