### PR TITLE
[GenAI] Add support for com.github.java-json-tools:json-patch:1.13 using gpt-5.5

### DIFF
--- a/metadata/com.github.java-json-tools/json-patch/1.13/reachability-metadata.json
+++ b/metadata/com.github.java-json-tools/json-patch/1.13/reachability-metadata.json
@@ -1,0 +1,157 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.msgsimple.load.MessageBundles"
+      },
+      "type" : "com.github.fge.jsonpatch.JsonPatchMessages",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.msgsimple.load.MessageBundles"
+      },
+      "type" : "com.github.fge.jackson.jsonpointer.JsonPointerMessages",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jackson.jsonpointer.JsonPointer"
+      },
+      "type" : "com.github.fge.jackson.jsonpointer.JsonPointer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.JsonPatch",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.AddOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer",
+            "com.fasterxml.jackson.databind.JsonNode"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.CopyOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer",
+            "com.github.fge.jackson.jsonpointer.JsonPointer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.MoveOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer",
+            "com.github.fge.jackson.jsonpointer.JsonPointer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.RemoveOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.ReplaceOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer",
+            "com.fasterxml.jackson.databind.JsonNode"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.JsonPatch"
+      },
+      "type" : "com.github.fge.jsonpatch.TestOperation",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.github.fge.jackson.jsonpointer.JsonPointer",
+            "com.fasterxml.jackson.databind.JsonNode"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.github.fge.jsonpatch.mergepatch.JsonMergePatch"
+      },
+      "type" : "com.github.fge.jsonpatch.mergepatch.JsonMergePatchDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.github.java-json-tools/json-patch/index.json
+++ b/metadata/com.github.java-json-tools/json-patch/index.json
@@ -1,17 +1,19 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "1.13",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-sources.jar",
-    "repository-url" : "https://github.com/java-json-tools/json-patch",
-    "test-code-url" : "https://github.com/java-json-tools/json-patch/tree/v$version$/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-javadoc.jar",
-    "description" : "json-patch implements JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7386) for Java applications. It provides Jackson-based operations for applying, representing, and validating JSON document changes.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "1.13",
+    "source-code-url": "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-sources.jar",
+    "repository-url": "https://github.com/java-json-tools/json-patch",
+    "test-code-url": "https://github.com/java-json-tools/json-patch/tree/v$version$/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-javadoc.jar",
+    "description": "json-patch implements JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7386) for Java applications. It provides Jackson-based operations for applying, representing, and validating JSON document changes.",
+    "tested-versions": [
       "1.13"
     ],
-    "allowed-packages" : [
-      "com.github.fge.jsonpatch"
+    "allowed-packages": [
+      "com.github.fge.jsonpatch",
+      "com.github.fge.jackson.jsonpointer",
+      "com.github.fge.msgsimple.load"
     ]
   }
 ]

--- a/metadata/com.github.java-json-tools/json-patch/index.json
+++ b/metadata/com.github.java-json-tools/json-patch/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.13",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-sources.jar",
+    "repository-url" : "https://github.com/java-json-tools/json-patch",
+    "test-code-url" : "https://github.com/java-json-tools/json-patch/tree/v$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/java-json-tools/json-patch/$version$/json-patch-$version$-javadoc.jar",
+    "description" : "json-patch implements JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7386) for Java applications. It provides Jackson-based operations for applying, representing, and validating JSON document changes.",
+    "tested-versions" : [
+      "1.13"
+    ],
+    "allowed-packages" : [
+      "com.github.fge.jsonpatch"
+    ]
+  }
+]

--- a/stats/com.github.java-json-tools/json-patch/1.13/execution-metrics.json
+++ b/stats/com.github.java-json-tools/json-patch/1.13/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-05": {
+    "timestamp": "2026-05-05T11:52:55.816865Z",
+    "library": "com.github.java-json-tools:json-patch:1.13",
+    "starting_commit": "6ff66b8b9eb52826b8c1d2916864666595a7b68b",
+    "ending_commit": "62bfa4e233bd603a30bc091f4fee1ba1d1fb71d9",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.13",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1299,
+          "missed": 386,
+          "ratio": 0.77092,
+          "total": 1685
+        },
+        "line": {
+          "covered": 304,
+          "missed": 79,
+          "ratio": 0.793734,
+          "total": 383
+        },
+        "method": {
+          "covered": 76,
+          "missed": 22,
+          "ratio": 0.77551,
+          "total": 98
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 91843,
+      "cached_input_tokens_used": 612352,
+      "output_tokens_used": 11737,
+      "iterations": 3,
+      "cost_usd": 0.6583,
+      "generated_loc": 267,
+      "tested_library_loc": 304,
+      "metadata_entries": 22,
+      "code_coverage_percent": 79.37
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java",
+      "metadata_file": "metadata/com.github.java-json-tools/json-patch/1.13/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.java-json-tools/json-patch/1.13/stats.json
+++ b/stats/com.github.java-json-tools/json-patch/1.13/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.13",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1299,
+        "missed" : 386,
+        "ratio" : 0.77092,
+        "total" : 1685
+      },
+      "line" : {
+        "covered" : 304,
+        "missed" : 79,
+        "ratio" : 0.793734,
+        "total" : 383
+      },
+      "method" : {
+        "covered" : 76,
+        "missed" : 22,
+        "ratio" : 0.77551,
+        "total" : 98
+      }
+    }
+  } ]
+}

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/.gitignore
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/build.gradle
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.github.java-json-tools:json-patch:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/gradle.properties
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.github.java-json-tools:json-patch:1.13
+library.version = 1.13
+metadata.dir = com.github.java-json-tools/json-patch/1.13/

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/settings.gradle
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.java-json-tools.json-patch_tests'

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_java_json_tools.json_patch;
+
+import org.junit.jupiter.api.Test;
+
+class Json_patchTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
@@ -185,6 +185,49 @@ public class Json_patchTest {
     }
 
     @Test
+    void appliesJsonPatchOperationsAtDocumentRoot() throws Exception {
+        JsonNode source = json("""
+                {
+                  "status": "draft",
+                  "items": ["old"]
+                }
+                """);
+        JsonPatch addAtRoot = JsonPatch.fromJson(json("""
+                [
+                  {"op": "add", "path": "", "value": ["replacement"]}
+                ]
+                """));
+        JsonPatch replaceAtRoot = JsonPatch.fromJson(json("""
+                [
+                  {"op": "replace", "path": "", "value": {"status": "published"}}
+                ]
+                """));
+        JsonPatch removeAtRoot = JsonPatch.fromJson(json("""
+                [
+                  {"op": "remove", "path": ""}
+                ]
+                """));
+
+        JsonNode added = addAtRoot.apply(source);
+        JsonNode replaced = replaceAtRoot.apply(source);
+        JsonNode removed = removeAtRoot.apply(source);
+
+        assertThat(added).isEqualTo(json("""
+                ["replacement"]
+                """));
+        assertThat(replaced).isEqualTo(json("""
+                {"status": "published"}
+                """));
+        assertThat(removed.isMissingNode()).isTrue();
+        assertThat(source).isEqualTo(json("""
+                {
+                  "status": "draft",
+                  "items": ["old"]
+                }
+                """));
+    }
+
+    @Test
     void testOperationComparesJsonNumbersByNumericValue() throws Exception {
         JsonNode source = json("""
                 {

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
@@ -185,6 +185,38 @@ public class Json_patchTest {
     }
 
     @Test
+    void testOperationComparesJsonNumbersByNumericValue() throws Exception {
+        JsonNode source = json("""
+                {
+                  "threshold": 1,
+                  "items": [
+                    {"price": 2.00}
+                  ],
+                  "status": "pending"
+                }
+                """);
+        JsonPatch patch = JsonPatch.fromJson(json("""
+                [
+                  {"op": "test", "path": "/threshold", "value": 1.0},
+                  {"op": "test", "path": "/items/0/price", "value": 2},
+                  {"op": "replace", "path": "/status", "value": "accepted"}
+                ]
+                """));
+
+        JsonNode patched = patch.apply(source);
+
+        assertThat(patched).isEqualTo(json("""
+                {
+                  "threshold": 1,
+                  "items": [
+                    {"price": 2.00}
+                  ],
+                  "status": "accepted"
+                }
+                """));
+    }
+
+    @Test
     void reportsInvalidPatchDocumentsAndFailedOperations() throws Exception {
         JsonPatch failingTest = JsonPatch.fromJson(json("""
                 [

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/src/test/java/com_github_java_json_tools/json_patch/Json_patchTest.java
@@ -6,11 +6,212 @@
  */
 package com_github_java_json_tools.json_patch;
 
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.github.fge.jackson.jsonpointer.JsonPointer;
+import com.github.fge.jsonpatch.AddOperation;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchException;
+import com.github.fge.jsonpatch.JsonPatchOperation;
+import com.github.fge.jsonpatch.ReplaceOperation;
+import com.github.fge.jsonpatch.TestOperation;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
 import org.junit.jupiter.api.Test;
 
-class Json_patchTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Json_patchTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void appliesRfc6902PatchWithAllOperationTypesAndEscapedPointers() throws Exception {
+        JsonNode source = json("""
+                {
+                  "name": "original",
+                  "foo": ["bar", "quux"],
+                  "nested": {
+                    "a/b": 7,
+                    "t~n": true
+                  }
+                }
+                """);
+        JsonNode originalSource = source.deepCopy();
+        JsonPatch patch = JsonPatch.fromJson(json("""
+                [
+                  {"op": "add", "path": "/baz", "value": "qux"},
+                  {"op": "add", "path": "/foo/-", "value": "tail"},
+                  {"op": "replace", "path": "/name", "value": "updated"},
+                  {"op": "copy", "from": "/nested/a~1b", "path": "/copied"},
+                  {"op": "move", "from": "/foo/1", "path": "/moved"},
+                  {"op": "remove", "path": "/nested/t~0n"},
+                  {"op": "test", "path": "/copied", "value": 7}
+                ]
+                """));
+
+        JsonNode patched = patch.apply(source);
+
+        assertThat(patched).isEqualTo(json("""
+                {
+                  "name": "updated",
+                  "foo": ["bar", "tail"],
+                  "nested": {
+                    "a/b": 7
+                  },
+                  "baz": "qux",
+                  "copied": 7,
+                  "moved": "quux"
+                }
+                """));
+        assertThat(source).isEqualTo(originalSource);
+        assertThat(patched).isNotSameAs(source);
+    }
+
+    @Test
+    void composesPatchOperationsProgrammatically() throws Exception {
+        JsonNode source = json("""
+                {
+                  "inventory": [
+                    {"sku": "A-1", "count": 2, "tags": []},
+                    {"sku": "B-2", "count": 8, "tags": ["clearance"]}
+                  ]
+                }
+                """);
+        JsonPatch patch = new JsonPatch(Arrays.<JsonPatchOperation>asList(
+                new AddOperation(new JsonPointer("/inventory/1/tags/-"), NODE_FACTORY.textNode("featured")),
+                new ReplaceOperation(new JsonPointer("/inventory/0/count"), NODE_FACTORY.numberNode(4)),
+                new TestOperation(new JsonPointer("/inventory/1/tags/0"), NODE_FACTORY.textNode("clearance"))
+        ));
+
+        JsonNode patched = patch.apply(source);
+
+        assertThat(patched).isEqualTo(json("""
+                {
+                  "inventory": [
+                    {"sku": "A-1", "count": 4, "tags": []},
+                    {"sku": "B-2", "count": 8, "tags": ["clearance", "featured"]}
+                  ]
+                }
+                """));
+    }
+
+    @Test
+    void computesDiffsThatTransformSourceIntoTarget() throws Exception {
+        JsonNode source = json("""
+                {
+                  "id": 1,
+                  "name": "old",
+                  "items": ["a", "b", "c"],
+                  "obsolete": true,
+                  "nested": {
+                    "flag": false
+                  }
+                }
+                """);
+        JsonNode target = json("""
+                {
+                  "id": 1,
+                  "name": "new",
+                  "items": ["a", "c", "d"],
+                  "nested": {
+                    "flag": true
+                  },
+                  "added": {
+                    "x": 1
+                  }
+                }
+                """);
+
+        JsonNode diffJson = JsonDiff.asJson(source, target);
+        JsonPatch patchFromJson = JsonPatch.fromJson(diffJson);
+        JsonPatch patch = JsonDiff.asJsonPatch(source, target);
+
+        assertThat(diffJson).isNotEmpty();
+        assertThat(patchFromJson.apply(source)).isEqualTo(target);
+        assertThat(patch.apply(source)).isEqualTo(target);
+    }
+
+    @Test
+    void appliesJsonMergePatchToObjectsAndNonObjectTargets() throws Exception {
+        JsonNode source = json("""
+                {
+                  "title": "Goodbye!",
+                  "author": {
+                    "givenName": "John",
+                    "familyName": "Doe"
+                  },
+                  "tags": ["sample", "draft"],
+                  "content": "This will be removed"
+                }
+                """);
+        JsonMergePatch mergePatch = JsonMergePatch.fromJson(json("""
+                {
+                  "title": "Hello!",
+                  "author": {
+                    "familyName": null,
+                    "givenName": "John"
+                  },
+                  "tags": ["example"],
+                  "content": null,
+                  "metadata": {
+                    "reviewed": true
+                  }
+                }
+                """));
+
+        JsonNode patched = mergePatch.apply(source);
+        JsonNode replacement = JsonMergePatch.fromJson(json("\"replacement\"")).apply(source);
+
+        assertThat(patched).isEqualTo(json("""
+                {
+                  "title": "Hello!",
+                  "author": {
+                    "givenName": "John"
+                  },
+                  "tags": ["example"],
+                  "metadata": {
+                    "reviewed": true
+                  }
+                }
+                """));
+        assertThat(replacement).isEqualTo(NODE_FACTORY.textNode("replacement"));
+    }
+
+    @Test
+    void reportsInvalidPatchDocumentsAndFailedOperations() throws Exception {
+        JsonPatch failingTest = JsonPatch.fromJson(json("""
+                [
+                  {"op": "test", "path": "/enabled", "value": false}
+                ]
+                """));
+        JsonPatch removingMissingValue = JsonPatch.fromJson(json("""
+                [
+                  {"op": "remove", "path": "/missing"}
+                ]
+                """));
+
+        assertThatExceptionOfType(JsonPatchException.class)
+                .isThrownBy(() -> failingTest.apply(json("""
+                        {"enabled": true}
+                        """)));
+        assertThatExceptionOfType(JsonPatchException.class)
+                .isThrownBy(() -> removingMissingValue.apply(json("{}")));
+        assertThatThrownBy(() -> JsonPatch.fromJson(json("""
+                [
+                  {"op": "unknown", "path": "/enabled"}
+                ]
+                """)))
+                .isInstanceOf(IOException.class);
+    }
+
+    private static JsonNode json(String content) throws IOException {
+        return MAPPER.readTree(content);
     }
 }

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/user-code-filter.json
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.github.fge.jsonpatch.**"
+    }
+  ]
+}

--- a/tests/src/com.github.java-json-tools/json-patch/1.13/user-code-filter.json
+++ b/tests/src/com.github.java-json-tools/json-patch/1.13/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.github.fge.jsonpatch.**"
+      "includeClasses" : "com.github.fge.jsonpatch.**"
+    },
+    {
+      "includeClasses" : "com_github_java_json_tools.json_patch.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3301

This PR introduces tests and metadata for com.github.java-json-tools:json-patch:1.13, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 91843
- Cached input tokens: 612352
- Output tokens: 11737
- Metadata entries: 22
- Iterations: 3
- Library coverage percentage: 79.37
- Generated lines of code: 267
- Tested library lines of code: 304

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1299/1685 (77.09%)
- Line: 304/383 (79.37%)
- Method: 76/98 (77.55%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
