### PR TITLE
Stage native metadata before final merge

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -76,6 +76,12 @@ Local Forge automation must run without `sudo`. Local CI verification fails
 fast instead of prompting for an administrator password if a command or script
 would require elevated privileges.
 
+Forge scopes `GRADLE_USER_HOME` per reachability-repo worktree so parallel
+workers do not share Gradle daemons, but reuses one shared Gradle wrapper
+distribution cache under the system temp directory. Set
+`FORGE_GRADLE_DISTRIBUTIONS_HOME` to override that cache location, or
+`FORGE_GRADLE_USER_HOME` to override the full Gradle user home.
+
 ## Manual Workflows
 
 The top-level worker delegates to these lower-level entry points. Use them

--- a/forge/ai_workflows/fix_metadata_codex.py
+++ b/forge/ai_workflows/fix_metadata_codex.py
@@ -3,11 +3,14 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import json
+import os
 import subprocess
 import sys
 
 from utility_scripts.task_logs import build_task_log_path, display_log_path
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.gradle_environment import gradle_command_environment
 
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1200
@@ -17,6 +20,8 @@ def run_codex_metadata_fix(
         reachability_metadata_path: str,
         coordinates: str,
         reproduction_command: str | None = None,
+        graalvm_home: str | None = None,
+        base_env: dict[str, str] | None = None,
 ) -> tuple[int, str, bool]:
     """Run Codex to update metadata entries for the target library.
 
@@ -24,7 +29,28 @@ def run_codex_metadata_fix(
     https://github.com/oracle/graalvm-reachability-metadata/blob/master/skills/fix-missing-reachability-metadata/SKILL.md
     """
     reachability_metadata_path = require_complete_reachability_repo(reachability_metadata_path)
+    log_path = build_task_log_path("metadata-fix", coordinates, "codex.log")
+    log_path_display = display_log_path(log_path)
+    codex_env = _codex_environment(reachability_metadata_path, graalvm_home, base_env)
+    required_graalvm_home = codex_env.get("GRAALVM_HOME")
+    if not required_graalvm_home or not _has_native_image(required_graalvm_home):
+        print(
+            "ERROR: Codex metadata fix requires the exact GraalVM home from the failed run, "
+            "but no GraalVM distribution with bin/native-image could be resolved.",
+            file=sys.stderr,
+        )
+        return (1, log_path, False)
+    graalvm_version = _native_image_version(required_graalvm_home, codex_env)
+    developer_instructions = _codex_graalvm_instructions(required_graalvm_home, graalvm_version)
     prompt = f"Fix the metadata entries for {coordinates}"
+    prompt += (
+        "\n\nRequired GraalVM for every reproduction and verification command:\n"
+        f"- GRAALVM_HOME={required_graalvm_home}\n"
+        f"- JAVA_HOME={required_graalvm_home}\n"
+        f"- native-image --version:\n{graalvm_version}\n"
+        "\nUse this exact GraalVM distribution. Do not switch to another GraalVM, "
+        "even if another `native-image` appears earlier on PATH."
+    )
     if reproduction_command:
         prompt += f"\n\nReproduce the failure with:\n{reproduction_command}"
     cmd = [
@@ -32,17 +58,17 @@ def run_codex_metadata_fix(
         "--dangerously-bypass-approvals-and-sandbox",
         "--json",
         "-c", 'reasoning.effort="high"',
+        "-c", f"developer_instructions={json.dumps(developer_instructions)}",
         "-m", CODEX_MODEL_NAME,
         prompt,
     ]
-    log_path = build_task_log_path("metadata-fix", coordinates, "codex.log")
-    log_path_display = display_log_path(log_path)
     print(f"[Codex running... Output: {log_path_display}]")
     try:
         with open(log_path, "w", encoding="utf-8") as log_file:
             result = subprocess.run(
                 cmd,
                 cwd=reachability_metadata_path,
+                env=codex_env,
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 timeout=CODEX_TIMEOUT_SECONDS,
@@ -61,3 +87,50 @@ def run_codex_metadata_fix(
             file=sys.stderr,
         )
     return (result.returncode, log_path, False)
+
+
+def _codex_environment(
+        reachability_metadata_path: str,
+        graalvm_home: str | None,
+        base_env: dict[str, str] | None,
+) -> dict[str, str]:
+    env = dict(base_env or os.environ)
+    if graalvm_home:
+        env["GRAALVM_HOME"] = graalvm_home
+        env["JAVA_HOME"] = graalvm_home
+    return gradle_command_environment(reachability_metadata_path, env)
+
+
+def _has_native_image(graalvm_home: str) -> bool:
+    return os.path.isfile(os.path.join(graalvm_home, "bin", "native-image"))
+
+
+def _native_image_version(graalvm_home: str, env: dict[str, str]) -> str:
+    native_image = os.path.join(graalvm_home, "bin", "native-image")
+    try:
+        result = subprocess.run(
+            [native_image, "--version"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"<unable to run {native_image} --version: {exc}>"
+    return result.stdout.strip() or f"<native-image --version exited {result.returncode} without output>"
+
+
+def _codex_graalvm_instructions(graalvm_home: str, graalvm_version: str) -> str:
+    return (
+        "Hard requirement for this metadata-fix run: every Gradle, Java, and native-image command "
+        "must use the exact same GraalVM distribution as the failed run.\n"
+        f"Set and preserve GRAALVM_HOME={graalvm_home}\n"
+        f"Set and preserve JAVA_HOME={graalvm_home}\n"
+        "Do not use another GraalVM installation from PATH, SDKMAN, latest_graalvm_home, or any symlink "
+        "unless it resolves to this same distribution.\n"
+        "Before verifying, check `native-image --version` and ensure it matches this required version:\n"
+        f"{graalvm_version}\n"
+        "If this GraalVM distribution is unavailable, fail instead of reproducing or verifying with another version."
+    )

--- a/forge/ai_workflows/fix_ni_run.py
+++ b/forge/ai_workflows/fix_ni_run.py
@@ -138,7 +138,12 @@ def main(argv=None) -> int:
             )
             return result.returncode
         print(f"[pipeline] Detected missing metadata entries for {library}. Running Codex fix.")
-        codex_rc, _codex_log, _codex_timed_out = run_codex_metadata_fix(reachability_metadata_path, library)
+        gradle_env = gradle_command_environment(reachability_metadata_path)
+        codex_rc, _codex_log, _codex_timed_out = run_codex_metadata_fix(
+            reachability_metadata_path,
+            library,
+            graalvm_home=gradle_env.get("GRAALVM_HOME"),
+        )
         if codex_rc != 0:
             print(f"ERROR: Codex failed with return code: {codex_rc}", file=sys.stderr)
             return codex_rc

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -185,6 +185,7 @@ class WorkflowStrategy(ABC):
                 stage_name: str,
                 command_runner: Callable[[], str],
                 reproduction_command: str,
+                command_env: dict[str, str] | None,
         ) -> str:
             log_stage("post-generation-test", f"Running {stage_name} for {library}")
             test_output = command_runner()
@@ -193,10 +194,13 @@ class WorkflowStrategy(ABC):
                 return RUN_STATUS_SUCCESS
 
             log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
+            codex_env = gradle_command_environment(repo_path, command_env)
             codex_rc, codex_log_path, codex_timed_out = run_codex_metadata_fix(
                 repo_path,
                 library,
                 reproduction_command=reproduction_command,
+                graalvm_home=codex_env.get("GRAALVM_HOME"),
+                base_env=command_env,
             )
             recovery_test_output = test_output
             if not codex_timed_out and codex_rc == 0:
@@ -240,6 +244,7 @@ class WorkflowStrategy(ABC):
             "current-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd),
             test_cmd,
+            None,
         )
         if regular_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE
@@ -252,6 +257,7 @@ class WorkflowStrategy(ABC):
             "future-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd, future_defaults_env),
             f"GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all {test_cmd}",
+            future_defaults_env,
         )
         if future_defaults_status == RUN_STATUS_FAILURE:
             return RUN_STATUS_FAILURE

--- a/forge/docs/dynamic-access-workflow.md
+++ b/forge/docs/dynamic-access-workflow.md
@@ -212,11 +212,11 @@ batch suffix when the flush contains more than one class step. If the loop
 finishes, or a large-library chunk boundary is reached, with fewer than the
 configured number of queued class steps, the strategy flushes that partial
 batch before returning. The gate always starts with the normal JVM-agent
-metadata path:
+metadata path, but writes that output to a per-gate staging directory:
 
 ```text
-./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar
-./gradlew test -Pcoordinates=<g:a:v>
+./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar --metadataOutputDir=<output_dir>/agent
+./gradlew test -Pcoordinates=<g:a:v> -PmetadataConfigDirs=<output_dir>/agent
 ```
 
 If the coordinate passes, the gate returns `PASSED` without native tracing.
@@ -231,10 +231,11 @@ failed tracing to Codex. Pi is not part of this gate.
 Effects within this workflow:
 
 1. The gate keeps metadata cumulative. JVM-agent output is written to the
-   durable `metadata/<group>/<artifact>/<version>/` directory; if native
-   tracing was needed, the merged trace output is also folded into that
-   durable metadata file before the next batch starts or before the phase
-   returns.
+   gate-local `<output_dir>/agent` directory; if native tracing was needed,
+   merged trace output is written to `<output_dir>/trace`. Only after the
+   gate passes are existing durable metadata, staged agent metadata, and
+   staged trace metadata merged into the durable
+   `metadata/<group>/<artifact>/<version>/` directory.
 2. The dynamic-access coverage report is regenerated **after** the gate so
    that any call sites covered by JVM-agent, traced, or Codex-supplied metadata are
    reflected in the next class's prompt delta.

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -112,6 +112,12 @@ Each entry in `strategies/predefined_strategies.json` must provide:
 - Either `GRAALVM_HOME` or `JAVA_HOME` must point to a GraalVM distribution.
   Both variables are then aligned to that distribution. If neither does, the
   workflow exits with an error.
+- Agent repair steps must use the exact same GraalVM distribution as the
+  Gradle or Native Image failure that triggered them. This is a hard
+  requirement: Forge must pass the selected `GRAALVM_HOME`, `JAVA_HOME`, and
+  full `native-image --version` output into Codex instructions, run Codex with
+  `GRAALVM_HOME` and `JAVA_HOME` pinned to that same distribution, and fail
+  instead of reproducing or verifying with a different GraalVM installation.
 - `gh` CLI authenticated against the reachability repo is required for any
   script in `git_scripts/` or `complete_pipelines/`.
 - `FORGE_PARALLELISM` controls how many issue workflows the top-level worker

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -14,11 +14,15 @@ The verification gate ensures that the test binary passes on Native Image
 for a given coordinate. The ordered recovery contract is:
 
 1. Try the normal JVM `native-image-agent` path first via
-   `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
-   This is the primary metadata source and must not be skipped. If this path
-   fails, continue with native tracing instead of routing directly to Codex.
+   `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar
+   --metadataOutputDir=<output_dir>/agent`. This is the primary metadata
+   source and must not be skipped. It is staged separately from durable
+   repository metadata. If this path fails, continue with native tracing
+   instead of routing directly to Codex.
 2. If JVM-agent metadata was generated, run the regular coordinate validation
-   (`./gradlew test -Pcoordinates=<g:a:v>`). If the native tests pass, return
+   (`./gradlew test -Pcoordinates=<g:a:v>
+   -PmetadataConfigDirs=<output_dir>/agent`). If the native tests pass, merge
+   the staged agent metadata into durable repository metadata and return
    `PASSED`.
 3. If native testing still fails after JVM-agent metadata was generated, or if
    the JVM-agent metadata path failed, use native tracing as a fallback. Each
@@ -27,14 +31,16 @@ for a given coordinate. The ordered recovery contract is:
    `-H:+MetadataTracingSupport`, `--exact-reachability-metadata`, and
    `-H:MissingRegistrationReportingMode=Exit`.
 4. If native tracing converges, merge the accepted trace dirs into
-   `output_dir`, fold the merged metadata into the durable
-   `metadata/<group>/<artifact>/<version>/reachability-metadata.json`,
-   and return `PASSED`. If tracing stalls, exhausts its budget, or fails
-   for a non-metadata reason, route the accumulated diagnostics to codex.
-   Codex is the final recovery step — the only failures that bypass it
-   are failures of the post-success merge or durable-aggregation steps
-   themselves, which are infrastructure problems codex cannot repair and
-   therefore terminate as `FAILED` directly (see §4 gate semantics).
+   `<output_dir>/trace`, then run one final native-image-utils merge over
+   existing durable metadata, `<output_dir>/agent` when present, and
+   `<output_dir>/trace` when present. The final merge result is copied to
+   `metadata/<group>/<artifact>/<version>/reachability-metadata.json`, and
+   the gate returns `PASSED`. If tracing stalls, exhausts its budget, or
+   fails for a non-metadata reason, route the accumulated diagnostics to
+   codex. Codex is the final recovery step — the only failures that bypass
+   it are failures of the post-success trace merge or final durable merge,
+   which are infrastructure problems codex cannot repair and therefore
+   terminate as `FAILED` directly (see §4 gate semantics).
 
 Pi is **not** invoked. Removing failing tests would mask exactly the code
 issues that must surface to the coding agent.
@@ -54,7 +60,7 @@ branch to its checkpoint.
 | --- | --- | --- |
 | Coordinate `group:artifact:version` | Caller | Identifies the test module. |
 | Reachability repo path | Caller | Working directory for Gradle. |
-| Output directory | Caller | Absolute path for fallback native-trace metadata. The caller picks a path namespaced per (library, class) for the dynamic-access caller, or per coordinate for non-class-scoped callers — same convention as [native-metadata-exploration.md §4](native-metadata-exploration.md#4-output). On a trace-backed `PASSED`, the gate merges all accepted per-cycle trace dirs into this directory (one `mergeNativeTraceMetadata` invocation). If the JVM-agent metadata path alone passes, this directory may remain empty. |
+| Output directory | Caller | Absolute staging root for this gate invocation. The caller picks a path namespaced per (library, class) for the dynamic-access caller, or per coordinate for non-class-scoped callers — same convention as [native-metadata-exploration.md §4](native-metadata-exploration.md#4-output). The gate writes JVM-agent metadata to `<output_dir>/agent`, merged trace metadata to `<output_dir>/trace`, and writes durable repository metadata only after the final native-image-utils merge succeeds. |
 | Condition packages | `condition_packages` argument to `verify_native_test_passes` | Default `[group]`. Passed to the binary at run time as `-XX:TraceMetadataConditionPackages=...`. |
 | Outer budget | Strategy parameter `max-native-test-verification-iterations` | Default **100**. In practice convergence is expected within a handful of cycles; the high default is a soft cap, not a target. Each cycle rebuilds `nativeTestCompile`, so the wall-clock cost is dominated by native-image build time. |
 | Per-cycle timeout | `cycle_timeout_seconds` argument | Default 30 minutes. Caps the preflight `./gradlew test` invocation and each `runNativeTraceImage` invocation; on timeout the step is treated as a non-zero exit and routed to codex. |
@@ -64,15 +70,13 @@ branch to its checkpoint.
 `NativeTestVerificationResult` carries:
 
 - `status` — `PASSED`, `PASSED_WITH_INTERVENTION`, or `FAILED`.
-- `output_dir` — echoes the caller's input. Populated with merged trace
-  metadata only when a fallback trace cycle reaches binary exit `0` (one
-  `mergeNativeTraceMetadata` invocation at the end). It may remain empty
-  when JVM-agent metadata alone made the native tests pass, when Codex is
-  invoked before tracing, or when Codex is invoked after a stalled trace
-  fallback. Empty on `FAILED`, except when the failure is the trace-output
-  merge (`mergeNativeTraceMetadata`) or the durable-metadata aggregation
-  step itself — in that case `output_dir` may contain whatever the
-  partially completed merge wrote before the failure.
+- `output_dir` — echoes the caller's input. `<output_dir>/agent` contains
+  staged JVM-agent metadata when `generateMetadata` succeeds.
+  `<output_dir>/trace` contains merged trace metadata only when a fallback
+  trace cycle reaches binary exit `0`. The durable
+  `metadata/<group>/<artifact>/<version>/reachability-metadata.json` file is
+  updated only by the final native-image-utils merge. On `FAILED`, staging
+  dirs may contain partially completed agent or trace output.
 - `iterations_used` — number of outer cycles consumed.
 - `last_native_test_log_path` — absolute path to the last relevant
   Gradle log (`generateMetadata`, `test`, or `runNativeTraceImage`).
@@ -91,18 +95,20 @@ branch to its checkpoint.
 
 ```mermaid
 flowchart TD
-    Start([invoke gate]) --> Init[reset output_dir + runs_dir<br/>config_dirs = []<br/>i = 0]
-    Init --> Agent[gradlew generateMetadata<br/>--agentAllowedPackages=fromJar]
+    Start([invoke gate]) --> Init[reset output_dir + runs_dir<br/>agent_dir = output_dir/agent<br/>trace_dir = output_dir/trace<br/>config_dirs = []<br/>i = 0]
+    Init --> Agent[gradlew generateMetadata<br/>--agentAllowedPackages=fromJar<br/>--metadataOutputDir=agent_dir]
     Agent -- fail --> Outer{i &lt; max-native-test-verification-iterations?}
-    Agent -- pass --> Test[gradlew test<br/>-Pcoordinates=&lt;g:a:v&gt;]
-    Test -- pass --> PassAgent([return PASSED])
+    Agent -- pass --> Test[gradlew test<br/>-Pcoordinates=&lt;g:a:v&gt;<br/>-PmetadataConfigDirs=agent_dir]
+    Test -- pass --> FinalAgent[final merge<br/>durable + agent_dir]
+    FinalAgent --> PassAgent([return PASSED])
     Test -- fails before nativeTest --> Codex
     Test -- nativeTest fails --> Outer
     Outer -- no --> Codex
     Outer -- yes --> Run[gradlew runNativeTraceImage<br/>-PtraceMetadataPath=runs/cycle-i<br/>-PtraceMetadataConditionPackages=&lt;packages&gt;<br/>-PmetadataConfigDirs=&lt;config_dirs&gt;]
     Run --> Route{binary exit code}
-    Route -- 0 --> Merge[mergeNativeTraceMetadata<br/>config_dirs &rarr; output_dir]
-    Merge --> Pass([return PASSED])
+    Route -- 0 --> MergeTrace[mergeNativeTraceMetadata<br/>accepted trace dirs &rarr; trace_dir]
+    MergeTrace --> FinalTrace[final merge<br/>durable + agent_dir + trace_dir]
+    FinalTrace --> Pass([return PASSED])
     Route -- 172 --> Append[config_dirs += runs/cycle-i]
     Append --> Bump[i = i + 1]
     Bump --> Outer
@@ -116,15 +122,18 @@ flowchart TD
 Gate semantics:
 
 - **JVM agent first.** The first metadata action is always
-  `./gradlew generateMetadata -Pcoordinates=<g:a:v> --agentAllowedPackages=fromJar`.
-  The JVM agent observes the test suite on HotSpot and writes the normal
-  repository metadata. Native tracing must not run before this step. If
-  metadata generation fails, the gate logs the failure and starts native
-  tracing with no accepted trace dirs.
+  `./gradlew generateMetadata -Pcoordinates=<g:a:v>
+  --agentAllowedPackages=fromJar --metadataOutputDir=<output_dir>/agent`.
+  The JVM agent observes the test suite on HotSpot and writes staged agent
+  metadata. Native tracing must not run before this step. If metadata
+  generation fails, the gate logs the failure and starts native tracing with
+  no accepted trace dirs.
 - **Native test run second.** After JVM-agent metadata is generated, the
-  gate runs `./gradlew test -Pcoordinates=<g:a:v>`. A pass returns
-  `PASSED` without invoking native tracing. A failure before `nativeTest`
-  is treated as a code/test problem and is routed to codex.
+  gate runs `./gradlew test -Pcoordinates=<g:a:v>
+  -PmetadataConfigDirs=<output_dir>/agent`. A pass finalizes staged agent
+  metadata into durable repository metadata and returns `PASSED` without
+  invoking native tracing. A failure before `nativeTest` is treated as a
+  code/test problem and is routed to codex.
 - **Native tracing is fallback.** The trace loop starts after JVM-agent
   metadata generation fails, or after JVM-agent metadata exists and native
   testing still fails.
@@ -132,9 +141,10 @@ Gate semantics:
   `./gradlew runNativeTraceImage -Pcoordinates=<g:a:v>
   -PtraceMetadataPath=<runs_dir>/cycle-<i>
   -PtraceMetadataConditionPackages=<packages>
-  -PmetadataConfigDirs=<config_dirs>` (the last property is omitted on
-  the first cycle when no trace dirs have been accepted yet). The
-  resulting binary is built with `-H:+MetadataTracingSupport`,
+  -PmetadataConfigDirs=<config_dirs>` where `config_dirs` is the staged
+  agent dir, when present, followed by accepted trace dirs. The last
+  property is omitted only when no staged agent metadata and no accepted
+  trace dirs exist. The resulting binary is built with `-H:+MetadataTracingSupport`,
   `--exact-reachability-metadata`, and
   `-H:MissingRegistrationReportingMode=Exit` (see
   [native-metadata-exploration.md §7.2](native-metadata-exploration.md#72-runnativetraceimage)).
@@ -142,9 +152,10 @@ Gate semantics:
   exact-metadata-aware exit code.
 - **Exit-code routing**:
   - `0` → the metadata accumulated in `config_dirs` plus the code under
-    test are sufficient. The gate runs a single
-    `mergeNativeTraceMetadata` to populate `output_dir` with the merged
-    metadata and returns.
+    test are sufficient. The gate runs `mergeNativeTraceMetadata` to
+    populate `<output_dir>/trace` with merged accepted trace metadata, then
+    runs the final native-image-utils merge over durable metadata, staged
+    agent metadata, and staged trace metadata before returning `PASSED`.
   - `172` → `ExitStatus.MISSING_METADATA`. The trace dir captured at
     least one missing access; appending it to `config_dirs` makes the
     next cycle's build see that metadata. If the current `172` cycle
@@ -175,21 +186,22 @@ Gate semantics:
   for diagnostics.)
 - **Hard fail.** If codex does not converge, the gate returns `FAILED` and
   the calling workflow aborts; see §6.
-- **Merge and aggregation failures are terminal without codex.** Two
-  post-success steps run after a trace cycle returns binary exit `0`:
-  (a) `./gradlew mergeNativeTraceMetadata` consolidates the accepted
-  per-cycle dirs into `output_dir`; (b) the durable-metadata aggregation
-  folds `output_dir/reachability-metadata.json` into
+- **Final merge failures are terminal without codex.** After the gate has
+  enough staged metadata to pass, it performs one durable native-image-utils
+  merge. The inputs are existing durable metadata when present,
+  `<output_dir>/agent` when present, and `<output_dir>/trace` when present.
+  The merge result is copied to
   `metadata/<group>/<artifact>/<version>/reachability-metadata.json`. If
-  either step fails, the gate returns `FAILED` directly. Codex is **not**
-  invoked for these failures: they are infrastructure problems (Gradle
-  merge task, filesystem write, malformed durable JSON) downstream of a
-  successful trace, and codex cannot repair the metadata pipeline itself.
-  The calling workflow handles them like any other `FAILED` (§6). This is
-  the only carve-out from the "only codex failure may FAIL" invariant —
-  every other failure mode (JVM-agent failure, `gradlew test` failure
-  before `nativeTest`, `172` with no usable / no new metadata, non-`0`/
-  `172` trace cycle exit, budget exhaustion) routes through codex first.
+  the trace-output merge or final durable merge fails, the gate returns
+  `FAILED` directly. Codex is **not** invoked for these failures: they are
+  infrastructure problems (Gradle merge task, filesystem write, malformed
+  metadata input) downstream of a successful validation path, and codex
+  cannot repair the metadata pipeline itself. The calling workflow handles
+  them like any other `FAILED` (§6). This is the only carve-out from the
+  "only codex failure may FAIL" invariant — every other failure mode
+  (JVM-agent failure, `gradlew test` failure before `nativeTest`, `172`
+  with no usable / no new metadata, non-`0`/`172` trace cycle exit, budget
+  exhaustion) routes through codex first.
 
 ## 5. Reusable Implementation Surface
 
@@ -213,16 +225,22 @@ def verify_native_test_passes(
 The module composes existing helpers and owns no domain logic of its own:
 
 - `./gradlew generateMetadata -Pcoordinates=...
-  --agentAllowedPackages=fromJar` — primary JVM-agent metadata collection,
-  attempted before the trace loop.
-- `./gradlew test -Pcoordinates=...` — normal coordinate validation after
-  JVM-agent metadata is available.
+  --agentAllowedPackages=fromJar --metadataOutputDir=<output_dir>/agent` —
+  primary JVM-agent metadata collection, attempted before the trace loop and
+  staged outside durable repository metadata.
+- `./gradlew test -Pcoordinates=...
+  -PmetadataConfigDirs=<output_dir>/agent` — normal coordinate validation
+  after JVM-agent metadata is available.
 - `./gradlew runNativeTraceImage -Pcoordinates=...
   -PtraceMetadataPath=<runs_dir>/cycle-<i>
   -PtraceMetadataConditionPackages=<packages>
-  -PmetadataConfigDirs=<accepted dirs>` — fallback trace-cycle execution.
+  -PmetadataConfigDirs=<agent dir,accepted trace dirs>` — fallback trace-cycle execution.
 - `./gradlew mergeNativeTraceMetadata -PinputDirs=...
-  -PoutputDir=<output_dir>` — single final merge on trace-backed `PASSED`.
+  -PoutputDir=<output_dir>/trace` — trace-dir merge on trace-backed
+  `PASSED`.
+- `./gradlew mergeNativeTraceMetadata -PinputDirs=...
+  -PoutputDir=<temporary merge dir>` — final durable merge of existing
+  durable metadata plus staged agent and trace metadata.
 - `run_codex_metadata_fix` — codex acts as the coding agent after JVM-agent
   metadata plus native tracing fail to produce passing native tests. Pi is
   **not** invoked.
@@ -256,26 +274,28 @@ A `verify_native_test_passes(...)` invocation is correct iff:
    across runs.
 2. Before any native-trace cycle starts, the gate invokes
    `./gradlew generateMetadata -Pcoordinates=...
-   --agentAllowedPackages=fromJar`.
+   --agentAllowedPackages=fromJar --metadataOutputDir=<output_dir>/agent`.
 3. If JVM-agent metadata generation fails, the gate starts native tracing
    with no accepted trace dirs.
 4. After successful JVM-agent metadata generation, the gate invokes
-   `./gradlew test -Pcoordinates=...`. If the coordinate passes, return
+   `./gradlew test -Pcoordinates=...
+   -PmetadataConfigDirs=<output_dir>/agent`. If the coordinate passes,
+   finalize staged agent metadata into durable repository metadata and return
    `PASSED` without native tracing.
 5. Each fallback outer cycle invokes `./gradlew runNativeTraceImage
    -Pcoordinates=... -PtraceMetadataPath=<runs_dir>/cycle-<i>
    -PtraceMetadataConditionPackages=<packages>` exactly once, with
-   `-PmetadataConfigDirs=<accepted dirs>` appended whenever any prior
-   cycle was accepted.
+   `-PmetadataConfigDirs=<agent dir,accepted trace dirs>` appended whenever
+   staged agent metadata or any prior accepted trace cycle exists.
 6. The verification binary's exit code is recovered from Gradle's
    "exit value N" log line and routed:
    - `0` → run `mergeNativeTraceMetadata` once with all accepted run
-     dirs as `-PinputDirs=` and the caller's `output_dir` as
-     `-PoutputDir=`, then fold the resulting reachability metadata into
+     dirs as `-PinputDirs=` and `<output_dir>/trace` as `-PoutputDir=`,
+     then run one final native-image-utils merge of durable metadata,
+     `<output_dir>/agent`, and `<output_dir>/trace`, copy that result to
      `metadata/<group>/<artifact>/<version>/reachability-metadata.json`,
-     then return `PASSED`. If either the `mergeNativeTraceMetadata` task
-     or the durable-aggregation step fails, return `FAILED` directly —
-     codex is **not** invoked for these post-success infrastructure
+     and return `PASSED`. If either merge fails, return `FAILED` directly
+     — codex is **not** invoked for these post-success infrastructure
      failures.
    - `172` with new trace metadata entries → append
      `runs_dir/cycle-<i>` to the running config dirs and continue to the

--- a/forge/docs/native-test-verification.md
+++ b/forge/docs/native-test-verification.md
@@ -177,8 +177,12 @@ Gate semantics:
 - **Codex after trace failure.** `metadata-gap-exhausted`, stalled
   metadata progress, trace timeouts, and non-172 trace failures all route
   to codex with a reproduction command that includes the accepted trace
-  dirs as `metadataConfigDirs`. `FAILED` is returned only when codex does
-  not converge.
+  dirs as `metadataConfigDirs`. The codex process and codex instructions
+  must pin `GRAALVM_HOME`, `JAVA_HOME`, and the full `native-image --version`
+  output to the exact GraalVM distribution used by the failed gate command.
+  Codex must fail instead of reproducing or verifying with a different
+  GraalVM installation. `FAILED` is returned only when codex does not
+  converge.
 - **Codex keeps prior config_dirs.** Codex's fixes are additive; the gate
   does not discard `config_dirs` before codex runs. (Codex returns
   terminally so the question of carrying state across codex is moot for

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -56,11 +56,15 @@ from ai_workflows.improve_library_coverage import (
 )
 from ai_workflows.workflow_strategies.workflow_strategy import RUN_STATUS_CHUNK_READY, RUN_STATUS_FAILURE
 from git_scripts.common_git import (
+    GITHUB_TRANSIENT_RETRY_ATTEMPTS,
     GitHubRateLimitExceeded,
+    _github_retry_delay_seconds,
+    _log_github_transient_retry,
     ensure_gh_authenticated,
     get_issue_project_item_status,
     get_origin_owner,
     is_github_rate_limit_text,
+    is_github_transient_failure_text,
     log_github_query,
     run_github_command_with_retries,
     run_github_json_with_retries,
@@ -398,28 +402,41 @@ def gh(
         input_text: str | None = None,
         cwd: str | None = None,
         quiet: bool = False,
+        max_attempts: int = GITHUB_TRANSIENT_RETRY_ATTEMPTS,
 ) -> subprocess.CompletedProcess:
     """Run a gh CLI command and return the completed process."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
     cmd = ["gh", *args]
     env = {**os.environ, "GH_PROMPT_DISABLED": "1", "GH_PAGER": ""}
     if not quiet:
         log_github_query(args)
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        env=env,
-        input=input_text,
-        cwd=cwd,
-    )
-    if check and result.returncode != 0:
+    for attempt in range(1, max_attempts + 1):
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            input=input_text,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            return result
+
         error_text = "\n".join(part for part in (result.stderr, result.stdout) if part)
-        if is_github_rate_limit_text(error_text):
+        if check and is_github_rate_limit_text(error_text):
             raise GitHubRateLimitExceeded("GitHub API rate limit exceeded")
-        if not quiet:
-            print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
-        result.check_returncode()
-    return result
+        if attempt < max_attempts and is_github_transient_failure_text(error_text):
+            _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+            time.sleep(_github_retry_delay_seconds(attempt))
+            continue
+        if check:
+            if not quiet:
+                print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
+            result.check_returncode()
+        return result
+
+    raise RuntimeError("GitHub command exhausted retries")
 
 
 def gh_json(*args: str, quiet: bool = False) -> any:

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import inspect
 import json
 import os
 import shutil
@@ -92,14 +93,7 @@ def ensure_gh_authenticated() -> None:
         )
         sys.exit(1)
     try:
-        log_github_query(("auth", "status", "--hostname", "github.com"))
-        subprocess.run(
-            ["gh", "auth", "status", "--hostname", "github.com"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
+        gh("auth", "status", "--hostname", "github.com")
     except subprocess.CalledProcessError:
         print("GitHub CLI is not authenticated for github.com. Run 'gh auth login' and try again.")
         sys.exit(1)
@@ -109,7 +103,7 @@ class GitHubRateLimitExceeded(RuntimeError):
     """Raised when GitHub reports an exhausted API rate-limit bucket."""
 
 
-GITHUB_TRANSIENT_RETRY_ATTEMPTS = 3
+GITHUB_TRANSIENT_RETRY_ATTEMPTS = 5
 GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS = 2.0
 GITHUB_LOG_REDACTED_FLAGS = {
     "--body",
@@ -198,7 +192,7 @@ def _format_github_retry_reason(reason: str) -> str:
 
 
 def _github_retry_delay_seconds(attempt: int) -> float:
-    return GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS * attempt
+    return GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
 
 
 def _log_github_transient_retry(reason: str, attempt: int, max_attempts: int, quiet: bool) -> None:
@@ -259,34 +253,68 @@ def log_github_query(args: Iterable[str]) -> None:
     print(f"[github-query] gh {' '.join(formatted_args)}")
 
 
+def _gh_runner_accepts_max_attempts(gh_runner: Callable[..., subprocess.CompletedProcess]) -> bool:
+    try:
+        signature = inspect.signature(gh_runner)
+    except (TypeError, ValueError):
+        return False
+    return (
+        "max_attempts" in signature.parameters
+        or any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
+    )
+
+
+def _run_gh_runner_once(
+        gh_runner: Callable[..., subprocess.CompletedProcess],
+        args: tuple[str, ...],
+        quiet: bool,
+) -> subprocess.CompletedProcess:
+    if _gh_runner_accepts_max_attempts(gh_runner):
+        return gh_runner(*args, quiet=quiet, max_attempts=1)
+    return gh_runner(*args, quiet=quiet)
+
+
 def gh(
         *args: str,
         check: bool = True,
         input_text: str | None = None,
         cwd=None,
         quiet: bool = False,
+        max_attempts: int = GITHUB_TRANSIENT_RETRY_ATTEMPTS,
 ) -> subprocess.CompletedProcess:
     """Run a gh CLI command and return the completed process."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
     cmd = ["gh", *args]
     env = {**os.environ, "GH_PROMPT_DISABLED": "1", "GH_PAGER": ""}
     if not quiet:
         log_github_query(args)
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        env=env,
-        input=input_text,
-        cwd=cwd,
-    )
-    if check and result.returncode != 0:
+    for attempt in range(1, max_attempts + 1):
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            input=input_text,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            return result
+
         error_text = "\n".join(part for part in (result.stderr, result.stdout) if part)
-        if is_github_rate_limit_text(error_text):
+        if check and is_github_rate_limit_text(error_text):
             raise GitHubRateLimitExceeded("GitHub API rate limit exceeded")
-        if not quiet:
-            print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
-        result.check_returncode()
-    return result
+        if attempt < max_attempts and is_github_transient_failure_text(error_text):
+            _log_github_transient_retry(error_text, attempt, max_attempts, quiet)
+            time.sleep(_github_retry_delay_seconds(attempt))
+            continue
+        if check:
+            if not quiet:
+                print(f"ERROR: {' '.join(cmd)}\n{result.stderr}", file=sys.stderr)
+            result.check_returncode()
+        return result
+
+    raise RuntimeError("GitHub command exhausted retries")
 
 
 def run_github_json_with_retries(
@@ -300,7 +328,7 @@ def run_github_json_with_retries(
     for attempt in range(1, max_attempts + 1):
         command_quiet = quiet or attempt < max_attempts
         try:
-            result = gh_runner(*args, quiet=command_quiet)
+            result = _run_gh_runner_once(gh_runner, args, command_quiet)
         except subprocess.CalledProcessError as exc:
             error_text = _github_error_text_from_exception(exc)
             if attempt < max_attempts and is_github_transient_failure_text(error_text):
@@ -336,7 +364,7 @@ def run_github_command_with_retries(
     for attempt in range(1, max_attempts + 1):
         command_quiet = quiet or attempt < max_attempts
         try:
-            return gh_runner(*args, quiet=command_quiet)
+            return _run_gh_runner_once(gh_runner, args, command_quiet)
         except subprocess.CalledProcessError as exc:
             error_text = _github_error_text_from_exception(exc)
             if attempt < max_attempts and is_github_transient_failure_text(error_text):
@@ -372,7 +400,12 @@ def gh_json(*args: str) -> Any:
 def gh_with_retries(*args: str, quiet: bool = False, cwd: str | None = None) -> subprocess.CompletedProcess:
     """Run a read-only gh CLI command with retries for transient failures."""
     return run_github_with_retries(
-        lambda *gh_args, quiet=False: gh(*gh_args, cwd=cwd, quiet=quiet),
+        lambda *gh_args, quiet=False, max_attempts=1: gh(
+            *gh_args,
+            cwd=cwd,
+            quiet=quiet,
+            max_attempts=max_attempts,
+        ),
         args,
         quiet=quiet,
     )
@@ -656,7 +689,6 @@ def find_issue_for_coordinates(search_string: str, repo: str):
 
     # Build the gh issue list command
     command = [
-        "gh",
         "issue",
         "list",
         "--repo", repo,
@@ -666,17 +698,9 @@ def find_issue_for_coordinates(search_string: str, repo: str):
         "--json", "number"
     ]
 
-    print(f"Executing command: {' '.join(command)}")
+    print(f"Executing command: gh {' '.join(command)}")
 
-    # Run the command and let exceptions propagate to fail fast
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        check=True
-    )
-
-    issue_data = json.loads(result.stdout)
+    issue_data = gh_json(*command)
 
     if isinstance(issue_data, list) and len(issue_data) > 0 and 'number' in issue_data[0]:
         return issue_data[0]['number']

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -75,10 +75,18 @@ def stage_and_commit(
         metadata_version: str,
         coordinates: str,
         repo_path: str,
-):
+) -> None:
     """Stage the expected files/directories and commit with the required message."""
     test_version_dir = os.path.join("tests", "src", group, artifact, test_version)
     test_sources_dir = os.path.join(test_version_dir, "src", "test", "java")
+    test_native_image_metadata_dir = os.path.join(
+        test_version_dir,
+        "src",
+        "test",
+        "resources",
+        "META-INF",
+        "native-image",
+    )
     candidate_paths = [
         str(os.path.join(test_version_dir, "build.gradle")),
         str(os.path.join("metadata", group, artifact, "index.json")),
@@ -88,6 +96,8 @@ def stage_and_commit(
 
     if os.path.exists(os.path.join(repo_path, test_sources_dir)):
         candidate_paths.append(str(test_sources_dir))
+    if os.path.exists(os.path.join(repo_path, test_native_image_metadata_dir)):
+        candidate_paths.append(str(test_native_image_metadata_dir))
 
     user_code_filter = os.path.join(test_version_dir, "user-code-filter.json")
     if os.path.exists(os.path.join(repo_path, user_code_filter)):
@@ -95,6 +105,27 @@ def stage_and_commit(
 
     commit_message = f"Generated metadata for {coordinates}"
     stage_and_commit_common(candidate_paths, commit_message, cwd=repo_path)
+
+
+def assert_no_tracked_worktree_changes(repo_path: str) -> None:
+    """Fail with actionable paths when expected staging left tracked changes behind."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    status_output = result.stdout.strip()
+    if not status_output:
+        return
+
+    raise RuntimeError(
+        "Native-image-run PR finalization left tracked worktree changes before rebase. "
+        "Stage these paths in make_pr_ni_run_fix.py or discard them before finalization:\n"
+        f"{status_output}"
+    )
 
 
 def create_pull_request(
@@ -273,6 +304,7 @@ def push_current_branch_to_origin(
         coordinates=new_coordinates,
         repo_path=repo_path,
     )
+    assert_no_tracked_worktree_changes(repo_path)
     base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
     subprocess.run(["git", "rebase", base_ref], cwd=repo_path, check=True)
     local_ci_verification = run_local_ci_verification(

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -287,6 +287,52 @@ class GitHubRateLimitTests(unittest.TestCase):
             with self.assertRaises(common_git.GitHubRateLimitExceeded):
                 common_git.gh("api", "graphql")
 
+    def test_common_gh_retries_transient_failure(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr="gh: HTTP 502",
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", side_effect=[failed_process, successful_process]) as run, \
+                patch.object(common_git.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            common_git.gh("issue", "comment", "1412", "--body", "body")
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+        self.assertIn("GitHub API transient failure", stderr.getvalue())
+
+    def test_common_gh_retries_transient_failure_with_check_false(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr='Get "https://api.github.com/repos/example/repo": context deadline exceeded',
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="{}",
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", side_effect=[failed_process, successful_process]) as run, \
+                patch.object(common_git.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO):
+            result = common_git.gh("pr", "view", "--repo", "example/repo", check=False)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+
     def test_common_gh_json_raises_typed_rate_limit_error_from_graphql_payload(self) -> None:
         completed_process = subprocess.CompletedProcess(
             ["gh"],

--- a/forge/tests/test_fix_metadata_codex.py
+++ b/forge/tests/test_fix_metadata_codex.py
@@ -1,0 +1,121 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_FORGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_FORGE_ROOT))
+
+from ai_workflows.fix_metadata_codex import run_codex_metadata_fix  # noqa: E402
+
+
+class FixMetadataCodexTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = tempfile.mkdtemp(prefix="repo-")
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        _make_complete_reachability_repo(self.repo)
+        self.graalvm_home = tempfile.mkdtemp(prefix="graalvm-")
+        self.addCleanup(shutil.rmtree, self.graalvm_home, ignore_errors=True)
+        os.makedirs(os.path.join(self.graalvm_home, "bin"))
+        Path(self.graalvm_home, "bin", "native-image").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+
+    def test_pins_codex_environment_and_instructions_to_resolved_graalvm(self) -> None:
+        calls: list[tuple[list[str], dict]] = []
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append((list(cmd), kwargs))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=self.repo + "\n")
+            if cmd[0].endswith("native-image"):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        "native-image 25.0.2 2026-01-20\n"
+                        "GraalVM Runtime Environment Oracle GraalVM 25.1.0-dev+10.1 "
+                        "(build 25.0.2+10-LTS-jvmci-25.1-b17)\n"
+                    ),
+                )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch.dict(os.environ, {"GRAALVM_HOME": self.graalvm_home, "JAVA_HOME": "/other-jdk"}, clear=True), \
+                patch("ai_workflows.fix_metadata_codex.subprocess.run", side_effect=fake_run):
+            rc, _log_path, timed_out = run_codex_metadata_fix(self.repo, "g:a:1.0")
+
+        self.assertEqual(rc, 0)
+        self.assertFalse(timed_out)
+        codex_cmd, codex_kwargs = calls[-1]
+        self.assertEqual(codex_cmd[:2], ["codex", "exec"])
+        self.assertEqual(codex_kwargs["env"]["GRAALVM_HOME"], self.graalvm_home)
+        self.assertEqual(codex_kwargs["env"]["JAVA_HOME"], self.graalvm_home)
+        developer_instructions = _developer_instructions_from(codex_cmd)
+        self.assertIn(self.graalvm_home, developer_instructions)
+        self.assertIn("jvmci-25.1-b17", developer_instructions)
+        self.assertIn("GRAALVM_HOME=" + self.graalvm_home, codex_cmd[-1])
+        self.assertIn("jvmci-25.1-b17", codex_cmd[-1])
+
+    def test_explicit_graalvm_home_overrides_base_environment_for_codex(self) -> None:
+        inherited_graalvm = tempfile.mkdtemp(prefix="inherited-graalvm-")
+        self.addCleanup(shutil.rmtree, inherited_graalvm, ignore_errors=True)
+        os.makedirs(os.path.join(inherited_graalvm, "bin"))
+        Path(inherited_graalvm, "bin", "native-image").write_text("", encoding="utf-8")
+        calls: list[tuple[list[str], dict]] = []
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append((list(cmd), kwargs))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=self.repo + "\n")
+            if cmd[0].endswith("native-image"):
+                return subprocess.CompletedProcess(cmd, 0, stdout="native-image pinned\n")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("ai_workflows.fix_metadata_codex.subprocess.run", side_effect=fake_run):
+            rc, _log_path, timed_out = run_codex_metadata_fix(
+                self.repo,
+                "g:a:1.0",
+                graalvm_home=self.graalvm_home,
+                base_env={"GRAALVM_HOME": inherited_graalvm, "JAVA_HOME": inherited_graalvm},
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertFalse(timed_out)
+        codex_env = calls[-1][1]["env"]
+        self.assertEqual(codex_env["GRAALVM_HOME"], self.graalvm_home)
+        self.assertEqual(codex_env["JAVA_HOME"], self.graalvm_home)
+
+
+def _developer_instructions_from(cmd: list[str]) -> str:
+    for index, part in enumerate(cmd):
+        if part == "-c" and cmd[index + 1].startswith("developer_instructions="):
+            return json.loads(cmd[index + 1].split("=", 1)[1])
+    raise AssertionError(f"developer_instructions not found in command: {cmd}")
+
+
+def _make_complete_reachability_repo(path: str) -> None:
+    subprocess.run(["git", "init", "-b", "master"], cwd=path, check=True, stdout=subprocess.PIPE)
+    for directory in ("forge", "metadata", "tests", os.path.join("gradle", "wrapper")):
+        os.makedirs(os.path.join(path, directory), exist_ok=True)
+    Path(path, "gradlew").write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+    Path(path, "settings.gradle").write_text("rootProject.name = 'test'\n", encoding="utf-8")
+    Path(path, "build.gradle").write_text("plugins { id 'java' }\n", encoding="utf-8")
+    Path(path, "gradle", "wrapper", "gradle-wrapper.jar").write_text("wrapper jar\n", encoding="utf-8")
+    Path(path, "gradle", "wrapper", "gradle-wrapper.properties").write_text(
+        "distributionUrl=https\\://services.gradle.org/distributions/gradle-bin.zip\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -193,6 +193,60 @@ class IssueClaimPreflightTests(unittest.TestCase):
             with self.assertRaises(forge_metadata.GitHubRateLimitExceeded):
                 forge_metadata.gh("issue", "view", "2099")
 
+    def test_gh_retries_direct_transient_failure(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr="gh: HTTP 503",
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch.object(
+                forge_metadata.subprocess,
+                "run",
+                side_effect=[failed_process, successful_process],
+        ) as run, \
+                patch.object(forge_metadata.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            forge_metadata.gh("issue", "edit", "2099", "--add-label", "human-intervention")
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+        self.assertIn("GitHub API transient failure", stderr.getvalue())
+
+    def test_gh_retries_direct_transient_failure_with_check_false(self) -> None:
+        failed_process = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            stdout="",
+            stderr="gh: HTTP 504",
+        )
+        successful_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout="{}",
+            stderr="",
+        )
+
+        with patch.object(
+                forge_metadata.subprocess,
+                "run",
+                side_effect=[failed_process, successful_process],
+        ) as run, \
+                patch.object(forge_metadata.time, "sleep") as sleep, \
+                patch("sys.stderr", new_callable=io.StringIO):
+            result = forge_metadata.gh("api", "/repos/example/repo/labels/demo", check=False)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(common_git.GITHUB_TRANSIENT_RETRY_BASE_DELAY_SECONDS)
+
     def test_gh_json_raises_typed_rate_limit_error_from_graphql_payload(self) -> None:
         completed_process = subprocess.CompletedProcess(
             ["gh"],

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import patch
 
 from utility_scripts.gradle_environment import (
+    FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV,
     FORGE_GRADLE_USER_HOME_ENV,
     gradle_command_environment,
     gradle_user_home_for_repo,
@@ -37,12 +38,38 @@ class GradleEnvironmentTests(unittest.TestCase):
             self.assertEqual(env["GRADLE_USER_HOME"], expected_gradle_user_home)
             self.assertTrue(os.path.isdir(env["GRADLE_USER_HOME"]))
 
+    def test_default_gradle_homes_share_wrapper_distributions(self) -> None:
+        with tempfile.TemporaryDirectory() as first_repo, tempfile.TemporaryDirectory() as second_repo:
+            with patch.dict(os.environ, {}, clear=True):
+                first_env = gradle_command_environment(first_repo)
+                second_env = gradle_command_environment(second_repo)
+
+            first_dists = os.path.join(first_env["GRADLE_USER_HOME"], "wrapper", "dists")
+            second_dists = os.path.join(second_env["GRADLE_USER_HOME"], "wrapper", "dists")
+            expected_dists = os.path.join(tempfile.gettempdir(), "metadata-forge-gradle", "wrapper-dists")
+
+            self.assertNotEqual(first_env["GRADLE_USER_HOME"], second_env["GRADLE_USER_HOME"])
+            self.assertEqual(os.path.realpath(first_dists), expected_dists)
+            self.assertEqual(os.path.realpath(second_dists), expected_dists)
+
+    def test_explicit_gradle_distributions_override_is_honored(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_dists:
+            with patch.dict(os.environ, {}, clear=True):
+                env = gradle_command_environment(
+                    repo_path,
+                    {FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV: gradle_dists},
+                )
+
+            dists_path = os.path.join(env["GRADLE_USER_HOME"], "wrapper", "dists")
+            self.assertEqual(os.path.realpath(dists_path), gradle_dists)
+
     def test_explicit_gradle_home_override_is_honored(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_home:
             with patch.dict(os.environ, {FORGE_GRADLE_USER_HOME_ENV: gradle_home}, clear=True):
                 env = gradle_command_environment(repo_path)
 
             self.assertEqual(env["GRADLE_USER_HOME"], gradle_home)
+            self.assertFalse(os.path.exists(os.path.join(gradle_home, "wrapper", "dists")))
 
     def test_base_env_gradle_home_override_is_honored(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_home:

--- a/forge/tests/test_make_pr_ni_run_fix.py
+++ b/forge/tests/test_make_pr_ni_run_fix.py
@@ -3,7 +3,9 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import os
 import subprocess
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -57,6 +59,75 @@ class SevereMetadataDropGuardrailTests(unittest.TestCase):
         self.assertIn("Retained metadata entries: 0.00%", body)
         self.assertIn("fixes-native-image-run-fail", labels)
         self.assertIn("human-intervention", labels)
+
+
+class NativeImageRunFinalizationTests(unittest.TestCase):
+    def test_stage_and_commit_includes_test_native_image_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            native_image_metadata_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(native_image_metadata_dir)
+
+            with patch.object(make_pr_ni_run_fix, "stage_and_commit_common") as stage_and_commit, \
+                    patch.object(
+                        make_pr_ni_run_fix,
+                        "stats_artifact_dir",
+                        return_value=os.path.join(repo_path, "stats", "org.example", "demo"),
+                    ):
+                make_pr_ni_run_fix.stage_and_commit(
+                    group="org.example",
+                    artifact="demo",
+                    test_version="1.0.0",
+                    metadata_version="2.0.0",
+                    coordinates="org.example:demo:2.0.0",
+                    repo_path=repo_path,
+                )
+
+        staged_paths = stage_and_commit.call_args.args[0]
+        self.assertIn(
+            os.path.join(
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            ),
+            staged_paths,
+        )
+
+    def test_tracked_worktree_guard_reports_remaining_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            subprocess.run(["git", "init"], cwd=repo_path, check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(["git", "config", "user.email", "forge@example.com"], cwd=repo_path, check=True)
+            subprocess.run(["git", "config", "user.name", "Forge Test"], cwd=repo_path, check=True)
+
+            tracked_file = os.path.join(repo_path, "tracked.txt")
+            with open(tracked_file, "w", encoding="utf-8") as file:
+                file.write("before\n")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=repo_path, check=True)
+            subprocess.run(["git", "commit", "-m", "baseline"], cwd=repo_path, check=True, stdout=subprocess.DEVNULL)
+
+            with open(tracked_file, "w", encoding="utf-8") as file:
+                file.write("after\n")
+
+            with self.assertRaisesRegex(RuntimeError, "tracked.txt"):
+                make_pr_ni_run_fix.assert_no_tracked_worktree_changes(repo_path)
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -167,6 +167,104 @@ class CollectEntriesTests(unittest.TestCase):
         self.assertNotEqual(nme._collect_entries(a), nme._collect_entries(b))
 
 
+class MetadataAggregationTests(unittest.TestCase):
+    """Durable trace aggregation is delegated to native-image-utils."""
+
+    def setUp(self) -> None:
+        self.repo = tempfile.mkdtemp(prefix="repo-")
+        self.addCleanup(_rmtree, self.repo)
+        _make_complete_reachability_repo(self.repo)
+        self.metadata_dir = Path(self.repo) / "metadata" / "g" / "a" / "1.0"
+        self.metadata_dir.mkdir(parents=True)
+        self.output_dir = tempfile.mkdtemp(prefix="native-trace-output-")
+        self.addCleanup(_rmtree, self.output_dir)
+
+    def test_uses_native_image_utils_to_preserve_order_sensitive_metadata(self) -> None:
+        durable_metadata_path = self.metadata_dir / "reachability-metadata.json"
+        durable_metadata_path.write_text(
+            json.dumps({
+                "reflection": [
+                    {
+                        "type": "com.example.Target",
+                        "methods": [
+                            {
+                                "name": "m",
+                                "parameterTypes": ["java.lang.String", "int"],
+                            }
+                        ],
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+        Path(self.output_dir, "reachability-metadata.json").write_text(
+            json.dumps({
+                "reflection": [
+                    {
+                        "type": "com.example.Target",
+                        "methods": [
+                            {
+                                "name": "m",
+                                "parameterTypes": ["int", "java.lang.String"],
+                            }
+                        ],
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+        merge_calls: list[list[str]] = []
+
+        with patch(
+            "utility_scripts.native_test_verification.subprocess.run",
+            side_effect=self._fake_native_image_utils_merge(merge_calls),
+        ):
+            self.assertTrue(ntv._aggregate_trace_metadata(self.repo, "g:a:1.0", self.output_dir))
+
+        durable_metadata = json.loads(durable_metadata_path.read_text(encoding="utf-8"))
+        methods = [
+            entry["methods"][0]["parameterTypes"]
+            for entry in durable_metadata["reflection"]
+        ]
+        self.assertIn(["java.lang.String", "int"], methods)
+        self.assertIn(["int", "java.lang.String"], methods)
+        self.assertEqual(len(methods), 2)
+        self.assertEqual(len(merge_calls), 1)
+        self.assertIn(str(self.metadata_dir), _command_property(" ".join(merge_calls[0]), "-PinputDirs"))
+        self.assertIn(self.output_dir, _command_property(" ".join(merge_calls[0]), "-PinputDirs"))
+
+    @staticmethod
+    def _fake_native_image_utils_merge(calls: list[list[str]]):
+        def _fake(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(list(cmd))
+            input_dirs = next(
+                (a.split("=", 1)[1] for a in cmd if a.startswith("-PinputDirs=")),
+                "",
+            ).split(",")
+            output_dir = next(
+                (a.split("=", 1)[1] for a in cmd if a.startswith("-PoutputDir=")),
+                None,
+            )
+            merged_reflection = []
+            for input_dir in input_dirs:
+                metadata_path = Path(input_dir) / "reachability-metadata.json"
+                if metadata_path.is_file():
+                    try:
+                        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+                    except json.JSONDecodeError:
+                        return subprocess.CompletedProcess(cmd, 1)
+                    merged_reflection.extend(payload.get("reflection", []))
+            if output_dir:
+                Path(output_dir).mkdir(parents=True, exist_ok=True)
+                Path(output_dir, "reachability-metadata.json").write_text(
+                    json.dumps({"reflection": merged_reflection}),
+                    encoding="utf-8",
+                )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        return _fake
+
+
 class PrintCollectedMetadataTests(unittest.TestCase):
     """Readable logging of per-cycle trace metadata."""
 
@@ -308,7 +406,10 @@ class GateRoutingTests(unittest.TestCase):
                     for input_dir in input_dirs:
                         metadata_path = Path(input_dir) / "reachability-metadata.json"
                         if metadata_path.is_file():
-                            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+                            try:
+                                payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+                            except json.JSONDecodeError:
+                                return subprocess.CompletedProcess(cmd, 1)
                             merged_reflection.extend(payload.get("reflection", []))
                     Path(output_dir).mkdir(parents=True, exist_ok=True)
                     Path(output_dir, "reachability-metadata.json").write_text(
@@ -559,9 +660,11 @@ class GateRoutingTests(unittest.TestCase):
             )
         self.assertEqual(result.status, ntv.STATUS_PASSED)
         merge_calls = [call for call in calls if "mergeNativeTraceMetadata" in call]
-        self.assertEqual(len(merge_calls), 1)
+        self.assertEqual(len(merge_calls), 2)
         input_dirs = next(arg for arg in merge_calls[0] if arg.startswith("-PinputDirs="))
         self.assertIn("cycle-0", input_dirs)
+        durable_input_dirs = next(arg for arg in merge_calls[1] if arg.startswith("-PinputDirs="))
+        self.assertIn(self.output_dir, durable_input_dirs)
 
     def test_routes_to_codex_and_prints_stacktrace_when_172_produces_no_metadata(self) -> None:
         fake, _calls = self._fake_run_factory(

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -219,7 +219,7 @@ class MetadataAggregationTests(unittest.TestCase):
             "utility_scripts.native_test_verification.subprocess.run",
             side_effect=self._fake_native_image_utils_merge(merge_calls),
         ):
-            self.assertTrue(ntv._aggregate_trace_metadata(self.repo, "g:a:1.0", self.output_dir))
+            self.assertTrue(ntv._finalize_staged_metadata(self.repo, "g:a:1.0", [self.output_dir]))
 
         durable_metadata = json.loads(durable_metadata_path.read_text(encoding="utf-8"))
         methods = [
@@ -363,6 +363,16 @@ class GateRoutingTests(unittest.TestCase):
             if hasattr(stdout, "write"):
                 stdout.write(log_text)
             if "generateMetadata" in cmd:
+                output_dir = next(
+                    (a.split("=", 1)[1] for a in cmd if a.startswith("--metadataOutputDir=")),
+                    None,
+                )
+                if generate_metadata_rc == 0 and output_dir:
+                    Path(output_dir).mkdir(parents=True, exist_ok=True)
+                    Path(output_dir, "reachability-metadata.json").write_text(
+                        json.dumps({"reflection": [{"type": "com.example.AgentGenerated"}]}),
+                        encoding="utf-8",
+                    )
                 return subprocess.CompletedProcess(cmd, generate_metadata_rc)
             if "test" in cmd:
                 if hasattr(stdout, "write") and test_failed_task is not None:
@@ -515,7 +525,7 @@ class GateRoutingTests(unittest.TestCase):
             )
         self.assertEqual(result.status, ntv.STATUS_PASSED)
         self.assertIn(
-            os.path.join(self.output_dir, "reachability-metadata.json"),
+            os.path.join(self.output_dir, "trace", "reachability-metadata.json"),
             output.getvalue(),
         )
 
@@ -621,7 +631,7 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.intervention_records, [])
 
     def test_aggregate_failure_returns_failed_without_invoking_codex(self) -> None:
-        # Malformed durable metadata makes _aggregate_trace_metadata raise; the
+        # Malformed durable metadata makes final native-image-utils merge fail; the
         # gate must surface FAILED directly per the spec carve-out.
         metadata_dir = Path(self.repo) / "metadata" / "g" / "a" / "1.0"
         metadata_dir.mkdir(parents=True)
@@ -664,7 +674,7 @@ class GateRoutingTests(unittest.TestCase):
         input_dirs = next(arg for arg in merge_calls[0] if arg.startswith("-PinputDirs="))
         self.assertIn("cycle-0", input_dirs)
         durable_input_dirs = next(arg for arg in merge_calls[1] if arg.startswith("-PinputDirs="))
-        self.assertIn(self.output_dir, durable_input_dirs)
+        self.assertIn(os.path.join(self.output_dir, "trace"), durable_input_dirs)
 
     def test_routes_to_codex_and_prints_stacktrace_when_172_produces_no_metadata(self) -> None:
         fake, _calls = self._fake_run_factory(
@@ -800,6 +810,8 @@ class GateRoutingTests(unittest.TestCase):
         self.assertTrue(any("generateMetadata" in c for c in calls))
         self.assertFalse(any("test" in c for c in calls))
         self.assertTrue(any("runNativeTraceImage" in c for c in calls))
+        first_trace_call = next(c for c in calls if "runNativeTraceImage" in c)
+        self.assertFalse(any(c.startswith("-PmetadataConfigDirs=") for c in first_trace_call))
         self.assertIn(
             "generateMetadata failure reason: Caused by: java.lang.InternalError: platform encoding not initialized",
             output.getvalue(),

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -869,6 +869,31 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(len(result.intervention_records), 1)
         self.assertEqual(result.intervention_records[0].kind, "codex")
 
+    def test_routes_to_codex_with_same_graalvm_home_as_gate_commands(self) -> None:
+        graalvm_home = tempfile.mkdtemp(prefix="gate-graalvm-")
+        self.addCleanup(_rmtree, graalvm_home)
+        Path(graalvm_home, "bin").mkdir()
+        Path(graalvm_home, "bin", "native-image").write_text("", encoding="utf-8")
+        fake, _calls = self._fake_run_factory([1])
+        with patch.dict(os.environ, {"GRAALVM_HOME": graalvm_home, "JAVA_HOME": "/plain-jdk"}, clear=True), patch(
+                "utility_scripts.native_test_verification.subprocess.run",
+                side_effect=fake,
+        ), patch(
+            "utility_scripts.native_test_verification.run_codex_metadata_fix",
+            return_value=(0, "/tmp/codex.log", False),
+        ) as codex_mock:
+            result = ntv.verify_native_test_passes(
+                reachability_repo_path=self.repo,
+                coordinate="g:a:1.0",
+                output_dir=self.output_dir,
+                max_iterations=5,
+            )
+
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
+        self.assertEqual(codex_mock.call_args.kwargs["graalvm_home"], graalvm_home)
+        self.assertEqual(codex_mock.call_args.kwargs["base_env"]["GRAALVM_HOME"], graalvm_home)
+        self.assertEqual(codex_mock.call_args.kwargs["base_env"]["JAVA_HOME"], graalvm_home)
+
     def test_failed_when_codex_does_not_converge(self) -> None:
         fake, _calls = self._fake_run_factory([1])
         with patch(

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -10,7 +10,9 @@ import os
 import tempfile
 
 FORGE_GRADLE_USER_HOME_ENV = "FORGE_GRADLE_USER_HOME"
+FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV = "FORGE_GRADLE_DISTRIBUTIONS_HOME"
 _GRADLE_USER_HOME_ROOT = "metadata-forge-gradle"
+_GRADLE_DISTRIBUTIONS_DIR = "wrapper-dists"
 
 
 def gradle_user_home_for_repo(repo_path: str) -> str:
@@ -22,8 +24,11 @@ def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None =
     """Return an environment that keeps Gradle daemons scoped to one worktree."""
     env = dict(os.environ if base_env is None else base_env)
     _align_graalvm_java_home(env)
-    gradle_user_home = _resolve_gradle_user_home(repo_path, env.get(FORGE_GRADLE_USER_HOME_ENV))
+    user_home_override = env.get(FORGE_GRADLE_USER_HOME_ENV)
+    gradle_user_home = _resolve_gradle_user_home(repo_path, user_home_override)
     os.makedirs(gradle_user_home, exist_ok=True)
+    if not user_home_override:
+        _share_gradle_wrapper_distributions(gradle_user_home, env.get(FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV))
     env["GRADLE_USER_HOME"] = gradle_user_home
     return env
 
@@ -50,3 +55,27 @@ def _resolve_gradle_user_home(repo_path: str, override: str | None) -> str:
 
     repo_id = hashlib.sha256(os.path.realpath(repo_path).encode("utf-8")).hexdigest()[:16]
     return os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT, repo_id)
+
+
+def _share_gradle_wrapper_distributions(gradle_user_home: str, override: str | None) -> None:
+    shared_dists_dir = _resolve_gradle_distributions_home(override)
+    os.makedirs(shared_dists_dir, exist_ok=True)
+    wrapper_dir = os.path.join(gradle_user_home, "wrapper")
+    os.makedirs(wrapper_dir, exist_ok=True)
+
+    dists_path = os.path.join(wrapper_dir, "dists")
+    if os.path.islink(dists_path) or os.path.exists(dists_path):
+        return
+
+    try:
+        os.symlink(shared_dists_dir, dists_path)
+    except FileExistsError:
+        return
+    except OSError:
+        os.makedirs(dists_path, exist_ok=True)
+
+
+def _resolve_gradle_distributions_home(override: str | None) -> str:
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+    return os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT, _GRADLE_DISTRIBUTIONS_DIR)

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -103,6 +103,8 @@ def verify_native_test_passes(
         raise ValueError("max_iterations must be >= 1")
     if not os.path.isabs(output_dir):
         raise ValueError("output_dir must be an absolute path")
+    command_env = gradle_command_environment(reachability_repo_path)
+    required_graalvm_home = command_env.get("GRAALVM_HOME")
 
     runs_dir = os.path.normpath(os.path.join(output_dir, "..", "runs"))
     _reset_directory(output_dir)
@@ -148,6 +150,8 @@ def verify_native_test_passes(
             reachability_repo_path,
             coordinate,
             reproduction_command=reproduction_command,
+            graalvm_home=required_graalvm_home,
+            base_env=command_env,
         )
         intervention_records.append(
             InterventionRecord(
@@ -172,6 +176,7 @@ def verify_native_test_passes(
         coordinate=coordinate,
         output_dir=agent_metadata_dir,
         log_path=generate_metadata_log_path,
+        env=command_env,
     )
     last_log_path = generate_metadata_log_path
     agent_metadata_dirs = [agent_metadata_dir] if generate_metadata_rc == 0 else []
@@ -190,14 +195,16 @@ def verify_native_test_passes(
             metadata_config_dirs=[agent_metadata_dir],
             log_path=test_log_path,
             timeout_seconds=cycle_timeout_seconds,
+            env=command_env,
         )
         last_log_path = test_log_path
         if test_rc == 0:
             log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
             if not _finalize_staged_metadata(
-                    reachability_repo_path=reachability_repo_path,
-                    coordinate=coordinate,
-                    metadata_dirs=[agent_metadata_dir],
+                reachability_repo_path=reachability_repo_path,
+                coordinate=coordinate,
+                metadata_dirs=[agent_metadata_dir],
+                env=command_env,
             ):
                 return _make_result(STATUS_FAILED, 0)
             return _make_result(STATUS_PASSED, 0)
@@ -226,6 +233,7 @@ def verify_native_test_passes(
             metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
             log_path=log_path,
             timeout_seconds=cycle_timeout_seconds,
+            env=command_env,
         )
         last_log_path = log_path
         last_binary_rc = binary_rc if binary_rc is not None else gradle_rc
@@ -245,12 +253,14 @@ def verify_native_test_passes(
                 reachability_repo_path=reachability_repo_path,
                 run_dirs=run_dirs_to_merge,
                 output_dir=trace_metadata_dir,
+                env=command_env,
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
             if not _finalize_staged_metadata(
                 reachability_repo_path=reachability_repo_path,
                 coordinate=coordinate,
                 metadata_dirs=agent_metadata_dirs + [trace_metadata_dir],
+                env=command_env,
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
             return _make_result(STATUS_PASSED, cycle + 1)
@@ -352,6 +362,7 @@ def _run_generate_metadata(
         coordinate: str,
         output_dir: str,
         log_path: str,
+        env: dict[str, str],
 ) -> int:
     """Run JVM-agent metadata generation for the coordinate into a staging dir."""
     cmd = [
@@ -365,6 +376,7 @@ def _run_generate_metadata(
         reachability_repo_path=reachability_repo_path,
         cmd=cmd,
         log_path=log_path,
+        env=env,
     ).returncode
 
 
@@ -374,6 +386,7 @@ def _run_coordinate_test(
         metadata_config_dirs: list[str],
         log_path: str,
         timeout_seconds: int,
+        env: dict[str, str],
 ) -> tuple[int, str | None]:
     """Run normal coordinate tests and return the first failed Gradle task."""
     cmd = ["./gradlew", "test", f"-Pcoordinates={coordinate}"]
@@ -384,6 +397,7 @@ def _run_coordinate_test(
         cmd=cmd,
         log_path=log_path,
         timeout_seconds=timeout_seconds,
+        env=env,
     )
     return result.returncode, _parse_first_failed_task(log_path)
 
@@ -401,6 +415,7 @@ def _run_logged_gradle_command(
         cmd: list[str],
         log_path: str,
         timeout_seconds: int | None = None,
+        env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a Gradle command and write stdout/stderr to ``log_path``."""
     log_stage(
@@ -413,7 +428,7 @@ def _run_logged_gradle_command(
             return subprocess.run(
                 cmd,
                 cwd=reachability_repo_path,
-                env=gradle_command_environment(reachability_repo_path),
+                env=env or gradle_command_environment(reachability_repo_path),
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 check=False,
@@ -517,6 +532,7 @@ def _run_native_trace_image(
         metadata_config_dirs: list[str],
         log_path: str,
         timeout_seconds: int = DEFAULT_CYCLE_TIMEOUT_SECONDS,
+        env: dict[str, str] | None = None,
 ) -> tuple[int, int | None]:
     """Run ``runNativeTraceImage`` and surface the binary's exit code.
 
@@ -549,7 +565,7 @@ def _run_native_trace_image(
             result = subprocess.run(
                 cmd,
                 cwd=reachability_repo_path,
-                env=gradle_command_environment(reachability_repo_path),
+                env=env or gradle_command_environment(reachability_repo_path),
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 check=False,
@@ -805,6 +821,7 @@ def _merge_into_output(
         reachability_repo_path: str,
         run_dirs: list[str],
         output_dir: str,
+        env: dict[str, str] | None = None,
 ) -> bool:
     """Merge accepted per-cycle trace dirs into the caller's ``output_dir``."""
     return _merge_metadata_dirs(
@@ -812,6 +829,7 @@ def _merge_into_output(
         run_dirs,
         output_dir,
         print_output_path=True,
+        env=env,
     )
 
 
@@ -820,6 +838,7 @@ def _merge_metadata_dirs(
         input_dirs: list[str],
         output_dir: str,
         print_output_path: bool = False,
+        env: dict[str, str] | None = None,
 ) -> bool:
     """Merge metadata directories through native-image-utils."""
     if not input_dirs:
@@ -835,7 +854,7 @@ def _merge_metadata_dirs(
         result = subprocess.run(
             cmd,
             cwd=reachability_repo_path,
-            env=gradle_command_environment(reachability_repo_path),
+            env=env or gradle_command_environment(reachability_repo_path),
             check=False,
             timeout=_MERGE_TIMEOUT_SECONDS,
         )
@@ -871,6 +890,7 @@ def _finalize_staged_metadata(
         reachability_repo_path: str,
         coordinate: str,
         metadata_dirs: list[str],
+        env: dict[str, str] | None = None,
 ) -> bool:
     """Merge staged agent/trace metadata into the durable library metadata file."""
     staged_metadata_dirs = _existing_metadata_dirs(metadata_dirs)
@@ -909,7 +929,7 @@ def _finalize_staged_metadata(
     try:
         with tempfile.TemporaryDirectory(prefix="native-trace-durable-") as temp_dir:
             merged_output_dir = os.path.join(temp_dir, "merged")
-            if not _merge_metadata_dirs(reachability_repo_path, input_dirs, merged_output_dir):
+            if not _merge_metadata_dirs(reachability_repo_path, input_dirs, merged_output_dir, env=env):
                 return False
             merged_metadata_path = os.path.join(merged_output_dir, _AGGREGATED_METADATA_FILE_NAME)
             if not os.path.isfile(merged_metadata_path):

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -107,6 +107,8 @@ def verify_native_test_passes(
     runs_dir = os.path.normpath(os.path.join(output_dir, "..", "runs"))
     _reset_directory(output_dir)
     _reset_directory(runs_dir)
+    agent_metadata_dir = os.path.join(output_dir, "agent")
+    trace_metadata_dir = os.path.join(output_dir, "trace")
     condition_packages = condition_packages or _default_condition_packages(coordinate)
 
     log_stage(
@@ -168,9 +170,11 @@ def verify_native_test_passes(
     generate_metadata_rc = _run_generate_metadata(
         reachability_repo_path=reachability_repo_path,
         coordinate=coordinate,
+        output_dir=agent_metadata_dir,
         log_path=generate_metadata_log_path,
     )
     last_log_path = generate_metadata_log_path
+    agent_metadata_dirs = [agent_metadata_dir] if generate_metadata_rc == 0 else []
     if generate_metadata_rc != 0:
         failure_reason = _summarize_gradle_failure_reason(generate_metadata_log_path)
         log_stage(
@@ -183,19 +187,26 @@ def verify_native_test_passes(
         test_rc, failed_task = _run_coordinate_test(
             reachability_repo_path=reachability_repo_path,
             coordinate=coordinate,
+            metadata_config_dirs=[agent_metadata_dir],
             log_path=test_log_path,
             timeout_seconds=cycle_timeout_seconds,
         )
         last_log_path = test_log_path
         if test_rc == 0:
             log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
+            if not _finalize_staged_metadata(
+                    reachability_repo_path=reachability_repo_path,
+                    coordinate=coordinate,
+                    metadata_dirs=[agent_metadata_dir],
+            ):
+                return _make_result(STATUS_FAILED, 0)
             return _make_result(STATUS_PASSED, 0)
         if failed_task != "nativeTest":
             failed_task_display = failed_task or "unknown"
             return _route_to_codex(
                 stage="test",
                 reason=f"test failed before native trace fallback (failed_task={failed_task_display}, exit={test_rc})",
-                reproduction_command=_coordinate_test_command(coordinate),
+                reproduction_command=_coordinate_test_command(coordinate, [agent_metadata_dir]),
                 iterations_used=0,
             )
 
@@ -212,7 +223,7 @@ def verify_native_test_passes(
             coordinate=coordinate,
             run_dir=run_dir,
             condition_packages=condition_packages,
-            metadata_config_dirs=accepted_run_dirs,
+            metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
             log_path=log_path,
             timeout_seconds=cycle_timeout_seconds,
         )
@@ -233,13 +244,13 @@ def verify_native_test_passes(
             if not _merge_into_output(
                 reachability_repo_path=reachability_repo_path,
                 run_dirs=run_dirs_to_merge,
-                output_dir=output_dir,
+                output_dir=trace_metadata_dir,
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
-            if not _aggregate_trace_metadata(
+            if not _finalize_staged_metadata(
                 reachability_repo_path=reachability_repo_path,
                 coordinate=coordinate,
-                output_dir=output_dir,
+                metadata_dirs=agent_metadata_dirs + [trace_metadata_dir],
             ):
                 return _make_result(STATUS_FAILED, cycle + 1)
             return _make_result(STATUS_PASSED, cycle + 1)
@@ -258,7 +269,7 @@ def verify_native_test_passes(
                         coordinate=coordinate,
                         run_dir=run_dir,
                         condition_packages=condition_packages,
-                        metadata_config_dirs=accepted_run_dirs,
+                        metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
                     ),
                     iterations_used=cycle + 1,
                 )
@@ -279,7 +290,7 @@ def verify_native_test_passes(
                         coordinate=coordinate,
                         run_dir=run_dir,
                         condition_packages=condition_packages,
-                        metadata_config_dirs=accepted_run_dirs,
+                        metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
                     ),
                     iterations_used=cycle + 1,
                 )
@@ -302,7 +313,7 @@ def verify_native_test_passes(
                 coordinate=coordinate,
                 run_dir=run_dir,
                 condition_packages=condition_packages,
-                metadata_config_dirs=accepted_run_dirs,
+                metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
             ),
             iterations_used=cycle + 1,
         )
@@ -319,14 +330,17 @@ def verify_native_test_passes(
             coordinate=coordinate,
             run_dir=os.path.join(runs_dir, "codex-repro-metadata-gap-exhausted"),
             condition_packages=condition_packages,
-            metadata_config_dirs=accepted_run_dirs,
+            metadata_config_dirs=_existing_metadata_dirs(agent_metadata_dirs + accepted_run_dirs),
         ),
         iterations_used=max_iterations,
     )
 
 
-def _coordinate_test_command(coordinate: str) -> str:
-    return f"./gradlew test -Pcoordinates={coordinate}"
+def _coordinate_test_command(coordinate: str, metadata_config_dirs: list[str] | None = None) -> str:
+    parts = ["./gradlew test", f"-Pcoordinates={coordinate}"]
+    if metadata_config_dirs:
+        parts.append(f"-PmetadataConfigDirs={','.join(metadata_config_dirs)}")
+    return " ".join(parts)
 
 
 def _default_condition_packages(coordinate: str) -> list[str]:
@@ -336,14 +350,16 @@ def _default_condition_packages(coordinate: str) -> list[str]:
 def _run_generate_metadata(
         reachability_repo_path: str,
         coordinate: str,
+        output_dir: str,
         log_path: str,
 ) -> int:
-    """Run JVM-agent metadata generation for the coordinate."""
+    """Run JVM-agent metadata generation for the coordinate into a staging dir."""
     cmd = [
         "./gradlew",
         "generateMetadata",
         f"-Pcoordinates={coordinate}",
         "--agentAllowedPackages=fromJar",
+        f"--metadataOutputDir={output_dir}",
     ]
     return _run_logged_gradle_command(
         reachability_repo_path=reachability_repo_path,
@@ -355,11 +371,14 @@ def _run_generate_metadata(
 def _run_coordinate_test(
         reachability_repo_path: str,
         coordinate: str,
+        metadata_config_dirs: list[str],
         log_path: str,
         timeout_seconds: int,
 ) -> tuple[int, str | None]:
     """Run normal coordinate tests and return the first failed Gradle task."""
     cmd = ["./gradlew", "test", f"-Pcoordinates={coordinate}"]
+    if metadata_config_dirs:
+        cmd.append(f"-PmetadataConfigDirs={','.join(metadata_config_dirs)}")
     result = _run_logged_gradle_command(
         reachability_repo_path=reachability_repo_path,
         cmd=cmd,
@@ -367,6 +386,14 @@ def _run_coordinate_test(
         timeout_seconds=timeout_seconds,
     )
     return result.returncode, _parse_first_failed_task(log_path)
+
+
+def _existing_metadata_dirs(paths: list[str]) -> list[str]:
+    return [
+        path
+        for path in paths
+        if os.path.isfile(os.path.join(path, _AGGREGATED_METADATA_FILE_NAME))
+    ]
 
 
 def _run_logged_gradle_command(
@@ -840,15 +867,15 @@ def _print_aggregated_metadata_path(output_dir: str) -> None:
     )
 
 
-def _aggregate_trace_metadata(
+def _finalize_staged_metadata(
         reachability_repo_path: str,
         coordinate: str,
-        output_dir: str,
+        metadata_dirs: list[str],
 ) -> bool:
-    """Merge trace-backed metadata into the durable library metadata file."""
-    trace_metadata_path = os.path.join(output_dir, _AGGREGATED_METADATA_FILE_NAME)
-    if not os.path.isfile(trace_metadata_path):
-        log_stage(_GATE_STAGE, "native trace produced no reachability-metadata.json to aggregate")
+    """Merge staged agent/trace metadata into the durable library metadata file."""
+    staged_metadata_dirs = _existing_metadata_dirs(metadata_dirs)
+    if not staged_metadata_dirs:
+        log_stage(_GATE_STAGE, "no staged reachability-metadata.json to finalize")
         return True
 
     try:
@@ -877,7 +904,7 @@ def _aggregate_trace_metadata(
     input_dirs = []
     if os.path.isfile(durable_metadata_path):
         input_dirs.append(durable_metadata_dir)
-    input_dirs.append(output_dir)
+    input_dirs.extend(staged_metadata_dirs)
 
     try:
         with tempfile.TemporaryDirectory(prefix="native-trace-durable-") as temp_dir:
@@ -906,7 +933,7 @@ def _aggregate_trace_metadata(
         return False
     log_stage(
         _GATE_STAGE,
-        f"aggregated native trace metadata into {os.path.relpath(durable_metadata_path, reachability_repo_path)}",
+        f"finalized staged metadata into {os.path.relpath(durable_metadata_path, reachability_repo_path)}",
     )
     return True
 

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 
 from ai_workflows.fix_metadata_codex import run_codex_metadata_fix
@@ -779,12 +780,27 @@ def _merge_into_output(
         output_dir: str,
 ) -> bool:
     """Merge accepted per-cycle trace dirs into the caller's ``output_dir``."""
-    if not run_dirs:
+    return _merge_metadata_dirs(
+        reachability_repo_path,
+        run_dirs,
+        output_dir,
+        print_output_path=True,
+    )
+
+
+def _merge_metadata_dirs(
+        reachability_repo_path: str,
+        input_dirs: list[str],
+        output_dir: str,
+        print_output_path: bool = False,
+) -> bool:
+    """Merge metadata directories through native-image-utils."""
+    if not input_dirs:
         return True
     cmd = [
         "./gradlew",
         "mergeNativeTraceMetadata",
-        f"-PinputDirs={','.join(run_dirs)}",
+        f"-PinputDirs={','.join(input_dirs)}",
         f"-PoutputDir={output_dir}",
     ]
     log_stage(_GATE_STAGE, f"$ {' '.join(cmd)}", indent_level=1)
@@ -803,7 +819,8 @@ def _merge_into_output(
                 indent_level=1,
             )
             return False
-        _print_aggregated_metadata_path(output_dir)
+        if print_output_path:
+            _print_aggregated_metadata_path(output_dir)
         return True
     except subprocess.TimeoutExpired:
         log_stage(
@@ -842,29 +859,51 @@ def _aggregate_trace_metadata(
             artifact,
             library_version,
         )
-        durable_metadata_path = os.path.join(
-            reachability_repo_path,
-            "metadata",
-            group,
-            artifact,
-            metadata_version,
-            _AGGREGATED_METADATA_FILE_NAME,
-        )
-        durable_metadata = _read_metadata_json(durable_metadata_path)
-        trace_metadata = _read_metadata_json(trace_metadata_path)
-        merged_metadata = _merge_metadata(durable_metadata, trace_metadata)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        log_stage(_GATE_STAGE, f"failed to aggregate native trace metadata: {exc}", indent_level=1)
+    except (OSError, ValueError) as exc:
+        log_stage(_GATE_STAGE, f"failed to resolve durable metadata path: {exc}", indent_level=1)
         return False
 
-    if merged_metadata == durable_metadata:
-        log_stage(_GATE_STAGE, "native trace metadata already present in durable metadata")
-        return True
+    durable_metadata_dir = os.path.join(
+        reachability_repo_path,
+        "metadata",
+        group,
+        artifact,
+        metadata_version,
+    )
+    durable_metadata_path = os.path.join(
+        durable_metadata_dir,
+        _AGGREGATED_METADATA_FILE_NAME,
+    )
+    input_dirs = []
+    if os.path.isfile(durable_metadata_path):
+        input_dirs.append(durable_metadata_dir)
+    input_dirs.append(output_dir)
 
-    os.makedirs(os.path.dirname(durable_metadata_path), exist_ok=True)
-    with open(durable_metadata_path, "w", encoding="utf-8") as metadata_file:
-        json.dump(merged_metadata, metadata_file, indent=2)
-        metadata_file.write("\n")
+    try:
+        with tempfile.TemporaryDirectory(prefix="native-trace-durable-") as temp_dir:
+            merged_output_dir = os.path.join(temp_dir, "merged")
+            if not _merge_metadata_dirs(reachability_repo_path, input_dirs, merged_output_dir):
+                return False
+            merged_metadata_path = os.path.join(merged_output_dir, _AGGREGATED_METADATA_FILE_NAME)
+            if not os.path.isfile(merged_metadata_path):
+                log_stage(
+                    _GATE_STAGE,
+                    "native-image-utils produced no reachability-metadata.json for durable aggregation",
+                    indent_level=1,
+                )
+                return False
+            if os.path.isfile(durable_metadata_path) and _same_file_contents(
+                    durable_metadata_path,
+                    merged_metadata_path,
+            ):
+                log_stage(_GATE_STAGE, "native trace metadata already present in durable metadata")
+                return True
+
+            os.makedirs(durable_metadata_dir, exist_ok=True)
+            shutil.copyfile(merged_metadata_path, durable_metadata_path)
+    except OSError as exc:
+        log_stage(_GATE_STAGE, f"failed to aggregate native trace metadata: {exc}", indent_level=1)
+        return False
     log_stage(
         _GATE_STAGE,
         f"aggregated native trace metadata into {os.path.relpath(durable_metadata_path, reachability_repo_path)}",
@@ -872,64 +911,9 @@ def _aggregate_trace_metadata(
     return True
 
 
-def _read_metadata_json(path: str) -> dict:
-    if not os.path.isfile(path):
-        return {}
-    with open(path, "r", encoding="utf-8") as metadata_file:
-        data = json.load(metadata_file)
-    if not isinstance(data, dict):
-        raise ValueError(f"Reachability metadata must be a JSON object: {path}")
-    return data
-
-
-def _merge_metadata(base: dict, addition: dict) -> dict:
-    merged = dict(base)
-    for key, value in addition.items():
-        if key not in merged:
-            merged[key] = value
-            continue
-        merged[key] = _merge_metadata_value(merged[key], value)
-    return merged
-
-
-def _merge_metadata_value(base_value: object, addition_value: object) -> object:
-    if isinstance(base_value, list) and isinstance(addition_value, list):
-        merged = list(base_value)
-        seen_entries = {_canonical_metadata_key(entry) for entry in merged}
-        for entry in addition_value:
-            entry_key = _canonical_metadata_key(entry)
-            if entry_key not in seen_entries:
-                merged.append(entry)
-                seen_entries.add(entry_key)
-        return merged
-    if isinstance(base_value, dict) and isinstance(addition_value, dict):
-        return _merge_metadata(base_value, addition_value)
-    if base_value == addition_value:
-        return base_value
-    return addition_value
-
-
-def _canonical_metadata_key(value: object) -> str:
-    """Stable string key for an entry, treating nested arrays as unordered sets.
-
-    Reachability metadata leaf arrays (`methods`, `fields`, `queriedMethods`, …)
-    are semantic sets, so two entries that differ only in inner-array order
-    must dedup as one. Sorting recursively makes the JSON dump invariant under
-    those reorderings.
-    """
-    return json.dumps(_canonicalize(value), sort_keys=True, separators=(",", ":"))
-
-
-def _canonicalize(value: object) -> object:
-    if isinstance(value, list):
-        canonical_items = [_canonicalize(item) for item in value]
-        return sorted(
-            canonical_items,
-            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
-        )
-    if isinstance(value, dict):
-        return {key: _canonicalize(val) for key, val in value.items()}
-    return value
+def _same_file_contents(left_path: str, right_path: str) -> bool:
+    with open(left_path, "rb") as left_file, open(right_path, "rb") as right_file:
+        return left_file.read() == right_file.read()
 
 
 def _reset_directory(path: str) -> None:

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -125,7 +125,12 @@ def run_metadata_fix_until_tests_pass(
             break
 
         log_stage("metadata-fix", f"Running Codex metadata fix for {library} after {graalvm_env_var_name} failure")
-        codex_rc, _codex_log_path, codex_timed_out = run_codex_metadata_fix(repo_path, library)
+        codex_rc, _codex_log_path, codex_timed_out = run_codex_metadata_fix(
+            repo_path,
+            library,
+            graalvm_home=graalvm_home,
+            base_env=build_graalvm_environment(graalvm_home),
+        )
         if codex_timed_out:
             print(
                 f"ERROR: Codex metadata fix timed out while validating {library} with {graalvm_env_var_name}.",

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -572,9 +572,6 @@ graalvmNative {
         uri(tck.metadataRoot.get().asFile)
     }
     agent {
-        metadataCopy {
-            mergeWithExisting = true
-        }
     }
     binaries {
         test {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GenerateMetadataTask.java
@@ -32,6 +32,7 @@ public abstract class GenerateMetadataTask extends DefaultTask {
 
     private String coordinates;
     private String agentAllowedPackages;
+    private String metadataOutputDir;
 
     {
         Object coordsProp = getProject().findProperty("coordinates");
@@ -67,6 +68,17 @@ public abstract class GenerateMetadataTask extends DefaultTask {
         return agentAllowedPackages;
     }
 
+    @Option(option = "metadataOutputDir", description = "Directory where generated agent metadata is copied without durable final merge")
+    public void setMetadataOutputDir(String metadataOutputDir) {
+        this.metadataOutputDir = metadataOutputDir;
+    }
+
+    @Input
+    @Optional
+    public String getMetadataOutputDir() {
+        return metadataOutputDir;
+    }
+
     @TaskAction
     public void run() throws IOException {
         Path testsDirectory = GeneralUtils.computeTestsDirectory(getLayout(), coordinates);
@@ -82,7 +94,18 @@ public abstract class GenerateMetadataTask extends DefaultTask {
             MetadataGenerationUtils.addUserCodeFilterFile(testsDirectory, List.of(coordinatesValue.group()));
             MetadataGenerationUtils.addAgentConfigBlock(testsDirectory);
         }
-        MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
+        if (metadataOutputDir == null || metadataOutputDir.isBlank()) {
+            MetadataGenerationUtils.collectMetadata(getExecOperations(), testsDirectory, getLayout(), coordinates, gradlewPath);
+        } else {
+            MetadataGenerationUtils.collectMetadata(
+                    getExecOperations(),
+                    testsDirectory,
+                    getLayout(),
+                    coordinates,
+                    gradlewPath,
+                    Path.of(metadataOutputDir)
+            );
+        }
         if (isFromJarAllowedPackages()) {
             MetadataGenerationUtils.setAllowedPackagesInIndexJson(getLayout(), coordinatesValue, packageList);
         }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -30,13 +30,16 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Static utility class for operations shared by metadata-generation tasks.
@@ -189,12 +192,33 @@ public final class MetadataGenerationUtils {
      */
     public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout, String coordinates, Path gradlew) {
         Path metadataDirectory = GeneralUtils.computeMetadataDirectory(layout, coordinates);
+        try {
+            Path agentMetadataDirectory = Files.createTempDirectory("generate-metadata-agent-");
+            Path mergedMetadataDirectory = Files.createTempDirectory("generate-metadata-merged-");
+            try {
+                collectMetadata(execOps, testsDirectory, layout, coordinates, gradlew, agentMetadataDirectory);
+                mergeMetadataIntoDurableDirectory(execOps, layout, gradlew, metadataDirectory, agentMetadataDirectory, mergedMetadataDirectory);
+            } finally {
+                deleteRecursively(agentMetadataDirectory);
+                deleteRecursively(mergedMetadataDirectory);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot prepare metadata generation staging directories", e);
+        }
+    }
+
+    /**
+     * Runs Gradle tasks to generate metadata using the agent and copies
+     * the results into the requested output directory without durable merging.
+     */
+    public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout, String coordinates, Path gradlew, Path metadataDirectory) {
+        Path resolvedMetadataDirectory = resolveMetadataDirectory(layout, metadataDirectory);
 
         GeneralUtils.printInfo("Generating metadata");
         GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("-Pagent", "test"), "Cannot generate metadata", testsDirectory);
 
         GeneralUtils.printInfo("Performing metadata copy");
-        GeneralUtils.invokeCommand(execOps, gradlew + " metadataCopy --task test --dir " + metadataDirectory, "Cannot perform metadata copy", testsDirectory);
+        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("metadataCopy", "--task", "test", "--dir", resolvedMetadataDirectory.toString()), "Cannot perform metadata copy", testsDirectory);
     }
 
     /**
@@ -203,6 +227,27 @@ public final class MetadataGenerationUtils {
      */
     public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout, String coordinates, Path gradlew, String gvmTckLv) {
         Path metadataDirectory = GeneralUtils.computeMetadataDirectory(layout, coordinates);
+        try {
+            Path agentMetadataDirectory = Files.createTempDirectory("generate-metadata-agent-");
+            Path mergedMetadataDirectory = Files.createTempDirectory("generate-metadata-merged-");
+            try {
+                collectMetadata(execOps, testsDirectory, layout, coordinates, gradlew, gvmTckLv, agentMetadataDirectory);
+                mergeMetadataIntoDurableDirectory(execOps, layout, gradlew, metadataDirectory, agentMetadataDirectory, mergedMetadataDirectory);
+            } finally {
+                deleteRecursively(agentMetadataDirectory);
+                deleteRecursively(mergedMetadataDirectory);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot prepare metadata generation staging directories", e);
+        }
+    }
+
+    /**
+     * Runs Gradle tasks to generate metadata using the agent with a specific GVM_TCK_LV
+     * and copies the results into the requested output directory without durable merging.
+     */
+    public static void collectMetadata(ExecOperations execOps, Path testsDirectory, ProjectLayout layout, String coordinates, Path gradlew, String gvmTckLv, Path metadataDirectory) {
+        Path resolvedMetadataDirectory = resolveMetadataDirectory(layout, metadataDirectory);
 
         Map<String, String> env = Map.of("GVM_TCK_LV", gvmTckLv);
 
@@ -210,7 +255,56 @@ public final class MetadataGenerationUtils {
         GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("-Pagent", "test"), env, "Cannot generate metadata", testsDirectory);
 
         GeneralUtils.printInfo("Performing metadata copy");
-        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("metadataCopy", "--task", "test", "--dir", metadataDirectory.toString()), env, "Cannot perform metadata copy", testsDirectory);
+        GeneralUtils.invokeCommand(execOps, gradlew.toString(), List.of("metadataCopy", "--task", "test", "--dir", resolvedMetadataDirectory.toString()), env, "Cannot perform metadata copy", testsDirectory);
+    }
+
+    private static Path resolveMetadataDirectory(ProjectLayout layout, Path metadataDirectory) {
+        if (metadataDirectory.isAbsolute()) {
+            return metadataDirectory;
+        }
+        return layout.getProjectDirectory().getAsFile().toPath().resolve(metadataDirectory).normalize();
+    }
+
+    private static void mergeMetadataIntoDurableDirectory(
+            ExecOperations execOps,
+            ProjectLayout layout,
+            Path gradlew,
+            Path durableMetadataDirectory,
+            Path agentMetadataDirectory,
+            Path mergedMetadataDirectory
+    ) throws IOException {
+        List<Path> inputDirectories = Files.isRegularFile(durableMetadataDirectory.resolve("reachability-metadata.json"))
+                ? List.of(durableMetadataDirectory, agentMetadataDirectory)
+                : List.of(agentMetadataDirectory);
+        GeneralUtils.printInfo("Merging generated metadata");
+        GeneralUtils.invokeCommand(
+                execOps,
+                gradlew.toString(),
+                List.of(
+                        "mergeNativeTraceMetadata",
+                        "-PinputDirs=" + String.join(",", inputDirectories.stream().map(Path::toString).toList()),
+                        "-PoutputDir=" + mergedMetadataDirectory
+                ),
+                "Cannot merge generated metadata",
+                layout.getProjectDirectory().getAsFile().toPath()
+        );
+        Path mergedMetadataFile = mergedMetadataDirectory.resolve("reachability-metadata.json");
+        if (!Files.isRegularFile(mergedMetadataFile)) {
+            throw new RuntimeException("Merged metadata file was not created: " + mergedMetadataFile);
+        }
+        Files.createDirectories(durableMetadataDirectory);
+        Files.copy(mergedMetadataFile, durableMetadataDirectory.resolve("reachability-metadata.json"), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(path)) {
+            for (Path currentPath : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(currentPath);
+            }
+        }
     }
 
     /**

--- a/tests/tck-build-logic/src/main/resources/contributing/agent.template
+++ b/tests/tck-build-logic/src/main/resources/contributing/agent.template
@@ -6,8 +6,5 @@ graalvmNative {
                 userCodeFilterPath = "user-code-filter.json"
             }
         }
-        metadataCopy {
-            mergeWithExisting = true
-        }
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
@@ -65,7 +65,8 @@ class FixTestNativeImageRunTests {
                 .contains("\"tested-versions\" : [\n      \"4.2.2.Final\"\n    ]");
         assertThat(readGradlewInvocations())
                 .contains("4.2.2.Final|-Pagent test")
-                .contains("4.2.2.Final|metadataCopy --task test --dir " + metadataDirectory(NEW_VERSION))
+                .contains("4.2.2.Final|metadataCopy --task test --dir ")
+                .contains("|mergeNativeTraceMetadata -PinputDirs=")
                 .contains("4.2.2.Final|test -Pcoordinates=" + NEW_COORDINATES);
     }
 
@@ -148,6 +149,18 @@ class FixTestNativeImageRunTests {
                       break
                     fi
                     shift
+                  done
+                  exit 0
+                fi
+                if [ "$1" = "mergeNativeTraceMetadata" ]; then
+                  for arg in "$@"; do
+                    case "$arg" in
+                      -PoutputDir=*)
+                        out="${arg#-PoutputDir=}"
+                        mkdir -p "$out"
+                        printf '{"reflection":[]}\\n' > "$out/reachability-metadata.json"
+                        ;;
+                    esac
                   done
                   exit 0
                 fi

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/GenerateMetadataTaskTests.java
@@ -57,11 +57,33 @@ class GenerateMetadataTaskTests {
                 .contains("graalvmNative")
                 .contains("agent")
                 .contains("userCodeFilterPath = \"user-code-filter.json\"")
-                .contains("metadataCopy")
-                .contains("mergeWithExisting = true");
+                .doesNotContain("mergeWithExisting");
         assertThat(readGradlewInvocations())
                 .contains("tests/src/org.lz4/lz4-java/1.8.0|-Pagent test")
-                .contains("tests/src/org.lz4/lz4-java/1.8.0|metadataCopy --task test --dir " + tempDir.resolve("metadata/org.lz4/lz4-java/1.8.0"));
+                .contains("tests/src/org.lz4/lz4-java/1.8.0|metadataCopy --task test --dir ")
+                .contains("mergeNativeTraceMetadata")
+                .contains("-PoutputDir=");
+        assertThat(tempDir.resolve("metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json")).exists();
+    }
+
+    @Test
+    void runWithMetadataOutputDirCopiesAgentMetadataToStagingOnly() throws IOException {
+        Coordinates coordinates = Coordinates.parse("org.lz4:lz4-java:1.8.0");
+        installLibraryArtifact(coordinates, List.of("net/jpountz/lz4/LZ4Factory.class"));
+        Project project = createProject();
+        prepareTestProject(coordinates, "plugins { id 'java' }\n");
+        Path stagedMetadataDir = tempDir.resolve("staged-agent-metadata");
+        TestGenerateMetadataTask task = registerGenerateMetadataTask(project, "generateMetadata", coordinates);
+        task.setAgentAllowedPackages("fromJar");
+        task.setMetadataOutputDir(stagedMetadataDir.toString());
+
+        task.run();
+
+        assertThat(stagedMetadataDir.resolve("reachability-metadata.json")).exists();
+        assertThat(tempDir.resolve("metadata/org.lz4/lz4-java/1.8.0/reachability-metadata.json")).doesNotExist();
+        assertThat(readGradlewInvocations())
+                .contains("metadataCopy --task test --dir " + stagedMetadataDir)
+                .doesNotContain("mergeNativeTraceMetadata");
     }
 
     @Test
@@ -208,6 +230,17 @@ class GenerateMetadataTaskTests {
                       break
                     fi
                     shift
+                  done
+                fi
+                if [ "$1" = "mergeNativeTraceMetadata" ]; then
+                  for arg in "$@"; do
+                    case "$arg" in
+                      -PoutputDir=*)
+                        out="${arg#-PoutputDir=}"
+                        mkdir -p "$out"
+                        printf '{}\n' > "$out/reachability-metadata.json"
+                        ;;
+                    esac
                   done
                 fi
                 exit 0


### PR DESCRIPTION
Closes #5954

## What does this PR do?

Stages JVM-agent metadata in `<output_dir>/agent` and native trace metadata in `<output_dir>/trace`, then performs one final `mergeNativeTraceMetadata` into durable repository metadata after the native-test gate passes.

Also updates `generateMetadata` so the default durable path stages agent output and merges with existing durable metadata via native-image-utils, while `--metadataOutputDir` copies agent output to a staging directory only. The JVMTI agent `metadataCopy.mergeWithExisting` setting is removed because durable merging is now explicit.

Codex metadata repair now runs with `GRAALVM_HOME` and `JAVA_HOME` pinned to the same GraalVM distribution that produced the triggering Gradle or Native Image failure. The exact home and full `native-image --version` output are passed into Codex instructions, and the functional/native-test specs make this a hard requirement.

The native-test verification spec and dynamic-access workflow docs now describe the separated staging folders, final merge behavior, and Codex GraalVM pinning behavior.

Validation run:
- `PYTHONPATH=forge python3 -m unittest forge.tests.test_native_test_verification forge.tests.test_dynamic_access_iterative_strategy`
- `./gradlew :tck-build-logic:test --stacktrace`
- `./gradlew checkstyle --stacktrace` was started and passed many coordinate sub-builds, then stopped because it iterates broadly across generated library projects and was no longer scoped to this change.
- `python3 -m py_compile ai_workflows/fix_metadata_codex.py utility_scripts/workflow_setup.py utility_scripts/native_test_verification.py ai_workflows/workflow_strategies/workflow_strategy.py ai_workflows/fix_ni_run.py tests/test_fix_metadata_codex.py`
- `python3 -m unittest tests.test_native_test_verification tests.test_fix_metadata_codex tests.test_workflow_strategy`
- `git diff --check`

Known unrelated validation issue:
- `./gradlew :tck-build-logic:check --stacktrace` fails in `validatePlugins` on existing `AbstractLibraryStatsTask.getStatsFile()` `@Internal` annotation handling.

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/native_test_verification.py` runs Gradle tasks, writes gate staging directories, and copies final merged metadata into durable repository metadata.
- `forge/ai_workflows/fix_metadata_codex.py` shells out to `codex exec`, pins the Codex process environment to the required GraalVM, and records the Codex metadata-fix log.
- `tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java` runs `metadataCopy`, `mergeNativeTraceMetadata`, and temporary staging directory cleanup during metadata generation.

### Open question

- Local review noted that retrying transient GitHub CLI failures by default can duplicate non-idempotent mutations such as comments, PR creation, or workflow reruns. Confirm whether retries should be limited to explicitly idempotent `gh` calls.
- Local review noted that staged metadata passed via `-PmetadataConfigDirs` may not affect a `./gradlew test` start task in the TCK Gradle script. Confirm whether the gate should validate staged metadata through a native-test-specific task or another staging path.