### PR TITLE
Prevent Forge from using invalid issue worktrees

### DIFF
--- a/forge/ai_workflows/fix_metadata_codex.py
+++ b/forge/ai_workflows/fix_metadata_codex.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from utility_scripts.task_logs import build_task_log_path, display_log_path
+from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1200
@@ -22,6 +23,7 @@ def run_codex_metadata_fix(
     Requires the ``fix-missing-reachability-metadata`` skill. The skill definition lives at:
     https://github.com/oracle/graalvm-reachability-metadata/blob/master/skills/fix-missing-reachability-metadata/SKILL.md
     """
+    reachability_metadata_path = require_complete_reachability_repo(reachability_metadata_path)
     prompt = f"Fix the metadata entries for {coordinates}"
     if reproduction_command:
         prompt += f"\n\nReproduce the failure with:\n{reproduction_command}"

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -92,6 +92,7 @@ from utility_scripts.metadata_index import (
 )
 from utility_scripts.metrics_writer import read_pending_metrics
 from utility_scripts.repo_path_resolver import (
+    git_env_limited_to_repo_root,
     get_forge_subdir_name,
     get_repo_root,
     require_complete_reachability_repo,
@@ -2795,6 +2796,22 @@ def _build_failed_generation_fallback_comment(
     )
 
 
+def claimed_issue_worktree_is_valid(claimed_issue: ClaimedIssue, stage: str) -> bool:
+    """Return True when analysis agents may safely run in the claimed issue worktree."""
+    try:
+        require_claimed_issue_worktree(claimed_issue, stage)
+        return True
+    except Exception as exc:
+        print(
+            (
+                f"ERROR: Skipping {stage} for issue #{claimed_issue.issue['number']} "
+                f"because the claimed worktree is invalid: {exc!r}"
+            ),
+            file=sys.stderr,
+        )
+        return False
+
+
 def run_codex_failed_generation_analysis(
         claimed_issue: ClaimedIssue,
         candidate: HumanInterventionCandidate,
@@ -2804,6 +2821,13 @@ def run_codex_failed_generation_analysis(
     """Use Codex to analyze a failed library-generation run and write an issue comment."""
     run_metrics = _load_pending_run_metrics(claimed_issue.scratch_metrics_repo_path)
     log_paths = collect_issue_log_paths(claimed_issue, started_at)
+    if not claimed_issue_worktree_is_valid(claimed_issue, "failed-run analysis"):
+        return _build_failed_generation_fallback_comment(
+            claimed_issue,
+            candidate,
+            log_paths,
+            preservation_result,
+        )
     prompt = _build_failed_generation_analysis_prompt(
         claimed_issue,
         candidate,
@@ -2898,6 +2922,8 @@ def run_human_intervention_analysis(
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
     read_only_files = _collect_human_intervention_read_only_files(claimed_issue)
     prompt = _build_human_intervention_analysis_prompt(claimed_issue, candidate)
+    if not claimed_issue_worktree_is_valid(claimed_issue, "human-intervention analysis"):
+        return _build_human_intervention_fallback_comment(claimed_issue, candidate)
 
     try:
         agent = init_workflow_agent(
@@ -3069,6 +3095,28 @@ def build_origin_branch_url(repo_path: str, branch_name: str) -> str:
     return f"https://github.com/{origin_owner}/{repo_name}/tree/{quote(branch_name, safe='')}"
 
 
+def require_claimed_issue_worktree(claimed_issue: ClaimedIssue, stage: str) -> str:
+    """Require the claimed issue path to be the exact isolated reachability worktree."""
+    try:
+        resolved_path = require_complete_reachability_repo(claimed_issue.worktree_path)
+    except SystemExit as exc:
+        raise RuntimeError(
+            (
+                f"Issue #{claimed_issue.issue['number']} {stage} requires a valid isolated "
+                f"worktree at {claimed_issue.worktree_path}."
+            )
+        ) from exc
+    expected_path = os.path.abspath(claimed_issue.worktree_path)
+    if resolved_path != expected_path:
+        raise RuntimeError(
+            (
+                f"Issue #{claimed_issue.issue['number']} {stage} resolved the wrong "
+                f"worktree root: expected {expected_path}, got {resolved_path}."
+            )
+        )
+    return resolved_path
+
+
 def copy_library_logs_to_preserved_worktree(claimed_issue: ClaimedIssue) -> str | None:
     """Copy the current library logs into the preserved worktree and return the repo-relative path."""
     safe_library_name = sanitize_library_log_segment(claimed_issue.issue_coordinates)
@@ -3102,27 +3150,29 @@ def copy_library_logs_to_preserved_worktree(claimed_issue: ClaimedIssue) -> str 
 def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservationResult:
     """Commit and push the failed run worktree so it survives workspace cleanup."""
     branch_name = build_failure_preservation_branch_name(claimed_issue)
-    repo_path = claimed_issue.worktree_path
+    repo_path = require_claimed_issue_worktree(claimed_issue, "failure preservation")
+    git_env = git_env_limited_to_repo_root(repo_path)
     issue_number = claimed_issue.issue["number"]
 
     log_stage("preserve-failed-work", f"Preserving failed work for issue #{issue_number} on branch {branch_name}")
-    subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, check=True)
+    subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, env=git_env, check=True)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
-    subprocess.run(["git", "add", "-A"], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo_path, env=git_env, check=True)
     if logs_destination_relpath is not None:
-        subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, check=True)
-    diff_result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, check=False)
+        subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, env=git_env, check=True)
+    diff_result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, env=git_env, check=False)
     committed_changes = diff_result.returncode != 0
     if committed_changes:
         subprocess.run(
             ["git", "commit", "-m", f"Preserve failed automation work for issue #{issue_number}"],
             cwd=repo_path,
+            env=git_env,
             check=True,
         )
     else:
         log_stage("preserve-failed-work", f"No uncommitted work found for issue #{issue_number}; pushing branch at current HEAD.")
 
-    subprocess.run(["git", "push", "-u", "origin", branch_name], cwd=repo_path, check=True)
+    subprocess.run(["git", "push", "-u", "origin", branch_name], cwd=repo_path, env=git_env, check=True)
     branch_url = build_origin_branch_url(repo_path, branch_name)
     log_stage("preserve-failed-work", f"Preserved failed work for issue #{issue_number}: {branch_url}")
     return FailurePreservationResult(
@@ -3140,17 +3190,19 @@ def refresh_preserved_branch_logs(
     if preservation_result is None:
         return
 
-    repo_path = claimed_issue.worktree_path
+    repo_path = require_claimed_issue_worktree(claimed_issue, "preserved log refresh")
+    git_env = git_env_limited_to_repo_root(repo_path)
     issue_number = claimed_issue.issue["number"]
-    subprocess.run(["git", "switch", preservation_result.branch_name], cwd=repo_path, check=True)
+    subprocess.run(["git", "switch", preservation_result.branch_name], cwd=repo_path, env=git_env, check=True)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
     if logs_destination_relpath is None:
         return
 
-    subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, check=True)
+    subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, env=git_env, check=True)
     diff_result = subprocess.run(
         ["git", "diff", "--cached", "--quiet", "--", logs_destination_relpath],
         cwd=repo_path,
+        env=git_env,
         check=False,
     )
     if diff_result.returncode == 0:
@@ -3160,9 +3212,10 @@ def refresh_preserved_branch_logs(
     subprocess.run(
         ["git", "commit", "-m", f"Add automation logs for issue #{issue_number}"],
         cwd=repo_path,
+        env=git_env,
         check=True,
     )
-    subprocess.run(["git", "push"], cwd=repo_path, check=True)
+    subprocess.run(["git", "push"], cwd=repo_path, env=git_env, check=True)
     log_stage("preserve-failed-work", f"Updated preserved branch logs for issue #{issue_number}.")
 
 
@@ -3303,6 +3356,7 @@ def invoke_pipeline(
 ) -> bool:
     """Run the matching workflow for the claimed issue in its isolated worktree."""
     issue_number = claimed_issue.issue["number"]
+    require_claimed_issue_worktree(claimed_issue, "workflow execution")
 
     if claimed_issue.label == LABEL_LIBRARY_NEW:
         print()
@@ -4186,6 +4240,7 @@ def finalize_successful_issue(
         claimed_issue: ClaimedIssue,
 ) -> None:
     """Create the PR for a successful isolated workflow run."""
+    require_claimed_issue_worktree(claimed_issue, "successful finalization")
     large_library_state_path = find_progress_state_path(
         claimed_issue.scratch_metrics_repo_path,
         claimed_issue.issue["number"],
@@ -4399,6 +4454,7 @@ def process_claimed_issue_lifecycle(
             if is_interrupt_exception(exc) or is_user_interrupt_requested():
                 mark_user_interrupt_requested()
                 revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
+                raise
             else:
                 try:
                     handle_failed_claimed_issue(
@@ -4420,6 +4476,7 @@ def process_claimed_issue_lifecycle(
                     mark_user_interrupt_requested()
                     revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
                     raise
+                return False
         raise
     finally:
         try:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -116,6 +116,7 @@ class FinalizeSuccessfulIssueTests(unittest.TestCase):
         claimed_issue = _claimed_issue()
 
         with patch.object(forge_metadata, "find_progress_state_path", return_value=None), \
+                patch.object(forge_metadata, "require_claimed_issue_worktree"), \
                 patch.object(forge_metadata, "_load_pending_run_metrics", return_value={"status": "success"}), \
                 patch.object(forge_metadata, "metadata_coordinate_parts", return_value=("org.example", "lib", "1.0.0")), \
                 patch.object(forge_metadata, "is_not_for_native_image", return_value=True), \
@@ -1975,6 +1976,7 @@ class InterruptHandlingTests(unittest.TestCase):
         claimed_issue = _claimed_issue()
 
         with patch.object(forge_metadata, "run_add_new_library_support_workflow", return_value=130), \
+                patch.object(forge_metadata, "require_claimed_issue_worktree"), \
                 patch.object(forge_metadata, "require_graalvm_home_env") as require_graalvm_home:
             with self.assertRaises(KeyboardInterrupt):
                 forge_metadata.invoke_pipeline(claimed_issue, None, False)
@@ -2010,6 +2012,70 @@ class InterruptHandlingTests(unittest.TestCase):
         handle_failed_claimed_issue.assert_not_called()
         revert_claimed_issue.assert_called_once_with(claimed_issue, "Ctrl+C interrupt")
         cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
+
+    def test_unhandled_system_exit_is_failed_issue_not_queue_stopper(self) -> None:
+        claimed_issue = _claimed_issue()
+
+        with patch.object(forge_metadata, "run_claimed_issue", side_effect=SystemExit(1)), \
+                patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
+            handled = forge_metadata.process_claimed_issue_lifecycle(
+                claimed_issue,
+                strategy_name=None,
+                keep_tests_without_dynamic_access=False,
+                canonical_metrics_repo_path="/tmp/metrics",
+            )
+
+        self.assertFalse(handled)
+        handle_completed_run.assert_not_called()
+        handle_failed_claimed_issue.assert_called_once()
+        cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
+
+    def test_failed_run_analysis_uses_fallback_when_worktree_is_invalid(self) -> None:
+        claimed_issue = _claimed_issue()
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name=None,
+            workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+            reason="job_failed",
+        )
+
+        with patch.object(forge_metadata, "_load_pending_run_metrics", return_value=None), \
+                patch.object(forge_metadata, "collect_issue_log_paths", return_value=[]), \
+                patch.object(forge_metadata, "require_claimed_issue_worktree", side_effect=RuntimeError("invalid")), \
+                patch.object(forge_metadata.subprocess, "run") as run:
+            comment = forge_metadata.run_codex_failed_generation_analysis(
+                claimed_issue,
+                candidate,
+                started_at=123.0,
+                preservation_result=None,
+            )
+
+        self.assertIn("Human intervention needed", comment)
+        run.assert_not_called()
+
+    def test_human_intervention_analysis_uses_fallback_when_worktree_is_invalid(self) -> None:
+        claimed_issue = _claimed_issue()
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name="strategy",
+            workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+            reason="low_dynamic_access_coverage",
+        )
+        strategy = {"model": "test-model"}
+
+        with patch.object(forge_metadata, "load_strategy_by_name", return_value=strategy), \
+                patch.object(forge_metadata, "_collect_human_intervention_read_only_files", return_value=[]), \
+                patch.object(forge_metadata, "require_claimed_issue_worktree", side_effect=RuntimeError("invalid")), \
+                patch.object(forge_metadata, "init_workflow_agent") as init_agent:
+            comment = forge_metadata.run_human_intervention_analysis(
+                claimed_issue,
+                candidate,
+                started_at=123.0,
+                preservation_result=None,
+            )
+
+        self.assertIn("Human intervention needed", comment)
+        init_agent.assert_not_called()
 
     def test_human_intervention_posting_noops_after_interrupt(self) -> None:
         forge_metadata.mark_user_interrupt_requested()

--- a/forge/tests/test_git_worktree_regressions.py
+++ b/forge/tests/test_git_worktree_regressions.py
@@ -80,6 +80,14 @@ class GitWorktreeRegressionTests(unittest.TestCase):
 
             self.assertEqual(require_complete_reachability_repo(repo_root), repo_root)
 
+    def test_complete_reachability_repo_validation_accepts_symlink_to_full_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
+            link_root = os.path.join(temp_dir, "linked-repo")
+            os.symlink(repo_root, link_root)
+
+            self.assertEqual(require_complete_reachability_repo(link_root), os.path.abspath(link_root))
+
     def test_complete_reachability_repo_validation_rejects_partial_library_dir(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             partial_dir = os.path.join(temp_dir, "tests", "src", "org.example", "demo", "1.0.0")
@@ -95,6 +103,17 @@ class GitWorktreeRegressionTests(unittest.TestCase):
 
             with self.assertRaises(SystemExit):
                 require_complete_reachability_repo(artifact_dir)
+
+    def test_complete_reachability_repo_validation_rejects_nested_leftover_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
+            leftover_dir = os.path.join(repo_root, "forge", "local_repositories", "forge_worktrees", "1412-deadbeef")
+            os.makedirs(os.path.join(leftover_dir, "tests"), exist_ok=True)
+            os.makedirs(os.path.join(leftover_dir, "build"), exist_ok=True)
+
+            self.assertEqual(_git(["rev-parse", "--show-toplevel"], cwd=leftover_dir).stdout.strip(), repo_root)
+            with self.assertRaises(SystemExit):
+                require_complete_reachability_repo(leftover_dir)
 
     def test_complete_reachability_repo_validation_rejects_checkout_missing_gradlew(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -190,6 +209,42 @@ class GitWorktreeRegressionTests(unittest.TestCase):
             self.assertEqual(scratch_metrics_path, os.path.join(worktree_path, "forge"))
             validate.assert_called_once_with(worktree_path)
             _git(["worktree", "remove", "--force", worktree_path], cwd=reachability_repo)
+
+    def test_failed_work_preservation_rejects_broken_nested_worktree_without_switching_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            reachability_repo = _create_reachability_repo(os.path.join(temp_dir, "graalvm-reachability-metadata"))
+            broken_worktree_path = os.path.join(
+                reachability_repo,
+                "forge",
+                "local_repositories",
+                "forge_worktrees",
+                "1412-deadbeef",
+            )
+            os.makedirs(os.path.join(broken_worktree_path, "tests"), exist_ok=True)
+            claimed_issue = forge_metadata.ClaimedIssue(
+                issue={
+                    "number": 1412,
+                    "title": "Add support for org.example:lib:1.0.0",
+                },
+                label=forge_metadata.LABEL_LIBRARY_NEW,
+                item_id="item-1",
+                base_reachability_metadata_path=reachability_repo,
+                worktree_path=broken_worktree_path,
+                scratch_metrics_repo_path=os.path.join(broken_worktree_path, "forge"),
+                issue_coordinates="org.example:lib:1.0.0",
+            )
+
+            forge_metadata.preservation_failed_worktree_paths.clear()
+            with patch.object(
+                    forge_metadata,
+                    "build_failure_preservation_branch_name",
+                    return_value="ai/test/human-intervention/issue-1412",
+            ):
+                preservation_result = forge_metadata.preserve_failed_work_for_follow_up(claimed_issue)
+
+            self.assertIsNone(preservation_result)
+            self.assertEqual(_git(["branch", "--show-current"], cwd=reachability_repo).stdout.strip(), "master")
+            self.assertIn(broken_worktree_path, forge_metadata.preservation_failed_worktree_paths)
 
     def test_ensure_local_metrics_repo_accepts_git_worktrees(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -139,6 +139,7 @@ def verify_native_test_passes(
             _GATE_STAGE,
             f"{stage}: {reason}; routing to codex (terminal)",
         )
+        require_complete_reachability_repo(reachability_repo_path)
         codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
             reachability_repo_path,
             coordinate,
@@ -157,6 +158,7 @@ def verify_native_test_passes(
                 f"codex did not converge (timed_out={codex_timed_out}, rc={codex_rc}); FAILED",
             )
             return _make_result(STATUS_FAILED, iterations_used)
+        require_complete_reachability_repo(reachability_repo_path)
         log_stage(_GATE_STAGE, "codex finished; trusting codex's outcome")
         return _make_result(STATUS_PASSED_WITH_INTERVENTION, iterations_used)
 

--- a/forge/utility_scripts/repo_path_resolver.py
+++ b/forge/utility_scripts/repo_path_resolver.py
@@ -19,6 +19,14 @@ def get_forge_subdir_name() -> str:
     return os.path.basename(get_repo_root())
 
 
+def git_env_limited_to_repo_root(repo_root: str) -> dict[str, str]:
+    """Return an environment that prevents Git from discovering parent repos."""
+    resolved_root = os.path.abspath(repo_root)
+    env = os.environ.copy()
+    env["GIT_CEILING_DIRECTORIES"] = os.path.dirname(resolved_root)
+    return env
+
+
 def _run_git(cmd: list[str], cwd: str) -> None:
     """Run a git command and exit with a clear error on failure."""
     result = subprocess.run(
@@ -37,18 +45,22 @@ def _run_git(cmd: list[str], cwd: str) -> None:
 
 
 def _is_git_checkout(repo_root: str) -> bool:
-    """Return True when the path is a git checkout, including linked worktrees."""
+    """Return True when the exact path is a git checkout, including linked worktrees."""
     if not os.path.isdir(repo_root):
         return False
 
+    resolved_root = os.path.abspath(repo_root)
     result = subprocess.run(
-        ["git", "rev-parse", "--git-dir"],
-        cwd=repo_root,
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=resolved_root,
+        env=git_env_limited_to_repo_root(resolved_root),
         check=False,
         capture_output=True,
         text=True,
     )
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+    return os.path.realpath(result.stdout.strip()) == os.path.realpath(resolved_root)
 
 
 def ensure_local_reachability_repo(reachability_root: str) -> str:
@@ -172,7 +184,7 @@ def require_complete_reachability_repo(repo_root: str) -> str:
             file=sys.stderr,
         )
         raise SystemExit(1)
-    return repo_root
+    return os.path.abspath(repo_root)
 
 
 def resolve_parent_reachability_repo() -> str:


### PR DESCRIPTION
### Summary
- require exact issue worktree roots before Forge workflow execution, finalization, preservation, and Codex repair
- prevent Git commands in issue worktree paths from discovering the parent checkout
- keep non-interrupt lifecycle failures scoped to the current issue instead of stopping the queue

### Testing
- `.venv/bin/python -m unittest tests.test_git_worktree_regressions tests.test_forge_metadata`
- `.venv/bin/python -m py_compile utility_scripts/repo_path_resolver.py forge_metadata.py ai_workflows/fix_metadata_codex.py utility_scripts/native_test_verification.py tests/test_git_worktree_regressions.py tests/test_forge_metadata.py`

Fixes #5930