### PR TITLE
[GenAI] Test fix for org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final using gpt-5.5

### DIFF
--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/reachability-metadata.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/reachability-metadata.json
@@ -1,0 +1,304 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryLoader"
+      },
+      "type": "java.lang.String",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "byte[]"
+          ]
+        },
+        {
+          "name": "getBytes",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+      },
+      "type": "java.util.AbstractCollection",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.DirectByteBufferDeallocator"
+      },
+      "type": "java.nio.ByteBuffer",
+      "methods": [
+        {
+          "name": "clear",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL"
+      },
+      "type": "org.wildfly.openssl.SSL$LibraryLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "load",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "org.wildfly.openssl.SSL$LibraryLoader"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL"
+      },
+      "type": "org.wildfly.openssl.SSLImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "org.wildfly.openssl.SSLImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "head"
+        },
+        {
+          "name": "tail"
+        }
+      ],
+      "methods": [
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque$Node"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque$Node",
+      "fields": [
+        {
+          "name": "item"
+        },
+        {
+          "name": "next"
+        },
+        {
+          "name": "prev"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque$Node"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque$Node"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.DirectByteBufferDeallocator"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.FastConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.ConcurrentDirectDeque"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+      },
+      "type": "org.wildfly.openssl.util.PortableConcurrentDirectDeque"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "linux-x86_64/libwfssl.so"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.Messages"
+      },
+      "glob": "org/wildfly/openssl/OpenSSLMessages_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "org/wildfly/openssl/SSL$LibraryLoader.class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.wildfly.openssl.SSL$LibraryClassLoader"
+      },
+      "glob": "org/wildfly/openssl/SSLImpl.class"
+    },
+    {
+      "bundle": "org.wildfly.openssl.OpenSSLMessages"
+    }
+  ]
+}

--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.1.1.Final",
+    "tested-versions" : [
+      "2.1.1.Final"
+    ],
+    "allowed-packages" : [
+      "org.wildfly.openssl"
+    ]
+  },
+  {
     "metadata-version" : "2.0.0.Alpha1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl-java/$version$/wildfly-openssl-java-$version$-sources.jar",
     "repository-url" : "https://github.com/wildfly-security/wildfly-openssl",

--- a/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
+++ b/metadata/org.wildfly.openssl/wildfly-openssl-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.1.1.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/wildfly/openssl/wildfly-openssl-java/$version$/wildfly-openssl-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/wildfly-security/wildfly-openssl",
+    "test-code-url" : "https://github.com/wildfly-security/wildfly-openssl/tree/$version$/java/src/test",
+    "documentation-url" : "https://github.com/wildfly-security/wildfly-openssl/blob/$version$/README.md",
+    "description" : "WildFly OpenSSL Java provides Java bindings for OpenSSL and exposes them through JSSE-compatible SSLContext and security provider APIs. The java artifact contains the Java side of the binding and expects the native library to be supplied separately or through a platform-specific WildFly OpenSSL artifact.",
     "tested-versions" : [
       "2.1.1.Final"
     ],

--- a/stats/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/execution-metrics.json
+++ b/stats/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-05": {
+    "timestamp": "2026-05-05T22:16:06.556060Z",
+    "library": "org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final",
+    "starting_commit": "f9ec7b0e16bc2745762d4a2a0c26ce1ff1c4cd86",
+    "ending_commit": "37af90f49a32c47a4c2a67f779e2863b282d94b6",
+    "previous_library": "org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2378,
+          "missed": 17439,
+          "ratio": 0.119998,
+          "total": 19817
+        },
+        "line": {
+          "covered": 609,
+          "missed": 3412,
+          "ratio": 0.151455,
+          "total": 4021
+        },
+        "method": {
+          "covered": 112,
+          "missed": 659,
+          "ratio": 0.145266,
+          "total": 771
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.0.Alpha1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2371,
+          "missed": 16864,
+          "ratio": 0.123265,
+          "total": 19235
+        },
+        "line": {
+          "covered": 601,
+          "missed": 3281,
+          "ratio": 0.154817,
+          "total": 3882
+        },
+        "method": {
+          "covered": 112,
+          "missed": 630,
+          "ratio": 0.150943,
+          "total": 742
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 27457,
+      "cached_input_tokens_used": 252928,
+      "output_tokens_used": 2296,
+      "iterations": 1,
+      "cost_usd": 0.1954,
+      "tested_library_loc": 609,
+      "metadata_entries": 51,
+      "previous_library_metadata_entries": 51,
+      "code_coverage_percent": 15.15,
+      "previous_library_coverage_percent": 15.48
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java",
+      "metadata_file": "metadata/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/stats.json
+++ b/stats/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.1.1.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 22,
+      "totalCalls" : 22
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2378,
+        "missed" : 17439,
+        "ratio" : 0.119998,
+        "total" : 19817
+      },
+      "line" : {
+        "covered" : 609,
+        "missed" : 3412,
+        "ratio" : 0.151455,
+        "total" : 4021
+      },
+      "method" : {
+        "covered" : 112,
+        "missed" : 659,
+        "ratio" : 0.145266,
+        "total" : 771
+      }
+    }
+  } ]
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/.gitignore
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+repositories {
+    exclusiveContent {
+        forRepository {
+            mavenCentral {
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeGroup "org.wildfly.openssl"
+        }
+    }
+}
+
+dependencies {
+    testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion@jar"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion@jar"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String nativeLibraryVersion = "2.1.0.Final"
 
 repositories {
     exclusiveContent {
@@ -27,7 +28,7 @@ repositories {
 
 dependencies {
     testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion@jar"
-    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion@jar"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$nativeLibraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/gradle.properties
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final
+library.version = 2.1.1.Final
+metadata.dir = org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/settings.gradle
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.wildfly.openssl.wildfly-openssl-java_tests'

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/ConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/ConcurrentDirectDequeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.ConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrentDirectDequeTest {
+    @Test
+    void newInstanceCreatesUsableDequeWithTokenRemoval() {
+        ConcurrentDirectDeque<String> deque = ConcurrentDirectDeque.newInstance();
+
+        Object firstToken = deque.offerFirstAndReturnToken("first");
+        Object lastToken = deque.offerLastAndReturnToken("last");
+
+        assertThat(firstToken).isNotNull();
+        assertThat(lastToken).isNotNull();
+        assertThat(deque).containsExactly("first", "last");
+
+        deque.removeToken(firstToken);
+        assertThat(deque).containsExactly("last");
+        assertThat(deque.pollFirst()).isEqualTo("last");
+        assertThat(deque).isEmpty();
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/DirectByteBufferDeallocatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.DirectByteBufferDeallocator;
+
+import sun.misc.Unsafe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DirectByteBufferDeallocatorTest {
+    @Test
+    void freeReleasesDirectByteBufferThroughPublicApi() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(32);
+        buffer.putInt(0, 42);
+
+        DirectByteBufferDeallocator.free(buffer);
+
+        assertThat(buffer.isDirect()).isTrue();
+    }
+
+    @Test
+    void freeIgnoresNullAndHeapByteBuffers() {
+        ByteBuffer heapBuffer = ByteBuffer.allocate(16);
+
+        DirectByteBufferDeallocator.free(null);
+        DirectByteBufferDeallocator.free(heapBuffer);
+
+        assertThat(heapBuffer.isDirect()).isFalse();
+    }
+
+    @Test
+    void freeCanUseCleanerMethodFallback() throws ReflectiveOperationException {
+        Unsafe unsafe = getUnsafe();
+        Field unsafeField = getDirectByteBufferDeallocatorField("UNSAFE");
+        Field cleanerField = getDirectByteBufferDeallocatorField("cleaner");
+        Field cleanerCleanField = getDirectByteBufferDeallocatorField("cleanerClean");
+        Object originalUnsafe = readStaticField(unsafe, unsafeField);
+        Object originalCleaner = readStaticField(unsafe, cleanerField);
+        Object originalCleanerClean = readStaticField(unsafe, cleanerCleanField);
+        Method clear = ByteBuffer.class.getMethod("clear");
+
+        try {
+            writeStaticField(unsafe, unsafeField, null);
+            writeStaticField(unsafe, cleanerField, clear);
+            writeStaticField(unsafe, cleanerCleanField, clear);
+            assertThat(readStaticField(unsafe, unsafeField)).isNull();
+
+            ByteBuffer buffer = ByteBuffer.allocateDirect(32);
+
+            DirectByteBufferDeallocator.free(buffer);
+
+            assertThat(buffer.isDirect()).isTrue();
+        } finally {
+            writeStaticField(unsafe, unsafeField, originalUnsafe);
+            writeStaticField(unsafe, cleanerField, originalCleaner);
+            writeStaticField(unsafe, cleanerCleanField, originalCleanerClean);
+        }
+    }
+
+    private static Field getDirectByteBufferDeallocatorField(String fieldName) throws NoSuchFieldException {
+        Field field = DirectByteBufferDeallocator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static Unsafe getUnsafe() throws ReflectiveOperationException {
+        Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+        theUnsafe.setAccessible(true);
+        return (Unsafe) theUnsafe.get(null);
+    }
+
+    private static Object readStaticField(Unsafe unsafe, Field field) {
+        return unsafe.getObject(unsafe.staticFieldBase(field), unsafe.staticFieldOffset(field));
+    }
+
+    private static void writeStaticField(Unsafe unsafe, Field field, Object value) {
+        unsafe.putObject(unsafe.staticFieldBase(field), unsafe.staticFieldOffset(field), value);
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/FastConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/FastConcurrentDirectDequeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.FastConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FastConcurrentDirectDequeTest {
+    @Test
+    void serializationRoundTripPreservesElementsInDequeOrder() throws IOException, ClassNotFoundException {
+        FastConcurrentDirectDeque<String> original = new FastConcurrentDirectDeque<>();
+        original.addLast("first");
+        original.addLast("second");
+        original.addFirst("zero");
+
+        byte[] serialized = serialize(original);
+        FastConcurrentDirectDeque<String> restored = deserialize(serialized);
+
+        assertThat(restored).containsExactly("zero", "first", "second");
+        assertThat(restored.pollFirst()).isEqualTo("zero");
+        assertThat(restored.pollLast()).isEqualTo("second");
+        assertThat(restored).containsExactly("first");
+    }
+
+    private static byte[] serialize(FastConcurrentDirectDeque<String> deque) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(deque);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static FastConcurrentDirectDeque<String> deserialize(byte[] serialized)
+        throws IOException, ClassNotFoundException {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (FastConcurrentDirectDeque<String>) input.readObject();
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/PortableConcurrentDirectDequeTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/PortableConcurrentDirectDequeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.openssl.util.PortableConcurrentDirectDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PortableConcurrentDirectDequeTest {
+    @Test
+    void serializationRoundTripPreservesElementsInDequeOrder() throws IOException, ClassNotFoundException {
+        PortableConcurrentDirectDeque<String> original = new PortableConcurrentDirectDeque<>();
+        original.addLast("first");
+        original.addLast("second");
+        original.addFirst("zero");
+
+        byte[] serialized = serialize(original);
+        PortableConcurrentDirectDeque<String> restored = deserialize(serialized);
+
+        assertThat(restored).containsExactly("zero", "first", "second");
+        assertThat(restored.pollFirst()).isEqualTo("zero");
+        assertThat(restored.pollLast()).isEqualTo("second");
+        assertThat(restored).containsExactly("first");
+    }
+
+    private static byte[] serialize(PortableConcurrentDirectDeque<String> deque) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(deque);
+        }
+        return bytes.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static PortableConcurrentDirectDeque<String> deserialize(byte[] serialized)
+        throws IOException, ClassNotFoundException {
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return (PortableConcurrentDirectDeque<String>) input.readObject();
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/SSLTest.java
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/src/test/java/org_wildfly_openssl/wildfly_openssl_java/SSLTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_wildfly_openssl.wildfly_openssl_java;
+
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.wildfly.openssl.SSL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SSLTest {
+    @Test
+    void getInstanceUsesPackagedNativeLibraryFallback(@TempDir Path openSslDirectory) {
+        String originalOpenSslPath = System.getProperty(SSL.ORG_WILDFLY_OPENSSL_PATH);
+        String originalWfsslPath = System.getProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH);
+        try {
+            System.setProperty(SSL.ORG_WILDFLY_OPENSSL_PATH, openSslDirectory.toString());
+            System.clearProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH);
+
+            try {
+                SSL ssl = SSL.getInstance();
+
+                assertThat(ssl).isNotNull();
+            } catch (RuntimeException exception) {
+                assertThat(hasInvocationTargetExceptionCause(exception)).isFalse();
+            } catch (Error error) {
+                if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                    throw error;
+                }
+            }
+        } finally {
+            setOrClearProperty(SSL.ORG_WILDFLY_OPENSSL_PATH, originalOpenSslPath);
+            setOrClearProperty(SSL.ORG_WILDFLY_LIBWFSSL_PATH, originalWfsslPath);
+        }
+    }
+
+    private static boolean hasInvocationTargetExceptionCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof InvocationTargetException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static void setOrClearProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.wildfly.openssl.**"
+    }
+  ]
+}

--- a/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
+++ b/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.wildfly.openssl.**"
+      "includeClasses" : "org.wildfly.openssl.**"
+    },
+    {
+      "includeClasses" : "org_wildfly_openssl.wildfly_openssl_java.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4846

This PR provides test fixes and new metadata for org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 27457
- Cached input tokens: 252928
- Output tokens: 2296
- Metadata entries: 51
- Iterations: 1
- Library coverage percentage: 15.15
- Previous library version metadata entries: 51
- Previous library version coverage percentage: 15.48

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `942a3585e38ecf958ad668365c1f0a15c5fb8a07`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 22/22 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 22/22 covered calls (100.00%)

**Reflection:**
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 19/19 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 19/19 covered calls (100.00%)

**Resources:**
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 3/3 covered calls (100.00%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 2371/19235 (12.33%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 2378/19817 (12.00%)

**Line:**
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 601/3882 (15.48%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 609/4021 (15.15%)

**Method:**
- org.wildfly.openssl:wildfly-openssl-java:2.0.0.Alpha1: 112/742 (15.09%)
- org.wildfly.openssl:wildfly-openssl-java:2.1.1.Final: 112/771 (14.53%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
index 3b477b24d8..205d6d87ee 100644
--- 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/build.gradle
+++ 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String nativeLibraryVersion = "2.1.0.Final"
 
 repositories {
     exclusiveContent {
@@ -27,7 +28,7 @@ repositories {
 
 dependencies {
     testImplementation "org.wildfly.openssl:wildfly-openssl-java:$libraryVersion@jar"
-    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$libraryVersion@jar"
+    testRuntimeOnly "org.wildfly.openssl:wildfly-openssl-linux-x86_64:$nativeLibraryVersion@jar"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/user-code-filter.json 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
index 76a7702de8..63e8c2edc7 100644
--- 1/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.0.0.Alpha1/user-code-filter.json
+++ 2/tests/src/org.wildfly.openssl/wildfly-openssl-java/2.1.1.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.wildfly.openssl.**"
+      "includeClasses" : "org.wildfly.openssl.**"
+    },
+    {
+      "includeClasses" : "org_wildfly_openssl.wildfly_openssl_java.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
