### PR TITLE
[GenAI] Add support for org.json4s:json4s-jackson_3:4.0.7 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-jackson_3/4.0.7/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-jackson_3/4.0.7/reachability-metadata.json
@@ -1,0 +1,26 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JsonMethods$"
+      },
+      "type" : "org.json4s.jackson.JsonMethods$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.Json$UtilMethods"
+      },
+      "type" : "org.json4s.jackson.Json$UtilMethods",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-jackson_3/index.json
+++ b/metadata/org.json4s/json4s-jackson_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_3/$version$/json4s-jackson_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/jackson/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson_3/$version$/json4s-jackson_3-$version$-javadoc.jar",
+    "description" : "Json4s is a Scala JSON library that provides a shared JSON AST plus parsing, querying, transformation, extraction, and serialization APIs. The json4s-jackson artifact supplies the Jackson-backed parser and serializer integration for using that AST on Scala 3/JVM projects.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "4.0.7"
+    ],
+    "allowed-packages" : [
+      "org.json4s.jackson"
+    ]
+  }
+]

--- a/stats/org.json4s/json4s-jackson_3/4.0.7/execution-metrics.json
+++ b/stats/org.json4s/json4s-jackson_3/4.0.7/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T02:49:56.467849Z",
+    "library": "org.json4s:json4s-jackson_3:4.0.7",
+    "starting_commit": "2d25290d4e3bf63d4578e8d86bd013d861ebd944",
+    "ending_commit": "f8194268ef9c5bd4569677106ec4851a0c07e2ce",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.7",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 204,
+          "missed": 236,
+          "ratio": 0.463636,
+          "total": 440
+        },
+        "line": {
+          "covered": 29,
+          "missed": 9,
+          "ratio": 0.763158,
+          "total": 38
+        },
+        "method": {
+          "covered": 26,
+          "missed": 32,
+          "ratio": 0.448276,
+          "total": 58
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 203473,
+      "cached_input_tokens_used": 1779712,
+      "output_tokens_used": 30278,
+      "iterations": 4,
+      "cost_usd": 1.7982,
+      "generated_loc": 322,
+      "tested_library_loc": 29,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 24,
+      "code_coverage_percent": 76.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala",
+      "metadata_file": "metadata/org.json4s/json4s-jackson_3/4.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-jackson_3/4.0.7/stats.json
+++ b/stats/org.json4s/json4s-jackson_3/4.0.7/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.7",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 204,
+        "missed" : 236,
+        "ratio" : 0.463636,
+        "total" : 440
+      },
+      "line" : {
+        "covered" : 29,
+        "missed" : 9,
+        "ratio" : 0.763158,
+        "total" : 38
+      },
+      "method" : {
+        "covered" : 26,
+        "missed" : 32,
+        "ratio" : 0.448276,
+        "total" : 58
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/.gitignore
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-jackson_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/gradle.properties
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-jackson_3:4.0.7
+library.version = 4.0.7
+metadata.dir = org.json4s/json4s-jackson_3/4.0.7/

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/settings.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-jackson_3_tests'

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -138,5 +138,43 @@
         }
       ]
     }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonEmailNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonEmailNotification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonNotificationBatch$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonNotificationBatch.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonSmsNotification$.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ParanamerReader$"
+      },
+      "glob" : "org_json4s/json4s_jackson_3/JacksonSmsNotification.class"
+    }
   ]
 }

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,142 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonEmailNotification",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "recipient"
+        },
+        {
+          "name" : "subject"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonNotificationBatch",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "scala.collection.immutable.List"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "notifications"
+        },
+        {
+          "name" : "owner"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.PropertyDescriptor"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonSmsNotification",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "boolean"
+          ]
+        }
+      ],
+      "fields" : [
+        {
+          "name" : "number"
+        },
+        {
+          "name" : "urgent"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonEmailNotification$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonNotificationBatch$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonSmsNotification$"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonEmailNotification"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonNotificationBatch"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.Reflector$ClassDescriptorBuilder"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonSmsNotification"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonEmailNotification$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonNotificationBatch$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.reflect.ScalaSigReader$"
+      },
+      "type" : "org_json4s.json4s_jackson_3.JacksonSmsNotification$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
@@ -33,6 +33,14 @@ case class JacksonMoney(amount: BigDecimal, currency: String)
 
 case class JacksonAccount(name: String, score: Int)
 
+sealed trait JacksonNotification
+
+case class JacksonEmailNotification(subject: String, recipient: String) extends JacksonNotification
+
+case class JacksonSmsNotification(number: String, urgent: Boolean) extends JacksonNotification
+
+case class JacksonNotificationBatch(owner: String, notifications: List[JacksonNotification])
+
 class JacksonMoneySerializer extends CustomSerializer[JacksonMoney](_ => (
   {
     case JObject(fields) =>
@@ -227,6 +235,35 @@ class Json4s_jackson_3Test {
     JacksonSerialization.write(source, outputStream)
     val streamedJson: String = outputStream.toString(StandardCharsets.UTF_8)
     assertEquals(parsed, parse(streamedJson, useBigDecimalForDouble = true))
+  }
+
+  @Test
+  def writesAndReadsPolymorphicValuesWithShortTypeHints(): Unit = {
+    implicit val formats: Formats = JacksonSerialization.formats(
+      ShortTypeHints(
+        List(classOf[JacksonEmailNotification], classOf[JacksonSmsNotification]),
+        "kind"
+      )
+    )
+
+    val batch: JacksonNotificationBatch = JacksonNotificationBatch(
+      owner = "operations",
+      notifications = List(
+        JacksonEmailNotification("deployment", "ops@example.com"),
+        JacksonSmsNotification("+15550101", urgent = true)
+      )
+    )
+
+    val jsonText: String = JacksonSerialization.write(batch)
+    val parsed: JValue = parse(jsonText)
+    assertEquals(JString("operations"), parsed \ "owner")
+    assertEquals(JString("JacksonEmailNotification"), (parsed \ "notifications")(0) \ "kind")
+    assertEquals(JString("deployment"), (parsed \ "notifications")(0) \ "subject")
+    assertEquals(JString("JacksonSmsNotification"), (parsed \ "notifications")(1) \ "kind")
+    assertEquals(JBool.True, (parsed \ "notifications")(1) \ "urgent")
+
+    val restored: JacksonNotificationBatch = JacksonSerialization.read[JacksonNotificationBatch](jsonText)
+    assertEquals(batch, restored)
   }
 
   @Test

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_jackson_3
+
+import org.junit.jupiter.api.Test
+
+class Json4s_jackson_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
@@ -6,6 +6,7 @@
  */
 package org_json4s.json4s_jackson_3
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -26,6 +27,7 @@ import java.io.StringWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
 
 case class JacksonMoney(amount: BigDecimal, currency: String)
 
@@ -273,6 +275,46 @@ class Json4s_jackson_3Test {
     assertEquals(JString("hello"), prettyAst \ "message")
     assertEquals(JLong(2L), prettyAst \ "count")
     assertTrue(prettyText.contains("\n"))
+  }
+
+  @Test
+  def integratesJson4sAstWithJacksonObjectMapperModule(): Unit = {
+    val jacksonMapper: ObjectMapper = new ObjectMapper()
+    jacksonMapper.registerModule(Json4sScalaModule)
+    jacksonMapper.configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+    jacksonMapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+
+    val value: JValue = JObject(
+      JField("title", JString("module")),
+      JField("omitted", JNothing),
+      JField("numbers", JArray(List(JInt(BigInt("1234567890123456789012345")), JDecimal(BigDecimal("10.25"))))),
+      JField("labels", JSet(Set(JString("json4s"), JString("jackson")))),
+      JField("presentNull", JNull)
+    )
+
+    val jsonText: String = jacksonMapper.writeValueAsString(value)
+    val jsonNode: JsonNode = jacksonMapper.readTree(jsonText)
+    assertEquals("module", jsonNode.get("title").asText())
+    assertFalse(jsonNode.has("omitted"))
+    assertTrue(jsonNode.get("labels").isArray)
+    assertEquals(Set("json4s", "jackson"), jsonNode.get("labels").elements().asScala.map(_.asText()).toSet)
+    assertTrue(jsonNode.get("presentNull").isNull)
+
+    val restored: JValue = jacksonMapper.readValue(jsonText, classOf[JValue])
+    assertEquals(JString("module"), restored \ "title")
+    assertEquals(JNothing, restored \ "omitted")
+    assertEquals(JInt(BigInt("1234567890123456789012345")), (restored \ "numbers")(0))
+    assertEquals(JDecimal(BigDecimal("10.25")), (restored \ "numbers")(1))
+    val restoredLabels: Set[String] = (restored \ "labels") match {
+      case JArray(labels) => labels.collect { case JString(label) => label }.toSet
+      case other => fail(s"Expected labels array but got $other")
+    }
+    assertEquals(Set("json4s", "jackson"), restoredLabels)
+    assertEquals(JNull, restored \ "presentNull")
+
+    val objectValue: JObject = jacksonMapper.readValue("""{"active":true,"count":3}""", classOf[JObject])
+    assertEquals(JBool.True, objectValue \ "active")
+    assertEquals(JInt(3), objectValue \ "count")
   }
 
   @Test

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_3/Json4s_jackson_3Test.scala
@@ -6,11 +6,290 @@
  */
 package org_json4s.json4s_jackson_3
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.json4s.*
+import org.json4s.jackson.Json
+import org.json4s.jackson.Json4sScalaModule
+import org.json4s.jackson.JsonMethods.*
+import org.json4s.jackson.Serialization as JacksonSerialization
+import org.json4s.jackson.{compactJson, parseJson, parseJsonOpt, prettyJson, renderJValue}
+import org.json4s.prefs.EmptyValueStrategy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+case class JacksonMoney(amount: BigDecimal, currency: String)
+
+case class JacksonAccount(name: String, score: Int)
+
+class JacksonMoneySerializer extends CustomSerializer[JacksonMoney](_ => (
+  {
+    case JObject(fields) =>
+      val amount: BigDecimal = fields.collectFirst { case JField("amount", JDecimal(value)) => value }.get
+      val currency: String = fields.collectFirst { case JField("currency", JString(value)) => value }.get
+      JacksonMoney(amount, currency)
+  },
+  { case money: JacksonMoney =>
+    JObject(
+      JField("amount", JDecimal(money.amount)),
+      JField("currency", JString(money.currency))
+    )
+  }
+))
 
 class Json4s_jackson_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def parsesJsonFromSupportedInputsAndHonorsNumberModes(): Unit = {
+    val jsonText: String =
+      """
+        |{
+        |  "message": "hello\nworld",
+        |  "unicode": "caf\u00e9",
+        |  "flags": [true, false, null],
+        |  "price": 12.50,
+        |  "maxLong": 9223372036854775807,
+        |  "largeInteger": 922337203685477580812345
+        |}
+        |""".stripMargin
+
+    val parsedWithBigNumbers: JValue = parse(jsonText, useBigDecimalForDouble = true, useBigIntForLong = true)
+    assertEquals(JString("hello\nworld"), parsedWithBigNumbers \ "message")
+    assertEquals(JString("café"), parsedWithBigNumbers \ "unicode")
+    assertEquals(JArray(List(JBool.True, JBool.False, JNull)), parsedWithBigNumbers \ "flags")
+    assertEquals(JDecimal(BigDecimal("12.50")), parsedWithBigNumbers \ "price")
+    assertEquals(JInt(BigInt("9223372036854775807")), parsedWithBigNumbers \ "maxLong")
+    assertEquals(JInt(BigInt("922337203685477580812345")), parsedWithBigNumbers \ "largeInteger")
+
+    val parsedWithJvmNumbers: JValue = parse(
+      new StringReader("""{"price":12.5,"maxLong":9223372036854775807}"""),
+      useBigDecimalForDouble = false,
+      useBigIntForLong = false
+    )
+    assertEquals(JDouble(12.5d), parsedWithJvmNumbers \ "price")
+    assertEquals(JLong(9223372036854775807L), parsedWithJvmNumbers \ "maxLong")
+
+    val bytes: Array[Byte] = """{"stream":true,"values":[1,2]}""".getBytes(StandardCharsets.UTF_8)
+    val inputStream: ByteArrayInputStream = new ByteArrayInputStream(bytes)
+    try {
+      val parsedFromStream: JValue = parse(inputStream, useBigDecimalForDouble = true)
+      assertEquals(JBool.True, parsedFromStream \ "stream")
+      assertEquals(JArray(List(JInt(1), JInt(2))), parsedFromStream \ "values")
+    } finally {
+      inputStream.close()
+    }
+
+    val tempFile: Path = Files.createTempFile("json4s-jackson", ".json")
+    try {
+      Files.writeString(tempFile, """{"file":"ok","nested":{"n":3}}""", StandardCharsets.UTF_8)
+      val parsedFromFile: JValue = parse(tempFile.toFile)
+      assertEquals(JString("ok"), parsedFromFile \ "file")
+      assertEquals(JInt(3), parsedFromFile \ "nested" \ "n")
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+
+    assertEquals(Some(JArray(List(JInt(1), JInt(2), JInt(3)))), parseOpt("[1,2,3]"))
+    assertEquals(None, parseOpt("""{"broken":]}"""))
+  }
+
+  @Test
+  def rendersCompactsAndPrettyPrintsJacksonJsonValues(): Unit = {
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("line", JString("one\ntwo")),
+      JField("missing", JNothing),
+      JField("items", JArray(List(JInt(1), JNothing, JNull))),
+      JField("nested", JObject(JField("enabled", JBool.True)))
+    )
+
+    try {
+      val renderedWithNulls: JValue = render(
+        value,
+        alwaysEscapeUnicode = true,
+        emptyValueStrategy = EmptyValueStrategy.preserve
+      )
+      assertEquals(
+        JObject(
+          JField("name", JString("café")),
+          JField("line", JString("one\ntwo")),
+          JField("missing", JNull),
+          JField("items", JArray(List(JInt(1), JNull, JNull))),
+          JField("nested", JObject(JField("enabled", JBool.True)))
+        ),
+        renderedWithNulls
+      )
+      assertEquals(
+        """{"name":"caf\u00E9","line":"one\ntwo","missing":null,"items":[1,null,null],"nested":{"enabled":true}}""",
+        compact(renderedWithNulls)
+      )
+
+      val prettyText: String = pretty(renderedWithNulls)
+      assertTrue(prettyText.contains("\n"))
+      assertTrue(prettyText.contains("\"nested\""))
+      assertTrue(prettyText.contains("caf\\u00E9"))
+
+      val renderedSkippingEmptyValues: JValue = render(value, emptyValueStrategy = EmptyValueStrategy.skip)
+      assertEquals(JNothing, renderedSkippingEmptyValues \ "missing")
+      assertEquals(JArray(List(JInt(1), JNothing, JNull)), renderedSkippingEmptyValues \ "items")
+    } finally {
+      render(JNothing, alwaysEscapeUnicode = false)
+    }
+  }
+
+  @Test
+  def convertsBetweenJValuesAndJacksonJsonNodes(): Unit = {
+    val objectNode: ObjectNode = mapper.createObjectNode()
+    objectNode.put("name", "Ada")
+    objectNode.put("active", true)
+    objectNode.putArray("scores").add(10).add(20)
+    objectNode.putObject("address").put("city", "London")
+
+    val value: JValue = fromJsonNode(objectNode)
+    assertEquals(JString("Ada"), value \ "name")
+    assertEquals(JBool.True, value \ "active")
+    assertEquals(JArray(List(JInt(10), JInt(20))), value \ "scores")
+    assertEquals(JString("London"), value \ "address" \ "city")
+
+    val jsonNode: JsonNode = asJsonNode(value)
+    assertTrue(jsonNode.isObject)
+    assertEquals("Ada", jsonNode.get("name").asText())
+    assertEquals(20, jsonNode.get("scores").get(1).asInt())
+    assertEquals(value, fromJsonNode(jsonNode))
+  }
+
+  @Test
+  def exposesPackageLevelJacksonHelpers(): Unit = {
+    implicit val formats: Formats = DefaultFormats.withEscapeUnicode.preservingEmptyValues
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("missing", JNothing),
+      JField("values", JArray(List(JInt(1), JNothing, JNull)))
+    )
+
+    try {
+      val rendered: JValue = renderJValue(value)
+      assertEquals(JNull, rendered \ "missing")
+      assertEquals(JArray(List(JInt(1), JNull, JNull)), rendered \ "values")
+      assertEquals("""{"name":"caf\u00E9","missing":null,"values":[1,null,null]}""", compactJson(rendered))
+      assertTrue(prettyJson(rendered).contains("\n"))
+
+      val parsed: JValue = parseJson("""{"ok":true,"numbers":[1,2,3]}""")
+      assertEquals(JBool.True, parsed \ "ok")
+      assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "numbers")
+      assertEquals(Some(parsed), parseJsonOpt("""{"ok":true,"numbers":[1,2,3]}"""))
+      assertEquals(None, parseJsonOpt("""{"ok":]}"""))
+    } finally {
+      render(JNothing, alwaysEscapeUnicode = false)
+    }
+  }
+
+  @Test
+  def serializesAndReadsCollectionsThroughJacksonSerialization(): Unit = {
+    implicit val formats: Formats = JacksonSerialization.formats(NoTypeHints).withBigDecimal
+
+    val source: Map[String, Any] = Map(
+      "title" -> "Quarterly",
+      "active" -> true,
+      "ids" -> List(1, 2, 3),
+      "amounts" -> List(BigDecimal("12.50"), BigDecimal("19.99")),
+      "metadata" -> Map("region" -> "EMEA", "priority" -> 2)
+    )
+
+    val jsonText: String = JacksonSerialization.write(source)
+    val parsed: JValue = parse(jsonText, useBigDecimalForDouble = true)
+    assertEquals(JString("Quarterly"), parsed \ "title")
+    assertEquals(JBool.True, parsed \ "active")
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), parsed \ "ids")
+    assertEquals(JArray(List(JDecimal(BigDecimal("12.50")), JDecimal(BigDecimal("19.99")))), parsed \ "amounts")
+    assertEquals(JString("EMEA"), parsed \ "metadata" \ "region")
+    assertEquals(JInt(2), parsed \ "metadata" \ "priority")
+
+    val readerValue: Map[String, List[Int]] = JacksonSerialization.read[Map[String, List[Int]]](new StringReader("""{"ids":[1,2,3]}"""))
+    assertEquals(Map("ids" -> List(1, 2, 3)), readerValue)
+
+    val prettyWriter: StringWriter = new StringWriter()
+    assertSame(prettyWriter, JacksonSerialization.writePretty(source, prettyWriter))
+    assertTrue(prettyWriter.toString.contains("\n"))
+    assertEquals(parsed, parse(prettyWriter.toString, useBigDecimalForDouble = true))
+
+    val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    JacksonSerialization.write(source, outputStream)
+    val streamedJson: String = outputStream.toString(StandardCharsets.UTF_8)
+    assertEquals(parsed, parse(streamedJson, useBigDecimalForDouble = true))
+  }
+
+  @Test
+  def appliesCustomSerializersToCollections(): Unit = {
+    implicit val formats: Formats = DefaultFormats.withBigDecimal + new JacksonMoneySerializer
+
+    val prices: List[JacksonMoney] = List(
+      JacksonMoney(BigDecimal("19.99"), "EUR"),
+      JacksonMoney(BigDecimal("2.50"), "EUR")
+    )
+    val pricesJson: String = JacksonSerialization.write(prices)
+    val pricesValue: JValue = parse(pricesJson, useBigDecimalForDouble = true)
+
+    assertEquals(JDecimal(BigDecimal("19.99")), pricesValue(0) \ "amount")
+    assertEquals(JString("EUR"), pricesValue(0) \ "currency")
+    assertEquals(JDecimal(BigDecimal("2.50")), pricesValue(1) \ "amount")
+    assertEquals(prices, JacksonSerialization.read[List[JacksonMoney]](pricesJson))
+
+    val mappedJson: String = JacksonSerialization.write(Map("total" -> prices.head))
+    val mappedValue: JValue = parse(mappedJson, useBigDecimalForDouble = true)
+    assertEquals(JDecimal(BigDecimal("19.99")), mappedValue \ "total" \ "amount")
+    assertEquals(Map("total" -> prices.head), JacksonSerialization.read[Map[String, JacksonMoney]](mappedJson))
+  }
+
+  @Test
+  def usesJsonFacadeWithExplicitFormatsAndMapper(): Unit = {
+    val customMapper: ObjectMapper = new ObjectMapper()
+    customMapper.registerModule(Json4sScalaModule)
+    val json: Json = Json(DefaultFormats.withBigDecimal.withLong, customMapper)
+
+    val parsed: JValue = json.parse("""{"price":12.50,"maxLong":9223372036854775807}""")
+    assertEquals(JDecimal(BigDecimal("12.50")), parsed \ "price")
+    assertEquals(JLong(9223372036854775807L), parsed \ "maxLong")
+    assertEquals(None, json.parseOpt("""{"broken":]}"""))
+
+    val writer: StringWriter = new StringWriter()
+    val returnedWriter: StringWriter = json.write(List(Map("letter" -> "a"), Map("letter" -> "b")), writer)
+    assertSame(writer, returnedWriter)
+    assertEquals(
+      JArray(List(JObject(JField("letter", JString("a"))), JObject(JField("letter", JString("b"))))),
+      json.parse(writer.toString)
+    )
+
+    val prettyText: String = json.writePretty(Map("message" -> "hello", "count" -> 2))
+    val prettyAst: JValue = json.parse(prettyText)
+    assertEquals(JString("hello"), prettyAst \ "message")
+    assertEquals(JLong(2L), prettyAst \ "count")
+    assertTrue(prettyText.contains("\n"))
+  }
+
+  @Test
+  def usesJacksonJsonMethodsWithPublicReadersAndWriters(): Unit = {
+    import org.json4s.DefaultReaders.*
+    import org.json4s.DefaultWriters.*
+
+    implicit val accountWriter: Writer[JacksonAccount] = Writer.writer2[String, Int, JacksonAccount](account => (account.name, account.score))("name", "score")
+    implicit val accountReader: Reader[JacksonAccount] = Reader.reader2[String, Int, JacksonAccount](JacksonAccount.apply)("name", "score")
+
+    val account: JacksonAccount = JacksonAccount("jackson", 42)
+    val accountJson: JValue = asJValue(account)
+    assertEquals(JObject(JField("name", JString("jackson")), JField("score", JInt(42))), accountJson)
+    assertEquals(account, fromJValue[JacksonAccount](accountJson))
+
+    val collectionJson: JValue = asJValue(Map("ids" -> List(1, 2, 3), "scores" -> List(10, 20)))
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), collectionJson \ "ids")
+    assertEquals(Map("ids" -> List(1, 2, 3)), fromJValue[Map[String, List[Int]]](JObject(JField("ids", JArray(List(JInt(1), JInt(2), JInt(3)))))))
   }
 }

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.json4s.jackson.**"
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.json4s.jackson.**"
+      "includeClasses" : "org.json4s.jackson.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_jackson_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5433

This PR introduces tests and metadata for org.json4s:json4s-jackson_3:4.0.7, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 203473
- Cached input tokens: 1779712
- Output tokens: 30278
- Metadata entries: 4
- Test-only metadata entries: 24
- Iterations: 4
- Library coverage percentage: 76.32
- Generated lines of code: 322
- Tested library lines of code: 29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `3654df7bbbb8d4708990a9d7636a914ca46372f0`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 204/440 (46.36%)
- Line: 29/38 (76.32%)
- Method: 26/58 (44.83%)

### Local CI Verification

- Status: `success`
- Commands run: 19
- Fixup attempts: 1
