### PR TITLE
[GenAI] Add support for org.json4s:json4s-jackson-core_3:4.0.7 using gpt-5.5

### DIFF
--- a/metadata/org.json4s/json4s-jackson-core_3/4.0.7/reachability-metadata.json
+++ b/metadata/org.json4s/json4s-jackson-core_3/4.0.7/reachability-metadata.json
@@ -1,0 +1,15 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.json4s.jackson.JsonMethods$"
+      },
+      "type" : "org.json4s.jackson.JsonMethods$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.json4s/json4s-jackson-core_3/index.json
+++ b/metadata/org.json4s/json4s-jackson-core_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson-core_3/$version$/json4s-jackson-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/json4s/json4s",
+    "test-code-url" : "https://github.com/json4s/json4s/tree/v$version$/jackson-core/src/test/scala",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/json4s/json4s-jackson-core_3/$version$/json4s-jackson-core_3-$version$-javadoc.jar",
+    "description" : "json4s-jackson-core provides the Jackson-backed core integration for json4s, including serializers, deserializers, Scala module support, and JSON parsing and rendering methods that operate on the json4s AST. It lets Scala 3 JVM applications use Jackson's parser and databinding infrastructure with json4s JValue data structures for reading, writing, and transforming JSON.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "4.0.7"
+    ],
+    "allowed-packages" : [
+      "org.json4s.jackson"
+    ]
+  }
+]

--- a/stats/org.json4s/json4s-jackson-core_3/4.0.7/execution-metrics.json
+++ b/stats/org.json4s/json4s-jackson-core_3/4.0.7/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T08:16:13.681039Z",
+    "library": "org.json4s:json4s-jackson-core_3:4.0.7",
+    "starting_commit": "2a1f3c8db80a85b7004466056f60e1925d0a6618",
+    "ending_commit": "09f1428d8332d45f469fba6774e665149069553e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.7",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 848,
+          "missed": 331,
+          "ratio": 0.719254,
+          "total": 1179
+        },
+        "line": {
+          "covered": 117,
+          "missed": 8,
+          "ratio": 0.936,
+          "total": 125
+        },
+        "method": {
+          "covered": 57,
+          "missed": 28,
+          "ratio": 0.670588,
+          "total": 85
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 117549,
+      "cached_input_tokens_used": 1125376,
+      "output_tokens_used": 16685,
+      "iterations": 3,
+      "cost_usd": 1.0632,
+      "generated_loc": 230,
+      "tested_library_loc": 117,
+      "metadata_entries": 2,
+      "code_coverage_percent": 93.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala",
+      "metadata_file": "metadata/org.json4s/json4s-jackson-core_3/4.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.json4s/json4s-jackson-core_3/4.0.7/stats.json
+++ b/stats/org.json4s/json4s-jackson-core_3/4.0.7/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.7",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 848,
+        "missed" : 331,
+        "ratio" : 0.719254,
+        "total" : 1179
+      },
+      "line" : {
+        "covered" : 117,
+        "missed" : 8,
+        "ratio" : 0.936,
+        "total" : 125
+      },
+      "method" : {
+        "covered" : 57,
+        "missed" : 28,
+        "ratio" : 0.670588,
+        "total" : 85
+      }
+    }
+  } ]
+}

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/.gitignore
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.json4s:json4s-jackson-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/gradle.properties
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.json4s:json4s-jackson-core_3:4.0.7
+library.version = 4.0.7
+metadata.dir = org.json4s/json4s-jackson-core_3/4.0.7/

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/settings.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.json4s.json4s-jackson-core_3_tests'

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_json4s.json4s_jackson_core_3
+
+import org.junit.jupiter.api.Test
+
+class Json4s_jackson_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
@@ -163,6 +163,22 @@ class Json4s_jackson_core_3Test {
   }
 
   @Test
+  def rendersJsonSetsAsJsonArrays(): Unit = {
+    val value: JObject = JObject(
+      JField("labels", JSet(Set(JString("jackson"), JString("native"), JString("scala"))))
+    )
+
+    val compacted: String = JsonMethods.compact(JsonMethods.render(value))
+    val parsed: JValue = JsonMethods.parse(compacted)
+
+    val labels: Set[JValue] = (parsed \ "labels") match {
+      case JArray(values) => values.toSet
+      case other => fail(s"Expected rendered JSet to become a JSON array, but found $other")
+    }
+    assertEquals(Set(JString("jackson"), JString("native"), JString("scala")), labels)
+  }
+
+  @Test
   def convertsBetweenJson4sAstAndJacksonJsonNodes(): Unit = {
     val ast: JObject = JObject(
       JField("id", JInt(BigInt("12345678901234567890"))),

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
@@ -7,8 +7,10 @@
 package org_json4s.json4s_jackson_core_3
 
 import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.NullNode
 import org.json4s.*
@@ -207,6 +209,22 @@ class Json4s_jackson_core_3Test {
     assertEquals(JInt(42), converted \ "count")
     assertEquals(JNull, converted \ "nothing")
     assertEquals(JArray(List(JBool.True, JBool.False)), converted \ "flags")
+  }
+
+  @Test
+  def supportsCustomJacksonObjectMappersForJsonMethods(): Unit = {
+    val customJsonMethods: org.json4s.jackson.JsonMethods = new org.json4s.jackson.JsonMethods {
+      override val mapper: ObjectMapper = JsonMapper
+        .builder()
+        .addModule(new Json4sScalaModule())
+        .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+        .build()
+    }
+
+    val parsed: JValue = customJsonMethods.parse("""{'name':'custom','values':[1,true,null]}""")
+
+    assertEquals(JString("custom"), parsed \ "name")
+    assertEquals(JArray(List(JInt(1), JBool.True, JNull)), parsed \ "values")
   }
 
   @Test

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/src/test/scala/org_json4s/json4s_jackson_core_3/Json4s_jackson_core_3Test.scala
@@ -6,11 +6,233 @@
  */
 package org_json4s.json4s_jackson_core_3
 
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.NullNode
+import org.json4s.*
+import org.json4s.MonadicJValue.jvalueToMonadic
+import org.json4s.jackson.Json4sScalaModule
+import org.json4s.jackson.JsonMethods
+import org.json4s.prefs.EmptyValueStrategy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+
+import java.io.ByteArrayInputStream
+import java.io.StringReader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 class Json4s_jackson_core_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def parsesJsonFromStringsWithEscapesAndNestedStructures(): Unit = {
+    val source: String =
+      """
+        {
+          "message": "hello\njson4s",
+          "unicode": "\u2603",
+          "active": true,
+          "missing": null,
+          "items": [
+            {"id": 1, "name": "first"},
+            {"id": 2, "name": "second", "flags": [false, true]}
+          ]
+        }
+      """
+
+    val parsed: JValue = JsonMethods.parse(source)
+
+    assertEquals(JString("hello\njson4s"), parsed \ "message")
+    assertEquals(JString("☃"), parsed \ "unicode")
+    assertEquals(JBool.True, parsed \ "active")
+    assertEquals(JNull, parsed \ "missing")
+    assertEquals(JInt(1), (parsed \ "items")(0) \ "id")
+    assertEquals(JString("second"), (parsed \ "items")(1) \ "name")
+    assertEquals(JArray(List(JBool.False, JBool.True)), (parsed \ "items")(1) \ "flags")
   }
+
+  @Test
+  def honorsNumericParsingOptions(): Unit = {
+    val json: String = """{"small":7,"longValue":9223372036854775807,"decimal":1.25,"scientific":6.02e3}"""
+
+    val defaultParsed: JValue = JsonMethods.parse(json)
+    assertEquals(JInt(7), defaultParsed \ "small")
+    assertEquals(JInt(BigInt("9223372036854775807")), defaultParsed \ "longValue")
+    assertEquals(JDouble(1.25d), defaultParsed \ "decimal")
+    assertEquals(JDouble(6020.0d), defaultParsed \ "scientific")
+
+    val preciseParsed: JValue = JsonMethods.parse(
+      json,
+      useBigDecimalForDouble = true,
+      useBigIntForLong = false
+    )
+    assertEquals(JLong(7L), preciseParsed \ "small")
+    assertEquals(JLong(Long.MaxValue), preciseParsed \ "longValue")
+    assertEquals(JDecimal(BigDecimal("1.25")), preciseParsed \ "decimal")
+    assertEquals(JDecimal(BigDecimal("6.02E+3")), preciseParsed \ "scientific")
+  }
+
+  @Test
+  def parsesFromReadersStreamsAndFiles(): Unit = {
+    val reader: StringReader = new StringReader("""{"source":"reader","values":[1,2,3]}""")
+    val readerParsed: JValue = JsonMethods.parse(reader)
+    assertEquals(JString("reader"), readerParsed \ "source")
+    assertEquals(JArray(List(JInt(1), JInt(2), JInt(3))), readerParsed \ "values")
+
+    val stream: ByteArrayInputStream = new ByteArrayInputStream(
+      """{"source":"stream","text":"héllo"}""".getBytes(StandardCharsets.UTF_8)
+    )
+    try {
+      val streamParsed: JValue = JsonMethods.parse(stream)
+      assertEquals(JString("stream"), streamParsed \ "source")
+      assertEquals(JString("héllo"), streamParsed \ "text")
+    } finally {
+      stream.close()
+    }
+
+    val tempFile: Path = Files.createTempFile("json4s-jackson-core", ".json")
+    try {
+      Files.writeString(tempFile, """{"source":"file","enabled":true}""", StandardCharsets.UTF_8)
+
+      val fileParsed: JValue = JsonMethods.parse(tempFile.toFile)
+
+      assertEquals(JString("file"), fileParsed \ "source")
+      assertEquals(JBool.True, fileParsed \ "enabled")
+      assertEquals(Some(fileParsed), JsonMethods.parseOpt(tempFile.toFile))
+    } finally {
+      Files.deleteIfExists(tempFile)
+    }
+  }
+
+  @Test
+  def returnsOptionalResultsAndReportsMalformedJson(): Unit = {
+    assertEquals(Some(JObject(JField("ok", JBool.True))), JsonMethods.parseOpt("""{"ok":true}"""))
+    assertEquals(
+      Some(JObject(JField("n", JDecimal(BigDecimal("2.50"))))),
+      JsonMethods.parseOpt("""{"n":2.50}""", useBigDecimalForDouble = true)
+    )
+    assertEquals(None, JsonMethods.parseOpt("""{"unterminated":[1,2}"""))
+
+    val exception: JsonParseException = assertThrows(
+      classOf[JsonParseException],
+      () => JsonMethods.parse("""{"bad": tru}""")
+    )
+    assertTrue(exception.getMessage.contains("Unrecognized token"))
+  }
+
+  @Test
+  def rendersCompactsPrettyPrintsAndEscapesJsonValues(): Unit = {
+    val value: JObject = JObject(
+      JField("name", JString("café")),
+      JField("quote", JString("he said \"hi\"")),
+      JField("numbers", JArray(List(JInt(1), JDecimal(BigDecimal("2.50"))))),
+      JField("nested", JObject(JField("enabled", JBool.True)))
+    )
+
+    val escapedCompact: String = JsonMethods.compact(JsonMethods.render(value, alwaysEscapeUnicode = true))
+    assertEquals(
+      """{"name":"caf\u00E9","quote":"he said \"hi\"","numbers":[1,2.50],"nested":{"enabled":true}}""",
+      escapedCompact
+    )
+    assertEquals(value, JsonMethods.parse(escapedCompact, useBigDecimalForDouble = true))
+
+    val unescapedCompact: String = JsonMethods.compact(JsonMethods.render(value, alwaysEscapeUnicode = false))
+    assertTrue(unescapedCompact.contains("café"))
+
+    val pretty: String = JsonMethods.pretty(JsonMethods.render(value))
+    assertTrue(pretty.contains(System.lineSeparator()) || pretty.contains("\n"))
+    assertTrue(pretty.contains("\"enabled\" : true"))
+    assertEquals(value, JsonMethods.parse(pretty, useBigDecimalForDouble = true))
+  }
+
+  @Test
+  def appliesEmptyValueStrategiesBeforeJacksonSerialization(): Unit = {
+    val source: JObject = JObject(
+      JField("present", JString("value")),
+      JField("missing", JNothing),
+      JField("array", JArray(List(JInt(1), JNothing, JNull)))
+    )
+
+    val skipped: String = JsonMethods.compact(JsonMethods.render(source, emptyValueStrategy = EmptyValueStrategy.skip))
+    assertEquals("""{"present":"value","array":[1,null]}""", skipped)
+
+    val preserved: String = JsonMethods.compact(JsonMethods.render(source, emptyValueStrategy = EmptyValueStrategy.preserve))
+    assertEquals("""{"present":"value","missing":null,"array":[1,null,null]}""", preserved)
+  }
+
+  @Test
+  def convertsBetweenJson4sAstAndJacksonJsonNodes(): Unit = {
+    val ast: JObject = JObject(
+      JField("id", JInt(BigInt("12345678901234567890"))),
+      JField("name", JString("Ada")),
+      JField("active", JBool.True),
+      JField("tags", JArray(List(JString("scala"), JNull)))
+    )
+
+    val node: JsonNode = JsonMethods.asJsonNode(ast)
+
+    assertTrue(node.isObject)
+    assertEquals("Ada", node.get("name").asText())
+    assertEquals(BigInt("12345678901234567890").bigInteger, node.get("id").bigIntegerValue())
+    assertTrue(node.get("active").asBoolean())
+    assertTrue(node.get("tags").isArray)
+    assertEquals(ast, JsonMethods.fromJsonNode(node))
+
+    val objectNode = JsonNodeFactory.instance.objectNode()
+    objectNode.put("title", "from-node")
+    objectNode.put("count", 42L)
+    objectNode.set[JsonNode]("nothing", NullNode.instance)
+    objectNode.putArray("flags").add(true).add(false)
+
+    val converted: JValue = JsonMethods.fromJsonNode(objectNode)
+    assertEquals(JString("from-node"), converted \ "title")
+    assertEquals(JInt(42), converted \ "count")
+    assertEquals(JNull, converted \ "nothing")
+    assertEquals(JArray(List(JBool.True, JBool.False)), converted \ "flags")
+  }
+
+  @Test
+  def registersJson4sScalaModuleWithJacksonObjectMapper(): Unit = {
+    val mapper: ObjectMapper = new ObjectMapper().registerModule(new Json4sScalaModule())
+    val value: JObject = JObject(
+      JField("longValue", JLong(9000000000L)),
+      JField("decimal", JDecimal(BigDecimal("19.95"))),
+      JField("items", JArray(List(JString("book"), JBool.False, JNull)))
+    )
+
+    val serialized: String = mapper.writeValueAsString(value)
+    assertEquals("""{"longValue":9000000000,"decimal":19.95,"items":["book",false,null]}""", serialized)
+
+    val readAsJValue: JValue = mapper.readValue(serialized, classOf[JValue])
+    assertEquals(JLong(9000000000L), readAsJValue \ "longValue")
+    assertEquals(JDouble(19.95d), readAsJValue \ "decimal")
+    assertEquals(JArray(List(JString("book"), JBool.False, JNull)), readAsJValue \ "items")
+
+    val readAsJObject: JObject = mapper.readValue("""{"name":"module"}""", classOf[JObject])
+    assertEquals(JObject(JField("name", JString("module"))), readAsJObject)
+  }
+
+  @Test
+  def usesFacadeTypeClassHelpersAndCustomJsonInputs(): Unit = {
+    import org.json4s.DefaultReaders.*
+    import org.json4s.DefaultWriters.*
+
+    case class Account(name: String, score: Int)
+    implicit val accountWriter: Writer[Account] = Writer.writer2[String, Int, Account](account => (account.name, account.score))("name", "score")
+    implicit val accountReader: Reader[Account] = Reader.reader2[String, Int, Account](Account.apply)("name", "score")
+    given AsJsonInput[JsonEnvelope] = AsJsonInput.stringAsJsonInput.contramap(_.payload)
+
+    val account: Account = Account("jackson", 100)
+    val accountJson: JValue = JsonMethods.asJValue(account)
+    assertEquals(JObject(JField("name", JString("jackson")), JField("score", JInt(100))), accountJson)
+    assertEquals(account, JsonMethods.fromJValue[Account](accountJson))
+
+    val parsedEnvelope: JValue = JsonMethods.parse(new JsonEnvelope("""{"kind":"custom","tags":["public","api"]}"""))
+    assertEquals(JString("custom"), parsedEnvelope \ "kind")
+    assertEquals(JArray(List(JString("public"), JString("api"))), parsedEnvelope \ "tags")
+  }
+
+  private final class JsonEnvelope(val payload: String)
 }

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.json4s.jackson.**"
+    }
+  ]
+}

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/user-code-filter.json
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.json4s.jackson.**"
+      "includeClasses" : "org.json4s.jackson.**"
+    },
+    {
+      "includeClasses" : "org_json4s.json4s_jackson_core_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5488

This PR introduces tests and metadata for org.json4s:json4s-jackson-core_3:4.0.7, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 117549
- Cached input tokens: 1125376
- Output tokens: 16685
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 93.6
- Generated lines of code: 230
- Tested library lines of code: 117

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 848/1179 (71.93%)
- Line: 117/125 (93.60%)
- Method: 57/85 (67.06%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
