### PR TITLE
Fix Forge PR issue linking

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4214,7 +4214,6 @@ def build_large_library_pr_args(
     if large_library_state is None:
         return []
     args = [
-        "--issue-number", str(claimed_issue.issue["number"]),
         "--large-library-part", str(large_library_state.part),
         "--series-id", large_library_state.series_id,
         "--large-library-state-path", large_library_state_path or "",
@@ -4255,6 +4254,8 @@ def finalize_successful_issue(
         ensure_large_library_labels_exist_if_needed(claimed_issue)
     run_metrics = _load_pending_run_metrics(claimed_issue.scratch_metrics_repo_path)
     workflow_status = None if run_metrics is None else run_metrics.get("status")
+    issue_number = claimed_issue.issue["number"]
+    issue_number_args = ["--issue-number", str(issue_number)]
     large_library_pr_args = build_large_library_pr_args(
         claimed_issue,
         large_library_state,
@@ -4267,6 +4268,7 @@ def finalize_successful_issue(
             run_make_pr_not_for_native_image(
                 [
                     "--coordinates", claimed_issue.issue_coordinates,
+                    *issue_number_args,
                     "--reachability-metadata-path", claimed_issue.worktree_path,
                     "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 ]
@@ -4275,6 +4277,7 @@ def finalize_successful_issue(
         run_make_pr_new_library_support(
             [
                 "--coordinates", claimed_issue.issue_coordinates,
+                *issue_number_args,
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 *large_library_pr_args,
@@ -4287,6 +4290,7 @@ def finalize_successful_issue(
             [
                 "--coordinates", claimed_issue.current_coordinates,
                 "--new-version", claimed_issue.new_version,
+                "--issue-number", str(issue_number),
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
@@ -4298,6 +4302,7 @@ def finalize_successful_issue(
             [
                 "--coordinates", claimed_issue.current_coordinates,
                 "--new-version", claimed_issue.new_version,
+                "--issue-number", str(issue_number),
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
@@ -4309,6 +4314,7 @@ def finalize_successful_issue(
             [
                 "--coordinates", claimed_issue.current_coordinates,
                 "--new-version", claimed_issue.new_version,
+                "--issue-number", str(issue_number),
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
@@ -4319,6 +4325,7 @@ def finalize_successful_issue(
         run_make_pr_improve_coverage(
             [
                 "--coordinates", claimed_issue.issue_coordinates,
+                *issue_number_args,
                 "--reachability-metadata-path", claimed_issue.worktree_path,
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
                 *large_library_pr_args,

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -645,6 +645,13 @@ def stage_and_commit(paths: List[str], commit_message: str, cwd=None) -> None:
         print("No staged changes to commit.")
 
 
+def _issue_contains_exact_coordinate(issue: dict[str, Any], coordinates: str) -> bool:
+    """Return true when a GitHub issue title or body contains the exact coordinates."""
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    return coordinates in title or coordinates in body
+
+
 def find_issue_for_coordinates(search_string: str, repo: str):
     """
     Finds the open issue number in a GitHub repository matching the given search string in the title.
@@ -652,7 +659,7 @@ def find_issue_for_coordinates(search_string: str, repo: str):
     Returns:
         The issue number if found.
     """
-    gh_search_query = f"{search_string} in:title"
+    gh_search_query = f'"{search_string}" in:title,body'
 
     # Build the gh issue list command
     command = [
@@ -662,8 +669,8 @@ def find_issue_for_coordinates(search_string: str, repo: str):
         "--repo", repo,
         "--state", "open",
         "--search", gh_search_query,
-        "--limit", "1",
-        "--json", "number"
+        "--limit", "50",
+        "--json", "number,title,body"
     ]
 
     print(f"Executing command: {' '.join(command)}")
@@ -678,10 +685,23 @@ def find_issue_for_coordinates(search_string: str, repo: str):
 
     issue_data = json.loads(result.stdout)
 
-    if isinstance(issue_data, list) and len(issue_data) > 0 and 'number' in issue_data[0]:
-        return issue_data[0]['number']
+    exact_matches = [
+        issue
+        for issue in issue_data
+        if isinstance(issue, dict) and _issue_contains_exact_coordinate(issue, search_string)
+    ]
 
-    raise RuntimeError(f"No open issue found for search: {gh_search_query} in repo {repo}")
+    if len(exact_matches) == 1 and 'number' in exact_matches[0]:
+        return exact_matches[0]['number']
+
+    if len(exact_matches) > 1:
+        sorted_matches = sorted(
+            exact_matches,
+            key=lambda issue: int(issue.get("number") or 0),
+        )
+        return sorted_matches[0]['number']
+
+    raise RuntimeError(f"No open issue found for exact coordinates {search_string} in repo {repo}")
 
 
 def get_model_display_name(strategy_name: str) -> str:

--- a/forge/git_scripts/make_pr_java_run_fix.py
+++ b/forge/git_scripts/make_pr_java_run_fix.py
@@ -84,6 +84,7 @@ def create_pull_request(
         new_version: str,
         metrics_repo_root: str,
         repo_path: str,
+        issue_number: int | None = None,
 ):
     """Create a GitHub pull request for the java-run fix branch."""
     if shutil.which("gh") is None:
@@ -100,7 +101,7 @@ def create_pull_request(
 
     assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
 
-    issue_no = find_issue_common(new_coordinates, REPO)
+    issue_no = issue_number if issue_number is not None else find_issue_common(new_coordinates, REPO)
     metrics_entry = read_pending_metrics(metrics_repo_root)
     metrics = metrics_entry.get("metrics", {})
 
@@ -224,6 +225,7 @@ def build_parser():
         dest="metrics_repo_path",
         help="Path to the metrics repository root.",
     )
+    parser.add_argument("--issue-number", type=int, help="Explicit backing GitHub issue number.")
     return parser
 
 
@@ -235,7 +237,7 @@ def parse_flags(argv_list):
         explicit_repo_path=flags.reachability_metadata_path,
         explicit_metrics_repo_path=flags.metrics_repo_path,
     )
-    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.issue_number
 
 
 def push_current_branch_to_origin(
@@ -290,7 +292,7 @@ def push_current_branch_to_origin(
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(
+    old_coordinates, new_version, repo_path, metrics_repo_path, issue_number = parse_flags(
         argv if argv is not None else sys.argv[1:]
     )
 
@@ -310,6 +312,7 @@ def main(argv=None):
         new_version=new_version,
         metrics_repo_root=metrics_repo_path,
         repo_path=repo_path,
+        issue_number=issue_number,
     )
 
 if __name__ == "__main__":

--- a/forge/git_scripts/make_pr_javac_fix.py
+++ b/forge/git_scripts/make_pr_javac_fix.py
@@ -145,6 +145,7 @@ def create_pull_request(
         new_version: str,
         metrics_repo_root: str,
         repo_path: str,
+        issue_number: int | None = None,
 ):
     """
     Create a GitHub pull request for the current branch with an auto-generated body,
@@ -166,7 +167,7 @@ def create_pull_request(
 
     assert_no_dynamic_access_category_regressions(repo_path, old_coordinates, new_coordinates)
 
-    issue_no = find_issue_common(new_coordinates, REPO)
+    issue_no = issue_number if issue_number is not None else find_issue_common(new_coordinates, REPO)
     metrics_entry = load_fix_javac_metrics(
         metrics_repo_root=metrics_repo_root,
         old_coordinates=old_coordinates,
@@ -312,6 +313,7 @@ def build_parser():
             "If omitted, the forge directory in the selected worktree is used."
         ),
     )
+    parser.add_argument("--issue-number", type=int, help="Explicit backing GitHub issue number.")
     return parser
 
 
@@ -323,7 +325,7 @@ def parse_flags(argv_list):
         explicit_repo_path=flags.reachability_metadata_path,
         explicit_metrics_repo_path=flags.metrics_repo_path,
     )
-    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.issue_number
 
 
 def push_current_branch_to_origin(
@@ -378,7 +380,7 @@ def push_current_branch_to_origin(
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(
+    old_coordinates, new_version, repo_path, metrics_repo_path, issue_number = parse_flags(
         argv if argv is not None else sys.argv[1:]
     )
 
@@ -398,6 +400,7 @@ def main(argv=None):
         new_version=new_version,
         metrics_repo_root=metrics_repo_path,
         repo_path=repo_path,
+        issue_number=issue_number,
     )
 
 if __name__ == "__main__":

--- a/forge/git_scripts/make_pr_ni_run_fix.py
+++ b/forge/git_scripts/make_pr_ni_run_fix.py
@@ -105,6 +105,7 @@ def create_pull_request(
         artifact: str,
         repo_path: str,
         local_ci_verification: LocalCIVerificationResult | None = None,
+        issue_number: int | None = None,
 ):
     """Create a GitHub pull request for the current branch."""
     origin_owner = get_origin_owner(cwd=repo_path)
@@ -115,7 +116,7 @@ def create_pull_request(
         print(f"Pull request already exists for branch {branch}.")
         return
 
-    issue_no = find_issue_common(new_coordinates, REPO)
+    issue_no = issue_number if issue_number is not None else find_issue_common(new_coordinates, REPO)
 
     _, _, old_version = parse_coordinate_parts(old_coordinates)
     _, _, new_version = parse_coordinate_parts(new_coordinates)
@@ -228,6 +229,7 @@ def build_parser():
         dest="metrics_repo_path",
         help="Path to the metrics repository root.",
     )
+    parser.add_argument("--issue-number", type=int, help="Explicit backing GitHub issue number.")
     return parser
 
 
@@ -239,7 +241,7 @@ def parse_flags(argv_list):
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
     )
-    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path
+    return flags.coordinates, flags.new_version, repo_path, metrics_repo_path, flags.issue_number
 
 
 def push_current_branch_to_origin(
@@ -294,7 +296,9 @@ def push_current_branch_to_origin(
 def main(argv=None):
     ensure_gh_authenticated()
 
-    old_coordinates, new_version, repo_path, metrics_repo_path = parse_flags(argv if argv is not None else sys.argv[1:])
+    old_coordinates, new_version, repo_path, metrics_repo_path, issue_number = parse_flags(
+        argv if argv is not None else sys.argv[1:]
+    )
 
     branch, group, artifact, new_coordinates, local_ci_verification = push_current_branch_to_origin(
         old_coordinates=old_coordinates,
@@ -310,6 +314,7 @@ def main(argv=None):
         artifact=artifact,
         repo_path=repo_path,
         local_ci_verification=local_ci_verification,
+        issue_number=issue_number,
     )
 
 

--- a/forge/git_scripts/make_pr_not_for_native_image.py
+++ b/forge/git_scripts/make_pr_not_for_native_image.py
@@ -46,6 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Create a PR that adds a not-for-native-image marker index.",
     )
     parser.add_argument("--coordinates", required=True, help="Coordinates in group:artifact:version form")
+    parser.add_argument("--issue-number", type=int, help="Explicit backing GitHub issue number.")
     parser.add_argument("--reachability-metadata-path", help="Path to the reachability-metadata checkout")
     parser.add_argument(
         "--metrics-repo-path",
@@ -92,6 +93,7 @@ def create_pull_request(
         coordinates: str,
         repo_path: str,
         local_ci_verification: LocalCIVerificationResult | None = None,
+        issue_number: int | None = None,
 ) -> None:
     """Create the marker PR."""
     if shutil.which("gh") is None:
@@ -109,7 +111,7 @@ def create_pull_request(
         print(f"Pull request already exists for branch {branch}.")
         return
 
-    issue_no = find_issue_for_coordinates(coordinates, REPO)
+    issue_no = issue_number if issue_number is not None else find_issue_for_coordinates(coordinates, REPO)
     title = f"[GenAI] Mark {group}:{artifact} as not for Native Image"
     body = f"""
 ## What does this PR do?
@@ -155,7 +157,7 @@ def main(argv=None) -> None:
     )
     ensure_gh_authenticated()
     branch, local_ci_verification = push_marker_branch(args.coordinates, repo_path, metrics_repo_path)
-    create_pull_request(branch, args.coordinates, repo_path, local_ci_verification)
+    create_pull_request(branch, args.coordinates, repo_path, local_ci_verification, args.issue_number)
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -23,6 +23,56 @@ class ForgeRevisionSectionTests(unittest.TestCase):
         self.assertIn("- Forge commit hash: `abc123`", section)
 
 
+class IssueLookupTests(unittest.TestCase):
+    def test_find_issue_for_coordinates_uses_exact_coordinate_match(self) -> None:
+        completed_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout=(
+                "["
+                "{\"number\": 5405, \"title\": "
+                "\"Support for com.github.ajalt.mordant:mordant-jvm-jna-jvm:3.0.2\", \"body\": \"\"},"
+                "{\"number\": 5329, \"title\": "
+                "\"Support for com.github.ajalt.mordant:mordant-jvm:3.0.2\", \"body\": \"\"}"
+                "]"
+            ),
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", return_value=completed_process) as run:
+            issue_number = common_git.find_issue_for_coordinates(
+                "com.github.ajalt.mordant:mordant-jvm:3.0.2",
+                "oracle/graalvm-reachability-metadata",
+            )
+
+        self.assertEqual(issue_number, 5329)
+        command = run.call_args.args[0]
+        self.assertIn("--limit", command)
+        self.assertIn("50", command)
+        self.assertIn("number,title,body", command)
+
+    def test_find_issue_for_coordinates_picks_oldest_duplicate_exact_match(self) -> None:
+        completed_process = subprocess.CompletedProcess(
+            ["gh"],
+            0,
+            stdout=(
+                "["
+                "{\"number\": 2, \"title\": \"Retry org.example:demo:1.0.0\", \"body\": \"\"},"
+                "{\"number\": 1, \"title\": \"Support for org.example:demo:1.0.0\", \"body\": \"\"}"
+                "]"
+            ),
+            stderr="",
+        )
+
+        with patch.object(common_git.subprocess, "run", return_value=completed_process):
+            issue_number = common_git.find_issue_for_coordinates(
+                "org.example:demo:1.0.0",
+                "oracle/graalvm-reachability-metadata",
+            )
+
+        self.assertEqual(issue_number, 1)
+
+
 class DynamicAccessCategoryRegressionTests(unittest.TestCase):
     def test_reports_fully_covered_category_that_becomes_uncovered(self) -> None:
         old_stats = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -125,6 +125,7 @@ class FinalizeSuccessfulIssueTests(unittest.TestCase):
 
         make_pr.assert_called_once_with([
             "--coordinates", "org.example:lib:1.0.0",
+            "--issue-number", "1412",
             "--reachability-metadata-path", "/tmp/reachability-worktree",
             "--metrics-repo-path", "/tmp/metrics-worktree",
         ])

--- a/forge/tests/test_make_pr_not_for_native_image.py
+++ b/forge/tests/test_make_pr_not_for_native_image.py
@@ -71,7 +71,7 @@ class MakePrNotForNativeImageTests(unittest.TestCase):
                     return_value={"reason": "native-image does not apply"},
                 ), \
                 patch.object(make_pr_not_for_native_image, "get_origin_owner", return_value="me"), \
-                patch.object(make_pr_not_for_native_image, "find_issue_for_coordinates", return_value=1234), \
+                patch.object(make_pr_not_for_native_image, "find_issue_for_coordinates") as find_issue, \
                 patch.object(make_pr_not_for_native_image, "format_forge_revision_section", return_value="Forge revision"), \
                 patch.object(make_pr_not_for_native_image, "gh", side_effect=fake_gh):
             make_pr_not_for_native_image.create_pull_request(
@@ -79,10 +79,13 @@ class MakePrNotForNativeImageTests(unittest.TestCase):
                 "org.example:demo:1.0.0",
                 "/repo",
                 local_ci_verification,
+                issue_number=1234,
             )
 
         create_call = gh_calls[1]
         body = create_call[create_call.index("--body") + 1]
+        find_issue.assert_not_called()
+        self.assertIn("Fixes: #1234", body)
         self.assertIn("Local CI Verification", body)
         self.assertIn("Repository-level fix paths", body)
         self.assertIn("--label", create_call)


### PR DESCRIPTION
## Summary

Fixes: #6097

This PR makes Forge carry the claimed issue number through PR finalization instead of rediscovering issues from fuzzy coordinate search during PR creation.

Changes:
- pass `--issue-number` from Forge finalization into new-library, not-for-native-image, fix, and coverage PR paths
- add explicit issue-number support to the not-for-native-image and fix PR scripts
- make fallback coordinate lookup require an exact title/body coordinate match and fail on ambiguity
- add regression coverage for prefix coordinates such as `mordant-jvm` vs `mordant-jvm-jna-jvm`

## Testing

- `.venv/bin/python -m unittest tests.test_common_git.IssueLookupTests tests.test_make_pr_not_for_native_image.MakePrNotForNativeImageTests tests.test_make_pr_ni_run_fix.SevereMetadataDropGuardrailTests tests.test_forge_metadata.FinalizeSuccessfulIssueTests`
- `.venv/bin/python -m py_compile forge_metadata.py git_scripts/common_git.py git_scripts/make_pr_not_for_native_image.py git_scripts/make_pr_javac_fix.py git_scripts/make_pr_java_run_fix.py git_scripts/make_pr_ni_run_fix.py git_scripts/make_pr_improve_coverage.py git_scripts/make_pr_new_library_support.py`

### Open question

- The full `tests.test_forge_metadata` suite still has unrelated environment-sensitive failures around issue preflight/stop-marker behavior; the focused finalization regression test passes.
