### PR TITLE
[GenAI] Add support for org.typelevel:cats-core_3:2.6.1 using gpt-5.5

### DIFF
--- a/metadata/org.typelevel/cats-core_3/2.6.1/reachability-metadata.json
+++ b/metadata/org.typelevel/cats-core_3/2.6.1/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "cats.Eval$"
+      },
+      "type": "cats.Later",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.typelevel/cats-core_3/index.json
+++ b/metadata/org.typelevel/cats-core_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.6.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/typelevel/cats-core_3/$version$/cats-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/typelevel/cats",
+    "test-code-url" : "https://github.com/typelevel/cats/tree/v$version$/tests/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/typelevel/cats-core_3/$version$/cats-core_3-$version$-javadoc.jar",
+    "description" : "cats-core_3 provides Cats' core abstractions and data types for functional programming in Scala, including type classes such as Functor, Monad, Monoid, and Traverse. It supplies syntax, instances, and utilities that let Scala 3 applications compose effectful and generic code without depending on a specific effect runtime.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.6.1"
+    ],
+    "allowed-packages" : [
+      "cats"
+    ]
+  }
+]

--- a/stats/org.typelevel/cats-core_3/2.6.1/execution-metrics.json
+++ b/stats/org.typelevel/cats-core_3/2.6.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-05": {
+    "timestamp": "2026-05-05T21:10:21.248911Z",
+    "library": "org.typelevel:cats-core_3:2.6.1",
+    "starting_commit": "68c8e347baf1fc3d7f7f3f6016df77ccd9573a8b",
+    "ending_commit": "d0d032756829a26ac51100d5b690426842f92a52",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.6.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5344,
+          "missed": 126305,
+          "ratio": 0.040593,
+          "total": 131649
+        },
+        "line": {
+          "covered": 756,
+          "missed": 9540,
+          "ratio": 0.073427,
+          "total": 10296
+        },
+        "method": {
+          "covered": 858,
+          "missed": 14148,
+          "ratio": 0.057177,
+          "total": 15006
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 102016,
+      "cached_input_tokens_used": 538624,
+      "output_tokens_used": 20613,
+      "iterations": 4,
+      "cost_usd": 0.8877,
+      "generated_loc": 208,
+      "tested_library_loc": 756,
+      "metadata_entries": 2,
+      "code_coverage_percent": 7.34
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala",
+      "metadata_file": "metadata/org.typelevel/cats-core_3/2.6.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.typelevel/cats-core_3/2.6.1/stats.json
+++ b/stats/org.typelevel/cats-core_3/2.6.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.6.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5344,
+        "missed" : 126305,
+        "ratio" : 0.040593,
+        "total" : 131649
+      },
+      "line" : {
+        "covered" : 756,
+        "missed" : 9540,
+        "ratio" : 0.073427,
+        "total" : 10296
+      },
+      "method" : {
+        "covered" : 858,
+        "missed" : 14148,
+        "ratio" : 0.057177,
+        "total" : 15006
+      }
+    }
+  } ]
+}

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/.gitignore
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.typelevel:cats-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/gradle.properties
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.typelevel:cats-core_3:2.6.1
+library.version = 2.6.1
+metadata.dir = org.typelevel/cats-core_3/2.6.1/

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/settings.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.typelevel.cats-core_3_tests'

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
@@ -6,11 +6,217 @@
  */
 package org_typelevel.cats_core_3
 
+import cats.*
+import cats.data.*
+import cats.implicits.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class Cats_core_3Test {
+  private final case class Registration(name: String, age: Int, email: String)
+  private final case class ServiceConfig(host: String, port: Int)
+  private final case class User(name: String, age: Int)
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def evalSupportsMemoizationRepeatedEvaluationAndStackSafeDeferral(): Unit = {
+    var memoizedEvaluations: Int = 0
+    val memoized: Eval[String] = Eval.later {
+      memoizedEvaluations += 1
+      s"computed-$memoizedEvaluations"
+    }
+
+    assertThat(memoized.value).isEqualTo("computed-1")
+    assertThat(memoized.value).isEqualTo("computed-1")
+    assertThat(memoizedEvaluations).isEqualTo(1)
+
+    var repeatedEvaluations: Int = 0
+    val repeated: Eval[Int] = Eval.always {
+      repeatedEvaluations += 1
+      repeatedEvaluations
+    }
+
+    assertThat(repeated.value).isEqualTo(1)
+    assertThat(repeated.value).isEqualTo(2)
+
+    def sumFrom(current: Int, limit: Int, accumulated: Long): Eval[Long] = {
+      if current > limit then Eval.now(accumulated)
+      else Eval.defer(sumFrom(current + 1, limit, accumulated + current.toLong))
+    }
+
+    assertThat(sumFrom(1, 10000, 0L).value).isEqualTo(50005000L)
+  }
+
+  @Test
+  def validatedNelAccumulatesIndependentValidationFailures(): Unit = {
+    val validRegistration: ValidatedNel[String, Registration] = validateRegistration(
+      name = "Ada",
+      age = 36,
+      email = "ada@example.test"
+    )
+
+    assertThat(validRegistration.toEither).isEqualTo(Right(Registration("Ada", 36, "ada@example.test")))
+
+    val invalidRegistration: ValidatedNel[String, Registration] = validateRegistration(
+      name = "  ",
+      age = -1,
+      email = "not-an-email"
+    )
+
+    invalidRegistration match {
+      case Validated.Invalid(errors) =>
+        assertThat(errors.toList).isEqualTo(
+          List("name is required", "age must be non-negative", "email must contain @")
+        )
+      case Validated.Valid(value) =>
+        throw new AssertionError(s"Expected validation failures, got $value")
+    }
+  }
+
+  @Test
+  def parallelEitherSyntaxAccumulatesErrorsWhileSequentialEitherShortCircuits(): Unit = {
+    val missingName: Either[List[String], String] = Left(List("name missing"))
+    val missingAge: Either[List[String], Int] = Left(List("age missing"))
+
+    val sequential: Either[List[String], (String, Int)] = for {
+      name <- missingName
+      age <- missingAge
+    } yield (name, age)
+    val parallel: Either[List[String], (String, Int)] = (missingName, missingAge).parMapN((name, age) => (name, age))
+
+    assertThat(sequential).isEqualTo(Left(List("name missing")))
+    assertThat(parallel).isEqualTo(Left(List("name missing", "age missing")))
+
+    val validName: Either[List[String], String] = Right("Grace")
+    val validAge: Either[List[String], Int] = Right(85)
+    val user: Either[List[String], User] = (validName, validAge).parMapN((name, age) => User(name, age))
+
+    assertThat(user).isEqualTo(Right(User("Grace", 85)))
+  }
+
+  @Test
+  def optionTAndEitherTComposeNestedEffectfulComputations(): Unit = {
+    val options: OptionT[List, Int] = OptionT(List(Some(1), None, Some(3)))
+    val incrementedEvenValues: OptionT[List, Int] = options.map(_ + 1).filter(_ % 2 == 0)
+
+    assertThat(incrementedEvenValues.value).isEqualTo(List(Some(2), None, Some(4)))
+
+    val either: EitherT[Option, String, Int] = EitherT(Option(Right(21)))
+    val successful: EitherT[Option, String, Int] = either.map(_ * 2).semiflatMap(value => Option(value + 1))
+    val guarded: EitherT[Option, String, Int] = either.ensure("value was too small")(_ > 25)
+
+    assertThat(successful.value).isEqualTo(Some(Right(43)))
+    assertThat(guarded.value).isEqualTo(Some(Left("value was too small")))
+  }
+
+  @Test
+  def stateWriterReaderAndKleisliModelCommonFunctionalWorkflows(): Unit = {
+    val counter: State[Int, String] = for {
+      initial <- State.get[Int]
+      _ <- State.modify[Int](_ + 3)
+      updated <- State.get[Int]
+    } yield s"$initial->$updated"
+
+    assertThat(counter.run(4).value).isEqualTo((7, "4->7"))
+    assertThat(counter.runA(4).value).isEqualTo("4->7")
+
+    val writer: Writer[Vector[String], Int] = Writer(Vector("read base"), 5)
+      .flatMap(value => Writer(Vector("doubled"), value * 2))
+
+    assertThat(writer.run).isEqualTo((Vector("read base", "doubled"), 10))
+
+    val endpoint: Reader[ServiceConfig, String] = Reader(config => s"${config.host}:${config.port}")
+    val renderedEndpoint: String = endpoint.map(_.toUpperCase).run(ServiceConfig("localhost", 8080))
+
+    assertThat(renderedEndpoint).isEqualTo("LOCALHOST:8080")
+
+    val parseInt: Kleisli[Option, String, Int] = Kleisli(text => text.toIntOption)
+    val reciprocal: Kleisli[Option, Int, Double] = Kleisli(value => if value == 0 then None else Some(1.0 / value))
+    val pipeline: Kleisli[Option, String, Double] = parseInt.andThen(reciprocal)
+
+    assertThat(pipeline.run("4")).isEqualTo(Some(0.25))
+    assertThat(pipeline.run("0")).isEqualTo(None)
+    assertThat(pipeline.run("not-a-number")).isEqualTo(None)
+  }
+
+  @Test
+  def traverseFoldableAndNonEmptyCollectionsProvideGenericCollectionOperations(): Unit = {
+    val traversed: Option[List[Int]] = Traverse[List].traverse(List(1, 2, 3))(value => Option.when(value < 4)(value * 2))
+    val failedTraverse: Option[List[Int]] = Traverse[List].traverse(List(1, 2, 5))(value => Option.when(value < 4)(value * 2))
+    val totalLength: Int = Foldable[List].foldMap(List("a", "bb", "ccc"))(_.length)
+    val nonEmpty: NonEmptyList[Int] = NonEmptyList.of(1, 2, 3, 4)
+
+    assertThat(traversed).isEqualTo(Some(List(2, 4, 6)))
+    assertThat(failedTraverse).isEqualTo(None)
+    assertThat(totalLength).isEqualTo(6)
+    assertThat(Reducible[NonEmptyList].reduce(nonEmpty)).isEqualTo(10)
+    assertThat(nonEmpty.map(_ * 3).toList).isEqualTo(List(3, 6, 9, 12))
+  }
+
+  @Test
+  def iorCombinesWarningsWithSuccessfulValues(): Unit = {
+    val first: Ior[Chain[String], Int] = Ior.Both(Chain.one("rounded input"), 2)
+    val combined: Ior[Chain[String], Int] = first.flatMap { value =>
+      Ior.Both(Chain.one("used fallback multiplier"), value * 3)
+    }
+    val transformed: Ior[String, Int] = Ior.Both("warning", 10).leftMap(_.toUpperCase).map(_ + 5)
+
+    combined match {
+      case Ior.Both(warnings, value) =>
+        assertThat(warnings.toList).isEqualTo(List("rounded input", "used fallback multiplier"))
+        assertThat(value).isEqualTo(6)
+      case other =>
+        throw new AssertionError(s"Expected warnings and a value, got $other")
+    }
+    assertThat(transformed).isEqualTo(Ior.Both("WARNING", 15))
+  }
+
+  @Test
+  def coreTypeClassesAndSyntaxComposeDomainValues(): Unit = {
+    val mergedCounts: Map[String, Int] = Monoid[Map[String, Int]].combine(
+      Map("apples" -> 2, "pears" -> 1),
+      Map("apples" -> 3, "oranges" -> 4)
+    )
+    val optionalTotal: Option[Int] = Apply[Option].map2(Some(2), Some(40))(_ + _)
+    val identityResult: Id[Int] = Monad[Id].flatMap(40)(_ + 2)
+    val tupleShow: Show[(String, Int)] = Show.show { case (name, age) => s"$name is $age" }
+    val userShow: Show[User] = tupleShow.contramap((user: User) => (user.name, user.age))
+    val userOrder: Order[User] = Order.by[User, Int](_.age)
+
+    assertThat(mergedCounts).isEqualTo(Map("apples" -> 5, "pears" -> 1, "oranges" -> 4))
+    assertThat(optionalTotal).isEqualTo(Some(42))
+    assertThat(identityResult).isEqualTo(42)
+    assertThat(userShow.show(User("Ada", 36))).isEqualTo("Ada is 36")
+    assertThat(userOrder.compare(User("Grace", 85), User("Ada", 36))).isGreaterThan(0)
+    assertThat(Eq[List[Int]].eqv(List(1, 2, 3), List(1, 2, 3))).isTrue
+  }
+
+  @Test
+  def nestedMapsThroughStackedFunctorContexts(): Unit = {
+    val nested: Nested[Option, List, Int] = Nested(Some(List(1, 2, 3)))
+    val mapped: Nested[Option, List, String] = nested.map(value => s"value-${value + 1}")
+
+    assertThat(mapped.value).isEqualTo(Some(List("value-2", "value-3", "value-4")))
+  }
+
+  private def validateRegistration(name: String, age: Int, email: String): ValidatedNel[String, Registration] = {
+    (nonBlank("name", name), nonNegativeAge(age), validEmail(email)).mapN { (validName, validAge, validEmail) =>
+      Registration(validName, validAge, validEmail)
+    }
+  }
+
+  private def nonBlank(field: String, value: String): ValidatedNel[String, String] = {
+    val trimmed: String = value.trim
+    if trimmed.nonEmpty then trimmed.validNel[String]
+    else s"$field is required".invalidNel[String]
+  }
+
+  private def nonNegativeAge(age: Int): ValidatedNel[String, Int] = {
+    if age >= 0 then age.validNel[String]
+    else "age must be non-negative".invalidNel[Int]
+  }
+
+  private def validEmail(email: String): ValidatedNel[String, String] = {
+    if email.contains("@") then email.validNel[String]
+    else "email must contain @".invalidNel[String]
   }
 }

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
@@ -199,6 +199,22 @@ class Cats_core_3Test {
   }
 
   @Test
+  def constAccumulatesContextWhileRetaggingIgnoredValues(): Unit = {
+    type Collected[A] = Const[Vector[String], A]
+
+    val requiredName: Collected[String] = Const[Vector[String], String](Vector("name is required"))
+    val requiredEmail: Collected[String] = Const[Vector[String], String](Vector("email is required"))
+    val mapped: Collected[Int] = requiredName.map(_.length)
+    val combined: Collected[(String, String)] = Apply[Collected].map2(requiredName, requiredEmail)((name, email) =>
+      (name, email)
+    )
+
+    assertThat(mapped.getConst).isEqualTo(Vector("name is required"))
+    assertThat(combined.getConst).isEqualTo(Vector("name is required", "email is required"))
+    assertThat(combined.retag[Double].getConst).isEqualTo(Vector("name is required", "email is required"))
+  }
+
+  @Test
   def andThenComposesLargeFunctionPipelinesStackSafely(): Unit = {
     val identityPipeline: AndThen[Int, Int] = AndThen((value: Int) => value)
     val increment: Int => Int = value => value + 1

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
@@ -198,6 +198,22 @@ class Cats_core_3Test {
     assertThat(mapped.value).isEqualTo(Some(List("value-2", "value-3", "value-4")))
   }
 
+  @Test
+  def andThenComposesLargeFunctionPipelinesStackSafely(): Unit = {
+    val identityPipeline: AndThen[Int, Int] = AndThen((value: Int) => value)
+    val increment: Int => Int = value => value + 1
+    val pipeline: AndThen[Int, Int] = (1 to 10000).foldLeft(identityPipeline) { (current, _) =>
+      current.andThen(increment)
+    }
+    val formatted: AndThen[Int, String] = pipeline.andThen(value => s"total=$value")
+    val parsed: AndThen[String, Int] = AndThen((value: String) => value.stripPrefix("total=").toInt)
+
+    assertThat(pipeline(0)).isEqualTo(10000)
+    assertThat(formatted(5)).isEqualTo("total=10005")
+    assertThat(formatted.andThen(parsed)(7)).isEqualTo(10007)
+    assertThat(parsed.compose(formatted)(9)).isEqualTo(10009)
+  }
+
   private def validateRegistration(name: String, age: Int, email: String): ValidatedNel[String, Registration] = {
     (nonBlank("name", name), nonNegativeAge(age), validEmail(email)).mapN { (validName, validAge, validEmail) =>
       Registration(validName, validAge, validEmail)

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/src/test/scala/org_typelevel/cats_core_3/Cats_core_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_typelevel.cats_core_3
+
+import org.junit.jupiter.api.Test
+
+class Cats_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/user-code-filter.json
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "cats.**"
+    }
+  ]
+}

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/user-code-filter.json
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "cats.**"
+      "includeClasses" : "cats.**"
+    },
+    {
+      "includeClasses" : "org_typelevel.cats_core_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2665

This PR introduces tests and metadata for org.typelevel:cats-core_3:2.6.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 102016
- Cached input tokens: 538624
- Output tokens: 20613
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 7.34
- Generated lines of code: 208
- Tested library lines of code: 756

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `8a46a19c399cc5ba23c62e085e133cebe5bfbc64`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 5344/131649 (4.06%)
- Line: 756/10296 (7.34%)
- Method: 858/15006 (5.72%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
