### PR TITLE
[GenAI] Mark com.github.ajalt.mordant:mordant-jvm as not for Native Image

### DIFF
--- a/metadata/com.github.ajalt.mordant/mordant-jvm/index.json
+++ b/metadata/com.github.ajalt.mordant/mordant-jvm/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published mordant-jvm JAR contains only META-INF/MANIFEST.MF and a Kotlin module file and no JVM class files; implementation classes are provided by its JVM dependencies.",
+    "replacement": "com.github.ajalt.mordant:mordant-core-jvm:3.0.2 plus com.github.ajalt.mordant:mordant-jvm-jna-jvm:3.0.2, com.github.ajalt.mordant:mordant-jvm-ffm-jvm:3.0.2, and com.github.ajalt.mordant:mordant-jvm-graal-ffi-jvm:3.0.2"
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Fixes: #5329

This PR records `com.github.ajalt.mordant:mordant-jvm` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published mordant-jvm JAR contains only META-INF/MANIFEST.MF and a Kotlin module file and no JVM class files; implementation classes are provided by its JVM dependencies.

Replacement guidance:
- com.github.ajalt.mordant:mordant-core-jvm:3.0.2 plus com.github.ajalt.mordant:mordant-jvm-jna-jvm:3.0.2, com.github.ajalt.mordant:mordant-jvm-ffm-jvm:3.0.2, and com.github.ajalt.mordant:mordant-jvm-graal-ffi-jvm:3.0.2

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `6605c838764dbbba15b0862f84fdb3c98006b97d`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
