### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter:2.6.3 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use the class-bearing dependencies such as org.springframework.boot:spring-boot:2.6.3 and org.springframework.boot:spring-boot-autoconfigure:2.6.3."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2182

This PR records `org.springframework.boot:spring-boot-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter:2.6.3 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use the class-bearing dependencies such as org.springframework.boot:spring-boot:2.6.3 and org.springframework.boot:spring-boot-autoconfigure:2.6.3.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `942a3585e38ecf958ad668365c1f0a15c5fb8a07`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
