### PR TITLE
[GenAI] Add support for org.typelevel:cats-effect_3:2.5.1 using gpt-5.5

### DIFF
--- a/metadata/org.typelevel/cats-effect_3/2.5.1/reachability-metadata.json
+++ b/metadata/org.typelevel/cats-effect_3/2.5.1/reachability-metadata.json
@@ -1,0 +1,59 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "cats.effect.IOParallelNewtype"
+      },
+      "type" : "cats.effect.IOParallelNewtype",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "cats.effect.internals.IOContextShift"
+      },
+      "type" : "cats.effect.internals.IOContextShift",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "cats.effect.internals.IOContextShift"
+      },
+      "type" : "cats.effect.internals.IOContextShift$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "cats.effect.internals.IOTimer"
+      },
+      "type" : "cats.effect.internals.IOTimer",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "cats.effect.internals.IOTimer"
+      },
+      "type" : "cats.effect.internals.IOTimer$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.typelevel/cats-effect_3/index.json
+++ b/metadata/org.typelevel/cats-effect_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.5.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/typelevel/cats-effect_3/2.5.1/cats-effect_3-2.5.1-sources.jar",
+    "repository-url" : "https://github.com/typelevel/cats-effect",
+    "test-code-url" : "https://github.com/typelevel/cats-effect/tree/v2.5.1/core/shared/src/test/scala",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/typelevel/cats-effect_3/2.5.1/cats-effect_3-2.5.1-javadoc.jar",
+    "description" : "Cats Effect is a high-performance, asynchronous, and composable framework for building real-world Scala applications in a purely functional style. It provides the IO data type, resource-safety tools, concurrency primitives, and type classes for describing and controlling side effects.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.5.1"
+    ],
+    "allowed-packages" : [
+      "cats.effect"
+    ]
+  }
+]

--- a/stats/org.typelevel/cats-effect_3/2.5.1/execution-metrics.json
+++ b/stats/org.typelevel/cats-effect_3/2.5.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-05": {
+    "timestamp": "2026-05-05T21:19:17.831357Z",
+    "library": "org.typelevel:cats-effect_3:2.5.1",
+    "starting_commit": "fa7ceab60eb79600774856bd5cf83ea9ef7ae17b",
+    "ending_commit": "cd4cf02da63089e4696c1bb3074fc4bd533c407d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.5.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5802,
+          "missed": 23596,
+          "ratio": 0.19736,
+          "total": 29398
+        },
+        "line": {
+          "covered": 962,
+          "missed": 1908,
+          "ratio": 0.335192,
+          "total": 2870
+        },
+        "method": {
+          "covered": 567,
+          "missed": 2644,
+          "ratio": 0.176581,
+          "total": 3211
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 82447,
+      "cached_input_tokens_used": 434176,
+      "output_tokens_used": 16310,
+      "iterations": 4,
+      "cost_usd": 0.7064,
+      "generated_loc": 226,
+      "tested_library_loc": 962,
+      "metadata_entries": 10,
+      "code_coverage_percent": 33.52
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala",
+      "metadata_file": "metadata/org.typelevel/cats-effect_3/2.5.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.typelevel/cats-effect_3/2.5.1/stats.json
+++ b/stats/org.typelevel/cats-effect_3/2.5.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.5.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5802,
+        "missed" : 23596,
+        "ratio" : 0.19736,
+        "total" : 29398
+      },
+      "line" : {
+        "covered" : 962,
+        "missed" : 1908,
+        "ratio" : 0.335192,
+        "total" : 2870
+      },
+      "method" : {
+        "covered" : 567,
+        "missed" : 2644,
+        "ratio" : 0.176581,
+        "total" : 3211
+      }
+    }
+  } ]
+}

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/.gitignore
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/gradle.properties
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.typelevel:cats-effect_3:2.5.1
+library.version = 2.5.1
+metadata.dir = org.typelevel/cats-effect_3/2.5.1/

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/settings.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.typelevel.cats-effect_3_tests'

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_typelevel.cats_effect_3
+
+import org.junit.jupiter.api.Test
+
+class Cats_effect_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
@@ -22,6 +22,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
@@ -198,6 +201,35 @@ class Cats_effect_3Test {
     val result: (Int, Boolean) = await(program)
 
     assertThat(result).isEqualTo((99, true))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def contextShiftEvaluatesEffectsOnSpecifiedExecutionContext(): Unit = {
+    val executor: ExecutorService = Executors.newSingleThreadExecutor(new ThreadFactory {
+      override def newThread(runnable: Runnable): Thread = {
+        val thread: Thread = new Thread(runnable)
+        thread.setDaemon(true)
+        thread.setName("cats-effect-eval-on-test")
+        thread
+      }
+    })
+    val dedicatedExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
+
+    try {
+      val program: IO[(String, String)] = for {
+        shiftedThreadName <- contextShift.evalOn(dedicatedExecutionContext)(IO(Thread.currentThread().getName))
+        resumedThreadName <- IO(Thread.currentThread().getName)
+      } yield (shiftedThreadName, resumedThreadName)
+
+      val result: (String, String) = await(program)
+
+      assertThat(result._1).startsWith("cats-effect-eval-on-test")
+      assertThat(result._2).doesNotStartWith("cats-effect-eval-on-test")
+    } finally {
+      executor.shutdownNow()
+      executor.awaitTermination(1, TimeUnit.SECONDS)
+    }
   }
 
   @Test

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
@@ -9,6 +9,7 @@ package org_typelevel.cats_effect_3
 import cats.effect.Blocker
 import cats.effect.ConcurrentEffect
 import cats.effect.ContextShift
+import cats.effect.ExitCase
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.SyncIO
@@ -150,6 +151,25 @@ class Cats_effect_3Test {
     val result: (Boolean, Boolean, String, Long) = await(program)
 
     assertThat(result).isEqualTo((false, true, "payload", 1L))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def cancelingFiberRunsBracketCaseFinalizerWithCanceledExitCase(): Unit = {
+    val program: IO[ExitCase[Throwable]] = for {
+      started <- Deferred[IO, Unit]
+      canceled <- Deferred[IO, ExitCase[Throwable]]
+      fiber <- started.complete(()).bracketCase(_ => IO.never) { (_, exitCase) =>
+        canceled.complete(exitCase)
+      }.start
+      _ <- started.get
+      _ <- fiber.cancel
+      exitCase <- canceled.get.timeoutTo(1.second, IO.raiseError(new AssertionError("cancellation finalizer did not run")))
+    } yield exitCase
+
+    val result: ExitCase[Throwable] = await(program)
+
+    assertThat(result).isEqualTo(ExitCase.Canceled)
   }
 
   @Test

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/src/test/scala/org_typelevel/cats_effect_3/Cats_effect_3Test.scala
@@ -6,11 +6,210 @@
  */
 package org_typelevel.cats_effect_3
 
+import cats.effect.Blocker
+import cats.effect.ConcurrentEffect
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.SyncIO
+import cats.effect.Timer
+import cats.effect.concurrent.Deferred
+import cats.effect.concurrent.MVar
+import cats.effect.concurrent.Ref
+import cats.effect.concurrent.Semaphore
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 class Cats_effect_3Test {
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val effect: ConcurrentEffect[IO] = IO.ioConcurrentEffect(contextShift)
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+
+  private def await[A](io: IO[A]): A = {
+    io.unsafeRunTimed(5.seconds).getOrElse(throw new AssertionError("IO did not complete within the expected timeout"))
+  }
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def ioComposesLazySynchronousAndAsynchronousEffects(): Unit = {
+    var evaluations: Int = 0
+    val failure: IllegalStateException = new IllegalStateException("expected failure")
+
+    val program: IO[(Int, String, Int)] = for {
+      delayed <- IO {
+        evaluations += 1
+        40
+      }.map(_ + 2)
+      recovered <- IO.raiseError[Int](failure).attempt.map(_.fold(_.getMessage, _.toString))
+      asynchronous <- IO.async[Int](callback => callback(Right(21))).map(_ * 2)
+    } yield (delayed, recovered, asynchronous)
+
+    val result: (Int, String, Int) = await(program)
+
+    assertThat(evaluations).isEqualTo(1)
+    assertThat(result).isEqualTo((42, "expected failure", 42))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def resourceRunsFinalizersForSuccessfulAndFailedUses(): Unit = {
+    val events: ListBuffer[String] = ListBuffer.empty[String]
+    val failure: RuntimeException = new RuntimeException("use failed")
+
+    def managed(label: String): Resource[IO, String] = {
+      Resource.make(IO {
+        events += s"acquire-$label"
+        label
+      })(value => IO {
+        events += s"release-$value"
+      })
+    }
+
+    val program: IO[(Int, Either[Throwable, Int])] = for {
+      success <- managed("success").use(value => IO {
+        events += s"use-$value"
+        value.length
+      })
+      failed <- managed("failure").use(_ => IO.raiseError[Int](failure)).attempt
+    } yield (success, failed)
+
+    val result: (Int, Either[Throwable, Int]) = await(program)
+
+    assertThat(result._1).isEqualTo(7)
+    assertThat(result._2.left.toOption.orNull).isSameAs(failure)
+    assertThat(events.toList).isEqualTo(List(
+      "acquire-success",
+      "use-success",
+      "release-success",
+      "acquire-failure",
+      "release-failure"
+    ))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def refSupportsAtomicUpdatesModificationAndCompareAndSetAccess(): Unit = {
+    val program: IO[(Int, Boolean, Map[String, Int])] = for {
+      ref <- Ref.of[IO, Map[String, Int]](Map.empty[String, Int])
+      _ <- ref.update(_.updated("alpha", 1))
+      previous <- ref.modify { values =>
+        val nextValue: Int = values("alpha") + 1
+        (values.updated("alpha", nextValue), values("alpha"))
+      }
+      accessResult <- ref.access.flatMap { case (snapshot, setter) =>
+        setter(snapshot.updated("beta", 3)).flatMap(success => ref.get.map(values => (success, values)))
+      }
+    } yield (previous, accessResult._1, accessResult._2)
+
+    val result: (Int, Boolean, Map[String, Int]) = await(program)
+
+    assertThat(result).isEqualTo((1, true, Map("alpha" -> 2, "beta" -> 3)))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def deferredCoordinatesFibersWithoutBlockingThreads(): Unit = {
+    val program: IO[(String, Vector[String])] = for {
+      gate <- Deferred[IO, String]
+      observed <- Ref.of[IO, Vector[String]](Vector.empty[String])
+      fiber <- gate.get.flatMap(value => observed.update(_ :+ value).map(_ => value.reverse)).start
+      beforeComplete <- observed.get
+      _ <- gate.complete("ready")
+      joined <- fiber.join
+      afterComplete <- observed.get
+    } yield (s"$beforeComplete:$joined", afterComplete)
+
+    val result: (String, Vector[String]) = await(program)
+
+    assertThat(result).isEqualTo(("Vector():ydaer", Vector("ready")))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def semaphoreAndMVarCoordinatePermitProtectedExchange(): Unit = {
+    val program: IO[(Boolean, Boolean, String, Long)] = for {
+      semaphore <- Semaphore[IO](1L)
+      mailbox <- MVar[IO].empty[String]
+      _ <- semaphore.acquire
+      acquireWhileHeld <- semaphore.tryAcquire
+      _ <- semaphore.release
+      acquireAfterRelease <- semaphore.tryAcquire
+      _ <- if (acquireAfterRelease) semaphore.release else IO.unit
+      producer <- semaphore.withPermit(mailbox.put("payload")).start
+      received <- mailbox.take
+      _ <- producer.join
+      permits <- semaphore.available
+    } yield (acquireWhileHeld, acquireAfterRelease, received, permits)
+
+    val result: (Boolean, Boolean, String, Long) = await(program)
+
+    assertThat(result).isEqualTo((false, true, "payload", 1L))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def raceReturnsTheFirstCompletedEffect(): Unit = {
+    val program: IO[Either[String, String]] = IO.race(
+      timer.sleep(1.second).map(_ => "slow"),
+      IO.pure("fast")
+    )
+
+    val result: Either[String, String] = await(program)
+
+    assertThat(result).isEqualTo(Right("fast"))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def timerAndTimeoutToProduceBoundedFallbacks(): Unit = {
+    val neverCompletes: IO[Int] = IO.never
+    val program: IO[(Int, Boolean)] = for {
+      before <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+      value <- neverCompletes.timeoutTo(25.millis, IO.pure(99))
+      after <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+    } yield (value, after >= before)
+
+    val result: (Int, Boolean) = await(program)
+
+    assertThat(result).isEqualTo((99, true))
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def blockerEvaluatesBlockingWorkInsideManagedResource(): Unit = {
+    val program: IO[(String, Int)] = Blocker[IO].use { blocker =>
+      for {
+        threadName <- blocker.blockOn(IO(Thread.currentThread().getName))
+        computed <- blocker.delay(21 + 21)
+      } yield (threadName, computed)
+    }
+
+    val result: (String, Int) = await(program)
+
+    assertThat(result._1).isNotBlank
+    assertThat(result._2).isEqualTo(42)
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def syncIOEvaluatesPureSynchronousEffectsAndCapturesFailures(): Unit = {
+    var counter: Int = 0
+
+    val result: (Int, Either[Throwable, Int]) = SyncIO {
+      counter += 1
+      counter
+    }.flatMap(value => SyncIO.pure(value + 1))
+      .flatMap(value => SyncIO.raiseError[Int](new IllegalArgumentException(value.toString)).attempt.map(error => (value, error)))
+      .unsafeRunSync()
+
+    assertThat(counter).isEqualTo(1)
+    assertThat(result._1).isEqualTo(2)
+    assertThat(result._2.left.toOption.map(_.getMessage).orNull).isEqualTo("2")
   }
 }

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/user-code-filter.json
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "cats.effect.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5976

This PR introduces tests and metadata for org.typelevel:cats-effect_3:2.5.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 82447
- Cached input tokens: 434176
- Output tokens: 16310
- Metadata entries: 10
- Iterations: 4
- Library coverage percentage: 33.52
- Generated lines of code: 226
- Tested library lines of code: 962

### Metadata Forge

- Forge monitored branch: `origin/fix/staged-native-metadata-final-merge`
- Forge branch: `fix/staged-native-metadata-final-merge`
- Forge commit hash: `1309f959a3a4594f42e29dd8ee0d8b02c761943b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 5802/29398 (19.74%)
- Line: 962/2870 (33.52%)
- Method: 567/3211 (17.66%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
