### PR TITLE
[GenAI] Mark io.kotest:kotest-runner-junit5-jvm as not for Native Image

### DIFF
--- a/metadata/io.kotest/kotest-runner-junit5-jvm/index.json
+++ b/metadata/io.kotest/kotest-runner-junit5-jvm/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains only META-INF files, including a JUnit Platform TestEngine service descriptor, and no JVM class files; the implementation classes are published in kotest-runner-junit-platform-jvm.",
+    "replacement": "io.kotest:kotest-runner-junit-platform-jvm:6.1.11"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5317

This PR records `io.kotest:kotest-runner-junit5-jvm` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains only META-INF files, including a JUnit Platform TestEngine service descriptor, and no JVM class files; the implementation classes are published in kotest-runner-junit-platform-jvm.

Replacement guidance:
- io.kotest:kotest-runner-junit-platform-jvm:6.1.11

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f733e9eb4b4ffa52254e317a09b56ee56aca9932`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
