### PR TITLE
[GenAI] Test fix for io.smallrye.common:smallrye-common-process:2.17.0 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye.common/smallrye-common-process/2.17.0/reachability-metadata.json
+++ b/metadata/io.smallrye.common/smallrye-common-process/2.17.0/reachability-metadata.json
@@ -1,0 +1,68 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "io.smallrye.common.process.Logging_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "io.smallrye.common.process.Logging_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "io.smallrye.common.process.Logging_$logger_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "org.apache.log4j.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "type": "org.jboss.logmanager.LogManager"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging_$logger"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.smallrye.common.process.Logging"
+      },
+      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+    }
+  ]
+}

--- a/metadata/io.smallrye.common/smallrye-common-process/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-process/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.17.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-process/$version$/smallrye-common-process-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/smallrye-common",
+    "test-code-url" : "https://github.com/smallrye/smallrye-common/tree/$version$/process/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-process/$version$/smallrye-common-process-$version$-javadoc.jar",
+    "description" : "SmallRye Common Process provides Java utilities for safely launching subprocesses and managing their I/O. It also exposes helpers for inspecting the current Java process, reducing process-control and stream-handling boilerplate for JVM applications.",
     "tested-versions" : [
       "2.17.0"
     ],

--- a/metadata/io.smallrye.common/smallrye-common-process/index.json
+++ b/metadata/io.smallrye.common/smallrye-common-process/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.17.0",
+    "tested-versions" : [
+      "2.17.0"
+    ],
+    "allowed-packages" : [
+      "io.smallrye.common.process"
+    ]
+  },
+  {
     "metadata-version" : "2.16.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/common/smallrye-common-process/$version$/smallrye-common-process-$version$-sources.jar",
     "repository-url" : "https://github.com/smallrye/smallrye-common",

--- a/stats/io.smallrye.common/smallrye-common-process/2.17.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-process/2.17.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-05": {
+    "timestamp": "2026-05-05T08:59:13.396708Z",
+    "library": "io.smallrye.common:smallrye-common-process:2.17.0",
+    "starting_commit": "8fd2b341eb32e540530a22baf9d1f2d0bfc8e225",
+    "ending_commit": "6b25b188b5412ab6b206a8baa6aedc952d114aab",
+    "previous_library": "io.smallrye.common:smallrye-common-process:2.16.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.17.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3773,
+          "missed": 2306,
+          "ratio": 0.620661,
+          "total": 6079
+        },
+        "line": {
+          "covered": 898,
+          "missed": 541,
+          "ratio": 0.624044,
+          "total": 1439
+        },
+        "method": {
+          "covered": 206,
+          "missed": 139,
+          "ratio": 0.597101,
+          "total": 345
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.16.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3773,
+          "missed": 2306,
+          "ratio": 0.620661,
+          "total": 6079
+        },
+        "line": {
+          "covered": 898,
+          "missed": 541,
+          "ratio": 0.624044,
+          "total": 1439
+        },
+        "method": {
+          "covered": 206,
+          "missed": 139,
+          "ratio": 0.597101,
+          "total": 345
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 73761,
+      "cached_input_tokens_used": 1357312,
+      "output_tokens_used": 7854,
+      "iterations": 1,
+      "cost_usd": 0.9143,
+      "tested_library_loc": 898,
+      "metadata_entries": 10,
+      "previous_library_metadata_entries": 10,
+      "code_coverage_percent": 62.4,
+      "previous_library_coverage_percent": 62.4
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java",
+      "metadata_file": "metadata/io.smallrye.common/smallrye-common-process/2.17.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye.common/smallrye-common-process/2.17.0/stats.json
+++ b/stats/io.smallrye.common/smallrye-common-process/2.17.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.17.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3773,
+        "missed" : 2306,
+        "ratio" : 0.620661,
+        "total" : 6079
+      },
+      "line" : {
+        "covered" : 898,
+        "missed" : 541,
+        "ratio" : 0.624044,
+        "total" : 1439
+      },
+      "method" : {
+        "covered" : 206,
+        "missed" : 139,
+        "ratio" : 0.597101,
+        "total" : 345
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/.gitignore
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/build.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye.common:smallrye-common-process:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/gradle.properties
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye.common:smallrye-common-process:2.17.0
+library.version = 2.17.0
+metadata.dir = io.smallrye.common/smallrye-common-process/2.17.0/

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/settings.gradle
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.common.smallrye-common-process_tests'

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye_common.smallrye_common_process;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.smallrye.common.process.AbnormalExitException;
+import io.smallrye.common.process.PipelineExecutionException;
+import io.smallrye.common.process.ProcessBuilder;
+import io.smallrye.common.process.ProcessUtil;
+import io.smallrye.common.process.WaitableProcessHandle;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Smallrye_common_processTest {
+    private static final Duration EXIT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Path SHELL = requiredCommand("sh");
+    private static final Path CAT = requiredCommand("cat");
+    private static final Path GREP = requiredCommand("grep");
+
+    @Test
+    void processUtilitiesExposeNativeCharsetJavaCommandAndSearchPath() {
+        assertThat(ProcessUtil.nativeCharset()).isNotNull();
+        assertThat(ProcessUtil.searchPath()).doesNotContainNull();
+        assertThat(ProcessUtil.nameOfJava()).isIn("java", "java.exe");
+
+        Path javaPath = ProcessUtil.pathOfJava();
+        assertThat(javaPath).isNotNull();
+        if (javaPath.isAbsolute()) {
+            assertThat(Files.isExecutable(javaPath)).isTrue();
+        } else {
+            assertThat(javaPath).isEqualTo(Path.of(ProcessUtil.nameOfJava()));
+        }
+
+        assertThat(ProcessUtil.pathOfCommand(SHELL)).contains(SHELL);
+        Path missingCommand = Path.of("smallrye-common-process-command-that-should-not-exist");
+        assertThat(ProcessUtil.pathOfCommand(missingCommand)).isEmpty();
+    }
+
+    @Test
+    void execToStringAndStringListCaptureStandardOutput() {
+        String singleString = ProcessBuilder.execToString(SHELL, shellArguments("printf 'alpha\\nbeta\\n'"));
+        assertThat(singleString).isEqualTo("alpha\nbeta\n");
+
+        List<String> lines = shellCommand("printf 'one\\ntwo\\nthree\\n'")
+                .output()
+                .toStringList(10, 100)
+                .run();
+
+        assertThat(lines).containsExactly("one", "two", "three");
+    }
+
+    @Test
+    void inputFactoriesCanFeedProcessStandardInput() {
+        List<String> fromStrings = ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .charset(StandardCharsets.UTF_8)
+                .fromStrings(List.of("first", "second"))
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toStringList(5, 100)
+                .run();
+
+        assertThat(fromStrings).containsExactly("first", "second");
+
+        String fromReader = ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .charset(StandardCharsets.UTF_8)
+                .transferFrom(new StringReader("reader-input"))
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toSingleString(100)
+                .run();
+
+        assertThat(fromReader).isEqualTo("reader-input");
+
+        String fromBytes = ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .transferFrom(new ByteArrayInputStream("byte-input".getBytes(StandardCharsets.UTF_8)))
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toSingleString(100)
+                .run();
+
+        assertThat(fromBytes).isEqualTo("byte-input");
+    }
+
+    @Test
+    void inputAndOutputCanTransferThroughFiles(@TempDir Path tempDir) throws Exception {
+        Path input = tempDir.resolve("input.txt");
+        Path output = tempDir.resolve("output.txt");
+        Files.writeString(input, "from-file\n", StandardCharsets.UTF_8);
+
+        ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .transferFrom(input)
+                .output()
+                .transferTo(output)
+                .run();
+
+        shellCommand("printf 'appended\\n'")
+                .output()
+                .appendTo(output)
+                .run();
+
+        assertThat(Files.readString(output, StandardCharsets.UTF_8)).isEqualTo("from-file\nappended\n");
+    }
+
+    @Test
+    void outputCanBeCopiedTransferredAndProcessed() throws Exception {
+        ByteArrayOutputStream copiedBytes = new ByteArrayOutputStream();
+        String output = shellCommand("printf 'copy-me'")
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toSingleString(100)
+                .copyAndTransferTo(copiedBytes)
+                .run();
+
+        assertThat(output).isEqualTo("copy-me");
+        assertThat(copiedBytes.toString(StandardCharsets.UTF_8)).isEqualTo("copy-me");
+
+        StringWriter copiedCharacters = new StringWriter();
+        Integer lineCount = shellCommand("printf 'a\\nb\\nc\\n'")
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .processWith(reader -> (int) reader.lines().count())
+                .copyAndTransferTo(copiedCharacters)
+                .run();
+
+        assertThat(lineCount).isEqualTo(3);
+        assertThat(copiedCharacters.toString()).isEqualTo("a\nb\nc\n");
+
+        Integer byteCount = shellCommand("printf '12345'")
+                .output()
+                .processBytesWith(inputStream -> inputStream.readAllBytes().length)
+                .run();
+
+        assertThat(byteCount).isEqualTo(5);
+    }
+
+    @Test
+    void environmentAndWorkingDirectoryAreApplied(@TempDir Path tempDir) throws Exception {
+        Path marker = tempDir.resolve("marker.txt");
+        Files.writeString(marker, "marker", StandardCharsets.UTF_8);
+
+        String output = shellCommand("cat marker.txt; printf ':%s' \"$SMALLRYE_PROCESS_TEST_VALUE\"")
+                .directory(tempDir)
+                .environment(System.getenv())
+                .modifyEnvironment(environment -> environment.put("SMALLRYE_PROCESS_TEST_VALUE", "configured"))
+                .output()
+                .toSingleString(100)
+                .run();
+
+        assertThat(output).isEqualTo("marker:configured");
+    }
+
+    @Test
+    void errorStreamCanBeRedirectedOrCapturedOnFailure() {
+        String redirected = shellCommand("printf 'stdout'; printf ':stderr' >&2")
+                .error()
+                .redirect()
+                .output()
+                .toSingleString(100)
+                .run();
+
+        assertThat(redirected).contains("stdout").contains(":stderr");
+
+        AbnormalExitException exception = assertThrows(AbnormalExitException.class, () -> shellCommand(
+                "printf 'out-head\\nout-tail\\n'; printf 'err-head\\nerr-tail\\n' >&2; exit 7")
+                .output()
+                .gatherOnFail(true)
+                .captureHeadLines(1)
+                .captureTailLines(1)
+                .error()
+                .gatherOnFail(true)
+                .captureHeadLines(1)
+                .captureTailLines(1)
+                .run());
+
+        assertThat(exception.exitCode()).isEqualTo(7);
+        assertThat(exception.output()).containsExactly("out-head", "out-tail");
+        assertThat(exception.errorOutput()).containsExactly("err-head", "err-tail");
+        assertThat(exception.command()).isEqualTo(SHELL);
+        assertThat(exception.arguments()).containsExactlyElementsOf(shellArguments(
+                "printf 'out-head\\nout-tail\\n'; printf 'err-head\\nerr-tail\\n' >&2; exit 7"));
+        assertThat(exception.getMessage()).contains("exit code 7", "out-head", "err-head");
+    }
+
+    @Test
+    void exitCodeCheckerCanAcceptNonZeroExitStatus() {
+        String output = shellCommand("printf 'accepted'; exit 7")
+                .exitCodeChecker(exitCode -> exitCode == 7)
+                .output()
+                .toSingleString(100)
+                .run();
+
+        assertThat(output).isEqualTo("accepted");
+    }
+
+    @Test
+    void programmaticInputProducersCanFeedProcessStandardInput() {
+        List<String> producedCharacters = ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .charset(StandardCharsets.UTF_8)
+                .produceWith(writer -> writer.write("writer-line-one\nwriter-line-two\n"))
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toStringList(5, 100)
+                .run();
+
+        assertThat(producedCharacters).containsExactly("writer-line-one", "writer-line-two");
+
+        String producedBytes = ProcessBuilder.newBuilder(CAT)
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT)
+                .input()
+                .produceBytesWith(outputStream -> outputStream.write(
+                        "bytes-produced".getBytes(StandardCharsets.UTF_8)))
+                .output()
+                .charset(StandardCharsets.UTF_8)
+                .toSingleString(100)
+                .run();
+
+        assertThat(producedBytes).isEqualTo("bytes-produced");
+    }
+
+    @Test
+    void errorLinesCanBeConsumedWithoutChangingOutputResult() {
+        List<String> errorLines = new ArrayList<>();
+
+        String output = shellCommand("printf 'stdout-result'; printf 'warning-one\\nwarning-two\\n' >&2")
+                .output()
+                .toSingleString(100)
+                .error()
+                .consumeLinesWith(100, errorLines::add)
+                .run();
+
+        assertThat(output).isEqualTo("stdout-result");
+        assertThat(errorLines).containsExactly("warning-one", "warning-two");
+    }
+
+    @Test
+    void pipelineFeedsOutputIntoNextProcess() {
+        List<String> output = shellCommand("printf 'alpha\\nbravo\\ncharlie\\n'")
+                .output()
+                .pipeTo(GREP, "bravo")
+                .output()
+                .toStringList(5, 100)
+                .run();
+
+        assertThat(output).containsExactly("bravo");
+    }
+
+    @Test
+    void pipelineFailureReportsProcessExceptions() {
+        PipelineExecutionException exception = assertThrows(PipelineExecutionException.class,
+                () -> shellCommand("exit 3")
+                        .output()
+                        .pipeTo(SHELL, "-c", "cat >/dev/null; exit 4")
+                        .run());
+
+        assertThat(exception.processExecutionExceptions())
+                .hasSize(2)
+                .allSatisfy(processException -> assertThat(processException.command()).isEqualTo(SHELL));
+    }
+
+    @Test
+    void asynchronousExecutionInvokesWhileRunningHandler() throws Exception {
+        AtomicReference<WaitableProcessHandle> seenHandle = new AtomicReference<>();
+        CompletableFuture<String> future = shellCommand("printf 'async-output'")
+                .whileRunning(seenHandle::set)
+                .output()
+                .toSingleString(100)
+                .runAsync();
+
+        assertThat(future.get(10, TimeUnit.SECONDS)).isEqualTo("async-output");
+        assertThat(seenHandle.get()).isNotNull();
+        assertThat(seenHandle.get().pid()).isPositive();
+        assertThat(seenHandle.get().command()).isEqualTo(SHELL);
+        assertThat(seenHandle.get().arguments()).containsExactlyElementsOf(shellArguments("printf 'async-output'"));
+        assertThat(seenHandle.get().waitUninterruptiblyFor(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(seenHandle.get().exitValue()).isZero();
+    }
+
+    @Test
+    void processUtilityCanObserveAndDestroyPlainJdkProcesses() throws Exception {
+        java.lang.Process finished = new java.lang.ProcessBuilder(SHELL.toString(), "-c", "exit 0").start();
+        assertThat(ProcessUtil.stillRunningAfter(finished, Duration.ofSeconds(5))).isFalse();
+
+        java.lang.Process running = new java.lang.ProcessBuilder(SHELL.toString(), "-c", "read ignored").start();
+        try {
+            assertThat(ProcessUtil.stillRunningAfter(running, Duration.ofMillis(10))).isTrue();
+            ProcessUtil.destroyAllForcibly(running);
+            assertThat(ProcessUtil.stillRunningAfter(running, Duration.ofSeconds(5))).isFalse();
+        } finally {
+            ProcessUtil.destroyAllForcibly(running);
+        }
+    }
+
+    private static ProcessBuilder<Void> shellCommand(String script) {
+        return ProcessBuilder.newBuilder(SHELL, shellArguments(script))
+                .softExitTimeout(EXIT_TIMEOUT)
+                .hardExitTimeout(EXIT_TIMEOUT);
+    }
+
+    private static List<String> shellArguments(String script) {
+        return List.of("-c", script);
+    }
+
+    private static Path requiredCommand(String command) {
+        Optional<Path> path = ProcessUtil.pathOfCommand(Path.of(command));
+        return path.orElseThrow(
+                () -> new IllegalStateException("Required command is not available on PATH: " + command));
+    }
+}

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
@@ -22,10 +22,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.common.process.AbnormalExitException;
+import io.smallrye.common.process.Logging_$logger;
 import io.smallrye.common.process.PipelineExecutionException;
 import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.common.process.ProcessUtil;
 import io.smallrye.common.process.WaitableProcessHandle;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -37,6 +39,13 @@ public class Smallrye_common_processTest {
     private static final Path SHELL = requiredCommand("sh");
     private static final Path CAT = requiredCommand("cat");
     private static final Path GREP = requiredCommand("grep");
+
+    @Test
+    void generatedMessageLoggerIsReachableForProcessThreads() {
+        Logging_$logger logger = new Logging_$logger(Logger.getLogger("smallrye-common-process-test"));
+
+        assertThat(logger).isNotNull();
+    }
 
     @Test
     void processUtilitiesExposeNativeCharsetJavaCommandAndSearchPath() {

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.smallrye.common.process.**"
+    }
+  ]
+}

--- a/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
+++ b/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.smallrye.common.process.**"
+    },
+    {
+      "includeClasses" : "io_smallrye_common.smallrye_common_process.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4421

This PR provides test fixes and new metadata for io.smallrye.common:smallrye-common-process:2.17.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 73761
- Cached input tokens: 1357312
- Output tokens: 7854
- Metadata entries: 10
- Iterations: 1
- Library coverage percentage: 62.4
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 62.4

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.smallrye.common:smallrye-common-process:2.16.0: 0/0 covered calls (100.00%)
- io.smallrye.common:smallrye-common-process:2.17.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.smallrye.common:smallrye-common-process:2.16.0: 3773/6079 (62.07%)
- io.smallrye.common:smallrye-common-process:2.17.0: 3773/6079 (62.07%)

**Line:**
- io.smallrye.common:smallrye-common-process:2.16.0: 898/1439 (62.40%)
- io.smallrye.common:smallrye-common-process:2.17.0: 898/1439 (62.40%)

**Method:**
- io.smallrye.common:smallrye-common-process:2.16.0: 206/345 (59.71%)
- io.smallrye.common:smallrye-common-process:2.17.0: 206/345 (59.71%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.smallrye.common/smallrye-common-process/2.16.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java 2/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
index 08ecab110b..8d0d09c90b 100644
--- 1/tests/src/io.smallrye.common/smallrye-common-process/2.16.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
+++ 2/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/src/test/java/io_smallrye_common/smallrye_common_process/Smallrye_common_processTest.java
@@ -22,10 +22,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.smallrye.common.process.AbnormalExitException;
+import io.smallrye.common.process.Logging_$logger;
 import io.smallrye.common.process.PipelineExecutionException;
 import io.smallrye.common.process.ProcessBuilder;
 import io.smallrye.common.process.ProcessUtil;
 import io.smallrye.common.process.WaitableProcessHandle;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,6 +40,13 @@ public class Smallrye_common_processTest {
     private static final Path CAT = requiredCommand("cat");
     private static final Path GREP = requiredCommand("grep");
 
+    @Test
+    void generatedMessageLoggerIsReachableForProcessThreads() {
+        Logging_$logger logger = new Logging_$logger(Logger.getLogger("smallrye-common-process-test"));
+
+        assertThat(logger).isNotNull();
+    }
+
     @Test
     void processUtilitiesExposeNativeCharsetJavaCommandAndSearchPath() {
         assertThat(ProcessUtil.nativeCharset()).isNotNull();
diff --git 1/tests/src/io.smallrye.common/smallrye-common-process/2.16.0/user-code-filter.json 2/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
index b98cd34bb7..d1c65f9d26 100644
--- 1/tests/src/io.smallrye.common/smallrye-common-process/2.16.0/user-code-filter.json
+++ 2/tests/src/io.smallrye.common/smallrye-common-process/2.17.0/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.smallrye.common.process.**"
+    },
+    {
+      "includeClasses" : "io_smallrye_common.smallrye_common_process.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
