### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:kotlinx-coroutines-core as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-core/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-core/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; the POM declares org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2 for JVM consumption.",
+    "replacement": "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2187

This PR records `org.jetbrains.kotlinx:kotlinx-coroutines-core` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; the POM declares org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2 for JVM consumption.

Replacement guidance:
- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2

### Metadata Forge

- Forge monitored branch: `forge/take-blocked-issues`
- Forge branch: `forge/take-blocked-issues`
- Forge commit hash: `1193a78bba8ee15816745621d3f02a95d1a0ace6`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
