### PR TITLE
[GenAI] Add support for com.lihaoyi:requests_3:0.9.0 using gpt-5.5

### DIFF
--- a/metadata/com.lihaoyi/requests_3/0.9.0/reachability-metadata.json
+++ b/metadata/com.lihaoyi/requests_3/0.9.0/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "requests.Requester$"
+      },
+      "type": "requests.Requester$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "requests.Session"
+      },
+      "type": "requests.Session",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "requests.Util$"
+      },
+      "type": "requests.Util$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "requests.package$"
+      },
+      "type": "requests.package$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/com.lihaoyi/requests_3/index.json
+++ b/metadata/com.lihaoyi/requests_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.9.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/lihaoyi/requests_3/$version$/requests_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/com-lihaoyi/requests-scala",
+    "test-code-url" : "https://github.com/com-lihaoyi/requests-scala/tree/$version$/requests/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/lihaoyi/requests_3/$version$/requests_3-$version$-javadoc.jar",
+    "description" : "Requests-Scala is a Scala HTTP client inspired by Python Requests for making synchronous HTTP calls from JVM applications. It wraps Java networking APIs with a small Scala interface for building requests, sending request bodies, handling headers and authentication, and reading responses.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "0.9.0"
+    ],
+    "allowed-packages" : [
+      "requests"
+    ]
+  }
+]

--- a/stats/com.lihaoyi/requests_3/0.9.0/execution-metrics.json
+++ b/stats/com.lihaoyi/requests_3/0.9.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T07:46:25.492018Z",
+    "library": "com.lihaoyi:requests_3:0.9.0",
+    "starting_commit": "5f3b63a820282553d8a626fef2e5c65c880961a6",
+    "ending_commit": "db23ce54d99b155e005d4fcdbc3f170cba377454",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.9.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3867,
+          "missed": 5093,
+          "ratio": 0.431585,
+          "total": 8960
+        },
+        "line": {
+          "covered": 489,
+          "missed": 103,
+          "ratio": 0.826014,
+          "total": 592
+        },
+        "method": {
+          "covered": 254,
+          "missed": 453,
+          "ratio": 0.359264,
+          "total": 707
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 188108,
+      "cached_input_tokens_used": 1715200,
+      "output_tokens_used": 23081,
+      "iterations": 4,
+      "cost_usd": 1.55,
+      "generated_loc": 419,
+      "tested_library_loc": 489,
+      "metadata_entries": 8,
+      "code_coverage_percent": 82.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala",
+      "metadata_file": "metadata/com.lihaoyi/requests_3/0.9.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.lihaoyi/requests_3/0.9.0/stats.json
+++ b/stats/com.lihaoyi/requests_3/0.9.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.9.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3867,
+        "missed" : 5093,
+        "ratio" : 0.431585,
+        "total" : 8960
+      },
+      "line" : {
+        "covered" : 489,
+        "missed" : 103,
+        "ratio" : 0.826014,
+        "total" : 592
+      },
+      "method" : {
+        "covered" : 254,
+        "missed" : 453,
+        "ratio" : 0.359264,
+        "total" : 707
+      }
+    }
+  } ]
+}

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/.gitignore
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.lihaoyi:requests_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/gradle.properties
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.lihaoyi:requests_3:0.9.0
+library.version = 0.9.0
+metadata.dir = com.lihaoyi/requests_3/0.9.0/

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/settings.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.lihaoyi.requests_3_tests'

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/resources/META-INF/native-image/com.lihaoyi/requests_3-tests/native-image.properties
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/resources/META-INF/native-image/com.lihaoyi/requests_3-tests/native-image.properties
@@ -1,0 +1,1 @@
+Args = --enable-url-protocols=http

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
@@ -6,11 +6,401 @@
  */
 package com_lihaoyi.requests_3
 
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.InetSocketAddress
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
 class Requests_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def getSendsQueryParamsHeadersCookiesAndExposesTextResponseHelpers(): Unit = {
+    withServer { exchange =>
+      assertEquals("GET", exchange.getRequestMethod)
+      assertEquals("/inspect", exchange.getRequestURI.getPath)
+
+      val params: Map[String, Seq[String]] = queryParams(exchange.getRequestURI)
+      assertEquals(Seq("hello world"), params("q"))
+      assertEquals(Seq("one", "two"), params("repeat"))
+      assertEquals("native-image", exchange.getRequestHeaders.getFirst("X-Client"))
+      val cookieHeader: String = exchange.getRequestHeaders.getFirst("Cookie")
+      assertTrue(cookieHeader.contains("client-cookie"))
+      assertTrue(cookieHeader.contains("scala"))
+
+      sendText(
+        exchange,
+        200,
+        "first line\nsecond line\n",
+        Seq(
+          "Content-Type" -> "text/plain; charset=UTF-8",
+          "Set-Cookie" -> "server-cookie=stored; Path=/"
+        )
+      )
+    } { baseUrl =>
+      val response: requests.Response = requests.get(
+        s"$baseUrl/inspect",
+        params = Seq("q" -> "hello world", "repeat" -> "one", "repeat" -> "two"),
+        headers = Seq("X-Client" -> "native-image"),
+        cookieValues = Map("client-cookie" -> "scala"),
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+
+      assertEquals(200, response.statusCode)
+      assertTrue(response.is2xx)
+      assertFalse(response.is3xx)
+      assertEquals("first line\nsecond line\n", response.text())
+      assertEquals("first line\nsecond line", response.trim())
+      assertEquals(Vector("first line", "second line"), response.lines())
+      assertTrue(response.contentType.exists(_.startsWith("text/plain")))
+      assertEquals("stored", response.cookies("server-cookie").getValue)
+    }
+  }
+
+  @Test
+  def postFormDataUsesBasicAuthAndGzipRequestCompression(): Unit = {
+    withServer { exchange =>
+      assertEquals("POST", exchange.getRequestMethod)
+      assertEquals("Basic dXNlcjpwYXNz", exchange.getRequestHeaders.getFirst("Authorization"))
+      assertEquals("gzip", exchange.getRequestHeaders.getFirst("Content-Encoding"))
+      assertTrue(exchange.getRequestHeaders.getFirst("Content-Type").startsWith("application/x-www-form-urlencoded"))
+
+      val body: String = new String(gunzip(readRequestBody(exchange)), StandardCharsets.UTF_8)
+      val fields: Map[String, Seq[String]] = formFields(body)
+      assertEquals(Seq("Li Haoyi"), fields("name"))
+      assertEquals(Seq("New York"), fields("city"))
+      sendText(exchange, 201, "created")
+    } { baseUrl =>
+      val response: requests.Response = requests.post(
+        s"$baseUrl/form",
+        data = requests.RequestBlob.FormEncodedRequestBlob(Seq("name" -> "Li Haoyi", "city" -> "New York")),
+        auth = new requests.RequestAuth.Basic("user", "pass"),
+        compress = requests.Compress.Gzip,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+
+      assertEquals(201, response.statusCode)
+      assertEquals("created", response.text())
+    }
+  }
+
+  @Test
+  def multipartUploadWritesStringFileAndNioFileParts(): Unit = {
+    val filePart: Path = Files.createTempFile("requests-file-part", ".txt")
+    val nioFilePart: Path = Files.createTempFile("requests-nio-file-part", ".txt")
+    Files.writeString(filePart, "file body", StandardCharsets.UTF_8)
+    Files.writeString(nioFilePart, "nio file body", StandardCharsets.UTF_8)
+
+    try {
+      withServer { exchange =>
+        assertEquals("POST", exchange.getRequestMethod)
+        assertTrue(exchange.getRequestHeaders.getFirst("Content-Type").startsWith("multipart/form-data; boundary="))
+
+        val body: String = new String(readRequestBody(exchange), StandardCharsets.ISO_8859_1)
+        assertTrue(body.contains("name=\"field\""))
+        assertTrue(body.contains("plain value"))
+        assertTrue(body.contains("name=\"file\""))
+        assertTrue(body.contains("filename=\"file.txt\""))
+        assertTrue(body.contains("file body"))
+        assertTrue(body.contains("name=\"nioFile\""))
+        assertTrue(body.contains("filename=\"nio-file.txt\""))
+        assertTrue(body.contains("nio file body"))
+        sendText(exchange, 200, "multipart-ok")
+      } { baseUrl =>
+        val multipart: requests.MultiPart = requests.MultiPart(
+          requests.MultiItem("field", stringBlob("plain value")),
+          requests.MultiItem("file", requests.RequestBlob.FileRequestBlob(filePart.toFile), "file.txt"),
+          requests.MultiItem("nioFile", requests.RequestBlob.NioFileRequestBlob(nioFilePart), "nio-file.txt")
+        )
+
+        val response: requests.Response = requests.post(
+          s"$baseUrl/upload",
+          data = multipart,
+          readTimeout = 5000,
+          connectTimeout = 5000
+        )
+        assertEquals("multipart-ok", response.text())
+      }
+    } finally {
+      Files.deleteIfExists(filePart)
+      Files.deleteIfExists(nioFilePart)
+    }
+  }
+
+  @Test
+  def sessionPersistsCookiesAcrossRedirects(): Unit = {
+    withServer { exchange =>
+      exchange.getRequestURI.getPath match {
+        case "/set-cookie" =>
+          sendText(exchange, 200, "cookie-set", Seq("Set-Cookie" -> "session-id=abc123; Path=/"))
+        case "/redirect" =>
+          exchange.getResponseHeaders.add("Location", "/cookie-required")
+          exchange.sendResponseHeaders(302, -1)
+          exchange.close()
+        case "/cookie-required" =>
+          val cookie: String = Option(exchange.getRequestHeaders.getFirst("Cookie")).getOrElse("")
+          if (cookie.contains("session-id") && cookie.contains("abc123")) sendText(exchange, 200, "redirected with cookie")
+          else sendText(exchange, 403, "missing cookie")
+        case other =>
+          sendText(exchange, 404, s"unknown path: $other")
+      }
+    } { baseUrl =>
+      val session: requests.Session = requests.Session(readTimeout = 5000, connectTimeout = 5000)
+
+      val first: requests.Response = session.get(s"$baseUrl/set-cookie")
+      assertEquals("cookie-set", first.text())
+      assertEquals("abc123", session.cookies("session-id").getValue)
+
+      val redirected: requests.Response = session.get(s"$baseUrl/redirect", maxRedirects = 3)
+      assertEquals(200, redirected.statusCode)
+      assertEquals("redirected with cookie", redirected.text())
+      assertTrue(redirected.history.nonEmpty)
+      assertEquals(302, redirected.history.get.statusCode)
+    }
+  }
+
+  @Test
+  def unsuccessfulStatusThrowsByDefaultButCanBeReturnedWhenCheckIsDisabled(): Unit = {
+    withServer { exchange =>
+      exchange.getRequestURI.getPath match {
+        case "/missing" => sendText(exchange, 404, "not found")
+        case "/error" => sendText(exchange, 503, "temporarily unavailable")
+        case other => sendText(exchange, 500, s"unexpected path: $other")
+      }
+    } { baseUrl =>
+      val thrown: requests.RequestFailedException = assertThrows(
+        classOf[requests.RequestFailedException],
+        () => requests.get(s"$baseUrl/missing", readTimeout = 5000, connectTimeout = 5000)
+      )
+      assertEquals(404, thrown.response.statusCode)
+      assertTrue(thrown.response.is4xx)
+      assertEquals("not found", thrown.response.text())
+
+      val missing: requests.Response = requests.get(
+        s"$baseUrl/missing",
+        check = false,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+      assertEquals(404, missing.statusCode)
+      assertTrue(missing.is4xx)
+      assertFalse(missing.is2xx)
+
+      val unavailable: requests.Response = requests.get(
+        s"$baseUrl/error",
+        check = false,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+      assertEquals(503, unavailable.statusCode)
+      assertTrue(unavailable.is5xx)
+    }
+  }
+
+  @Test
+  def streamingApiExposesResponseHeadersBeforeReadingBytes(): Unit = {
+    val expected: Array[Byte] = (0 until 256).map(_.toByte).toArray
+
+    withServer { exchange =>
+      sendBytes(
+        exchange,
+        200,
+        expected,
+        Seq("Content-Type" -> "application/octet-stream", "X-Stream" -> "present")
+      )
+    } { baseUrl =>
+      val seenStatus: AtomicInteger = new AtomicInteger(0)
+      val readable: geny.Readable = requests.get.stream(
+        s"$baseUrl/stream",
+        readTimeout = 5000,
+        connectTimeout = 5000,
+        onHeadersReceived = headers => {
+          seenStatus.set(headers.statusCode)
+          assertTrue(headers.is2xx)
+          assertFalse(headers.is4xx)
+          ()
+        }
+      )
+
+      val actual: Array[Byte] = readable.readBytesThrough(input => input.readAllBytes())
+      assertEquals(200, seenStatus.get())
+      assertArrayEquals(expected, actual)
+    }
+  }
+
+  @Test
+  def gzipResponsesAreDecompressedOnlyWhenAutoDecompressIsEnabled(): Unit = {
+    val plainText: String = "compressed response text"
+    val compressed: Array[Byte] = gzip(plainText.getBytes(StandardCharsets.UTF_8))
+
+    withServer { exchange =>
+      sendBytes(
+        exchange,
+        200,
+        compressed,
+        Seq("Content-Type" -> "text/plain; charset=UTF-8", "Content-Encoding" -> "gzip")
+      )
+    } { baseUrl =>
+      val decompressed: requests.Response = requests.get(
+        s"$baseUrl/gzip",
+        autoDecompress = true,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+      assertEquals(plainText, decompressed.text())
+      assertArrayEquals(plainText.getBytes(StandardCharsets.UTF_8), decompressed.bytes)
+
+      val raw: requests.Response = requests.get(
+        s"$baseUrl/gzip",
+        autoDecompress = false,
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+      assertArrayEquals(compressed, raw.bytes)
+    }
+  }
+
+  @Test
+  def putRequesterSendsBearerAuthAndRequestBody(): Unit = {
+    withServer { exchange =>
+      assertEquals("PUT", exchange.getRequestMethod)
+      assertEquals("Bearer token-123", exchange.getRequestHeaders.getFirst("Authorization"))
+      assertEquals("payload", new String(readRequestBody(exchange), StandardCharsets.UTF_8))
+      sendText(exchange, 202, "accepted")
+    } { baseUrl =>
+      val response: requests.Response = requests.put(
+        s"$baseUrl/resource",
+        data = stringBlob("payload"),
+        auth = requests.RequestAuth.Bearer("token-123"),
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+
+      assertEquals(202, response.statusCode)
+      assertEquals("accepted", response.text())
+    }
+  }
+
+  private def withServer(handler: HttpExchange => Unit)(test: String => Unit): Unit = {
+    val server: HttpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    val executor: ExecutorService = Executors.newCachedThreadPool { (runnable: Runnable) =>
+      val thread: Thread = new Thread(runnable, "requests-test-http-server")
+      thread.setDaemon(true)
+      thread
+    }
+    server.createContext(
+      "/",
+      new HttpHandler {
+        override def handle(exchange: HttpExchange): Unit = {
+          try handler(exchange)
+          catch {
+            case throwable: Throwable =>
+              if (exchange.getResponseCode == -1) {
+                val message: String = s"handler failed: ${throwable.getClass.getName}: ${throwable.getMessage}"
+                sendText(exchange, 500, message)
+              } else {
+                exchange.close()
+              }
+          }
+        }
+      }
+    )
+    server.setExecutor(executor)
+    server.start()
+
+    try test(s"http://127.0.0.1:${server.getAddress.getPort}")
+    finally {
+      server.stop(0)
+      executor.shutdownNow()
+      executor.awaitTermination(5, TimeUnit.SECONDS)
+    }
+  }
+
+  private def sendText(
+      exchange: HttpExchange,
+      statusCode: Int,
+      body: String,
+      headers: Seq[(String, String)] = Seq.empty
+  ): Unit = {
+    sendBytes(exchange, statusCode, body.getBytes(StandardCharsets.UTF_8), headers)
+  }
+
+  private def sendBytes(
+      exchange: HttpExchange,
+      statusCode: Int,
+      body: Array[Byte],
+      headers: Seq[(String, String)] = Seq.empty
+  ): Unit = {
+    headers.foreach { case (name, value) => exchange.getResponseHeaders.add(name, value) }
+    exchange.sendResponseHeaders(statusCode, body.length.toLong)
+    val output = exchange.getResponseBody
+    try output.write(body)
+    finally output.close()
+  }
+
+  private def readRequestBody(exchange: HttpExchange): Array[Byte] = {
+    val input = exchange.getRequestBody
+    try input.readAllBytes()
+    finally input.close()
+  }
+
+  private def stringBlob(value: String): requests.RequestBlob = {
+    requests.RequestBlob.ByteSourceRequestBlob[String](value)((text: String) => geny.Writable.StringWritable(text))
+  }
+
+  private def queryParams(uri: URI): Map[String, Seq[String]] = {
+    formFields(Option(uri.getRawQuery).getOrElse(""))
+  }
+
+  private def formFields(encoded: String): Map[String, Seq[String]] = {
+    encoded
+      .split("&")
+      .toSeq
+      .filter(_.nonEmpty)
+      .map { pair =>
+        val separator: Int = pair.indexOf('=')
+        val rawName: String = if (separator >= 0) pair.substring(0, separator) else pair
+        val rawValue: String = if (separator >= 0) pair.substring(separator + 1) else ""
+        decode(rawName) -> decode(rawValue)
+      }
+      .groupMap(_._1)(_._2)
+  }
+
+  private def decode(value: String): String = {
+    URLDecoder.decode(value, StandardCharsets.UTF_8)
+  }
+
+  private def gzip(bytes: Array[Byte]): Array[Byte] = {
+    val output = new ByteArrayOutputStream()
+    val gzipOutput = new GZIPOutputStream(output)
+    try gzipOutput.write(bytes)
+    finally gzipOutput.close()
+    output.toByteArray
+  }
+
+  private def gunzip(bytes: Array[Byte]): Array[Byte] = {
+    val input = new GZIPInputStream(new ByteArrayInputStream(bytes))
+    try input.readAllBytes()
+    finally input.close()
   }
 }

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_lihaoyi.requests_3
+
+import org.junit.jupiter.api.Test
+
+class Requests_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
@@ -301,6 +301,30 @@ class Requests_3Test {
     }
   }
 
+  @Test
+  def headRequesterReturnsHeadersWithoutResponseBody(): Unit = {
+    withServer { exchange =>
+      assertEquals("HEAD", exchange.getRequestMethod)
+      exchange.getResponseHeaders.add("Content-Type", "text/plain; charset=UTF-8")
+      exchange.getResponseHeaders.add("X-Head-Result", "metadata-only")
+      exchange.sendResponseHeaders(200, -1)
+      exchange.close()
+    } { baseUrl =>
+      val response: requests.Response = requests.head(
+        s"$baseUrl/metadata",
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+
+      assertEquals(200, response.statusCode)
+      assertTrue(response.is2xx)
+      assertEquals("", response.text())
+      assertArrayEquals(Array.empty[Byte], response.bytes)
+      assertTrue(response.contentType.exists(_.startsWith("text/plain")))
+      assertEquals(Seq("metadata-only"), response.headers("x-head-result"))
+    }
+  }
+
   private def withServer(handler: HttpExchange => Unit)(test: String => Unit): Unit = {
     val server: HttpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
     val executor: ExecutorService = Executors.newCachedThreadPool { (runnable: Runnable) =>

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/src/test/scala/com_lihaoyi/requests_3/Requests_3Test.scala
@@ -302,6 +302,39 @@ class Requests_3Test {
   }
 
   @Test
+  def requestObjectCanBeExecutedWithPatchRequester(): Unit = {
+    withServer { exchange =>
+      assertEquals("PATCH", exchange.getRequestMethod)
+      assertEquals("/configured", exchange.getRequestURI.getPath)
+
+      val params: Map[String, Seq[String]] = queryParams(exchange.getRequestURI)
+      assertEquals(Seq("42"), params("id"))
+      assertEquals(Seq("request object"), params("mode"))
+      assertEquals("yes", exchange.getRequestHeaders.getFirst("X-Configured"))
+      val cookieHeader: String = exchange.getRequestHeaders.getFirst("Cookie")
+      assertTrue(cookieHeader.contains("request-cookie"))
+      assertTrue(cookieHeader.contains("configured"))
+      assertEquals("patch-body", new String(readRequestBody(exchange), StandardCharsets.UTF_8))
+
+      sendText(exchange, 200, "patched", Seq("X-Patched" -> "true"))
+    } { baseUrl =>
+      val request: requests.Request = requests.Request(
+        url = s"$baseUrl/configured",
+        params = Seq("id" -> "42", "mode" -> "request object"),
+        headers = Seq("X-Configured" -> "yes"),
+        cookieValues = Map("request-cookie" -> "configured"),
+        readTimeout = 5000,
+        connectTimeout = 5000
+      )
+
+      val response: requests.Response = requests.patch(request, stringBlob("patch-body"), chunkedUpload = false)
+      assertEquals(200, response.statusCode)
+      assertEquals("patched", response.text())
+      assertEquals(Seq("true"), response.headers("x-patched"))
+    }
+  }
+
+  @Test
   def headRequesterReturnsHeadersWithoutResponseBody(): Unit = {
     withServer { exchange =>
       assertEquals("HEAD", exchange.getRequestMethod)

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "requests.**"
+      "includeClasses" : "requests.**"
+    },
+    {
+      "includeClasses" : "com_lihaoyi.requests_3.**"
     }
   ]
 }

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/user-code-filter.json
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "requests.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4906

This PR introduces tests and metadata for com.lihaoyi:requests_3:0.9.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 188108
- Cached input tokens: 1715200
- Output tokens: 23081
- Metadata entries: 8
- Iterations: 4
- Library coverage percentage: 82.6
- Generated lines of code: 419
- Tested library lines of code: 489

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3867/8960 (43.16%)
- Line: 489/592 (82.60%)
- Method: 254/707 (35.93%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
