### PR TITLE
[GenAI] Test fix for org.jboss.weld:weld-spi:2.2.SP2 using gpt-5.5

### DIFF
--- a/metadata/org.jboss.weld/weld-spi/2.2.SP2/reachability-metadata.json
+++ b/metadata/org.jboss.weld/weld-spi/2.2.SP2/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jboss.weld.bootstrap.api.SingletonProvider"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jboss.weld.bootstrap.api.SingletonProvider"
+      },
+      "type": "org.jboss.weld.bootstrap.api.helpers.RegistrySingletonProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jboss.weld/weld-spi/index.json
+++ b/metadata/org.jboss.weld/weld-spi/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.2.SP2",
+    "tested-versions" : [
+      "2.2.SP2"
+    ],
+    "allowed-packages" : [
+      "org.jboss.weld"
+    ]
+  },
+  {
     "metadata-version" : "2.1.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-sources.jar",
     "repository-url" : "https://github.com/weld/api",

--- a/metadata/org.jboss.weld/weld-spi/index.json
+++ b/metadata/org.jboss.weld/weld-spi/index.json
@@ -5,6 +5,11 @@
     "tested-versions" : [
       "2.2.SP2"
     ],
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-sources.jar",
+    "repository-url" : "https://github.com/weld/api",
+    "test-code-url" : "https://github.com/weld/api/tree/$version$/weld-spi/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-spi/$version$/weld-spi-$version$-javadoc.jar",
+    "description" : "Weld SPI provides the service-provider interfaces used to integrate Weld, the CDI reference implementation, with Java EE containers and runtime services. It defines bootstrap, deployment, resource, transaction, security, validation, EJB, injection, servlet, and serialization contracts for container integration.",
     "allowed-packages" : [
       "org.jboss.weld"
     ]

--- a/stats/org.jboss.weld/weld-spi/2.2.SP2/execution-metrics.json
+++ b/stats/org.jboss.weld/weld-spi/2.2.SP2/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_java_run_fail:2026-05-06": {
+    "timestamp": "2026-05-06T01:54:07.771983Z",
+    "library": "org.jboss.weld:weld-spi:2.2.SP2",
+    "starting_commit": "f9d764cef91018485c3bf2f65cf1fb5876a80a79",
+    "ending_commit": "db4d92d4ff280c1f130504295f3fd6df5bef4965",
+    "previous_library": "org.jboss.weld:weld-spi:2.1.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.SP2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 94,
+          "missed": 1421,
+          "ratio": 0.062046,
+          "total": 1515
+        },
+        "line": {
+          "covered": 28,
+          "missed": 325,
+          "ratio": 0.07932,
+          "total": 353
+        },
+        "method": {
+          "covered": 12,
+          "missed": 192,
+          "ratio": 0.058824,
+          "total": 204
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.1.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 67,
+          "missed": 1429,
+          "ratio": 0.044786,
+          "total": 1496
+        },
+        "line": {
+          "covered": 26,
+          "missed": 317,
+          "ratio": 0.075802,
+          "total": 343
+        },
+        "method": {
+          "covered": 11,
+          "missed": 190,
+          "ratio": 0.054726,
+          "total": 201
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 32642,
+      "cached_input_tokens_used": 124416,
+      "output_tokens_used": 1515,
+      "iterations": 1,
+      "cost_usd": 0.1077,
+      "tested_library_loc": 28,
+      "metadata_entries": 3,
+      "previous_library_metadata_entries": 2,
+      "code_coverage_percent": 7.93,
+      "previous_library_coverage_percent": 7.58
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java",
+      "metadata_file": "metadata/org.jboss.weld/weld-spi/2.2.SP2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.weld/weld-spi/2.2.SP2/stats.json
+++ b/stats/org.jboss.weld/weld-spi/2.2.SP2/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.2.SP2",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 94,
+        "missed" : 1421,
+        "ratio" : 0.062046,
+        "total" : 1515
+      },
+      "line" : {
+        "covered" : 28,
+        "missed" : 325,
+        "ratio" : 0.07932,
+        "total" : 353
+      },
+      "method" : {
+        "covered" : 12,
+        "missed" : 192,
+        "ratio" : 0.058824,
+        "total" : 204
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/.gitignore
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/build.gradle
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.weld:weld-spi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/gradle.properties
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.weld:weld-spi:2.2.SP2
+library.version = 2.2.SP2
+metadata.dir = org.jboss.weld/weld-spi/2.2.SP2/

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/settings.gradle
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.weld.weld-spi_tests'

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_weld.weld_spi;
+
+import org.jboss.weld.bootstrap.api.Singleton;
+import org.jboss.weld.bootstrap.api.SingletonProvider;
+import org.jboss.weld.bootstrap.api.helpers.IsolatedStaticSingletonProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SingletonProviderTest {
+    private static final String SINGLETON_ID = "test-deployment";
+
+    @BeforeEach
+    void resetBeforeTest() {
+        SingletonProvider.reset();
+    }
+
+    @AfterEach
+    void resetAfterTest() {
+        SingletonProvider.reset();
+    }
+
+    @Test
+    void instanceInitializesDefaultIsolatedStaticProvider() {
+        SingletonProvider provider = SingletonProvider.instance();
+
+        assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
+
+        Singleton<String> singleton = provider.create(String.class);
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
+        assertThatThrownBy(() -> singleton.get(SINGLETON_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Singleton is not set");
+
+        singleton.set(SINGLETON_ID, "stored value");
+        assertThat(singleton.isSet(SINGLETON_ID)).isTrue();
+        assertThat(singleton.get(SINGLETON_ID)).isEqualTo("stored value");
+
+        singleton.clear(SINGLETON_ID);
+        assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
+    }
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -8,7 +8,7 @@ package org_jboss_weld.weld_spi;
 
 import org.jboss.weld.bootstrap.api.Singleton;
 import org.jboss.weld.bootstrap.api.SingletonProvider;
-import org.jboss.weld.bootstrap.api.helpers.IsolatedStaticSingletonProvider;
+import org.jboss.weld.bootstrap.api.helpers.RegistrySingletonProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,16 +30,16 @@ public class SingletonProviderTest {
     }
 
     @Test
-    void instanceInitializesDefaultIsolatedStaticProvider() {
+    void instanceInitializesDefaultRegistryProvider() {
         SingletonProvider provider = SingletonProvider.instance();
 
-        assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
+        assertThat(provider).isInstanceOf(RegistrySingletonProvider.class);
 
         Singleton<String> singleton = provider.create(String.class);
         assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
         assertThatThrownBy(() -> singleton.get(SINGLETON_ID))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Singleton is not set");
+                .hasMessageContaining("Singleton not set for " + SINGLETON_ID);
 
         singleton.set(SINGLETON_ID, "stored value");
         assertThat(singleton.isSet(SINGLETON_ID)).isTrue();

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jboss.weld.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
+++ b/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jboss.weld.**"
+    },
+    {
+      "includeClasses" : "org_jboss_weld.weld_spi.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #5184

This PR provides test fixes and new metadata for org.jboss.weld:weld-spi:2.2.SP2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 32642
- Cached input tokens: 124416
- Output tokens: 1515
- Metadata entries: 3
- Iterations: 1
- Library coverage percentage: 7.93
- Previous library version metadata entries: 2
- Previous library version coverage percentage: 7.58

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b2255a811f49f27ecb550092785fb22baa0f7796`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jboss.weld:weld-spi:2.1.Final: 1/1 covered calls (100.00%)
- org.jboss.weld:weld-spi:2.2.SP2: 1/1 covered calls (100.00%)

**Reflection:**
- org.jboss.weld:weld-spi:2.1.Final: 1/1 covered calls (100.00%)
- org.jboss.weld:weld-spi:2.2.SP2: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jboss.weld:weld-spi:2.1.Final: 67/1496 (4.48%)
- org.jboss.weld:weld-spi:2.2.SP2: 94/1515 (6.20%)

**Line:**
- org.jboss.weld:weld-spi:2.1.Final: 26/343 (7.58%)
- org.jboss.weld:weld-spi:2.2.SP2: 28/353 (7.93%)

**Method:**
- org.jboss.weld:weld-spi:2.1.Final: 11/201 (5.47%)
- org.jboss.weld:weld-spi:2.2.SP2: 12/204 (5.88%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java 2/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
index a48d03e82c..f02ad16640 100644
--- 1/tests/src/org.jboss.weld/weld-spi/2.1.Final/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
+++ 2/tests/src/org.jboss.weld/weld-spi/2.2.SP2/src/test/java/org_jboss_weld/weld_spi/SingletonProviderTest.java
@@ -8,7 +8,7 @@ package org_jboss_weld.weld_spi;
 
 import org.jboss.weld.bootstrap.api.Singleton;
 import org.jboss.weld.bootstrap.api.SingletonProvider;
-import org.jboss.weld.bootstrap.api.helpers.IsolatedStaticSingletonProvider;
+import org.jboss.weld.bootstrap.api.helpers.RegistrySingletonProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,16 +30,16 @@ public class SingletonProviderTest {
     }
 
     @Test
-    void instanceInitializesDefaultIsolatedStaticProvider() {
+    void instanceInitializesDefaultRegistryProvider() {
         SingletonProvider provider = SingletonProvider.instance();
 
-        assertThat(provider).isInstanceOf(IsolatedStaticSingletonProvider.class);
+        assertThat(provider).isInstanceOf(RegistrySingletonProvider.class);
 
         Singleton<String> singleton = provider.create(String.class);
         assertThat(singleton.isSet(SINGLETON_ID)).isFalse();
         assertThatThrownBy(() -> singleton.get(SINGLETON_ID))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Singleton is not set");
+                .hasMessageContaining("Singleton not set for " + SINGLETON_ID);
 
         singleton.set(SINGLETON_ID, "stored value");
         assertThat(singleton.isSet(SINGLETON_ID)).isTrue();
diff --git 1/tests/src/org.jboss.weld/weld-spi/2.1.Final/user-code-filter.json 2/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
index 1e8fb2a59f..2ec6e0ac41 100644
--- 1/tests/src/org.jboss.weld/weld-spi/2.1.Final/user-code-filter.json
+++ 2/tests/src/org.jboss.weld/weld-spi/2.2.SP2/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "org.jboss.weld.**"
+    },
+    {
+      "includeClasses" : "org_jboss_weld.weld_spi.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
