### PR TITLE
[GenAI] Add support for org.jetbrains.kotlin:kotlin-test-testng:2.3.21 using gpt-5.5

### DIFF
--- a/metadata/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/reachability-metadata.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.testng.TestNG"
+      },
+      "type" : "org.testng.internal.thread.DefaultThreadPoolExecutorFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.testng.TestNG"
+      },
+      "type" : "org.testng.internal.DefaultListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.testng.TestNG"
+      },
+      "type" : "org.testng.internal.annotations.DisabledRetryAnalyzer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jetbrains.kotlin/kotlin-test-testng/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-test-testng/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.3.21",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-sources.jar",
+    "repository-url" : "https://github.com/JetBrains/kotlin",
+    "test-code-url" : "https://github.com/JetBrains/kotlin/tree/v$version$/libraries/kotlin.test/testng/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-javadoc.jar",
+    "description" : "kotlin-test-testng supplies the TestNG integration for Kotlin's kotlin.test API on the JVM. It maps Kotlin test annotations and assertion reporting to TestNG so Kotlin test code can run under the TestNG runner.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.3"
+    },
+    "tested-versions" : [
+      "2.3.21"
+    ],
+    "allowed-packages" : [
+      "kotlin.test.testng"
+    ]
+  }
+]

--- a/metadata/org.jetbrains.kotlin/kotlin-test-testng/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-test-testng/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.3.21",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-sources.jar",
-    "repository-url" : "https://github.com/JetBrains/kotlin",
-    "test-code-url" : "https://github.com/JetBrains/kotlin/tree/v$version$/libraries/kotlin.test/testng/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-javadoc.jar",
-    "description" : "kotlin-test-testng supplies the TestNG integration for Kotlin's kotlin.test API on the JVM. It maps Kotlin test annotations and assertion reporting to TestNG so Kotlin test code can run under the TestNG runner.",
-    "language" : {
-      "name" : "kotlin",
-      "version" : "2.3"
+    "latest": true,
+    "metadata-version": "2.3.21",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-sources.jar",
+    "repository-url": "https://github.com/JetBrains/kotlin",
+    "test-code-url": "https://github.com/JetBrains/kotlin/tree/v$version$/libraries/kotlin.test/testng/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-test-testng/$version$/kotlin-test-testng-$version$-javadoc.jar",
+    "description": "kotlin-test-testng supplies the TestNG integration for Kotlin's kotlin.test API on the JVM. It maps Kotlin test annotations and assertion reporting to TestNG so Kotlin test code can run under the TestNG runner.",
+    "language": {
+      "name": "kotlin",
+      "version": "2.3"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "2.3.21"
     ],
-    "allowed-packages" : [
-      "kotlin.test.testng"
+    "allowed-packages": [
+      "kotlin.test.testng",
+      "org.testng"
     ]
   }
 ]

--- a/stats/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/execution-metrics.json
+++ b/stats/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T07:37:18.609572Z",
+    "library": "org.jetbrains.kotlin:kotlin-test-testng:2.3.21",
+    "starting_commit": "7816966e74b9d7b6789fab73f49f01f8e06a3ee4",
+    "ending_commit": "39099a1d6c702b484d31f27001bb355e7c99f5da",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.3.21",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 56,
+          "missed": 27,
+          "ratio": 0.674699,
+          "total": 83
+        },
+        "line": {
+          "covered": 18,
+          "missed": 5,
+          "ratio": 0.782609,
+          "total": 23
+        },
+        "method": {
+          "covered": 8,
+          "missed": 2,
+          "ratio": 0.8,
+          "total": 10
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 127298,
+      "cached_input_tokens_used": 799744,
+      "output_tokens_used": 18576,
+      "iterations": 4,
+      "cost_usd": 0.9572,
+      "generated_loc": 274,
+      "tested_library_loc": 18,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 15,
+      "code_coverage_percent": 78.26
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt",
+      "metadata_file": "metadata/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/stats.json
+++ b/stats/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.3.21",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 56,
+        "missed" : 27,
+        "ratio" : 0.674699,
+        "total" : 83
+      },
+      "line" : {
+        "covered" : 18,
+        "missed" : 5,
+        "ratio" : 0.782609,
+        "total" : 23
+      },
+      "method" : {
+        "covered" : 8,
+        "missed" : 2,
+        "ratio" : 0.8,
+        "total" : 10
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/.gitignore
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jetbrains.kotlin:kotlin-test-testng:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/gradle.properties
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jetbrains.kotlin:kotlin-test-testng:2.3.21
+library.version = 2.3.21
+metadata.dir = org.jetbrains.kotlin/kotlin-test-testng/2.3.21/

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/settings.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jetbrains.kotlin.kotlin-test-testng_tests'

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
@@ -6,11 +6,229 @@
  */
 package org_jetbrains_kotlin.kotlin_test_testng
 
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Ignore
+import kotlin.test.Test as KotlinTest
+import kotlin.test.assertEquals as kotlinAssertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse as kotlinAssertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals as kotlinAssertNotEquals
+import kotlin.test.assertNotNull as kotlinAssertNotNull
+import kotlin.test.assertNull as kotlinAssertNull
+import kotlin.test.assertSame as kotlinAssertSame
+import kotlin.test.assertTrue as kotlinAssertTrue
+import kotlin.test.fail as kotlinFail
+import kotlin.test.testng.TestNGAsserter
+import kotlin.test.testng.TestNGContributor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.testng.ITestContext
+import org.testng.ITestListener
+import org.testng.ITestResult
+import org.testng.TestNG
 
-class Kotlin_test_testngTest {
+public class Kotlin_test_testngTest {
     @Test
-    fun test() {
-        println("This is just a placeholder, implement your test")
+    public fun contributorProvidesTestNgAsserterWhenTestNgIsAvailable(): Unit {
+        val contributedAsserter = TestNGContributor().contribute()
+
+        assertThat(contributedAsserter).isSameAs(TestNGAsserter)
+    }
+
+    @Test
+    public fun testNgAsserterDelegatesSuccessfulCoreAssertionsToTestNg(): Unit {
+        val sharedReference = Any()
+        val distinctReference = Any()
+
+        TestNGAsserter.assertEquals("lists with equal content should match", listOf("alpha", "beta"), listOf("alpha", "beta"))
+        TestNGAsserter.assertNotEquals("different numbers should not match", 41, 42)
+        TestNGAsserter.assertSame("same reference should be accepted", sharedReference, sharedReference)
+        TestNGAsserter.assertNotSame("different references should be accepted", sharedReference, distinctReference)
+        TestNGAsserter.assertNotNull("non-null value should be accepted", "value")
+        TestNGAsserter.assertNull("null value should be accepted", null)
+    }
+
+    @Test
+    public fun testNgAsserterReportsFailuresWithMessagesAndCauses(): Unit {
+        val equalityError = assertThrows(AssertionError::class.java) {
+            TestNGAsserter.assertEquals("explicit equality message", "expected", "actual")
+        }
+        assertThat(equalityError).hasMessageContaining("explicit equality message")
+
+        val nullError = assertThrows(AssertionError::class.java) {
+            TestNGAsserter.assertNotNull(null, null)
+        }
+        assertThat(nullError).hasMessageContaining("actual value is null")
+
+        val cause = IllegalStateException("root cause")
+        val failed = assertThrows(AssertionError::class.java) {
+            TestNGAsserter.fail("explicit failure", cause)
+        }
+        assertThat(failed).hasMessageContaining("explicit failure")
+        assertThat(failed.cause).isSameAs(cause)
+    }
+
+    @Test
+    public fun testNgAsserterUsesLazyMessagesForBooleanAssertions(): Unit {
+        val evaluations = AtomicInteger(0)
+
+        TestNGAsserter.assertTrue(
+            lazyMessage = {
+                evaluations.incrementAndGet()
+                "this message is only needed on failure"
+            },
+            actual = true,
+        )
+
+        assertThat(evaluations).hasValue(0)
+
+        val failure = assertThrows(AssertionError::class.java) {
+            TestNGAsserter.assertTrue(
+                lazyMessage = {
+                    evaluations.incrementAndGet()
+                    "computed boolean failure"
+                },
+                actual = false,
+            )
+        }
+
+        assertThat(evaluations).hasValue(1)
+        assertThat(failure).hasMessageContaining("computed boolean failure")
+    }
+
+    @Test
+    public fun kotlinTestTopLevelAssertionsUseTheTestNgAdapter(): Unit {
+        val sharedReference = Any()
+
+        kotlinAssertEquals("kotlin", "kot" + "lin", "top-level equality should delegate successfully")
+        kotlinAssertNotEquals("left", "right", "top-level inequality should delegate successfully")
+        kotlinAssertSame(sharedReference, sharedReference, "top-level identity should delegate successfully")
+        kotlinAssertNotNull("present", "top-level non-null assertion should delegate successfully")
+        kotlinAssertNull(null, "top-level null assertion should delegate successfully")
+        kotlinAssertTrue("top-level true assertion should delegate successfully") { 2 + 2 == 4 }
+        kotlinAssertFalse("top-level false assertion should delegate successfully") { 2 + 2 == 5 }
+
+        val failure = assertThrows(AssertionError::class.java) {
+            kotlinAssertEquals("expected", "actual", "top-level assertion failure")
+        }
+        assertThat(failure).hasMessageContaining("top-level assertion failure")
+    }
+
+    @Test
+    public fun kotlinTestExceptionAndTypeAssertionsWorkWithTestNgFailures(): Unit {
+        val thrown = assertFailsWith<IllegalArgumentException>("expected exception should be returned") {
+            throw IllegalArgumentException("bad argument")
+        }
+        kotlinAssertEquals("bad argument", thrown.message)
+
+        val typed: CharSequence = assertIs<String>("typed value", "assertIs should return the narrowed value")
+        kotlinAssertEquals(11, typed.length)
+
+        val mismatch = assertThrows(AssertionError::class.java) {
+            assertFailsWith<IllegalArgumentException>("wrong exception type should fail") {
+                throw IllegalStateException("wrong exception")
+            }
+        }
+        assertThat(mismatch).hasMessageContaining("wrong exception type should fail")
+    }
+
+    @Test
+    public fun kotlinTestAnnotationsAreUsableByATestNgRunner(): Unit {
+        KotlinTestTestNgAnnotatedSuite.resetCounters()
+        val listener = CountingTestNgListener()
+        val outputDirectory = Files.createTempDirectory("kotlin-test-testng-output")
+
+        try {
+            val testNg = TestNG(false)
+            testNg.setUseDefaultListeners(false)
+            testNg.setVerbose(0)
+            testNg.setOutputDirectory(outputDirectory.toString())
+            testNg.setTestClasses(arrayOf(KotlinTestTestNgAnnotatedSuite::class.java))
+            testNg.addListener(listener)
+
+            testNg.run()
+
+            assertThat(testNg.hasFailure()).isFalse()
+            assertThat(listener.failures).isEqualTo(0)
+            assertThat(listener.successes).isEqualTo(1)
+            assertThat(KotlinTestTestNgAnnotatedSuite.beforeCalls).hasValue(1)
+            assertThat(KotlinTestTestNgAnnotatedSuite.afterCalls).hasValue(1)
+            assertThat(KotlinTestTestNgAnnotatedSuite.executedTests).hasValue(1)
+            assertThat(KotlinTestTestNgAnnotatedSuite.ignoredTests).hasValue(0)
+        } finally {
+            outputDirectory.toFile().deleteRecursively()
+        }
+    }
+}
+
+public class KotlinTestTestNgAnnotatedSuite {
+    private var prepared = false
+
+    @BeforeTest
+    public fun setUp(): Unit {
+        prepared = true
+        beforeCalls.incrementAndGet()
+    }
+
+    @AfterTest
+    public fun tearDown(): Unit {
+        afterCalls.incrementAndGet()
+        prepared = false
+    }
+
+    @KotlinTest
+    public fun testAnnotatedWithKotlinTestRunsUnderTestNg(): Unit {
+        kotlinAssertTrue(prepared, "BeforeTest should run before each TestNG method")
+        executedTests.incrementAndGet()
+    }
+
+    @Ignore
+    @KotlinTest
+    public fun ignoredKotlinTestAnnotationIsHonoredByTestNg(): Unit {
+        ignoredTests.incrementAndGet()
+        kotlinFail("ignored Kotlin TestNG test should not be executed")
+    }
+
+    public companion object {
+        public val beforeCalls: AtomicInteger = AtomicInteger(0)
+        public val afterCalls: AtomicInteger = AtomicInteger(0)
+        public val executedTests: AtomicInteger = AtomicInteger(0)
+        public val ignoredTests: AtomicInteger = AtomicInteger(0)
+
+        public fun resetCounters(): Unit {
+            beforeCalls.set(0)
+            afterCalls.set(0)
+            executedTests.set(0)
+            ignoredTests.set(0)
+        }
+    }
+}
+
+private class CountingTestNgListener : ITestListener {
+    var successes: Int = 0
+        private set
+    var failures: Int = 0
+        private set
+
+    override fun onTestSuccess(result: ITestResult): Unit {
+        successes++
+    }
+
+    override fun onTestFailure(result: ITestResult): Unit {
+        failures++
+    }
+
+    override fun onTestFailedWithTimeout(result: ITestResult): Unit {
+        failures++
+    }
+
+    override fun onFinish(context: ITestContext): Unit {
+        failures += context.failedTests.allResults.size
+        failures += context.failedConfigurations.allResults.size
     }
 }

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
@@ -164,6 +164,39 @@ public class Kotlin_test_testngTest {
             outputDirectory.toFile().deleteRecursively()
         }
     }
+
+    @Test
+    public fun kotlinTestAnnotationSupportsTestNgExpectedExceptions(): Unit {
+        val listener = CountingTestNgListener()
+        val outputDirectory = Files.createTempDirectory("kotlin-test-testng-expected-exception-output")
+
+        try {
+            val testNg = TestNG(false)
+            testNg.setUseDefaultListeners(false)
+            testNg.setVerbose(0)
+            testNg.setOutputDirectory(outputDirectory.toString())
+            testNg.setTestClasses(arrayOf(KotlinTestTestNgExpectedExceptionSuite::class.java))
+            testNg.addListener(listener)
+
+            testNg.run()
+
+            assertThat(testNg.hasFailure()).isFalse()
+            assertThat(listener.failures).isEqualTo(0)
+            assertThat(listener.successes).isEqualTo(1)
+        } finally {
+            outputDirectory.toFile().deleteRecursively()
+        }
+    }
+}
+
+public class KotlinTestTestNgExpectedExceptionSuite {
+    @KotlinTest(
+        expectedExceptions = [IllegalArgumentException::class],
+        expectedExceptionsMessageRegExp = ".*expected marker.*",
+    )
+    public fun expectedExceptionIsTreatedAsTestSuccess(): Unit {
+        throw IllegalArgumentException("the expected marker is present")
+    }
 }
 
 public class KotlinTestTestNgAnnotatedSuite {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_kotlin.kotlin_test_testng
+
+import org.junit.jupiter.api.Test
+
+class Kotlin_test_testngTest {
+    @Test
+    fun test() {
+        println("This is just a placeholder, implement your test")
+    }
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/kotlin/org_jetbrains_kotlin/kotlin_test_testng/Kotlin_test_testngTest.kt
@@ -31,6 +31,7 @@ import org.testng.ITestContext
 import org.testng.ITestListener
 import org.testng.ITestResult
 import org.testng.TestNG
+import org.testng.annotations.DataProvider
 
 public class Kotlin_test_testngTest {
     @Test
@@ -187,6 +188,34 @@ public class Kotlin_test_testngTest {
             outputDirectory.toFile().deleteRecursively()
         }
     }
+
+    @Test
+    public fun kotlinTestAnnotationSupportsTestNgDataProviders(): Unit {
+        KotlinTestTestNgDataProviderSuite.resetCounters()
+        val listener = CountingTestNgListener()
+        val outputDirectory = Files.createTempDirectory("kotlin-test-testng-data-provider-output")
+
+        try {
+            val testNg = TestNG(false)
+            testNg.setUseDefaultListeners(false)
+            testNg.setVerbose(0)
+            testNg.setOutputDirectory(outputDirectory.toString())
+            testNg.setTestClasses(arrayOf(KotlinTestTestNgDataProviderSuite::class.java))
+            testNg.addListener(listener)
+
+            testNg.run()
+
+            assertThat(testNg.hasFailure()).isFalse()
+            assertThat(listener.failures).isEqualTo(0)
+            assertThat(listener.successes).isEqualTo(KotlinTestTestNgDataProviderSuite.providedRows)
+            assertThat(KotlinTestTestNgDataProviderSuite.invocations).hasValue(
+                KotlinTestTestNgDataProviderSuite.providedRows,
+            )
+            assertThat(KotlinTestTestNgDataProviderSuite.totalObservedLength).hasValue(11)
+        } finally {
+            outputDirectory.toFile().deleteRecursively()
+        }
+    }
 }
 
 public class KotlinTestTestNgExpectedExceptionSuite {
@@ -196,6 +225,32 @@ public class KotlinTestTestNgExpectedExceptionSuite {
     )
     public fun expectedExceptionIsTreatedAsTestSuccess(): Unit {
         throw IllegalArgumentException("the expected marker is present")
+    }
+}
+
+public class KotlinTestTestNgDataProviderSuite {
+    @DataProvider(name = "words")
+    public fun words(): Array<Array<Any>> = arrayOf(
+        arrayOf("alpha", 5),
+        arrayOf("kotlin", 6),
+    )
+
+    @KotlinTest(dataProvider = "words")
+    public fun dataProviderArgumentsAreDeliveredToKotlinTest(word: String, expectedLength: Int): Unit {
+        kotlinAssertEquals(expectedLength, word.length)
+        invocations.incrementAndGet()
+        totalObservedLength.addAndGet(word.length)
+    }
+
+    public companion object {
+        public val providedRows: Int = 2
+        public val invocations: AtomicInteger = AtomicInteger(0)
+        public val totalObservedLength: AtomicInteger = AtomicInteger(0)
+
+        public fun resetCounters(): Unit {
+            invocations.set(0)
+            totalObservedLength.set(0)
+        }
     }
 }
 

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,25 @@
+{
+  "reflection" : [
+    {
+      "type" : "org_jetbrains_kotlin.kotlin_test_testng.KotlinTestTestNgAnnotatedSuite",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allPublicConstructors" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org_jetbrains_kotlin.kotlin_test_testng.KotlinTestTestNgExpectedExceptionSuite",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allPublicConstructors" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org_jetbrains_kotlin.kotlin_test_testng.KotlinTestTestNgDataProviderSuite",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allPublicConstructors" : true,
+      "allPublicMethods" : true
+    }
+  ]
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "kotlin.test.testng.**"
+      "includeClasses" : "kotlin.test.testng.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_kotlin.kotlin_test_testng.**"
     }
   ]
 }

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "kotlin.test.testng.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5261

This PR introduces tests and metadata for org.jetbrains.kotlin:kotlin-test-testng:2.3.21, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 127298
- Cached input tokens: 799744
- Output tokens: 18576
- Metadata entries: 6
- Test-only metadata entries: 15
- Iterations: 4
- Library coverage percentage: 78.26
- Generated lines of code: 274
- Tested library lines of code: 18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `b004f41d926e832716f4633b59459b16e6e181de`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 56/83 (67.47%)
- Line: 18/23 (78.26%)
- Method: 8/10 (80.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
