### PR TITLE
[GenAI] Test fix for io.netty:netty-transport-classes-kqueue:4.2.2.Final using gpt-5.5

### DIFF
--- a/metadata/io.netty/netty-transport-classes-kqueue/4.2.2.Final/reachability-metadata.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/4.2.2.Final/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.netty.channel.kqueue.KQueueIoHandler"
+      },
+      "type": "io.netty.channel.kqueue.KQueueIoHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.AbstractReferenceCounted"
+      },
+      "type": "io.netty.util.AbstractReferenceCounted"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.DefaultAttributeMap"
+      },
+      "type": "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.io.FileDescriptor"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.CleanerJava24"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.CleanerJava24"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.PlatformDependent"
+      },
+      "type": "java.lang.management.RuntimeMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.netty.util.internal.ClassInitializerUtil"
+      },
+      "type": "java.nio.channels.FileChannel"
+    }
+  ]
+}

--- a/metadata/io.netty/netty-transport-classes-kqueue/index.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.2.2.Final",
+    "tested-versions" : [
+      "4.2.2.Final"
+    ],
+    "allowed-packages" : [
+      "io.netty.channel.kqueue"
+    ]
+  },
+  {
     "metadata-version" : "4.1.74.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-transport-classes-kqueue/index.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/index.json
@@ -1,27 +1,29 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.2.2.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-tests.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-javadoc.jar",
-    "description" : "Netty Transport Classes KQueue provides the Java classes for Netty's kqueue-based native transport on BSD-derived operating systems such as macOS. It lets Netty applications use the kqueue event notification mechanism for high-performance asynchronous network I/O when combined with the matching native transport artifacts.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.2.2.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-javadoc.jar",
+    "description": "Netty Transport Classes KQueue provides the Java classes for Netty's kqueue-based native transport on BSD-derived operating systems such as macOS. It lets Netty applications use the kqueue event notification mechanism for high-performance asynchronous network I/O when combined with the matching native transport artifacts.",
+    "tested-versions": [
       "4.2.2.Final"
     ],
-    "allowed-packages" : [
-      "io.netty.channel.kqueue"
+    "allowed-packages": [
+      "io.netty.channel.kqueue",
+      "io.netty.util",
+      "io.netty.util.internal"
     ]
   },
   {
-    "metadata-version" : "4.1.74.Final",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
-    "repository-url" : "https://github.com/netty/netty",
-    "test-code-url" : "https://github.com/netty/netty/tree/netty-$version$/transport-native-kqueue/src/test/java/io/netty/channel/kqueue",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-javadoc.jar",
-    "description" : "Netty Transport Classes KQueue provides the Java classes that implement Netty's kqueue-based transport integration on BSD-derived operating systems such as macOS. It enables Netty applications to use the native kqueue event notification mechanism for high-performance asynchronous network I/O when paired with the matching native transport artifacts.",
-    "tested-versions" : [
+    "metadata-version": "4.1.74.Final",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
+    "repository-url": "https://github.com/netty/netty",
+    "test-code-url": "https://github.com/netty/netty/tree/netty-$version$/transport-native-kqueue/src/test/java/io/netty/channel/kqueue",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-javadoc.jar",
+    "description": "Netty Transport Classes KQueue provides the Java classes that implement Netty's kqueue-based transport integration on BSD-derived operating systems such as macOS. It enables Netty applications to use the native kqueue event notification mechanism for high-performance asynchronous network I/O when paired with the matching native transport artifacts.",
+    "tested-versions": [
       "4.1.74.Final",
       "4.1.75.Final",
       "4.1.76.Final",
@@ -84,7 +86,7 @@
       "4.2.0.Final",
       "4.2.1.Final"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.netty.channel.kqueue"
     ]
   }

--- a/metadata/io.netty/netty-transport-classes-kqueue/index.json
+++ b/metadata/io.netty/netty-transport-classes-kqueue/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.2.2.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-sources.jar",
+    "repository-url" : "https://github.com/netty/netty",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-kqueue/$version$/netty-transport-classes-kqueue-$version$-javadoc.jar",
+    "description" : "Netty Transport Classes KQueue provides the Java classes for Netty's kqueue-based native transport on BSD-derived operating systems such as macOS. It lets Netty applications use the kqueue event notification mechanism for high-performance asynchronous network I/O when combined with the matching native transport artifacts.",
     "tested-versions" : [
       "4.2.2.Final"
     ],

--- a/stats/io.netty/netty-transport-classes-kqueue/4.2.2.Final/execution-metrics.json
+++ b/stats/io.netty/netty-transport-classes-kqueue/4.2.2.Final/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-06": {
+    "timestamp": "2026-05-06T04:04:05.799117Z",
+    "library": "io.netty:netty-transport-classes-kqueue:4.2.2.Final",
+    "starting_commit": "f8735994b3b1b81e2207ea70c19b0005029e2389",
+    "ending_commit": "ec93f0e684416fb5f7ccbd8cd404d589223c57c8",
+    "previous_library": "io.netty:netty-transport-classes-kqueue:4.1.74.Final",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.2.2.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 196,
+          "missed": 8958,
+          "ratio": 0.021411,
+          "total": 9154
+        },
+        "line": {
+          "covered": 49,
+          "missed": 2241,
+          "ratio": 0.021397,
+          "total": 2290
+        },
+        "method": {
+          "covered": 17,
+          "missed": 572,
+          "ratio": 0.028862,
+          "total": 589
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.1.74.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 334,
+          "missed": 8143,
+          "ratio": 0.039401,
+          "total": 8477
+        },
+        "line": {
+          "covered": 75,
+          "missed": 2042,
+          "ratio": 0.035427,
+          "total": 2117
+        },
+        "method": {
+          "covered": 26,
+          "missed": 521,
+          "ratio": 0.047532,
+          "total": 547
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 51189,
+      "cached_input_tokens_used": 644096,
+      "output_tokens_used": 8151,
+      "iterations": 1,
+      "cost_usd": 0.5665,
+      "tested_library_loc": 49,
+      "metadata_entries": 8,
+      "previous_library_metadata_entries": 35,
+      "code_coverage_percent": 2.14,
+      "previous_library_coverage_percent": 3.54
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java",
+      "metadata_file": "metadata/io.netty/netty-transport-classes-kqueue/4.2.2.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.netty/netty-transport-classes-kqueue/4.2.2.Final/stats.json
+++ b/stats/io.netty/netty-transport-classes-kqueue/4.2.2.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.2.2.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 196,
+        "missed" : 8958,
+        "ratio" : 0.021411,
+        "total" : 9154
+      },
+      "line" : {
+        "covered" : 49,
+        "missed" : 2241,
+        "ratio" : 0.021397,
+        "total" : 2290
+      },
+      "method" : {
+        "covered" : 17,
+        "missed" : 572,
+        "ratio" : 0.028862,
+        "total" : 589
+      }
+    }
+  } ]
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/.gitignore
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/build.gradle
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.netty:netty-transport-classes-kqueue:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/gradle.properties
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.netty:netty-transport-classes-kqueue:4.2.2.Final
+library.version = 4.2.2.Final
+metadata.dir = io.netty/netty-transport-classes-kqueue/4.2.2.Final/

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/settings.gradle
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.netty.netty-transport-classes-kqueue_tests'

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_netty.netty_transport_classes_kqueue;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.AcceptFilter;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueChannelConfig;
+import io.netty.channel.kqueue.KQueueChannelOption;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannelConfig;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannelConfig;
+import io.netty.channel.unix.DomainSocketReadMode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class Netty_transport_classes_kqueueTest {
+    @Test
+    void kqueueAvailabilityContractIsSelfConsistent() {
+        boolean available = KQueue.isAvailable();
+        Throwable cause = KQueue.unavailabilityCause();
+
+        assertThat(available).isEqualTo(cause == null);
+        if (available) {
+            assertThatCode(KQueue::ensureAvailability).doesNotThrowAnyException();
+            return;
+        }
+
+        assertThat(cause).isNotNull();
+        assertThat(KQueue.isTcpFastOpenClientSideAvailable()).isFalse();
+        assertThat(KQueue.isTcpFastOpenServerSideAvailable()).isFalse();
+
+        Throwable thrown = catchThrowable(KQueue::ensureAvailability);
+        assertThat(thrown).isInstanceOf(UnsatisfiedLinkError.class);
+        assertThat(thrown).hasMessageContaining("required native library");
+        assertThat(thrown.getCause()).isSameAs(cause);
+        assertThat(rootCauseMessage(thrown)).isNotBlank();
+    }
+
+    @Test
+    void acceptFilterExposesImmutableValueSemantics() {
+        AcceptFilter httpReady = new AcceptFilter("httpready", "GET");
+        AcceptFilter sameFilter = new AcceptFilter("httpready", "GET");
+        AcceptFilter differentName = new AcceptFilter("dataready", "GET");
+        AcceptFilter differentArgs = new AcceptFilter("httpready", "POST");
+
+        assertThat(httpReady.filterName()).isEqualTo("httpready");
+        assertThat(httpReady.filterArgs()).isEqualTo("GET");
+        assertThat(httpReady).isEqualTo(httpReady);
+        assertThat(httpReady).isEqualTo(sameFilter).hasSameHashCodeAs(sameFilter);
+        assertThat(httpReady).isNotEqualTo(differentName);
+        assertThat(httpReady).isNotEqualTo(differentArgs);
+        assertThat(httpReady).isNotEqualTo("httpready, GET");
+        assertThat(httpReady).hasToString("httpready, GET");
+    }
+
+    @Test
+    void acceptFilterRejectsNullComponents() {
+        assertThatThrownBy(() -> new AcceptFilter(null, "args"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filterName");
+        assertThatThrownBy(() -> new AcceptFilter("name", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filterArgs");
+    }
+
+    @Test
+    void kqueueChannelOptionsAreRegisteredInTheConstantPool() {
+        List<ChannelOption<?>> options = List.of(
+                KQueueChannelOption.SO_SNDLOWAT,
+                KQueueChannelOption.TCP_NOPUSH,
+                KQueueChannelOption.SO_ACCEPTFILTER,
+                KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS
+        );
+
+        assertThat(options).doesNotContainNull();
+        assertThat(new LinkedHashSet<>(options)).hasSize(options.size());
+
+        for (ChannelOption<?> option : options) {
+            assertThat(option.name()).isNotBlank();
+            assertThat(ChannelOption.valueOf(option.name())).isSameAs(option);
+        }
+    }
+
+    @Test
+    void publicChannelConstructorsRespectTransportAvailability() {
+        assertChannelConstructorMatchesAvailability(KQueueSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDatagramChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueServerDomainSocketChannel::new);
+        assertChannelConstructorMatchesAvailability(KQueueDomainDatagramChannel::new);
+    }
+
+    @Test
+    void eventLoopGroupConstructorRespectsTransportAvailability() {
+        assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+    }
+
+    @Test
+    void socketChannelConfigControlsTcpNoPushOption() {
+        if (KQueue.isAvailable()) {
+            KQueueSocketChannel channel = new KQueueSocketChannel();
+            try {
+                KQueueSocketChannelConfig config = channel.config();
+
+                assertThat(config.getOptions()).containsKey(KQueueChannelOption.TCP_NOPUSH);
+
+                config.setTcpNoPush(true);
+                assertThat(config.isTcpNoPush()).isTrue();
+                assertThat(config.getOption(KQueueChannelOption.TCP_NOPUSH)).isTrue();
+
+                assertThat(config.setOption(KQueueChannelOption.TCP_NOPUSH, false)).isTrue();
+                assertThat(config.isTcpNoPush()).isFalse();
+                assertThat(config.getOption(KQueueChannelOption.TCP_NOPUSH)).isFalse();
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(KQueueSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    @Test
+    void domainSocketChannelConfigControlsReadModeAndHalfClosure() {
+        if (KQueue.isAvailable()) {
+            KQueueDomainSocketChannel channel = new KQueueDomainSocketChannel();
+            try {
+                KQueueDomainSocketChannelConfig config = channel.config();
+
+                assertThat(config.getReadMode()).isEqualTo(DomainSocketReadMode.BYTES);
+                assertThat(config.setReadMode(DomainSocketReadMode.FILE_DESCRIPTORS)).isSameAs(config);
+                assertThat(config.getReadMode()).isEqualTo(DomainSocketReadMode.FILE_DESCRIPTORS);
+
+                assertThat(config.isAllowHalfClosure()).isFalse();
+                assertThat(config.setAllowHalfClosure(true)).isSameAs(config);
+                assertThat(config.isAllowHalfClosure()).isTrue();
+
+                assertThatThrownBy(() -> config.setReadMode(null))
+                        .isInstanceOf(NullPointerException.class)
+                        .hasMessageContaining("mode");
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(KQueueDomainSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
+        if (KQueue.isAvailable()) {
+            Channel channel = constructor.get();
+            try {
+                assertThat(channel.isOpen()).isTrue();
+                assertThat(channel.config()).isInstanceOf(KQueueChannelConfig.class);
+                assertTransportProvidesGuessOptionRoundTrips((KQueueChannelConfig) channel.config());
+            } finally {
+                channel.close().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static void assertTransportProvidesGuessOptionRoundTrips(KQueueChannelConfig config) {
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isFalse();
+
+        assertThat(config.setOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true)).isTrue();
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isTrue();
+        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isTrue();
+
+        assertThat(config.setRcvAllocTransportProvidesGuess(false)).isSameAs(config);
+        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+    }
+
+    private static void assertEventLoopGroupConstructorMatchesAvailability(
+            Supplier<? extends EventLoopGroup> constructor) {
+        if (KQueue.isAvailable()) {
+            EventLoopGroup group = constructor.get();
+            try {
+                assertThat(group.isShuttingDown()).isFalse();
+                ((KQueueEventLoopGroup) group).setIoRatio(25);
+                assertThatThrownBy(() -> ((KQueueEventLoopGroup) group).setIoRatio(0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("ioRatio");
+            } finally {
+                group.shutdownGracefully().syncUninterruptibly();
+            }
+            return;
+        }
+
+        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage() == null ? current.getClass().getName() : current.getMessage();
+    }
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.kqueue.AcceptFilter;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueChannelConfig;
@@ -21,7 +22,7 @@ import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannelConfig;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
@@ -89,8 +90,7 @@ public class Netty_transport_classes_kqueueTest {
         List<ChannelOption<?>> options = List.of(
                 KQueueChannelOption.SO_SNDLOWAT,
                 KQueueChannelOption.TCP_NOPUSH,
-                KQueueChannelOption.SO_ACCEPTFILTER,
-                KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS
+                KQueueChannelOption.SO_ACCEPTFILTER
         );
 
         assertThat(options).doesNotContainNull();
@@ -114,7 +114,8 @@ public class Netty_transport_classes_kqueueTest {
 
     @Test
     void eventLoopGroupConstructorRespectsTransportAvailability() {
-        assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+        assertEventLoopGroupConstructorMatchesAvailability(
+                () -> new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory()));
     }
 
     @Test
@@ -139,7 +140,7 @@ public class Netty_transport_classes_kqueueTest {
             return;
         }
 
-        assertThatThrownBy(KQueueSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(KQueueSocketChannel::new));
     }
 
     @Test
@@ -166,7 +167,7 @@ public class Netty_transport_classes_kqueueTest {
             return;
         }
 
-        assertThatThrownBy(KQueueDomainSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(KQueueDomainSocketChannel::new));
     }
 
     private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
@@ -175,26 +176,27 @@ public class Netty_transport_classes_kqueueTest {
             try {
                 assertThat(channel.isOpen()).isTrue();
                 assertThat(channel.config()).isInstanceOf(KQueueChannelConfig.class);
-                assertTransportProvidesGuessOptionRoundTrips((KQueueChannelConfig) channel.config());
+                assertChannelConfigOptionsRoundTrip((KQueueChannelConfig) channel.config());
             } finally {
                 channel.close().syncUninterruptibly();
             }
             return;
         }
 
-        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(constructor::get));
     }
 
-    private static void assertTransportProvidesGuessOptionRoundTrips(KQueueChannelConfig config) {
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
-        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isFalse();
+    private static void assertChannelConfigOptionsRoundTrip(KQueueChannelConfig config) {
+        assertThat(config.setConnectTimeoutMillis(1234)).isSameAs(config);
+        assertThat(config.getConnectTimeoutMillis()).isEqualTo(1234);
 
-        assertThat(config.setOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true)).isTrue();
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isTrue();
-        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isTrue();
+        assertThat(config.setWriteSpinCount(8)).isSameAs(config);
+        assertThat(config.getWriteSpinCount()).isEqualTo(8);
 
-        assertThat(config.setRcvAllocTransportProvidesGuess(false)).isSameAs(config);
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+        assertThat(config.setAutoRead(false)).isSameAs(config);
+        assertThat(config.isAutoRead()).isFalse();
+        assertThat(config.setOption(ChannelOption.AUTO_READ, true)).isTrue();
+        assertThat(config.isAutoRead()).isTrue();
     }
 
     private static void assertEventLoopGroupConstructorMatchesAvailability(
@@ -203,17 +205,23 @@ public class Netty_transport_classes_kqueueTest {
             EventLoopGroup group = constructor.get();
             try {
                 assertThat(group.isShuttingDown()).isFalse();
-                ((KQueueEventLoopGroup) group).setIoRatio(25);
-                assertThatThrownBy(() -> ((KQueueEventLoopGroup) group).setIoRatio(0))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("ioRatio");
+                assertThat(group.next()).isNotNull();
             } finally {
-                group.shutdownGracefully().syncUninterruptibly();
+                assertThat(group.shutdownGracefully().awaitUninterruptibly(5000)).isTrue();
             }
             return;
         }
 
-        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(constructor::get));
+    }
+
+    private static void assertTransportUnavailable(Throwable throwable) {
+        assertThat(throwable).isInstanceOfAny(UnsatisfiedLinkError.class, NoClassDefFoundError.class);
+        if (throwable instanceof UnsatisfiedLinkError) {
+            assertThat(KQueue.unavailabilityCause()).isNotNull();
+        } else {
+            assertThat(throwable).hasMessageContaining("Could not initialize class");
+        }
     }
 
     private static String rootCauseMessage(Throwable throwable) {

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.netty.channel.kqueue.**"
+    }
+  ]
+}

--- a/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
+++ b/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.netty.channel.kqueue.**"
+    },
+    {
+      "includeClasses" : "io_netty.netty_transport_classes_kqueue.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #5596

This PR provides test fixes and new metadata for io.netty:netty-transport-classes-kqueue:4.2.2.Final, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 51189
- Cached input tokens: 644096
- Output tokens: 8151
- Metadata entries: 8
- Iterations: 1
- Library coverage percentage: 2.14
- Previous library version metadata entries: 35
- Previous library version coverage percentage: 3.54

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f733e9eb4b4ffa52254e317a09b56ee56aca9932`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.netty:netty-transport-classes-kqueue:4.1.74.Final: 0/0 covered calls (100.00%)
- io.netty:netty-transport-classes-kqueue:4.2.2.Final: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.netty:netty-transport-classes-kqueue:4.1.74.Final: 334/8477 (3.94%)
- io.netty:netty-transport-classes-kqueue:4.2.2.Final: 196/9154 (2.14%)

**Line:**
- io.netty:netty-transport-classes-kqueue:4.1.74.Final: 75/2117 (3.54%)
- io.netty:netty-transport-classes-kqueue:4.2.2.Final: 49/2290 (2.14%)

**Method:**
- io.netty:netty-transport-classes-kqueue:4.1.74.Final: 26/547 (4.75%)
- io.netty:netty-transport-classes-kqueue:4.2.2.Final: 17/589 (2.89%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java 2/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
index 66aaa4c4d7..1658aa2ec0 100644
--- 1/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
+++ 2/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/src/test/java/io_netty/netty_transport_classes_kqueue/Netty_transport_classes_kqueueTest.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.kqueue.AcceptFilter;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueChannelConfig;
@@ -21,7 +22,7 @@ import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainDatagramChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueDomainSocketChannelConfig;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
@@ -89,8 +90,7 @@ public class Netty_transport_classes_kqueueTest {
         List<ChannelOption<?>> options = List.of(
                 KQueueChannelOption.SO_SNDLOWAT,
                 KQueueChannelOption.TCP_NOPUSH,
-                KQueueChannelOption.SO_ACCEPTFILTER,
-                KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS
+                KQueueChannelOption.SO_ACCEPTFILTER
         );
 
         assertThat(options).doesNotContainNull();
@@ -114,7 +114,8 @@ public class Netty_transport_classes_kqueueTest {
 
     @Test
     void eventLoopGroupConstructorRespectsTransportAvailability() {
-        assertEventLoopGroupConstructorMatchesAvailability(() -> new KQueueEventLoopGroup(1));
+        assertEventLoopGroupConstructorMatchesAvailability(
+                () -> new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory()));
     }
 
     @Test
@@ -139,7 +140,7 @@ public class Netty_transport_classes_kqueueTest {
             return;
         }
 
-        assertThatThrownBy(KQueueSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(KQueueSocketChannel::new));
     }
 
     @Test
@@ -166,7 +167,7 @@ public class Netty_transport_classes_kqueueTest {
             return;
         }
 
-        assertThatThrownBy(KQueueDomainSocketChannel::new).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(KQueueDomainSocketChannel::new));
     }
 
     private static void assertChannelConstructorMatchesAvailability(Supplier<? extends Channel> constructor) {
@@ -175,26 +176,27 @@ public class Netty_transport_classes_kqueueTest {
             try {
                 assertThat(channel.isOpen()).isTrue();
                 assertThat(channel.config()).isInstanceOf(KQueueChannelConfig.class);
-                assertTransportProvidesGuessOptionRoundTrips((KQueueChannelConfig) channel.config());
+                assertChannelConfigOptionsRoundTrip((KQueueChannelConfig) channel.config());
             } finally {
                 channel.close().syncUninterruptibly();
             }
             return;
         }
 
-        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(constructor::get));
     }
 
-    private static void assertTransportProvidesGuessOptionRoundTrips(KQueueChannelConfig config) {
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
-        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isFalse();
+    private static void assertChannelConfigOptionsRoundTrip(KQueueChannelConfig config) {
+        assertThat(config.setConnectTimeoutMillis(1234)).isSameAs(config);
+        assertThat(config.getConnectTimeoutMillis()).isEqualTo(1234);
 
-        assertThat(config.setOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS, true)).isTrue();
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isTrue();
-        assertThat(config.getOption(KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS)).isTrue();
+        assertThat(config.setWriteSpinCount(8)).isSameAs(config);
+        assertThat(config.getWriteSpinCount()).isEqualTo(8);
 
-        assertThat(config.setRcvAllocTransportProvidesGuess(false)).isSameAs(config);
-        assertThat(config.getRcvAllocTransportProvidesGuess()).isFalse();
+        assertThat(config.setAutoRead(false)).isSameAs(config);
+        assertThat(config.isAutoRead()).isFalse();
+        assertThat(config.setOption(ChannelOption.AUTO_READ, true)).isTrue();
+        assertThat(config.isAutoRead()).isTrue();
     }
 
     private static void assertEventLoopGroupConstructorMatchesAvailability(
@@ -203,17 +205,23 @@ public class Netty_transport_classes_kqueueTest {
             EventLoopGroup group = constructor.get();
             try {
                 assertThat(group.isShuttingDown()).isFalse();
-                ((KQueueEventLoopGroup) group).setIoRatio(25);
-                assertThatThrownBy(() -> ((KQueueEventLoopGroup) group).setIoRatio(0))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("ioRatio");
+                assertThat(group.next()).isNotNull();
             } finally {
-                group.shutdownGracefully().syncUninterruptibly();
+                assertThat(group.shutdownGracefully().awaitUninterruptibly(5000)).isTrue();
             }
             return;
         }
 
-        assertThatThrownBy(constructor::get).isInstanceOf(UnsatisfiedLinkError.class);
+        assertTransportUnavailable(catchThrowable(constructor::get));
+    }
+
+    private static void assertTransportUnavailable(Throwable throwable) {
+        assertThat(throwable).isInstanceOfAny(UnsatisfiedLinkError.class, NoClassDefFoundError.class);
+        if (throwable instanceof UnsatisfiedLinkError) {
+            assertThat(KQueue.unavailabilityCause()).isNotNull();
+        } else {
+            assertThat(throwable).hasMessageContaining("Could not initialize class");
+        }
     }
 
     private static String rootCauseMessage(Throwable throwable) {
diff --git 1/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json 2/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
index b0f50b931c..7fc0cd0fcd 100644
--- 1/tests/src/io.netty/netty-transport-classes-kqueue/4.1.74.Final/user-code-filter.json
+++ 2/tests/src/io.netty/netty-transport-classes-kqueue/4.2.2.Final/user-code-filter.json
@@ -5,6 +5,9 @@
     },
     {
       "includeClasses" : "io.netty.channel.kqueue.**"
+    },
+    {
+      "includeClasses" : "io_netty.netty_transport_classes_kqueue.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
