### PR TITLE
[GenAI] Add support for org.scodec:scodec-core_3:2.2.0 using gpt-5.5

### DIFF
--- a/metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json
+++ b/metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json
@@ -1,0 +1,37 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "scodec.Codec"
+      },
+      "type" : "scodec.Codec$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.codecs.ConditionalCodec"
+      },
+      "type" : "scodec.codecs.ConditionalCodec",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.codecs.DiscriminatorCodec"
+      },
+      "type" : "scodec.codecs.DiscriminatorCodec",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scodec/scodec-core_3/index.json
+++ b/metadata/org.scodec/scodec-core_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-core_3/$version$/scodec-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scodec/scodec",
+    "test-code-url" : "https://github.com/scodec/scodec/tree/v$version$/unitTests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-core_3/$version$/scodec-core_3-$version$-javadoc.jar",
+    "description" : "scodec-core_3 is Scodec's Scala 3 combinator library for describing binary formats and purely functional encoders and decoders. It provides the Codec, Encoder, Decoder, and predefined codec combinators used to map bit-level protocol data to typed Scala values with descriptive failures.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.2.0"
+    ],
+    "allowed-packages" : [
+      "scodec"
+    ]
+  }
+]

--- a/stats/org.scodec/scodec-bits_3/1.1.34/stats.json
+++ b/stats/org.scodec/scodec-bits_3/1.1.34/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1.34",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5527,
+        "missed" : 14371,
+        "ratio" : 0.277767,
+        "total" : 19898
+      },
+      "line" : {
+        "covered" : 899,
+        "missed" : 1331,
+        "ratio" : 0.403139,
+        "total" : 2230
+      },
+      "method" : {
+        "covered" : 296,
+        "missed" : 1044,
+        "ratio" : 0.220896,
+        "total" : 1340
+      }
+    }
+  } ]
+}

--- a/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
+++ b/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T07:57:41.229839Z",
+    "library": "org.scodec:scodec-core_3:2.2.0",
+    "starting_commit": "5ddbf81943e288e025de8df04c37c7e3d8a707b3",
+    "ending_commit": "aee90c23ccea83334634396025dbb1af6ad97cd2",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3611,
+          "missed": 13331,
+          "ratio": 0.213139,
+          "total": 16942
+        },
+        "line": {
+          "covered": 472,
+          "missed": 972,
+          "ratio": 0.32687,
+          "total": 1444
+        },
+        "method": {
+          "covered": 356,
+          "missed": 1469,
+          "ratio": 0.195068,
+          "total": 1825
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 142822,
+      "cached_input_tokens_used": 1590784,
+      "output_tokens_used": 20416,
+      "iterations": 4,
+      "cost_usd": 1.4079,
+      "generated_loc": 148,
+      "tested_library_loc": 472,
+      "metadata_entries": 6,
+      "code_coverage_percent": 32.69
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala",
+      "metadata_file": "metadata/org.scodec/scodec-core_3/2.2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scodec/scodec-core_3/2.2.0/stats.json
+++ b/stats/org.scodec/scodec-core_3/2.2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3611,
+        "missed" : 13331,
+        "ratio" : 0.213139,
+        "total" : 16942
+      },
+      "line" : {
+        "covered" : 472,
+        "missed" : 972,
+        "ratio" : 0.32687,
+        "total" : 1444
+      },
+      "method" : {
+        "covered" : 356,
+        "missed" : 1469,
+        "ratio" : 0.195068,
+        "total" : 1825
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/.gitignore
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/gradle.properties
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scodec:scodec-bits_3:1.1.34
+library.version = 1.1.34
+metadata.dir = org.scodec/scodec-bits_3/1.1.34/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/settings.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scodec.scodec-bits_3_tests'

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scodec.scodec_bits_3
+
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+import scodec.bits.{BitVector, ByteVector, HexDumpFormat}
+
+class Scodec_bits_3Test:
+
+  @Test
+  def byteVectorsPreserveEncodingsAndBitwiseOperations(): Unit =
+    val bytes: ByteVector = ByteVector.fromValidHex("cafe00ff")
+    val mask: ByteVector = ByteVector.fromValidHex("0ff0330f")
+
+    assertEquals("cafe00ff", bytes.toHex)
+    assertEquals(bytes, ByteVector.fromValidBase64(bytes.toBase64))
+    assertEquals("Cafe", ByteVector.fromValidHex("43616665").decodeUtf8.toOption.get)
+    assertArrayEquals(Array[Byte](0xCA.toByte, 0xFE.toByte, 0x00.toByte, 0xFF.toByte), bytes.toArray)
+    assertEquals("c50e33f0", bytes.xor(mask).toHex)
+    assertTrue(bytes.startsWith(ByteVector.fromValidHex("cafe")))
+
+  @Test
+  def bitVectorsSupportBitLevelSlicingAndConcatenation(): Unit =
+    val bits: BitVector = BitVector.fromValidBin("101011110001")
+    val prefix: BitVector = bits.take(4)
+    val suffix: BitVector = bits.drop(4)
+    val rebuilt: BitVector = prefix ++ suffix
+
+    assertEquals("101011110001", bits.toBin)
+    assertEquals("1010", prefix.toBin)
+    assertEquals(bits, rebuilt)
+    assertEquals(bits, BitVector(bits.toByteVector).take(bits.size))
+
+  @Test
+  def hexDumpFormattingRendersStableStructuredOutput(): Unit =
+    val bytes: ByteVector = ByteVector.fromValidHex("00010203040506070809")
+    val format: HexDumpFormat = HexDumpFormat.NoAnsi
+      .withIncludeAsciiColumn(false)
+      .withDataColumnCount(1)
+      .withDataColumnWidthInBytes(4)
+    val rendered: String = format.render(bytes)
+
+    assertTrue(rendered.contains("00000000"))
+    assertTrue(rendered.contains("00 01 02 03"))
+    assertTrue(rendered.contains("08 09"))

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "scodec.bits.**"
+    },
+    {
+      "includeClasses" : "org_scodec.scodec_bits_3.**"
+    }
+  ]
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/.gitignore
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scodec:scodec-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/gradle.properties
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scodec:scodec-core_3:2.2.0
+library.version = 2.2.0
+metadata.dir = org.scodec/scodec-core_3/2.2.0/

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/settings.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scodec.scodec-core_3_tests'

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scodec.scodec_core_3
+
+import org.junit.jupiter.api.Test
+
+class Scodec_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -144,6 +144,17 @@ class Scodec_core_3Test:
     assertFalse(Attempt.guard(false, "guard failed").isSuccessful)
 
   @Test
+  def variableSizeDelimitedCodecTerminatesPayloadsAndPreservesRemainders(): Unit =
+    val codec: Codec[String] = variableSizeDelimited(constant(hex("00")), utf8, 8)
+
+    assertEquals(hex("646f6e6500"), codec.encode("done").require)
+
+    val decoded: DecodeResult[String] = codec.decode(hex("646f6e6500cafe")).require
+    assertEquals("done", decoded.value)
+    assertEquals(hex("cafe"), decoded.remainder)
+    assertTrue(codec.decode(hex("646f6e65")).isFailure)
+
+  @Test
   def checksummedCodecAppendsValidatesAndPreservesRemainders(): Unit =
     val checksum: BitVector => BitVector = valueBits => valueBits.take(8).xor(valueBits.drop(8).take(8))
     val framing: Codec[(BitVector, BitVector)] = Codec.fromTuple((bits(16), bits(8)))

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -6,11 +6,155 @@
  */
 package org_scodec.scodec_core_3
 
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
+import scodec.{Attempt, Codec, DecodeResult, Decoder, Encoder, Err, SizeBound}
+import scodec.Codec.*
+import scodec.bits.{BitVector, ByteVector}
+import scodec.codecs.*
 
-class Scodec_core_3Test {
+final case class DerivedFrame(version: Int, urgent: Boolean, label: String) derives Codec
+
+sealed trait DerivedMessage derives Codec
+final case class DerivedText(id: Int, body: String) extends DerivedMessage
+final case class DerivedFlag(enabled: Boolean) extends DerivedMessage
+
+sealed trait Packet
+final case class TextPacket(value: String) extends Packet
+final case class CountPacket(value: Int) extends Packet
+
+class Scodec_core_3Test:
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def numericCodecsEncodeEndiannessAndPreserveRemainders(): Unit =
+    val codec: Codec[(Int, Int, Boolean)] = Codec.fromTuple((uint8, int16L, bool))
+    val encoded: BitVector = codec.encode((255, -2, true)).require
+
+    assertEquals("fffeff8", encoded.toHex)
+    assertEquals(25L, encoded.size)
+    assertEquals(SizeBound.exact(25), codec.sizeBound)
+
+    val decoded: DecodeResult[(Int, Int, Boolean)] = codec.decode(encoded ++ hex("abcd")).require
+    assertEquals((255, -2, true), decoded.value)
+    assertEquals(hex("abcd"), decoded.remainder)
+
+  @Test
+  def fixedSizeConstantsAndDropCombinatorsFramePayloads(): Unit =
+    val payloadCodec: Codec[Int] = constant(hex("aa")) ~> uint8 <~ constant(hex("bb"))
+    val paddedBytes: Codec[ByteVector] = bytes(4)
+
+    assertEquals(hex("aa07bb"), payloadCodec.encode(7).require)
+    assertEquals(7, payloadCodec.decode(hex("aa07bbcc")).require.value)
+    assertEquals(hex("cc"), payloadCodec.decode(hex("aa07bbcc")).require.remainder)
+
+    assertEquals(bytesHex("beef0000"), paddedBytes.encode(bytesHex("beef")).require.bytes)
+    val decoded: DecodeResult[ByteVector] = paddedBytes.decode(hex("beef0000cafe")).require
+    assertEquals(bytesHex("beef0000"), decoded.value)
+    assertEquals(hex("cafe"), decoded.remainder)
+
+    val strictFailure: String = failureMessage(bytesStrict(4).encode(bytesHex("beef")))
+    assertTrue(strictFailure.contains("exactly 32 bits"))
+
+  @Test
+  def variableSizedStringsCollectionsAndOptionalValuesRoundTrip(): Unit =
+    val stringCodec: Codec[String] = variableSizeBytes(uint8, utf8)
+    val vectorCodec: Codec[Vector[Int]] = vectorOfN(uint8, uint4)
+    val optionalCodec: Codec[Option[Int]] = optional(bool, uint8)
+    val defaultCodec: Codec[Int] = withDefaultValue(optionalCodec, 99)
+
+    assertEquals(hex("0568656c6c6f"), stringCodec.encode("hello").require)
+    val stringResult: DecodeResult[String] = stringCodec.decode(hex("0568656c6c6fcafe")).require
+    assertEquals("hello", stringResult.value)
+    assertEquals(hex("cafe"), stringResult.remainder)
+
+    assertRoundTrip(vectorCodec, Vector(1, 2, 15, 0))
+    assertEquals(Some(42), optionalCodec.decode(optionalCodec.encode(Some(42)).require).require.value)
+    assertEquals(None, optionalCodec.decode(optionalCodec.encode(None).require).require.value)
+    assertEquals(99, defaultCodec.decode(BitVector.low(1)).require.value)
+    assertEquals(12, defaultCodec.decode(defaultCodec.encode(12).require).require.value)
+
+  @Test
+  def transformedCodecsReportContextAndCompletionFailures(): Unit =
+    val evenByte: Codec[Int] = uint8.exmap(
+      value => Attempt.guard(value % 2 == 0, Err(s"not even: $value")).map(_ => value),
+      value => Attempt.guard(value % 2 == 0, Err(s"not even: $value")).map(_ => value)
+    )
+    val contextual: Codec[Int] = evenByte.withContext("payloadLength")
+
+    assertEquals(24, contextual.decode(hex("18ff")).require.value)
+    assertTrue(contextual.complete.decode(hex("18ff")).isFailure)
+
+    val encodeFailure: String = failureMessage(contextual.encode(5))
+    assertTrue(encodeFailure.contains("payloadLength"))
+    assertTrue(encodeFailure.contains("not even: 5"))
+
+    val decodeFailure: String = failureMessage(contextual.decode(hex("05")))
+    assertTrue(decodeFailure.contains("payloadLength"))
+    assertTrue(decodeFailure.contains("not even: 5"))
+
+  @Test
+  def derivedProductAndSumCodecsRoundTripPublicModels(): Unit =
+    val frame: DerivedFrame = DerivedFrame(7, urgent = true, "native-image")
+    assertRoundTrip(Codec[DerivedFrame], frame)
+
+    val text: DerivedMessage = DerivedText(1001, "status")
+    val flag: DerivedMessage = DerivedFlag(enabled = false)
+    assertRoundTrip(Codec[DerivedMessage], text)
+    assertRoundTrip(Codec[DerivedMessage], flag)
+
+  @Test
+  def discriminatedCodecSelectsCasesAndRejectsUnknownTags(): Unit =
+    val textCodec: Codec[TextPacket] = variableSizeBytes(uint8, utf8).xmap(TextPacket.apply, _.value)
+    val countCodec: Codec[CountPacket] = uint16.xmap(CountPacket.apply, _.value)
+    val packetCodec: Codec[Packet] = discriminated[Packet]
+      .by(uint8)
+      .subcaseP[TextPacket](1) { case text: TextPacket => text }(textCodec)
+      .subcaseP[CountPacket](2) { case count: CountPacket => count }(countCodec)
+
+    assertEquals(hex("01026f6b"), packetCodec.encode(TextPacket("ok")).require)
+    assertEquals(hex("020201"), packetCodec.encode(CountPacket(513)).require)
+    assertEquals(TextPacket("ok"), packetCodec.decode(hex("01026f6bff")).require.value)
+    assertEquals(hex("ff"), packetCodec.decode(hex("01026f6bff")).require.remainder)
+    assertEquals(CountPacket(513), packetCodec.decode(hex("020201")).require.value)
+
+    val unknownTag: String = failureMessage(packetCodec.decode(hex("09")))
+    assertTrue(unknownTag.contains("Unknown discriminator 9"))
+
+  @Test
+  def attemptEncoderAndDecoderUtilitiesComposePredictably(): Unit =
+    val encoder: Encoder[Int] = uint8.pcontramap[Int](value =>
+      Option.when(value >= 0 && value <= 255)(value)
+    )
+    val decoder: Decoder[Int] = uint8.emap(value =>
+      Attempt.guard(value > 0, Err("zero is reserved")).map(_ => value)
+    )
+    val codec: Codec[Int] = Codec(encoder, decoder)
+
+    assertEquals(hex("2a"), encoder.encode(42).require)
+    assertTrue(encoder.encode(-1).isFailure)
+    assertEquals(List(1, 2, 3), uint8.collect[List, Int](hex("010203"), None).require.value)
+    assertEquals(
+      (None, Vector(1, 2, 3)),
+      uint8.decodeAll((value: Int) => Vector(value))(Vector.empty[Int], _ ++ _)(hex("010203"))
+    )
+
+    assertEquals(5, codec.decode(hex("05")).require.value)
+    assertTrue(codec.decode(hex("00")).isFailure)
+    assertEquals(123, Attempt.fromOption(Some(123), Err("missing")).require)
+    assertFalse(Attempt.guard(false, "guard failed").isSuccessful)
+
+  private def assertRoundTrip[A](codec: Codec[A], value: A): BitVector =
+    val encoded: BitVector = codec.encode(value).require
+    val decoded: DecodeResult[A] = codec.decode(encoded).require
+    assertEquals(value, decoded.value)
+    assertTrue(decoded.remainder.isEmpty)
+    encoded
+
+  private def failureMessage[A](attempt: Attempt[A]): String =
+    attempt match
+      case Attempt.Failure(cause) => cause.messageWithContext
+      case Attempt.Successful(value) => throw new AssertionError(s"expected failure, got $value")
+
+  private def hex(value: String): BitVector = BitVector.fromValidHex(value)
+
+  private def bytesHex(value: String): ByteVector = ByteVector.fromValidHex(value)

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/src/test/scala/org_scodec/scodec_core_3/Scodec_core_3Test.scala
@@ -143,6 +143,21 @@ class Scodec_core_3Test:
     assertEquals(123, Attempt.fromOption(Some(123), Err("missing")).require)
     assertFalse(Attempt.guard(false, "guard failed").isSuccessful)
 
+  @Test
+  def checksummedCodecAppendsValidatesAndPreservesRemainders(): Unit =
+    val checksum: BitVector => BitVector = valueBits => valueBits.take(8).xor(valueBits.drop(8).take(8))
+    val framing: Codec[(BitVector, BitVector)] = Codec.fromTuple((bits(16), bits(8)))
+    val codec: Codec[Int] = checksummed(uint16, checksum, framing)
+
+    assertEquals(hex("123426"), codec.encode(0x1234).require)
+
+    val decoded: DecodeResult[Int] = codec.decode(hex("123426ff")).require
+    assertEquals(0x1234, decoded.value)
+    assertEquals(hex("ff"), decoded.remainder)
+
+    val checksumFailure: String = failureMessage(codec.decode(hex("123427")))
+    assertTrue(checksumFailure.contains("checksum mismatch"))
+
   private def assertRoundTrip[A](codec: Codec[A], value: A): BitVector =
     val encoded: BitVector = codec.encode(value).require
     val decoded: DecodeResult[A] = codec.decode(encoded).require

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "scodec.**"
+    }
+  ]
+}

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "scodec.**"
+      "includeClasses" : "scodec.**"
+    },
+    {
+      "includeClasses" : "org_scodec.scodec_core_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4943

This PR introduces tests and metadata for org.scodec:scodec-core_3:2.2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 142822
- Cached input tokens: 1590784
- Output tokens: 20416
- Metadata entries: 6
- Iterations: 4
- Library coverage percentage: 32.69
- Generated lines of code: 148
- Tested library lines of code: 472

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f733e9eb4b4ffa52254e317a09b56ee56aca9932`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3611/16942 (21.31%)
- Line: 472/1444 (32.69%)
- Method: 356/1825 (19.51%)

### Local CI Verification

- Status: `success`
- Commands run: 44
- Fixup attempts: 2
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `stats/org.scodec/scodec-bits_3/1.1.34/stats.json`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/.gitignore`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/build.gradle`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/gradle.properties`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/settings.gradle`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala`
  - `tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json`
