### PR TITLE
[GenAI] Add support for io.grpc:grpc-xds:1.68.0 using gpt-5.5

### DIFF
--- a/metadata/io.grpc/grpc-xds/1.68.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-xds/1.68.0/reachability-metadata.json
@@ -1,0 +1,158 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsParameters",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsParameters$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProvider",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProvider$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProviderInstance",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CertificateProviderInstance$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CombinedCertificateValidationContext",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext$CombinedCertificateValidationContext$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.TypedExtensionConfig",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.TypedExtensionConfig$Builder",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsKeyLog",
+      "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext"
+      },
+      "type": "io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsKeyLog$Builder",
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/io.grpc/grpc-xds/index.json
+++ b/metadata/io.grpc/grpc-xds/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.68.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-sources.jar",
+    "repository-url" : "https://github.com/grpc/grpc-java",
+    "test-code-url" : "https://github.com/grpc/grpc-java/tree/v$version$/xds/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-xds/$version$/grpc-xds-$version$-javadoc.jar",
+    "description" : "gRPC XDS provides Java support for xDS APIs in gRPC, enabling clients and servers to consume xDS-based service configuration, load balancing, routing, and security settings. It integrates with the grpc-java stack so JVM applications can participate in Envoy-style control-plane deployments.",
+    "tested-versions" : [
+      "1.68.0"
+    ],
+    "allowed-packages" : [
+      "io.grpc.xds"
+    ]
+  }
+]

--- a/stats/io.grpc/grpc-xds/1.68.0/execution-metrics.json
+++ b/stats/io.grpc/grpc-xds/1.68.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T01:46:25.545443Z",
+    "library": "io.grpc:grpc-xds:1.68.0",
+    "starting_commit": "ee820e23e3c0d3501b4f662410142932dee02e04",
+    "ending_commit": "ce1292f407a7da32675c632fb1acfb5d74bd9204",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.68.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15231,
+          "missed": 1017167,
+          "ratio": 0.014753,
+          "total": 1032398
+        },
+        "line": {
+          "covered": 3591,
+          "missed": 268701,
+          "ratio": 0.013188,
+          "total": 272292
+        },
+        "method": {
+          "covered": 755,
+          "missed": 62747,
+          "ratio": 0.011889,
+          "total": 63502
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 361413,
+      "cached_input_tokens_used": 3464192,
+      "output_tokens_used": 30997,
+      "iterations": 5,
+      "cost_usd": 2.662,
+      "generated_loc": 428,
+      "tested_library_loc": 3591,
+      "metadata_entries": 44,
+      "code_coverage_percent": 1.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java",
+      "metadata_file": "metadata/io.grpc/grpc-xds/1.68.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.grpc/grpc-xds/1.68.0/stats.json
+++ b/stats/io.grpc/grpc-xds/1.68.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.68.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15231,
+        "missed" : 1017167,
+        "ratio" : 0.014753,
+        "total" : 1032398
+      },
+      "line" : {
+        "covered" : 3591,
+        "missed" : 268701,
+        "ratio" : 0.013188,
+        "total" : 272292
+      },
+      "method" : {
+        "covered" : 755,
+        "missed" : 62747,
+        "ratio" : 0.011889,
+        "total" : 63502
+      }
+    }
+  } ]
+}

--- a/tests/src/io.grpc/grpc-xds/1.68.0/.gitignore
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.grpc/grpc-xds/1.68.0/build.gradle
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.grpc:grpc-xds:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-xds/1.68.0/gradle.properties
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.grpc:grpc-xds:1.68.0
+library.version = 1.68.0
+metadata.dir = io.grpc/grpc-xds/1.68.0/

--- a/tests/src/io.grpc/grpc-xds/1.68.0/settings.gradle
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.grpc.grpc-xds_tests'

--- a/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -6,11 +6,352 @@
  */
 package io_grpc.grpc_xds;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import com.google.protobuf.Duration;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ChannelCredentials;
+import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
+import io.grpc.Server;
+import io.grpc.ServerCredentials;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.xds.CdsLoadBalancerProvider;
+import io.grpc.xds.ClusterImplLoadBalancerProvider;
+import io.grpc.xds.ClusterResolverLoadBalancerProvider;
+import io.grpc.xds.CsdsService;
+import io.grpc.xds.LeastRequestLoadBalancerProvider;
+import io.grpc.xds.PriorityLoadBalancerProvider;
+import io.grpc.xds.RingHashLoadBalancerProvider;
+import io.grpc.xds.WeightedRoundRobinLoadBalancerProvider;
+import io.grpc.xds.WeightedTargetLoadBalancerProvider;
+import io.grpc.xds.WrrLocalityLoadBalancerProvider;
+import io.grpc.xds.XdsChannelCredentials;
+import io.grpc.xds.XdsNameResolverProvider;
+import io.grpc.xds.XdsServerBuilder;
+import io.grpc.xds.XdsServerCredentials;
+import io.grpc.xds.orca.OrcaOobUtil;
+import io.grpc.xds.orca.OrcaPerRequestUtil;
+import io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport;
+import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OpenRcaServiceGrpc;
+import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusDiscoveryServiceGrpc;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-class Grpc_xdsTest {
+public class Grpc_xdsTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void xdsCredentialsWrapFallbackCredentialsAndValidateNulls() {
+        ChannelCredentials fallbackChannelCredentials = InsecureChannelCredentials.create();
+        ChannelCredentials xdsChannelCredentials = XdsChannelCredentials.create(fallbackChannelCredentials);
+
+        assertThat(xdsChannelCredentials).isNotNull();
+        assertThat(xdsChannelCredentials.withoutBearerTokens()).isNotNull();
+        assertThatNullPointerException().isThrownBy(() -> XdsChannelCredentials.create(null));
+
+        ServerCredentials fallbackServerCredentials = InsecureServerCredentials.create();
+        ServerCredentials xdsServerCredentials = XdsServerCredentials.create(fallbackServerCredentials);
+
+        assertThat(xdsServerCredentials).isNotNull();
+        assertThatNullPointerException().isThrownBy(() -> XdsServerCredentials.create(null));
+    }
+
+    @Test
+    void xdsProvidersAreDiscoverableFromGrpcRegistries() {
+        LoadBalancerRegistry loadBalancerRegistry = LoadBalancerRegistry.getDefaultRegistry();
+
+        assertRegisteredProvider(loadBalancerRegistry, new RingHashLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new LeastRequestLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WeightedRoundRobinLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new CdsLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new ClusterResolverLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new ClusterImplLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new PriorityLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WeightedTargetLoadBalancerProvider());
+        assertRegisteredProvider(loadBalancerRegistry, new WrrLocalityLoadBalancerProvider());
+
+        NameResolverProvider xdsProvider = NameResolverRegistry.getDefaultRegistry().getProviderForScheme("xds");
+        assertThat(xdsProvider).isInstanceOf(XdsNameResolverProvider.class);
+        assertThat(xdsProvider.getDefaultScheme()).isEqualTo("xds");
+    }
+
+    @Test
+    void loadBalancerProvidersParsePublicServiceConfigShapes() {
+        assertConfigAccepted(new RingHashLoadBalancerProvider(), Map.of("minRingSize", 128.0, "maxRingSize", 4096.0));
+        assertConfigAccepted(new LeastRequestLoadBalancerProvider(), Map.of("choiceCount", 3.0));
+        assertConfigAccepted(
+                new WeightedRoundRobinLoadBalancerProvider(),
+                Map.of(
+                        "blackoutPeriod", "1s",
+                        "weightExpirationPeriod", "3s",
+                        "enableOobLoadReport", true,
+                        "oobReportingPeriod", "2s",
+                        "weightUpdatePeriod", "0.250s",
+                        "errorUtilizationPenalty", 1.5f));
+        assertConfigAccepted(new CdsLoadBalancerProvider(), Map.of("cluster", "payments-cluster"));
+
+        assertConfigRejected(new RingHashLoadBalancerProvider(), Map.of("minRingSize", 8.0, "maxRingSize", 4.0));
+        assertConfigRejected(new LeastRequestLoadBalancerProvider(), Map.of("choiceCount", 1.0));
+        assertConfigRejected(new WeightedTargetLoadBalancerProvider(), Map.of("targets", Map.of()));
+        assertConfigRejected(new WrrLocalityLoadBalancerProvider(), Map.of("childPolicy", List.of()));
+        assertConfigRejected(new PriorityLoadBalancerProvider(), Map.of());
+        assertConfigRejected(new ClusterResolverLoadBalancerProvider(), Map.of());
+        assertConfigRejected(new ClusterImplLoadBalancerProvider(), Map.of());
+    }
+
+    @Test
+    void csdsServiceBindsExpectedXdsStatusMethods() {
+        CsdsService service = CsdsService.newInstance();
+        ServerServiceDefinition definition = service.bindService();
+
+        assertThat(definition.getServiceDescriptor().getName())
+                .isEqualTo(ClientStatusDiscoveryServiceGrpc.SERVICE_NAME);
+        assertThat(methodFullNames(definition.getMethods()))
+                .containsExactlyInAnyOrder(
+                        ClientStatusDiscoveryServiceGrpc.getFetchClientStatusMethod().getFullMethodName(),
+                        ClientStatusDiscoveryServiceGrpc.getStreamClientStatusMethod().getFullMethodName());
+
+        ClientStatusRequest request = ClientStatusRequest.newBuilder()
+                .setNode(Node.newBuilder().setId("test-node").setCluster("test-cluster"))
+                .setExcludeResourceContents(true)
+                .build();
+        ClientStatusRequest parsed = request.toBuilder().build();
+
+        assertThat(parsed.getNode().getId()).isEqualTo("test-node");
+        assertThat(parsed.getNode().getCluster()).isEqualTo("test-cluster");
+        assertThat(parsed.getExcludeResourceContents()).isTrue();
+    }
+
+    @Test
+    void xdsServerBuilderAcceptsPublicCsdsServiceAndBootstrapOverride() throws Exception {
+        ServerCredentials credentials = XdsServerCredentials.create(InsecureServerCredentials.create());
+        Server server = XdsServerBuilder.forPort(0, credentials)
+                .addService(CsdsService.newInstance())
+                .xdsServingStatusListener(new RecordingServingStatusListener())
+                .drainGraceTime(1, TimeUnit.SECONDS)
+                .overrideBootstrapForTest(bootstrapOverride())
+                .build();
+
+        try {
+            assertThat(server).isNotNull();
+        } finally {
+            server.shutdownNow();
+            server.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void orcaProtosDescriptorsAndStubFactoriesAreUsable() {
+        OrcaLoadReportRequest request = OrcaLoadReportRequest.newBuilder()
+                .setReportInterval(Duration.newBuilder().setSeconds(1).build())
+                .addRequestCostNames("cpu-cost")
+                .addRequestCostNames("memory-cost")
+                .build();
+        OrcaLoadReportRequest parsedRequest = request.toBuilder().build();
+
+        assertThat(parsedRequest.getReportInterval().getSeconds()).isEqualTo(1);
+        assertThat(parsedRequest.getRequestCostNamesList()).containsExactly("cpu-cost", "memory-cost");
+
+        OrcaLoadReport report = OrcaLoadReport.newBuilder()
+                .setCpuUtilization(0.25)
+                .setMemUtilization(0.50)
+                .setRps(42)
+                .setRpsFractional(42.5)
+                .setEps(1.5)
+                .setApplicationUtilization(0.75)
+                .putRequestCost("cpu-cost", 2.0)
+                .putUtilization("gpu", 0.60)
+                .putNamedMetrics("queue-depth", 7.0)
+                .build();
+        OrcaLoadReport parsedReport = report.toBuilder().build();
+
+        assertThat(parsedReport.getCpuUtilization()).isEqualTo(0.25);
+        assertThat(parsedReport.getMemUtilization()).isEqualTo(0.50);
+        assertThat(parsedReport.getRps()).isEqualTo(42);
+        assertThat(parsedReport.getRpsFractional()).isEqualTo(42.5);
+        assertThat(parsedReport.getEps()).isEqualTo(1.5);
+        assertThat(parsedReport.getApplicationUtilization()).isEqualTo(0.75);
+        assertThat(parsedReport.getRequestCostOrThrow("cpu-cost")).isEqualTo(2.0);
+        assertThat(parsedReport.getUtilizationOrThrow("gpu")).isEqualTo(0.60);
+        assertThat(parsedReport.getNamedMetricsOrThrow("queue-depth")).isEqualTo(7.0);
+
+        assertThat(OpenRcaServiceGrpc.SERVICE_NAME).isEqualTo("xds.service.orca.v3.OpenRcaService");
+        assertThat(OpenRcaServiceGrpc.getStreamCoreMetricsMethod().getType())
+                .isEqualTo(MethodDescriptor.MethodType.SERVER_STREAMING);
+        assertThat(OpenRcaServiceGrpc.getServiceDescriptor().getMethods())
+                .contains(OpenRcaServiceGrpc.getStreamCoreMetricsMethod());
+
+        Channel channel = new NoopChannel();
+        assertThat(OpenRcaServiceGrpc.newStub(channel)).isNotNull();
+        assertThat(OpenRcaServiceGrpc.newBlockingStub(channel)).isNotNull();
+        assertThat(OpenRcaServiceGrpc.newFutureStub(channel)).isNotNull();
+    }
+
+    @Test
+    void orcaUtilitiesCreateReportingConfigurationAndPerRequestTracers() {
+        OrcaOobUtil.OrcaReportingConfig config = OrcaOobUtil.OrcaReportingConfig.newBuilder()
+                .setReportInterval(250, TimeUnit.MILLISECONDS)
+                .build();
+
+        assertThat(config.getReportIntervalNanos()).isEqualTo(TimeUnit.MILLISECONDS.toNanos(250));
+        assertThat(config.toBuilder().build().getReportIntervalNanos()).isEqualTo(config.getReportIntervalNanos());
+        assertThat(config.toString()).contains("reportIntervalNanos");
+
+        AtomicInteger delegateCalls = new AtomicInteger();
+        ClientStreamTracer.Factory delegateFactory = new ClientStreamTracer.Factory() {
+            @Override
+            public ClientStreamTracer newClientStreamTracer(ClientStreamTracer.StreamInfo info, Metadata headers) {
+                delegateCalls.incrementAndGet();
+                return new ClientStreamTracer() {};
+            }
+        };
+        OrcaPerRequestUtil perRequestUtil = OrcaPerRequestUtil.getInstance();
+        ClientStreamTracer.Factory factory = perRequestUtil.newOrcaClientStreamTracerFactory(
+                delegateFactory,
+                report -> assertThat(report).isNotNull());
+
+        ClientStreamTracer tracer = factory.newClientStreamTracer(
+                ClientStreamTracer.StreamInfo.newBuilder().setCallOptions(CallOptions.DEFAULT).build(),
+                new Metadata());
+
+        assertThat(tracer).isNotNull();
+        assertThat(delegateCalls).hasValue(1);
+        assertThat(perRequestUtil.newOrcaClientStreamTracerFactory(report -> assertThat(report).isNotNull()))
+                .isNotNull();
+    }
+
+    @Test
+    void managedChannelBuilderAcceptsXdsChannelCredentials() {
+        ChannelCredentials credentials = XdsChannelCredentials.create(InsecureChannelCredentials.create());
+
+        assertThatCode(() -> {
+            ManagedChannel channel = Grpc.newChannelBuilderForAddress("localhost", 8080, credentials).build();
+            try {
+                assertThat(channel).isNotNull();
+            } finally {
+                channel.shutdownNow();
+                channel.awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }).doesNotThrowAnyException();
+    }
+
+    private static void assertRegisteredProvider(LoadBalancerRegistry registry, LoadBalancerProvider provider) {
+        LoadBalancerProvider registeredProvider = registry.getProvider(provider.getPolicyName());
+
+        assertThat(registeredProvider).isNotNull();
+        assertThat(registeredProvider.isAvailable()).isTrue();
+        assertThat(registeredProvider.getPolicyName()).isEqualTo(provider.getPolicyName());
+    }
+
+    private static void assertConfigAccepted(LoadBalancerProvider provider, Map<String, ?> config) {
+        NameResolver.ConfigOrError result = provider.parseLoadBalancingPolicyConfig(config);
+
+        assertThat(result.getError()).isNull();
+        assertThat(result.getConfig()).isNotNull();
+    }
+
+    private static void assertConfigRejected(LoadBalancerProvider provider, Map<String, ?> config) {
+        NameResolver.ConfigOrError result = provider.parseLoadBalancingPolicyConfig(config);
+
+        assertThat(result.getError()).isNotNull();
+        assertThat(result.getError().getCode()).isNotEqualTo(Status.Code.OK);
+    }
+
+    private static Set<String> methodFullNames(Collection<ServerMethodDefinition<?, ?>> methods) {
+        Map<String, Boolean> fullNames = new HashMap<>();
+        for (ServerMethodDefinition<?, ?> method : methods) {
+            fullNames.put(method.getMethodDescriptor().getFullMethodName(), true);
+        }
+        return fullNames.keySet();
+    }
+
+    private static Map<String, ?> bootstrapOverride() {
+        return Map.of(
+                "xds_servers",
+                List.of(Map.of(
+                        "server_uri", "trafficdirector.googleapis.com:443",
+                        "channel_creds", List.of(Map.of("type", "insecure")))),
+                "node",
+                Map.of("id", "test-node", "cluster", "test-cluster"));
+    }
+
+    private static final class RecordingServingStatusListener implements XdsServerBuilder.XdsServingStatusListener {
+        private final AtomicInteger statusChanges = new AtomicInteger();
+
+        @Override
+        public void onServing() {
+            statusChanges.incrementAndGet();
+        }
+
+        @Override
+        public void onNotServing(Throwable throwable) {
+            statusChanges.incrementAndGet();
+            assertThat(throwable).isNotNull();
+        }
+    }
+
+    private static final class NoopChannel extends Channel {
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+            return new ClientCall<>() {
+                private boolean halfClosed;
+
+                @Override
+                public void start(Listener<ResponseT> responseListener, Metadata headers) {
+                    assertThat(responseListener).isNotNull();
+                    assertThat(headers).isNotNull();
+                }
+
+                @Override
+                public void request(int numberOfMessages) {
+                    assertThat(numberOfMessages).isPositive();
+                }
+
+                @Override
+                public void cancel(String message, Throwable cause) {
+                    assertThat(halfClosed).isFalse();
+                }
+
+                @Override
+                public void halfClose() {
+                    halfClosed = true;
+                }
+
+                @Override
+                public void sendMessage(RequestT message) {
+                    assertThat(message).isNotNull();
+                }
+            };
+        }
+
+        @Override
+        public String authority() {
+            return "noop-authority";
+        }
     }
 }

--- a/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -46,6 +46,10 @@ import io.grpc.xds.XdsChannelCredentials;
 import io.grpc.xds.XdsNameResolverProvider;
 import io.grpc.xds.XdsServerBuilder;
 import io.grpc.xds.XdsServerCredentials;
+import io.grpc.xds.client.Bootstrapper;
+import io.grpc.xds.client.BootstrapperImpl;
+import io.grpc.xds.client.EnvoyProtoData;
+import io.grpc.xds.client.XdsInitializationException;
 import io.grpc.xds.orca.OrcaOobUtil;
 import io.grpc.xds.orca.OrcaPerRequestUtil;
 import io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport;
@@ -54,6 +58,7 @@ import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusDiscoveryServiceGrpc;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -259,6 +264,74 @@ public class Grpc_xdsTest {
         }).doesNotThrowAnyException();
     }
 
+    @Test
+    void bootstrapperParsesXdsBootstrapNodeSecurityAndAuthorityConfiguration() throws Exception {
+        Bootstrapper.BootstrapInfo bootstrapInfo = new TestingBootstrapper().bootstrap(Map.of(
+                "xds_servers",
+                List.of(serverConfig("xds-primary.example.com:443", true)),
+                "node",
+                Map.of(
+                        "id",
+                        "bootstrap-node",
+                        "cluster",
+                        "bootstrap-cluster",
+                        "metadata",
+                        Map.of("environment", "test", "debug", true),
+                        "locality",
+                        Map.of("region", "us-central1", "zone", "us-central1-a", "sub_zone", "blue")),
+                "certificate_providers",
+                Map.of("file-provider", Map.of(
+                        "plugin_name",
+                        "file_watcher",
+                        "config",
+                        Map.of("certificate_file", "/tmp/cert.pem", "private_key_file", "/tmp/key.pem"))),
+                "server_listener_resource_name_template",
+                "grpc/server/%s",
+                "client_default_listener_resource_name_template",
+                "xdstp://traffic-director/global/envoy.config.listener.v3.Listener/%s",
+                "authorities",
+                Map.of("traffic-director", Map.of(
+                        "client_listener_resource_name_template",
+                        "xdstp://traffic-director/envoy.config.listener.v3.Listener/%s",
+                        "xds_servers",
+                        List.of(serverConfig("authority-xds.example.com:443", false))))));
+
+        Bootstrapper.ServerInfo primaryServer = bootstrapInfo.servers().get(0);
+        assertThat(primaryServer.target()).isEqualTo("xds-primary.example.com:443");
+        assertThat(primaryServer.ignoreResourceDeletion()).isTrue();
+        assertThat(primaryServer.implSpecificConfig())
+                .isEqualTo(Map.copyOf(serverConfig("xds-primary.example.com:443", true)));
+
+        EnvoyProtoData.Node xdsNode = bootstrapInfo.node();
+        Node envoyNode = xdsNode.toEnvoyProtoNode();
+        assertThat(xdsNode.getId()).isEqualTo("bootstrap-node");
+        assertThat(envoyNode.getCluster()).isEqualTo("bootstrap-cluster");
+        assertThat(envoyNode.getMetadata().getFieldsOrThrow("environment").getStringValue()).isEqualTo("test");
+        assertThat(envoyNode.getMetadata().getFieldsOrThrow("debug").getBoolValue()).isTrue();
+        assertThat(envoyNode.getLocality().getRegion()).isEqualTo("us-central1");
+        assertThat(envoyNode.getLocality().getZone()).isEqualTo("us-central1-a");
+        assertThat(envoyNode.getLocality().getSubZone()).isEqualTo("blue");
+        assertThat(envoyNode.getClientFeaturesList())
+                .contains(
+                        BootstrapperImpl.CLIENT_FEATURE_DISABLE_OVERPROVISIONING,
+                        BootstrapperImpl.CLIENT_FEATURE_RESOURCE_IN_SOTW);
+
+        Bootstrapper.CertificateProviderInfo certificateProvider = bootstrapInfo.certProviders().get("file-provider");
+        assertThat(certificateProvider.pluginName()).isEqualTo("file_watcher");
+        assertThat(certificateProvider.config().get("certificate_file")).isEqualTo("/tmp/cert.pem");
+
+        assertThat(bootstrapInfo.serverListenerResourceNameTemplate()).isEqualTo("grpc/server/%s");
+        assertThat(bootstrapInfo.clientDefaultListenerResourceNameTemplate())
+                .isEqualTo("xdstp://traffic-director/global/envoy.config.listener.v3.Listener/%s");
+
+        Bootstrapper.AuthorityInfo authority = bootstrapInfo.authorities().get("traffic-director");
+        assertThat(authority.clientListenerResourceNameTemplate())
+                .isEqualTo("xdstp://traffic-director/envoy.config.listener.v3.Listener/%s");
+        assertThat(authority.xdsServers()).hasSize(1);
+        assertThat(authority.xdsServers().get(0).target()).isEqualTo("authority-xds.example.com:443");
+        assertThat(authority.xdsServers().get(0).ignoreResourceDeletion()).isFalse();
+    }
+
     private static void assertRegisteredProvider(LoadBalancerRegistry registry, LoadBalancerProvider provider) {
         LoadBalancerProvider registeredProvider = registry.getProvider(provider.getPolicyName());
 
@@ -297,6 +370,30 @@ public class Grpc_xdsTest {
                         "channel_creds", List.of(Map.of("type", "insecure")))),
                 "node",
                 Map.of("id", "test-node", "cluster", "test-cluster"));
+    }
+
+    private static Map<String, ?> serverConfig(String serverUri, boolean ignoreResourceDeletion) {
+        return Map.of(
+                "server_uri",
+                serverUri,
+                "channel_creds",
+                List.of(Map.of("type", "insecure")),
+                "server_features",
+                ignoreResourceDeletion ? List.of("ignore_resource_deletion") : List.of());
+    }
+
+    private static final class TestingBootstrapper extends BootstrapperImpl {
+        @Override
+        protected String getJsonContent() throws IOException, XdsInitializationException {
+            throw new UnsupportedOperationException("bootstrap(Map) supplies configuration directly");
+        }
+
+        @Override
+        protected Object getImplSpecificConfig(Map<String, ?> rawServerConfig, String serverUri)
+                throws XdsInitializationException {
+            assertThat(rawServerConfig.get("server_uri")).isEqualTo(serverUri);
+            return Map.copyOf(rawServerConfig);
+        }
     }
 
     private static final class RecordingServingStatusListener implements XdsServerBuilder.XdsServingStatusListener {

--- a/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.Duration;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -36,6 +37,7 @@ import io.grpc.xds.CdsLoadBalancerProvider;
 import io.grpc.xds.ClusterImplLoadBalancerProvider;
 import io.grpc.xds.ClusterResolverLoadBalancerProvider;
 import io.grpc.xds.CsdsService;
+import io.grpc.xds.EnvoyServerProtoData;
 import io.grpc.xds.LeastRequestLoadBalancerProvider;
 import io.grpc.xds.PriorityLoadBalancerProvider;
 import io.grpc.xds.RingHashLoadBalancerProvider;
@@ -56,6 +58,9 @@ import io.grpc.xds.shaded.com.github.xds.data.orca.v3.OrcaLoadReport;
 import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OpenRcaServiceGrpc;
 import io.grpc.xds.shaded.com.github.xds.service.orca.v3.OrcaLoadReportRequest;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.config.core.v3.Node;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
+import io.grpc.xds.shaded.io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusDiscoveryServiceGrpc;
 import io.grpc.xds.shaded.io.envoyproxy.envoy.service.status.v3.ClientStatusRequest;
 import java.io.IOException;
@@ -247,6 +252,38 @@ public class Grpc_xdsTest {
         assertThat(delegateCalls).hasValue(1);
         assertThat(perRequestUtil.newOrcaClientStreamTracerFactory(report -> assertThat(report).isNotNull()))
                 .isNotNull();
+    }
+
+    @Test
+    void envoyTlsContextsConvertFromXdsProtosAndPreserveCommonSettings() {
+        CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
+                .addAlpnProtocols("h2")
+                .addAlpnProtocols("grpc-exp")
+                .build();
+        DownstreamTlsContext downstreamTlsContext = DownstreamTlsContext.newBuilder()
+                .setCommonTlsContext(commonTlsContext)
+                .setRequireClientCertificate(BoolValue.of(true))
+                .build();
+
+        EnvoyServerProtoData.DownstreamTlsContext convertedDownstreamTlsContext =
+                EnvoyServerProtoData.DownstreamTlsContext.fromEnvoyProtoDownstreamTlsContext(downstreamTlsContext);
+
+        assertThat(convertedDownstreamTlsContext.getCommonTlsContext().getAlpnProtocolsList())
+                .containsExactly("h2", "grpc-exp");
+        assertThat(convertedDownstreamTlsContext.isRequireClientCertificate()).isTrue();
+        assertThat(convertedDownstreamTlsContext)
+                .isEqualTo(new EnvoyServerProtoData.DownstreamTlsContext(commonTlsContext, true));
+
+        UpstreamTlsContext upstreamTlsContext = UpstreamTlsContext.newBuilder()
+                .setCommonTlsContext(commonTlsContext)
+                .setSni("backend.example.com")
+                .build();
+
+        EnvoyServerProtoData.UpstreamTlsContext convertedUpstreamTlsContext =
+                EnvoyServerProtoData.UpstreamTlsContext.fromEnvoyProtoUpstreamTlsContext(upstreamTlsContext);
+
+        assertThat(convertedUpstreamTlsContext.getCommonTlsContext()).isEqualTo(commonTlsContext);
+        assertThat(convertedUpstreamTlsContext.toString()).contains("commonTlsContext");
     }
 
     @Test

--- a/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/src/test/java/io_grpc/grpc_xds/Grpc_xdsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_xds;
+
+import org.junit.jupiter.api.Test;
+
+class Grpc_xdsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.grpc/grpc-xds/1.68.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.grpc.xds.**"
+    }
+  ]
+}

--- a/tests/src/io.grpc/grpc-xds/1.68.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-xds/1.68.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.grpc.xds.**"
+      "includeClasses" : "io.grpc.xds.**"
+    },
+    {
+      "includeClasses" : "io_grpc.grpc_xds.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4740

This PR introduces tests and metadata for io.grpc:grpc-xds:1.68.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 361413
- Cached input tokens: 3464192
- Output tokens: 30997
- Metadata entries: 44
- Iterations: 5
- Library coverage percentage: 1.32
- Generated lines of code: 428
- Tested library lines of code: 3591

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3654df7bbbb8d4708990a9d7636a914ca46372f0`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 15231/1032398 (1.48%)
- Line: 3591/272292 (1.32%)
- Method: 755/63502 (1.19%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
