### PR TITLE
[GenAI] Test fix for software.amazon.awssdk:checksums:2.42.0 using gpt-5.5

### DIFF
--- a/metadata/software.amazon.awssdk/checksums/2.42.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/checksums/2.42.0/reachability-metadata.json
@@ -1,0 +1,94 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      },
+      "type": "java.util.zip.CRC32C"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ChecksumProvider"
+      },
+      "type": "java.util.zip.CRC32C",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ChecksumProvider"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ConstructorCache"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC64NVME"
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.ChecksumProvider"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC64NVME",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC32C",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum"
+      },
+      "type": "software.amazon.awssdk.crt.checksums.CRC64NVME",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum"
+      },
+      "type": "software.amazon.awssdk.checksums.internal.SdkCrc32CChecksum",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/software.amazon.awssdk/checksums/index.json
+++ b/metadata/software.amazon.awssdk/checksums/index.json
@@ -117,6 +117,11 @@
   },
   {
     "metadata-version" : "2.42.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/software/amazon/awssdk/checksums/$version$/checksums-$version$-sources.jar",
+    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/core/checksums/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/software/amazon/awssdk/checksums/$version$/checksums-$version$-javadoc.jar",
+    "description" : "The AWS SDK for Java v2 checksums module provides checksum implementations and helpers used by SDK components. It supplies CRC and digest-based checksum support, including SDK checksum abstractions and internal implementations for AWS request and response checksum handling.",
     "tested-versions" : [
       "2.42.0"
     ],

--- a/metadata/software.amazon.awssdk/checksums/index.json
+++ b/metadata/software.amazon.awssdk/checksums/index.json
@@ -114,5 +114,14 @@
     "allowed-packages" : [
       "software.amazon.awssdk.checksums"
     ]
+  },
+  {
+    "metadata-version" : "2.42.0",
+    "tested-versions" : [
+      "2.42.0"
+    ],
+    "allowed-packages" : [
+      "software.amazon.awssdk.checksums"
+    ]
   }
 ]

--- a/stats/software.amazon.awssdk/checksums/2.42.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/checksums/2.42.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-05": {
+    "timestamp": "2026-05-05T14:07:15.735440Z",
+    "library": "software.amazon.awssdk:checksums:2.42.0",
+    "starting_commit": "ec05c96c672dc65aea45269f24679306f6d6278c",
+    "ending_commit": "de5e657beba79ab75ec329938079c914eddeb139",
+    "previous_library": "software.amazon.awssdk:checksums:2.34.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.42.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 17229,
+          "missed": 908,
+          "ratio": 0.949937,
+          "total": 18137
+        },
+        "line": {
+          "covered": 181,
+          "missed": 185,
+          "ratio": 0.494536,
+          "total": 366
+        },
+        "method": {
+          "covered": 66,
+          "missed": 54,
+          "ratio": 0.55,
+          "total": 120
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.34.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8907,
+          "missed": 9074,
+          "ratio": 0.495356,
+          "total": 17981
+        },
+        "line": {
+          "covered": 145,
+          "missed": 180,
+          "ratio": 0.446154,
+          "total": 325
+        },
+        "method": {
+          "covered": 55,
+          "missed": 54,
+          "ratio": 0.504587,
+          "total": 109
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 33471,
+      "cached_input_tokens_used": 284160,
+      "output_tokens_used": 5834,
+      "iterations": 2,
+      "cost_usd": 0.3171,
+      "tested_library_loc": 181,
+      "metadata_entries": 15,
+      "previous_library_metadata_entries": 15,
+      "code_coverage_percent": 49.45,
+      "previous_library_coverage_percent": 44.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java",
+      "metadata_file": "metadata/software.amazon.awssdk/checksums/2.42.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/software.amazon.awssdk/checksums/2.42.0/stats.json
+++ b/stats/software.amazon.awssdk/checksums/2.42.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.42.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 17229,
+        "missed" : 908,
+        "ratio" : 0.949937,
+        "total" : 18137
+      },
+      "line" : {
+        "covered" : 181,
+        "missed" : 185,
+        "ratio" : 0.494536,
+        "total" : 366
+      },
+      "method" : {
+        "covered" : 66,
+        "missed" : 54,
+        "ratio" : 0.55,
+        "total" : 120
+      }
+    }
+  } ]
+}

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/.gitignore
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/build.gradle
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+String awsCrtVersion = "0.38.9"
+
+dependencies {
+    testImplementation "software.amazon.awssdk:checksums:$libraryVersion"
+    testImplementation "software.amazon.awssdk.crt:aws-crt:$awsCrtVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/gradle.properties
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = software.amazon.awssdk:checksums:2.42.0
+library.version = 2.42.0
+metadata.dir = software.amazon.awssdk/checksums/2.42.0/

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/settings.gradle
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'software.amazon.awssdk.checksums_tests'

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java
@@ -8,10 +8,8 @@ package software_amazon_awssdk.checksums;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 import java.util.zip.CRC32C;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -19,10 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.checksums.SdkChecksum;
-import software.amazon.awssdk.checksums.internal.CrcChecksumProvider;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class CrcChecksumProviderTest {
+public class ChecksumProviderTest {
     private static final byte[] PAYLOAD =
         "The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
     private static final byte[] EXTRA_PAYLOAD = " on native image".getBytes(StandardCharsets.UTF_8);
@@ -31,7 +28,7 @@ public class CrcChecksumProviderTest {
     @Test
     @Order(1)
     void crc32cImplementationUsesJavaCrc32cConstructor() {
-        SdkChecksum checksum = CrcChecksumProvider.crc32cImplementation();
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32C);
         CRC32C expected = new CRC32C();
 
         checksum.update(PAYLOAD);
@@ -63,15 +60,9 @@ public class CrcChecksumProviderTest {
 
     @Test
     @Order(3)
-    void packagePrivateCrtCrc32cFactoryUsesCrtConstructor() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(CrcChecksumProvider.class, MethodHandles.lookup());
-        MethodHandle createCrtCrc32C = lookup.findStatic(
-            CrcChecksumProvider.class,
-            "createCrtCrc32C",
-            MethodType.methodType(SdkChecksum.class));
-
-        SdkChecksum checksum = (SdkChecksum) createCrtCrc32C.invokeExact();
-        CRC32C expected = new CRC32C();
+    void crc32AlgorithmSupportsMarkAndReset() {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32);
+        CRC32 expected = new CRC32();
 
         checksum.update(PAYLOAD);
         expected.update(PAYLOAD, 0, PAYLOAD.length);
@@ -84,8 +75,7 @@ public class CrcChecksumProviderTest {
 
         checksum.reset();
 
-        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
-        assertThat(checksum.getClass().getSimpleName()).isEqualTo("CrcCloneOnMarkChecksum");
+        assertThat(checksum.getClass().getSimpleName()).isEqualTo("Crc32Checksum");
         assertThat(checksum.getValue()).isEqualTo(expected.getValue());
         assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
     }

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.checksums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32C;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
+import software.amazon.awssdk.checksums.SdkChecksum;
+import software.amazon.awssdk.checksums.internal.CrcChecksumProvider;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CrcChecksumProviderTest {
+    private static final byte[] PAYLOAD =
+        "The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] EXTRA_PAYLOAD = " on native image".getBytes(StandardCharsets.UTF_8);
+    private static final String JAVA_CRC32C_PROVIDER_TYPE = "CrcCombineOnMarkChecksum";
+
+    @Test
+    @Order(1)
+    void crc32cImplementationUsesJavaCrc32cConstructor() {
+        SdkChecksum checksum = CrcChecksumProvider.crc32cImplementation();
+        CRC32C expected = new CRC32C();
+
+        checksum.update(PAYLOAD);
+        expected.update(PAYLOAD, 0, PAYLOAD.length);
+
+        assertThat(checksum.getClass().getSimpleName()).isEqualTo(JAVA_CRC32C_PROVIDER_TYPE);
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
+    }
+
+    @Test
+    @Order(2)
+    void crc64NvmeAlgorithmUsesCrtConstructor() {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC64NVME);
+
+        checksum.update(PAYLOAD);
+        long markedValue = checksum.getValue();
+
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(EXTRA_PAYLOAD);
+
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+
+        assertThat(checksum.getValue()).isEqualTo(markedValue);
+        assertThat(checksum.getChecksumBytes()).hasSize(Long.BYTES);
+    }
+
+    @Test
+    @Order(3)
+    void packagePrivateCrtCrc32cFactoryUsesCrtConstructor() throws Throwable {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(CrcChecksumProvider.class, MethodHandles.lookup());
+        MethodHandle createCrtCrc32C = lookup.findStatic(
+            CrcChecksumProvider.class,
+            "createCrtCrc32C",
+            MethodType.methodType(SdkChecksum.class));
+
+        SdkChecksum checksum = (SdkChecksum) createCrtCrc32C.invokeExact();
+        CRC32C expected = new CRC32C();
+
+        checksum.update(PAYLOAD);
+        expected.update(PAYLOAD, 0, PAYLOAD.length);
+        long markedValue = checksum.getValue();
+
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(EXTRA_PAYLOAD);
+
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getClass().getSimpleName()).isEqualTo("CrcCloneOnMarkChecksum");
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
+    }
+}

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/CrcCloneOnMarkChecksumTest.java
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/CrcCloneOnMarkChecksumTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.checksums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.checksums.internal.CrcCloneOnMarkChecksum;
+import software.amazon.awssdk.checksums.internal.SdkCrc32CChecksum;
+
+public class CrcCloneOnMarkChecksumTest {
+    private static final byte[] PREFIX = "The quick brown ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DISCARDED_SUFFIX = "fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] REPLACEMENT_SUFFIX = "cat naps".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void markAndResetCloneTheChecksumState() {
+        CrcCloneOnMarkChecksum checksum = new CrcCloneOnMarkChecksum(SdkCrc32CChecksum.create());
+        checksum.update(PREFIX);
+        long markedValue = checksum.getValue();
+
+        checksum.mark(Integer.MAX_VALUE);
+        checksum.update(DISCARDED_SUFFIX);
+        assertThat(checksum.getValue()).isNotEqualTo(markedValue);
+
+        checksum.reset();
+        assertThat(checksum.getValue()).isEqualTo(markedValue);
+
+        checksum.update(REPLACEMENT_SUFFIX);
+
+        SdkCrc32CChecksum expected = SdkCrc32CChecksum.create();
+        expected.update(PREFIX);
+        expected.update(REPLACEMENT_SUFFIX);
+        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
+        assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
+    }
+}

--- a/tests/src/software.amazon.awssdk/checksums/2.42.0/user-code-filter.json
+++ b/tests/src/software.amazon.awssdk/checksums/2.42.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "software.amazon.awssdk.checksums.**"
+    },
+    {
+      "includeClasses" : "software_amazon_awssdk.checksums.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #5944

This PR provides test fixes and new metadata for software.amazon.awssdk:checksums:2.42.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 33471
- Cached input tokens: 284160
- Output tokens: 5834
- Metadata entries: 15
- Iterations: 2
- Library coverage percentage: 49.45
- Previous library version metadata entries: 15
- Previous library version coverage percentage: 44.62

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c9b83f84aec57a2591dcabb08f2d1e856bdfb904`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- software.amazon.awssdk:checksums:2.34.0: 6/6 covered calls (100.00%)
- software.amazon.awssdk:checksums:2.42.0: 4/4 covered calls (100.00%)

**Reflection:**
- software.amazon.awssdk:checksums:2.34.0: 6/6 covered calls (100.00%)
- software.amazon.awssdk:checksums:2.42.0: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- software.amazon.awssdk:checksums:2.34.0: 8907/17981 (49.54%)
- software.amazon.awssdk:checksums:2.42.0: 17229/18137 (94.99%)

**Line:**
- software.amazon.awssdk:checksums:2.34.0: 145/325 (44.62%)
- software.amazon.awssdk:checksums:2.42.0: 181/366 (49.45%)

**Method:**
- software.amazon.awssdk:checksums:2.34.0: 55/109 (50.46%)
- software.amazon.awssdk:checksums:2.42.0: 66/120 (55.00%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java 2/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java
similarity index 74%
rename from /tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
rename to /tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java
index 83b1b564af..c3e27a63ef 100644
--- 1/tests/src/software.amazon.awssdk/checksums/2.34.0/src/test/java/software_amazon_awssdk/checksums/CrcChecksumProviderTest.java
+++ 2/tests/src/software.amazon.awssdk/checksums/2.42.0/src/test/java/software_amazon_awssdk/checksums/ChecksumProviderTest.java
@@ -8,10 +8,8 @@ package software_amazon_awssdk.checksums;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 import java.util.zip.CRC32C;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -19,10 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.checksums.DefaultChecksumAlgorithm;
 import software.amazon.awssdk.checksums.SdkChecksum;
-import software.amazon.awssdk.checksums.internal.CrcChecksumProvider;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class CrcChecksumProviderTest {
+public class ChecksumProviderTest {
     private static final byte[] PAYLOAD =
         "The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8);
     private static final byte[] EXTRA_PAYLOAD = " on native image".getBytes(StandardCharsets.UTF_8);
@@ -31,7 +28,7 @@ public class CrcChecksumProviderTest {
     @Test
     @Order(1)
     void crc32cImplementationUsesJavaCrc32cConstructor() {
-        SdkChecksum checksum = CrcChecksumProvider.crc32cImplementation();
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32C);
         CRC32C expected = new CRC32C();
 
         checksum.update(PAYLOAD);
@@ -63,15 +60,9 @@ public class CrcChecksumProviderTest {
 
     @Test
     @Order(3)
-    void packagePrivateCrtCrc32cFactoryUsesCrtConstructor() throws Throwable {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(CrcChecksumProvider.class, MethodHandles.lookup());
-        MethodHandle createCrtCrc32C = lookup.findStatic(
-            CrcChecksumProvider.class,
-            "createCrtCrc32C",
-            MethodType.methodType(SdkChecksum.class));
-
-        SdkChecksum checksum = (SdkChecksum) createCrtCrc32C.invokeExact();
-        CRC32C expected = new CRC32C();
+    void crc32AlgorithmSupportsMarkAndReset() {
+        SdkChecksum checksum = SdkChecksum.forAlgorithm(DefaultChecksumAlgorithm.CRC32);
+        CRC32 expected = new CRC32();
 
         checksum.update(PAYLOAD);
         expected.update(PAYLOAD, 0, PAYLOAD.length);
@@ -84,8 +75,7 @@ public class CrcChecksumProviderTest {
 
         checksum.reset();
 
-        assertThat(checksum.getValue()).isEqualTo(expected.getValue());
-        assertThat(checksum.getClass().getSimpleName()).isEqualTo("CrcCloneOnMarkChecksum");
+        assertThat(checksum.getClass().getSimpleName()).isEqualTo("Crc32Checksum");
         assertThat(checksum.getValue()).isEqualTo(expected.getValue());
         assertThat(checksum.getChecksumBytes()).hasSize(Integer.BYTES);
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
