### PR TITLE
Fix per-class native metadata aggregation

### DIFF
--- a/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
@@ -19,7 +19,7 @@ from utility_scripts.dynamic_access_report import (
     load_dynamic_access_coverage_report,
 )
 from utility_scripts.large_library_progress import LargeLibraryProgressState
-from utility_scripts.metadata_index import resolve_test_version
+from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.native_test_verification import (
     STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
     per_class_output_dir,
@@ -664,8 +664,14 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
 
     def _commit_library_metadata(self, message: str) -> None:
         """Stage and commit durable library metadata created by the class gate."""
+        metadata_version = resolve_metadata_version(
+            self.reachability_repo_path,
+            self.group,
+            self.artifact,
+            self.version,
+        )
         metadata_dir = os.path.join(
-            self.reachability_repo_path, "metadata", self.group, self.artifact, self.version,
+            self.reachability_repo_path, "metadata", self.group, self.artifact, metadata_version,
         )
         subprocess.run(
             ["git", "add", "-A", metadata_dir],

--- a/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
@@ -31,6 +31,7 @@ from utility_scripts.strategy_loader import load_strategy_by_name
 
 FALLBACK_STRATEGY_NAME = "basic_iterative_pi_gpt-5.4"
 DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 100
+DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE = 5
 
 
 @WorkflowStrategy.register("dynamic_access_iterative")
@@ -63,6 +64,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             "max-native-test-verification-iterations",
             DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
         )
+        self.native_test_verification_batch_size = self._parameter_int(
+            "native-test-verification-batch-size",
+            DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE,
+        )
+        if self.native_test_verification_batch_size < 1:
+            raise ValueError("Strategy parameter 'native-test-verification-batch-size' must be >= 1")
         self.large_library_progress_state: LargeLibraryProgressState | None = self.context.get(
             "large_library_progress_state",
         )
@@ -133,6 +140,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         prompt_iterations = 0
         successful_classes = 0
         processed_classes_this_part = 0
+        pending_native_test_classes: list[str] = []
         initial_part_covered_calls = current_report.covered_calls
         if self.large_library_progress_state is not None:
             initial_part_covered_calls = self._initial_part_covered_calls(current_report)
@@ -147,9 +155,23 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         }
         initial_class_count = len(current_report.classes)
 
+        def flush_native_test_batch(reason: str) -> bool:
+            nonlocal current_report
+            ok, gate_label = self._run_pending_native_test_verification_gate(
+                pending_native_test_classes,
+                reason,
+            )
+            if not ok:
+                return False
+            if gate_label is not None:
+                current_report = self._refresh_report_after_gate(gate_label) or current_report
+            return True
+
         while True:
             active_class = current_report.next_uncovered_class(exhausted_classes)
             if active_class is None:
+                if not flush_native_test_batch("end-of-classes"):
+                    return False, prompt_iterations
                 if (
                         successful_classes == 0
                         and self.keep_tests_without_dynamic_access
@@ -292,11 +314,18 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                             f"({current_report.covered_calls}/{current_report.total_calls})"
                         )
                         successful_classes += 1
-                        if not self._run_native_test_verification_gate(class_name):
+                        if not self._queue_native_test_verification_step(
+                                pending_native_test_classes,
+                                class_name,
+                        ):
                             gate_failed = True
                             exhausted_classes.add(class_name)
                             break
-                        current_report = self._refresh_report_after_gate(class_name) or current_report
+                        if self._native_test_verification_batch_ready(pending_native_test_classes):
+                            if not flush_native_test_batch("batch-size"):
+                                gate_failed = True
+                                exhausted_classes.add(class_name)
+                                break
                         self._mark_large_library_completed(class_name, current_report)
                     else:
                         self._print_dynamic_access_detail(
@@ -314,10 +343,16 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     )
                     successful_classes += 1
                     exhausted_classes.add(class_name)
-                    if not self._run_native_test_verification_gate(class_name):
+                    if not self._queue_native_test_verification_step(
+                            pending_native_test_classes,
+                            class_name,
+                    ):
                         gate_failed = True
                         break
-                    current_report = self._refresh_report_after_gate(class_name) or current_report
+                    if self._native_test_verification_batch_ready(pending_native_test_classes):
+                        if not flush_native_test_batch("batch-size"):
+                            gate_failed = True
+                            break
                     self._mark_large_library_completed(class_name, current_report)
                     break
                 if updated_class.covered_calls > active_class.covered_calls:
@@ -339,12 +374,16 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     class_checkpoint = subprocess.check_output(
                         ["git", "rev-parse", "HEAD"], text=True,
                     ).strip()
-                    if not self._run_native_test_verification_gate(class_name):
+                    if not self._queue_native_test_verification_step(
+                            pending_native_test_classes,
+                            class_name,
+                    ):
                         gate_failed = True
                         break
-                    refreshed = self._refresh_report_after_gate(class_name)
-                    if refreshed is not None:
-                        current_report = refreshed
+                    if self._native_test_verification_batch_ready(pending_native_test_classes):
+                        if not flush_native_test_batch("batch-size"):
+                            gate_failed = True
+                            break
                         updated_class = current_report.get_class(class_name) or updated_class
                     self._save_large_library_progress(current_report)
                 else:
@@ -422,6 +461,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     processed_classes_this_part,
                     initial_part_covered_calls,
             ):
+                if not flush_native_test_batch("large-library-chunk-boundary"):
+                    return False, prompt_iterations
                 self._last_phase_status = RUN_STATUS_CHUNK_READY
                 self._print_dynamic_access_message(
                     "Large-library chunk boundary reached after {count} class(es).".format(
@@ -430,6 +471,56 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 )
                 self._save_large_library_progress(current_report)
                 return True, prompt_iterations
+
+    def _queue_native_test_verification_step(
+            self,
+            pending_classes: list[str],
+            class_name: str,
+    ) -> bool:
+        """Queue one committed class step for the next native-test verification batch."""
+        pending_classes.append(class_name)
+        self._print_dynamic_access_detail(
+            "native-test gate: queued class={class_name} pending={pending}/{batch_size}".format(
+                class_name=class_name,
+                pending=len(pending_classes),
+                batch_size=self.native_test_verification_batch_size,
+            ),
+            indent_level=2,
+        )
+        return True
+
+    def _native_test_verification_batch_ready(self, pending_classes: list[str]) -> bool:
+        return len(pending_classes) >= self.native_test_verification_batch_size
+
+    def _run_pending_native_test_verification_gate(
+            self,
+            pending_classes: list[str],
+            reason: str,
+    ) -> tuple[bool, str | None]:
+        """Run and clear the pending native-test gate batch when any classes are queued."""
+        if not pending_classes:
+            return True, None
+        gate_label = self._native_test_verification_batch_label(pending_classes)
+        self._print_dynamic_access_detail(
+            "native-test gate: flushing {count} queued class step(s), reason={reason}".format(
+                count=len(pending_classes),
+                reason=reason,
+            ),
+            indent_level=2,
+        )
+        if not self._run_native_test_verification_gate(gate_label):
+            return False, gate_label
+        pending_classes.clear()
+        return True, gate_label
+
+    @staticmethod
+    def _native_test_verification_batch_label(class_names: list[str]) -> str:
+        if len(class_names) == 1:
+            return class_names[0]
+        return "{last_class}__native_batch_{count}".format(
+            last_class=class_names[-1],
+            count=len(class_names),
+        )
 
     def _run_native_test_verification_gate(self, class_name: str) -> bool:
         """Run the per-class native-test verification gate; return True if PASSED."""

--- a/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
@@ -675,13 +675,20 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
         subprocess.run(
             ["git", "add", "-A", metadata_dir],
-            cwd=self.reachability_repo_path, check=False,
-        )
-        subprocess.run(
-            ["git", "diff", "--cached", "--quiet"],
             cwd=self.reachability_repo_path,
-        ).returncode != 0 and subprocess.run(
-            ["git", "commit", "-m", message],
+            capture_output=True, check=False,
+        )
+        # `git diff --cached --quiet -- <path>` exits non-zero iff <path> has staged changes.
+        # Restricting to <metadata_dir> ensures unrelated staged files don't trigger a commit.
+        diff_rc = subprocess.run(
+            ["git", "diff", "--cached", "--quiet", "--", metadata_dir],
+            cwd=self.reachability_repo_path,
+            capture_output=True, check=False,
+        ).returncode
+        if diff_rc == 0:
+            return
+        subprocess.run(
+            ["git", "commit", "-m", message, "--", metadata_dir],
             cwd=self.reachability_repo_path,
             capture_output=True, check=False,
         )

--- a/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/dynamic_access_iterative_strategy.py
@@ -458,6 +458,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             f"native-test gate {result.status} for {class_name} after {result.iterations_used} cycles",
             indent_level=2,
         )
+        self._commit_library_metadata(f"Native metadata for {class_name}")
         return True
 
     def _refresh_report_after_gate(self, class_name: str):
@@ -650,6 +651,24 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
         subprocess.run(
             ["git", "add", "-A", tests_dir],
+            cwd=self.reachability_repo_path, check=False,
+        )
+        subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=self.reachability_repo_path,
+        ).returncode != 0 and subprocess.run(
+            ["git", "commit", "-m", message],
+            cwd=self.reachability_repo_path,
+            capture_output=True, check=False,
+        )
+
+    def _commit_library_metadata(self, message: str) -> None:
+        """Stage and commit durable library metadata created by the class gate."""
+        metadata_dir = os.path.join(
+            self.reachability_repo_path, "metadata", self.group, self.artifact, self.version,
+        )
+        subprocess.run(
+            ["git", "add", "-A", metadata_dir],
             cwd=self.reachability_repo_path, check=False,
         )
         subprocess.run(

--- a/forge/docs/dynamic-access-workflow.md
+++ b/forge/docs/dynamic-access-workflow.md
@@ -223,10 +223,10 @@ failed tracing to Codex. Pi is not part of this gate.
 
 Effects within this workflow:
 
-1. The contents of the gate's `output_dir`, if any trace-backed metadata
-   was merged there, are added to the agent's read-only context for
-   subsequent class iterations. The directory may remain empty when
-   JVM-agent metadata alone made the native tests pass.
+1. The gate keeps metadata cumulative. JVM-agent output is written to the
+   durable `metadata/<group>/<artifact>/<version>/` directory; if native
+   tracing was needed, the merged trace output is also folded into that
+   durable metadata file before the next class starts.
 2. The dynamic-access coverage report is regenerated **after** the gate so
    that any call sites covered by JVM-agent, traced, or Codex-supplied metadata are
    reflected in the next class's prompt delta.

--- a/forge/docs/dynamic-access-workflow.md
+++ b/forge/docs/dynamic-access-workflow.md
@@ -27,6 +27,7 @@ class until coverage is reached or the per-class budget is exhausted.
 | Per-attempt test-retry cap | strategy parameter `max-class-test-iterations` | yes |
 | Class iteration prompt | strategy `prompts["dynamic-access-iteration"]` | yes |
 | Per-class native-test verification budget | strategy parameter `max-native-test-verification-iterations` | yes (default 100) |
+| Native-test verification batch size | strategy parameter `native-test-verification-batch-size` | no (default 5; must be >= 1) |
 | Keep tests without DA gain | `--keep-tests-without-dynamic-access` | no |
 
 ## 3. Outputs
@@ -195,7 +196,9 @@ prompt-iteration count, and the entry script resets the branch to
 ### 6.4 Per-class native-test verification gate
 
 After every per-class iteration that committed a coverage gain — i.e. the
-**Resolved** or **PartialCommit** branches in §6.2 — the strategy invokes
+**Resolved** or **PartialCommit** branches in §6.2 — the strategy queues
+one native-test verification step. When the queue reaches
+`native-test-verification-batch-size` (default `5`), the strategy invokes
 the [Native test verification gate](native-test-verification.md) for the
 current coordinate with
 
@@ -204,8 +207,12 @@ output_dir = tests/src/<group>/<artifact>/<version>/build/natively-collected/<cl
 ```
 
 where `<class-key>` is a sanitized form of the class name the per-class
-iteration just resolved or advanced. The gate always starts with the
-normal JVM-agent metadata path:
+iteration that triggered the batch flush just resolved or advanced, with a
+batch suffix when the flush contains more than one class step. If the loop
+finishes, or a large-library chunk boundary is reached, with fewer than the
+configured number of queued class steps, the strategy flushes that partial
+batch before returning. The gate always starts with the normal JVM-agent
+metadata path:
 
 ```text
 ./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar
@@ -226,7 +233,8 @@ Effects within this workflow:
 1. The gate keeps metadata cumulative. JVM-agent output is written to the
    durable `metadata/<group>/<artifact>/<version>/` directory; if native
    tracing was needed, the merged trace output is also folded into that
-   durable metadata file before the next class starts.
+   durable metadata file before the next batch starts or before the phase
+   returns.
 2. The dynamic-access coverage report is regenerated **after** the gate so
    that any call sites covered by JVM-agent, traced, or Codex-supplied metadata are
    reflected in the next class's prompt delta.
@@ -310,7 +318,7 @@ useful.
 | `utility_scripts/source_context.py` | `populate_artifact_urls`, `normalize_source_context_types`, `prepare_source_contexts`, `resolve_test_source_layout`. |
 | `utility_scripts/dynamic_access_report.py` | `load_dynamic_access_coverage_report`, `compute_class_delta`, `format_call_sites`. |
 | `utility_scripts/native_metadata_exploration.py` | `run_native_metadata_exploration` — the standalone trace loop used as a precondition to codex fixup at finalization, and the Gradle task contract reused by the verification gate's fallback. See [native-metadata-exploration.md](native-metadata-exploration.md). |
-| `utility_scripts/native_test_verification.py` | `verify_native_test_passes` — the per-class gate invoked after every class with coverage gain; it runs JVM-agent metadata first, native tracing only as fallback, and Codex last. See [native-test-verification.md](native-test-verification.md). |
+| `utility_scripts/native_test_verification.py` | `verify_native_test_passes` — the native-test gate invoked for each configured batch of classes with coverage gain; it runs JVM-agent metadata first, native tracing only as fallback, and Codex last. See [native-test-verification.md](native-test-verification.md). |
 | `prompt_templates/dynamic_access/dynamic-access-iteration.md` | Per-class prompt template. |
 | Reachability-repo Gradle tasks | `scaffold`, `populateArtifactURLs`, `generateDynamicAccessCoverageReport`, `test`, `nativeTest`, `generateMetadata`, `generateLibraryStats`. |
 
@@ -328,11 +336,11 @@ support iff **all** of the following hold at exit:
    `run_native_metadata_exploration(...)` runs **before** any codex fixup; the
    fixup is invoked only when exploration returns `SUCCESS` or
    `BUDGET_EXHAUSTED`.
-3. After every per-class iteration that committed a coverage gain
-   (Resolved or PartialCommit), the
-   [native test verification gate](native-test-verification.md) was
-   invoked and returned `PASSED` or `PASSED_WITH_INTERVENTION`. A `FAILED`
-   gate result aborts the run with `RUN_STATUS_FAILURE`.
+3. After each configured batch of per-class iterations that committed a
+   coverage gain (Resolved or PartialCommit), and once more for any final
+   partial batch, the [native test verification gate](native-test-verification.md)
+   was invoked and returned `PASSED` or `PASSED_WITH_INTERVENTION`. A
+   `FAILED` gate result aborts the run with `RUN_STATUS_FAILURE`.
 4. The scaffold-placeholder quality gate
    (`cleanup_scaffold_placeholder_tests`) leaves no remaining placeholders.
 5. The metrics record validates against the active schema.

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -27,9 +27,14 @@ for a given coordinate. The ordered recovery contract is:
    `-H:+MetadataTracingSupport`, `--exact-reachability-metadata`, and
    `-H:MissingRegistrationReportingMode=Exit`.
 4. If native tracing converges, merge the accepted trace dirs into
-   `output_dir` and return `PASSED`. If tracing stalls, exhausts its budget,
-   or fails for a non-metadata reason, route the accumulated diagnostics to
-   codex. Codex is the final recovery step.
+   `output_dir`, fold the merged metadata into the durable
+   `metadata/<group>/<artifact>/<version>/reachability-metadata.json`,
+   and return `PASSED`. If tracing stalls, exhausts its budget, or fails
+   for a non-metadata reason, route the accumulated diagnostics to codex.
+   Codex is the final recovery step — the only failures that bypass it
+   are failures of the post-success merge or durable-aggregation steps
+   themselves, which are infrastructure problems codex cannot repair and
+   therefore terminate as `FAILED` directly (see §4 gate semantics).
 
 Pi is **not** invoked. Removing failing tests would mask exactly the code
 issues that must surface to the coding agent.
@@ -64,7 +69,10 @@ branch to its checkpoint.
   `mergeNativeTraceMetadata` invocation at the end). It may remain empty
   when JVM-agent metadata alone made the native tests pass, when Codex is
   invoked before tracing, or when Codex is invoked after a stalled trace
-  fallback. Empty on `FAILED`.
+  fallback. Empty on `FAILED`, except when the failure is the trace-output
+  merge (`mergeNativeTraceMetadata`) or the durable-metadata aggregation
+  step itself — in that case `output_dir` may contain whatever the
+  partially completed merge wrote before the failure.
 - `iterations_used` — number of outer cycles consumed.
 - `last_native_test_log_path` — absolute path to the last relevant
   Gradle log (`generateMetadata`, `test`, or `runNativeTraceImage`).
@@ -167,6 +175,21 @@ Gate semantics:
   for diagnostics.)
 - **Hard fail.** If codex does not converge, the gate returns `FAILED` and
   the calling workflow aborts; see §6.
+- **Merge and aggregation failures are terminal without codex.** Two
+  post-success steps run after a trace cycle returns binary exit `0`:
+  (a) `./gradlew mergeNativeTraceMetadata` consolidates the accepted
+  per-cycle dirs into `output_dir`; (b) the durable-metadata aggregation
+  folds `output_dir/reachability-metadata.json` into
+  `metadata/<group>/<artifact>/<version>/reachability-metadata.json`. If
+  either step fails, the gate returns `FAILED` directly. Codex is **not**
+  invoked for these failures: they are infrastructure problems (Gradle
+  merge task, filesystem write, malformed durable JSON) downstream of a
+  successful trace, and codex cannot repair the metadata pipeline itself.
+  The calling workflow handles them like any other `FAILED` (§6). This is
+  the only carve-out from the "only codex failure may FAIL" invariant —
+  every other failure mode (JVM-agent failure, `gradlew test` failure
+  before `nativeTest`, `172` with no usable / no new metadata, non-`0`/
+  `172` trace cycle exit, budget exhaustion) routes through codex first.
 
 ## 5. Reusable Implementation Surface
 
@@ -248,9 +271,12 @@ A `verify_native_test_passes(...)` invocation is correct iff:
    "exit value N" log line and routed:
    - `0` → run `mergeNativeTraceMetadata` once with all accepted run
      dirs as `-PinputDirs=` and the caller's `output_dir` as
-     `-PoutputDir=`, merge the resulting reachability metadata into
+     `-PoutputDir=`, then fold the resulting reachability metadata into
      `metadata/<group>/<artifact>/<version>/reachability-metadata.json`,
-     then return `PASSED`.
+     then return `PASSED`. If either the `mergeNativeTraceMetadata` task
+     or the durable-aggregation step fails, return `FAILED` directly —
+     codex is **not** invoked for these post-success infrastructure
+     failures.
    - `172` with new trace metadata entries → append
      `runs_dir/cycle-<i>` to the running config dirs and continue to the
      next outer cycle. Codex is **not** invoked.

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -248,7 +248,9 @@ A `verify_native_test_passes(...)` invocation is correct iff:
    "exit value N" log line and routed:
    - `0` → run `mergeNativeTraceMetadata` once with all accepted run
      dirs as `-PinputDirs=` and the caller's `output_dir` as
-     `-PoutputDir=`, then return `PASSED`.
+     `-PoutputDir=`, merge the resulting reachability metadata into
+     `metadata/<group>/<artifact>/<version>/reachability-metadata.json`,
+     then return `PASSED`.
    - `172` with new trace metadata entries → append
      `runs_dir/cycle-<i>` to the running config dirs and continue to the
      next outer cycle. Codex is **not** invoked.

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -6,6 +6,7 @@
 import io
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -63,6 +64,39 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                 {"org.example.Exhausted"},
             ),
             2,
+        )
+
+    def test_commit_library_metadata_stages_index_resolved_metadata_version(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            metadata_root = os.path.join(repo, "metadata", "org.example", "lib")
+            os.makedirs(metadata_root)
+            with open(os.path.join(metadata_root, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump([
+                    {
+                        "metadata-version": "1.0.0",
+                        "tested-versions": ["1.0.0", "1.1.0"],
+                    }
+                ], index_file)
+            strategy = self._strategy(
+                library="org.example:lib:1.1.0",
+                reachability_repo_path=repo,
+            )
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+                calls.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with patch(
+                    "ai_workflows.workflow_strategies.dynamic_access_iterative_strategy.subprocess.run",
+                    side_effect=fake_run,
+            ):
+                strategy._commit_library_metadata("Native metadata for org.example.Demo")
+
+        self.assertEqual(calls[0][:3], ["git", "add", "-A"])
+        self.assertEqual(
+            calls[0][3],
+            os.path.join(repo, "metadata", "org.example", "lib", "1.0.0"),
         )
 
     def test_first_large_library_part_uses_current_coverage_as_chunk_baseline(self) -> None:

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -82,9 +82,13 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                 reachability_repo_path=repo,
             )
             calls: list[list[str]] = []
+            metadata_dir = os.path.join(repo, "metadata", "org.example", "lib", "1.0.0")
 
             def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
                 calls.append(list(cmd))
+                # Simulate `git diff --cached --quiet` finding staged changes (rc=1).
+                if "diff" in cmd and "--quiet" in cmd:
+                    return subprocess.CompletedProcess(cmd, 1)
                 return subprocess.CompletedProcess(cmd, 0)
 
             with patch(
@@ -94,10 +98,37 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                 strategy._commit_library_metadata("Native metadata for org.example.Demo")
 
         self.assertEqual(calls[0][:3], ["git", "add", "-A"])
-        self.assertEqual(
-            calls[0][3],
-            os.path.join(repo, "metadata", "org.example", "lib", "1.0.0"),
-        )
+        self.assertEqual(calls[0][3], metadata_dir)
+        # Diff and commit must both be scoped to the metadata dir to avoid
+        # picking up unrelated staged files in the index.
+        self.assertEqual(calls[1][:5], ["git", "diff", "--cached", "--quiet", "--"])
+        self.assertEqual(calls[1][5], metadata_dir)
+        commit_call = calls[2]
+        self.assertEqual(commit_call[:3], ["git", "commit", "-m"])
+        self.assertEqual(commit_call[-2:], ["--", metadata_dir])
+
+    def test_commit_library_metadata_skips_commit_when_no_staged_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            os.makedirs(os.path.join(repo, "metadata", "org.example", "lib", "1.0.0"))
+            strategy = self._strategy(
+                library="org.example:lib:1.0.0",
+                reachability_repo_path=repo,
+            )
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+                calls.append(list(cmd))
+                # rc=0 from `git diff --cached --quiet` means nothing to commit.
+                return subprocess.CompletedProcess(cmd, 0)
+
+            with patch(
+                    "ai_workflows.workflow_strategies.dynamic_access_iterative_strategy.subprocess.run",
+                    side_effect=fake_run,
+            ):
+                strategy._commit_library_metadata("Native metadata for org.example.Demo")
+
+        self.assertEqual([cmd[1] for cmd in calls], ["add", "diff"])
+        self.assertFalse(any("commit" in cmd for cmd in calls))
 
     def test_first_large_library_part_uses_current_coverage_as_chunk_baseline(self) -> None:
         strategy = self._strategy()

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -192,6 +192,94 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             strategy.dynamic_access_report_path,
         )
 
+    def test_native_test_gate_flushes_leftover_classes_at_end(self) -> None:
+        class FakeAgent:
+            def send_prompt(self, prompt: str) -> None:
+                pass
+
+            def run_test_command(self, command: str) -> str:
+                return "BUILD SUCCESSFUL"
+
+            def clear_context(self) -> None:
+                pass
+
+        class_names = ["org.example.A", "org.example.B", "org.example.C", "org.example.D"]
+        reports = [
+            self._report_for_class_names(class_names, ["org.example.A"]),
+            self._report_for_class_names(class_names, ["org.example.A", "org.example.B"]),
+            self._report_for_class_names(class_names, ["org.example.A", "org.example.B", "org.example.C"]),
+            self._report_for_class_names(class_names, class_names),
+            self._report_for_class_names(class_names, class_names),
+        ]
+        strategy = self._strategy()
+        gate_calls: list[str] = []
+
+        def _gate(class_name: str) -> bool:
+            gate_calls.append(class_name)
+            return True
+
+        with patch.object(strategy, "_render_prompt", return_value="prompt"), \
+                patch.object(strategy, "_generate_dynamic_access_report", side_effect=reports), \
+                patch.object(strategy, "_commit_test_sources"), \
+                patch.object(strategy, "_run_native_test_verification_gate", side_effect=_gate), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.workflow_strategies.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="checkpoint\n",
+                ):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(
+                FakeAgent(),
+                self._report_for_class_names(class_names, []),
+            )
+
+        self.assertTrue(phase_ok)
+        self.assertEqual(iterations, 4)
+        self.assertEqual(gate_calls, ["org.example.D__native_batch_4"])
+
+    def test_native_test_gate_uses_configured_batch_size(self) -> None:
+        class FakeAgent:
+            def send_prompt(self, prompt: str) -> None:
+                pass
+
+            def run_test_command(self, command: str) -> str:
+                return "BUILD SUCCESSFUL"
+
+            def clear_context(self) -> None:
+                pass
+
+        class_names = ["org.example.A", "org.example.B", "org.example.C"]
+        reports = [
+            self._report_for_class_names(class_names, ["org.example.A"]),
+            self._report_for_class_names(class_names, ["org.example.A", "org.example.B"]),
+            self._report_for_class_names(class_names, ["org.example.A", "org.example.B"]),
+            self._report_for_class_names(class_names, class_names),
+            self._report_for_class_names(class_names, class_names),
+        ]
+        strategy = self._strategy(parameters={"native-test-verification-batch-size": 2})
+        gate_calls: list[str] = []
+
+        def _gate(class_name: str) -> bool:
+            gate_calls.append(class_name)
+            return True
+
+        with patch.object(strategy, "_render_prompt", return_value="prompt"), \
+                patch.object(strategy, "_generate_dynamic_access_report", side_effect=reports), \
+                patch.object(strategy, "_commit_test_sources"), \
+                patch.object(strategy, "_run_native_test_verification_gate", side_effect=_gate), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.workflow_strategies.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="checkpoint\n",
+                ):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(
+                FakeAgent(),
+                self._report_for_class_names(class_names, []),
+            )
+
+        self.assertTrue(phase_ok)
+        self.assertEqual(iterations, 3)
+        self.assertEqual(gate_calls, ["org.example.B__native_batch_2", "org.example.C"])
+
     def test_partially_covered_exhausted_class_is_persisted_for_continuation(self) -> None:
         class FakeAgent:
             def send_prompt(self, prompt: str) -> None:
@@ -471,18 +559,38 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             call_sites=[],
         )
 
+    @classmethod
+    def _report_for_class_names(
+            cls,
+            class_names: list[str],
+            covered_class_names: list[str],
+    ) -> DynamicAccessCoverageReport:
+        covered = set(covered_class_names)
+        return DynamicAccessCoverageReport(
+            coordinate="org.example:lib:1.0.0",
+            has_dynamic_access=True,
+            total_calls=len(class_names),
+            covered_calls=len(covered),
+            classes=[
+                cls._class_coverage(class_name, 1, 1 if class_name in covered else 0)
+                for class_name in class_names
+            ],
+        )
+
     @staticmethod
     def _strategy(**context) -> DynamicAccessIterativeStrategy:
         library = context.pop("library", "org.example:lib:1.0.0")
         reachability_repo_path = context.pop("reachability_repo_path", "/tmp/reachability")
+        parameters = {
+            "max-iterations": 1,
+            "max-class-test-iterations": 1,
+        }
+        parameters.update(context.pop("parameters", {}))
         return DynamicAccessIterativeStrategy(
             {
                 "model": "test-model",
                 "prompts": {"dynamic-access-iteration": "unused"},
-                "parameters": {
-                    "max-iterations": 1,
-                    "max-class-test-iterations": 1,
-                },
+                "parameters": parameters,
             },
             library=library,
             reachability_repo_path=reachability_repo_path,

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -288,6 +288,28 @@ class GateRoutingTests(unittest.TestCase):
                     )
                 # Gradle-side exit is always 0 (Exec uses ignoreExitValue).
                 return subprocess.CompletedProcess(cmd, 0)
+            if "mergeNativeTraceMetadata" in cmd:
+                input_dirs = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("-PinputDirs=")),
+                    "",
+                ).split(",")
+                output_dir = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("-PoutputDir=")),
+                    None,
+                )
+                if output_dir:
+                    merged_reflection = []
+                    for input_dir in input_dirs:
+                        metadata_path = Path(input_dir) / "reachability-metadata.json"
+                        if metadata_path.is_file():
+                            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+                            merged_reflection.extend(payload.get("reflection", []))
+                    Path(output_dir).mkdir(parents=True, exist_ok=True)
+                    Path(output_dir, "reachability-metadata.json").write_text(
+                        json.dumps({"reflection": merged_reflection}),
+                        encoding="utf-8",
+                    )
+                return subprocess.CompletedProcess(cmd, 0)
             # mergeNativeTraceMetadata or anything else — succeeds.
             return subprocess.CompletedProcess(cmd, 0)
 
@@ -388,6 +410,36 @@ class GateRoutingTests(unittest.TestCase):
         self.assertIn(
             os.path.join(self.output_dir, "reachability-metadata.json"),
             output.getvalue(),
+        )
+
+    def test_aggregates_trace_metadata_into_durable_library_metadata(self) -> None:
+        metadata_dir = Path(self.repo) / "metadata" / "g" / "a" / "1.0"
+        metadata_dir.mkdir(parents=True)
+        durable_metadata_path = metadata_dir / "reachability-metadata.json"
+        durable_metadata_path.write_text(
+            json.dumps({"reflection": [{"type": "com.example.Existing"}]}),
+            encoding="utf-8",
+        )
+        fake, _calls = self._fake_run_factory([172, 0])
+
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        durable_metadata = json.loads(durable_metadata_path.read_text(encoding="utf-8"))
+        reflected_types = {
+            entry["type"]
+            for entry in durable_metadata["reflection"]
+        }
+        self.assertIn("com.example.Existing", reflected_types)
+        self.assertTrue(
+            any(entry.startswith("com.example.Generated") for entry in reflected_types),
+            durable_metadata,
         )
 
     def test_merges_final_passing_run_when_it_collected_metadata(self) -> None:

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -485,6 +485,63 @@ class GateRoutingTests(unittest.TestCase):
             (metadata_root / "1.1" / "reachability-metadata.json").exists(),
         )
 
+    def test_merge_failure_returns_failed_without_invoking_codex(self) -> None:
+        # Spec carve-out: post-success merge failures terminate as FAILED
+        # directly because they are infrastructure problems codex cannot repair.
+        fake, _calls = self._fake_run_factory([0], metadata_exit_codes={0})
+
+        def merge_fails(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if "mergeNativeTraceMetadata" in cmd:
+                return subprocess.CompletedProcess(cmd, 1)
+            return fake(cmd, **kwargs)
+
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=merge_fails,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        codex_mock.assert_not_called()
+        self.assertEqual(result.intervention_records, [])
+
+    def test_aggregate_failure_returns_failed_without_invoking_codex(self) -> None:
+        # Malformed durable metadata makes _aggregate_trace_metadata raise; the
+        # gate must surface FAILED directly per the spec carve-out.
+        metadata_dir = Path(self.repo) / "metadata" / "g" / "a" / "1.0"
+        metadata_dir.mkdir(parents=True)
+        (metadata_dir / "reachability-metadata.json").write_text(
+            "this is not valid json",
+            encoding="utf-8",
+        )
+        fake, _calls = self._fake_run_factory([172, 0])
+
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=fake,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        codex_mock.assert_not_called()
+        self.assertEqual(result.intervention_records, [])
+
     def test_merges_final_passing_run_when_it_collected_metadata(self) -> None:
         fake, calls = self._fake_run_factory([0], metadata_exit_codes={0})
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -442,6 +442,49 @@ class GateRoutingTests(unittest.TestCase):
             durable_metadata,
         )
 
+    def test_aggregates_trace_metadata_into_index_resolved_metadata_version(self) -> None:
+        metadata_root = Path(self.repo) / "metadata" / "g" / "a"
+        metadata_dir = metadata_root / "1.0"
+        metadata_dir.mkdir(parents=True)
+        (metadata_root / "index.json").write_text(
+            json.dumps([
+                {
+                    "metadata-version": "1.0",
+                    "tested-versions": ["1.0", "1.1"],
+                }
+            ]),
+            encoding="utf-8",
+        )
+        durable_metadata_path = metadata_dir / "reachability-metadata.json"
+        durable_metadata_path.write_text(
+            json.dumps({"reflection": [{"type": "com.example.Existing"}]}),
+            encoding="utf-8",
+        )
+        fake, _calls = self._fake_run_factory([172, 0])
+
+        with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.1",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_PASSED)
+        durable_metadata = json.loads(durable_metadata_path.read_text(encoding="utf-8"))
+        reflected_types = {
+            entry["type"]
+            for entry in durable_metadata["reflection"]
+        }
+        self.assertIn("com.example.Existing", reflected_types)
+        self.assertTrue(
+            any(entry.startswith("com.example.Generated") for entry in reflected_types),
+            durable_metadata,
+        )
+        self.assertFalse(
+            (metadata_root / "1.1" / "reachability-metadata.json").exists(),
+        )
+
     def test_merges_final_passing_run_when_it_collected_metadata(self) -> None:
         fake, calls = self._fake_run_factory([0], metadata_exit_codes={0})
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake):

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -223,6 +223,12 @@ class GateRoutingTests(unittest.TestCase):
         self.repo = tempfile.mkdtemp(prefix="repo-")
         self.addCleanup(_rmtree, self.repo)
         _make_complete_reachability_repo(self.repo)
+        self.repo_validation = patch(
+            "utility_scripts.native_test_verification.require_complete_reachability_repo",
+            return_value=self.repo,
+        )
+        self.repo_validation.start()
+        self.addCleanup(self.repo_validation.stop)
         self.output_dir = os.path.join(
             tempfile.mkdtemp(prefix="output-"),
             "natively-collected",

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -892,15 +892,12 @@ def _merge_metadata(base: dict, addition: dict) -> dict:
     return merged
 
 
-def _merge_metadata_value(base_value, addition_value):
+def _merge_metadata_value(base_value: object, addition_value: object) -> object:
     if isinstance(base_value, list) and isinstance(addition_value, list):
         merged = list(base_value)
-        seen_entries = {
-            json.dumps(entry, sort_keys=True, separators=(",", ":"))
-            for entry in merged
-        }
+        seen_entries = {_canonical_metadata_key(entry) for entry in merged}
         for entry in addition_value:
-            entry_key = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+            entry_key = _canonical_metadata_key(entry)
             if entry_key not in seen_entries:
                 merged.append(entry)
                 seen_entries.add(entry_key)
@@ -910,6 +907,29 @@ def _merge_metadata_value(base_value, addition_value):
     if base_value == addition_value:
         return base_value
     return addition_value
+
+
+def _canonical_metadata_key(value: object) -> str:
+    """Stable string key for an entry, treating nested arrays as unordered sets.
+
+    Reachability metadata leaf arrays (`methods`, `fields`, `queriedMethods`, …)
+    are semantic sets, so two entries that differ only in inner-array order
+    must dedup as one. Sorting recursively makes the JSON dump invariant under
+    those reorderings.
+    """
+    return json.dumps(_canonicalize(value), sort_keys=True, separators=(",", ":"))
+
+
+def _canonicalize(value: object) -> object:
+    if isinstance(value, list):
+        canonical_items = [_canonicalize(item) for item in value]
+        return sorted(
+            canonical_items,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if isinstance(value, dict):
+        return {key: _canonicalize(val) for key, val in value.items()}
+    return value
 
 
 def _reset_directory(path: str) -> None:

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.metadata_index import resolve_metadata_version
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import (
@@ -834,13 +835,19 @@ def _aggregate_trace_metadata(
         return True
 
     try:
-        group, artifact, version = coordinate.split(":", 2)
+        group, artifact, library_version = coordinate.split(":", 2)
+        metadata_version = resolve_metadata_version(
+            reachability_repo_path,
+            group,
+            artifact,
+            library_version,
+        )
         durable_metadata_path = os.path.join(
             reachability_repo_path,
             "metadata",
             group,
             artifact,
-            version,
+            metadata_version,
             _AGGREGATED_METADATA_FILE_NAME,
         )
         durable_metadata = _read_metadata_json(durable_metadata_path)

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -234,6 +234,12 @@ def verify_native_test_passes(
                 output_dir=output_dir,
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
+            if not _aggregate_trace_metadata(
+                reachability_repo_path=reachability_repo_path,
+                coordinate=coordinate,
+                output_dir=output_dir,
+            ):
+                return _make_result(STATUS_FAILED, cycle + 1)
             return _make_result(STATUS_PASSED, cycle + 1)
 
         if binary_rc == MISSING_METADATA_EXIT_CODE:
@@ -814,6 +820,89 @@ def _print_aggregated_metadata_path(output_dir: str) -> None:
         os.path.join(output_dir, _AGGREGATED_METADATA_FILE_NAME),
         indent_level=1,
     )
+
+
+def _aggregate_trace_metadata(
+        reachability_repo_path: str,
+        coordinate: str,
+        output_dir: str,
+) -> bool:
+    """Merge trace-backed metadata into the durable library metadata file."""
+    trace_metadata_path = os.path.join(output_dir, _AGGREGATED_METADATA_FILE_NAME)
+    if not os.path.isfile(trace_metadata_path):
+        log_stage(_GATE_STAGE, "native trace produced no reachability-metadata.json to aggregate")
+        return True
+
+    try:
+        group, artifact, version = coordinate.split(":", 2)
+        durable_metadata_path = os.path.join(
+            reachability_repo_path,
+            "metadata",
+            group,
+            artifact,
+            version,
+            _AGGREGATED_METADATA_FILE_NAME,
+        )
+        durable_metadata = _read_metadata_json(durable_metadata_path)
+        trace_metadata = _read_metadata_json(trace_metadata_path)
+        merged_metadata = _merge_metadata(durable_metadata, trace_metadata)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        log_stage(_GATE_STAGE, f"failed to aggregate native trace metadata: {exc}", indent_level=1)
+        return False
+
+    if merged_metadata == durable_metadata:
+        log_stage(_GATE_STAGE, "native trace metadata already present in durable metadata")
+        return True
+
+    os.makedirs(os.path.dirname(durable_metadata_path), exist_ok=True)
+    with open(durable_metadata_path, "w", encoding="utf-8") as metadata_file:
+        json.dump(merged_metadata, metadata_file, indent=2)
+        metadata_file.write("\n")
+    log_stage(
+        _GATE_STAGE,
+        f"aggregated native trace metadata into {os.path.relpath(durable_metadata_path, reachability_repo_path)}",
+    )
+    return True
+
+
+def _read_metadata_json(path: str) -> dict:
+    if not os.path.isfile(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as metadata_file:
+        data = json.load(metadata_file)
+    if not isinstance(data, dict):
+        raise ValueError(f"Reachability metadata must be a JSON object: {path}")
+    return data
+
+
+def _merge_metadata(base: dict, addition: dict) -> dict:
+    merged = dict(base)
+    for key, value in addition.items():
+        if key not in merged:
+            merged[key] = value
+            continue
+        merged[key] = _merge_metadata_value(merged[key], value)
+    return merged
+
+
+def _merge_metadata_value(base_value, addition_value):
+    if isinstance(base_value, list) and isinstance(addition_value, list):
+        merged = list(base_value)
+        seen_entries = {
+            json.dumps(entry, sort_keys=True, separators=(",", ":"))
+            for entry in merged
+        }
+        for entry in addition_value:
+            entry_key = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+            if entry_key not in seen_entries:
+                merged.append(entry)
+                seen_entries.add(entry_key)
+        return merged
+    if isinstance(base_value, dict) and isinstance(addition_value, dict):
+        return _merge_metadata(base_value, addition_value)
+    if base_value == addition_value:
+        return base_value
+    return addition_value
 
 
 def _reset_directory(path: str) -> None:

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -154,6 +154,8 @@ boolean informationalTaskRequested = isTaskRequested("help") || isTaskRequested(
 boolean nativeTraceImageTaskRequested = !informationalTaskRequested &&
         (isTaskRequested("nativeTraceImage") || isTaskRequested("runNativeTraceImage"))
 boolean runNativeTraceImageTaskRequested = !informationalTaskRequested && isTaskRequested("runNativeTraceImage")
+boolean nativeTestTaskRequested = !informationalTaskRequested &&
+        (isTaskRequested("nativeTest") || isTaskRequested("nativeTestCompile"))
 
 Closure<String> requiredGradleProperty = { String propertyName ->
     String propertyValue = providers.gradleProperty(propertyName).getOrElse("")
@@ -339,7 +341,9 @@ Provider<List<String>> nativeTraceBuildArgs = providers.provider {
         buildArgs.add("-H:-UnlockExperimentalVMOptions")
     }
     List<String> metadataConfigDirs = commaSeparatedGradleProperty("metadataConfigDirs")
-    if (nativeTraceImageTaskRequested && !metadataConfigDirs.isEmpty()) {
+    boolean metadataConfigDirsRequested = project.hasProperty("metadataConfigDirs") &&
+            (nativeTraceImageTaskRequested || nativeTestTaskRequested)
+    if (metadataConfigDirsRequested && !metadataConfigDirs.isEmpty()) {
         buildArgs.add("-H:ConfigurationFileDirectories=${metadataConfigDirs.join(",")}")
     }
     if (runNativeTraceImageTaskRequested) {

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -360,8 +360,12 @@ Provider<List<String>> nativeTraceBuildArgs = providers.provider {
 }
 
 tasks.named("nativeTestCompile", BuildNativeImageTask).configure { BuildNativeImageTask task ->
-    if (runNativeTraceImageTaskRequested) {
-        task.doFirst {
+    task.doFirst {
+        File nativeImageOutputDirectory = task.outputFile.get().asFile.parentFile
+        if (!nativeImageOutputDirectory.isDirectory() && !nativeImageOutputDirectory.mkdirs()) {
+            throw new GradleException("Failed to create native-image output directory: ${nativeImageOutputDirectory.absolutePath}")
+        }
+        if (runNativeTraceImageTaskRequested) {
             requiredGradleProperty("traceMetadataPath")
         }
     }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -567,6 +567,11 @@ graalvmNative {
         enabled = true
         uri(tck.metadataRoot.get().asFile)
     }
+    agent {
+        metadataCopy {
+            mergeWithExisting = true
+        }
+    }
     binaries {
         test {
             if (override) {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AllCoordinatesExecTask.java
@@ -193,6 +193,19 @@ public abstract class AllCoordinatesExecTask extends CoordinatesAwareTask {
         return true;
     }
 
+    /**
+     * Forward a Gradle property to a subprocess command as `-P<name>=<value>` if the project sets it.
+     *
+     * Used by tasks that re-invoke `./gradlew` and must propagate inputs (e.g. `metadataConfigDirs`)
+     * to the inner build. No-op when the property is unset.
+     */
+    protected void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
+    }
+
     private static String md5(String s) {
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTask.java
@@ -29,11 +29,4 @@ public abstract class NativeTestCompileInvocationTask extends AllCoordinatesExec
     protected String errorMessageFor(String coordinates, int exitCode) {
         return "Native test compilation failed";
     }
-
-    private void appendProperty(List<String> command, String propertyName) {
-        Object propertyValue = getProject().findProperty(propertyName);
-        if (propertyValue != null) {
-            command.add("-P" + propertyName + "=" + propertyValue);
-        }
-    }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTask.java
@@ -6,6 +6,7 @@
  */
 package org.graalvm.internal.tck.harness.tasks;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -16,14 +17,23 @@ public abstract class NativeTestCompileInvocationTask extends AllCoordinatesExec
 
     @Override
     public List<String> commandFor(String coordinates) {
-        return List.of(
+        List<String> command = new ArrayList<>(List.of(
                 tckExtension.getRepoRoot().get().getAsFile().toPath().resolve("gradlew").toString(),
                 "nativeTestCompile"
-        );
+        ));
+        appendProperty(command, "metadataConfigDirs");
+        return command;
     }
 
     @Override
     protected String errorMessageFor(String coordinates, int exitCode) {
         return "Native test compilation failed";
+    }
+
+    private void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
     }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/NativeTraceImageInvocationTask.java
@@ -29,11 +29,4 @@ public abstract class NativeTraceImageInvocationTask extends AllCoordinatesExecT
     protected String errorMessageFor(String coordinates, int exitCode) {
         return "Native trace image compilation failed for " + coordinates + " with exit code " + exitCode + ".";
     }
-
-    private void appendProperty(List<String> command, String propertyName) {
-        Object propertyValue = getProject().findProperty(propertyName);
-        if (propertyValue != null) {
-            command.add("-P" + propertyName + "=" + propertyValue);
-        }
-    }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RunNativeTraceImageInvocationTask.java
@@ -32,11 +32,4 @@ public abstract class RunNativeTraceImageInvocationTask extends AllCoordinatesEx
     protected String errorMessageFor(String coordinates, int exitCode) {
         return "Native trace image run failed for " + coordinates + " with exit code " + exitCode + ".";
     }
-
-    private void appendProperty(List<String> command, String propertyName) {
-        Object propertyValue = getProject().findProperty(propertyName);
-        if (propertyValue != null) {
-            command.add("-P" + propertyName + "=" + propertyValue);
-        }
-    }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
@@ -37,6 +37,7 @@ public abstract class TestInvocationTask extends AllCoordinatesExecTask {
             defaultArgs.add("-Porg.gradle.java.installations.auto-detect=false");
             defaultArgs.add("-Porg.gradle.java.installations.paths=" + installPathsProperty.get());
         }
+        appendProperty(defaultArgs, "metadataConfigDirs");
         return defaultArgs;
     }
 
@@ -44,6 +45,13 @@ public abstract class TestInvocationTask extends AllCoordinatesExecTask {
     @Override
     protected String errorMessageFor(String coordinates, int exitCode) {
         return "Test for " + coordinates + " failed with exit code " + exitCode + ".";
+    }
+
+    private void appendProperty(List<String> command, String propertyName) {
+        Object propertyValue = getProject().findProperty(propertyName);
+        if (propertyValue != null) {
+            command.add("-P" + propertyName + "=" + propertyValue);
+        }
     }
 
     @Override

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/TestInvocationTask.java
@@ -47,13 +47,6 @@ public abstract class TestInvocationTask extends AllCoordinatesExecTask {
         return "Test for " + coordinates + " failed with exit code " + exitCode + ".";
     }
 
-    private void appendProperty(List<String> command, String propertyName) {
-        Object propertyValue = getProject().findProperty(propertyName);
-        if (propertyValue != null) {
-            command.add("-P" + propertyName + "=" + propertyValue);
-        }
-    }
-
     @Override
     protected void beforeEach(String coordinates, List<String> command) {
         String coordinateFilter = Objects.toString(getProject().findProperty("coordinates"), "");

--- a/tests/tck-build-logic/src/main/resources/contributing/agent.template
+++ b/tests/tck-build-logic/src/main/resources/contributing/agent.template
@@ -6,5 +6,8 @@ graalvmNative {
                 userCodeFilterPath = "user-code-filter.json"
             }
         }
+        metadataCopy {
+            mergeWithExisting = true
+        }
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
@@ -56,7 +56,9 @@ class GenerateMetadataTaskTests {
         assertThat(readTestBuildGradle(coordinates))
                 .contains("graalvmNative")
                 .contains("agent")
-                .contains("userCodeFilterPath = \"user-code-filter.json\"");
+                .contains("userCodeFilterPath = \"user-code-filter.json\"")
+                .contains("metadataCopy")
+                .contains("mergeWithExisting = true");
         assertThat(readGradlewInvocations())
                 .contains("tests/src/org.lz4/lz4-java/1.8.0|-Pagent test")
                 .contains("tests/src/org.lz4/lz4-java/1.8.0|metadataCopy --task test --dir " + tempDir.resolve("metadata/org.lz4/lz4-java/1.8.0"));

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/NativeTestCompileInvocationTaskTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.graalvm.internal.tck.harness.TckExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NativeTestCompileInvocationTaskTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void commandForForwardsMetadataConfigDirs() throws IOException {
+        Project project = createProject();
+        project.getExtensions().getExtraProperties().set("metadataConfigDirs", "/tmp/config-0,/tmp/config-1");
+
+        NativeTestCompileInvocationTask task = project.getTasks().create(
+                "nativeTestCompile",
+                NativeTestCompileInvocationTask.class
+        );
+
+        List<String> command = task.commandFor("com.example:demo:1.0.0");
+
+        assertThat(command)
+                .contains("nativeTestCompile")
+                .contains("-PmetadataConfigDirs=/tmp/config-0,/tmp/config-1");
+    }
+
+    private Project createProject() throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata"));
+        Files.createDirectories(tempDir.resolve("tests/src"));
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        project.getExtensions().create("tck", TckExtension.class, project);
+        return project;
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/TestInvocationTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/TestInvocationTaskTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.graalvm.internal.tck.harness.TckExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestInvocationTaskTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void commandForForwardsMetadataConfigDirs() throws IOException {
+        Project project = createProject();
+        project.getExtensions().getExtraProperties().set("metadataConfigDirs", "/tmp/config-0,/tmp/config-1");
+
+        TestInvocationTask task = project.getTasks().create("nativeTest", TestInvocationTask.class);
+
+        List<String> command = task.commandFor("com.example:demo:1.0.0");
+
+        assertThat(command)
+                .contains("nativeTest")
+                .contains("-PmetadataConfigDirs=/tmp/config-0,/tmp/config-1");
+    }
+
+    @Test
+    void commandForOmitsMetadataConfigDirsWhenPropertyUnset() throws IOException {
+        Project project = createProject();
+
+        TestInvocationTask task = project.getTasks().create("nativeTest", TestInvocationTask.class);
+
+        List<String> command = task.commandFor("com.example:demo:1.0.0");
+
+        assertThat(command).contains("nativeTest");
+        assertThat(command).noneMatch(arg -> arg.startsWith("-PmetadataConfigDirs="));
+    }
+
+    private Project createProject() throws IOException {
+        Files.createDirectories(tempDir.resolve("metadata"));
+        Files.createDirectories(tempDir.resolve("tests/src"));
+        Files.createDirectories(tempDir.resolve("tests/tck-build-logic"));
+        Files.writeString(tempDir.resolve("LICENSE"), "test");
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        project.getExtensions().create("tck", TckExtension.class, project);
+        return project;
+    }
+}


### PR DESCRIPTION
Closes #5924

## Summary
- aggregate successful native-trace output into durable library metadata before the next class starts
- commit durable metadata after each successful per-class native-test gate
- pass metadataConfigDirs through normal nativeTest/nativeTestCompile invocations
- document the cumulative metadata behavior and add focused unit coverage

## Validation
- PYTHONPATH=forge python3 -m unittest forge.tests.test_native_test_verification
- ./gradlew :tck-build-logic:test --stacktrace