### PR TITLE
[GenAI] Add support for org.jetbrains.exposed:exposed-core:1.0.0-beta-4 using gpt-5.5

### DIFF
--- a/metadata/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/reachability-metadata.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.exposed.v1.core.Table"
+      },
+      "type": "org.jetbrains.exposed.v1.core.IntegerColumnType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.exposed.v1.core.Table"
+      },
+      "type": "org.jetbrains.exposed.v1.core.ColumnType",
+      "methods": [
+        {
+          "name": "getNullable",
+          "parameterTypes": []
+        },
+        {
+          "name": "setNullable",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jetbrains.exposed/exposed-core/index.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.0.0-beta-4",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/exposed/exposed-core/$version$/exposed-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/JetBrains/Exposed",
+    "test-code-url" : "https://github.com/JetBrains/Exposed/tree/$version$/exposed-tests/src/test",
+    "documentation-url" : "https://github.com/JetBrains/Exposed/blob/$version$/docs/api/exposed-core/index.html",
+    "description" : "Exposed Core is the base module of JetBrains Exposed, a Kotlin SQL/ORM framework that provides the type-safe SQL DSL, table and column model, expressions, statements, and vendor dialect abstractions. It supplies the shared schema and query-building primitives used by the Exposed JDBC/R2DBC and DAO modules to work with relational databases from Kotlin applications.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.0"
+    },
+    "tested-versions" : [
+      "1.0.0-beta-4"
+    ],
+    "allowed-packages" : [
+      "org.jetbrains.exposed.v1"
+    ]
+  }
+]

--- a/stats/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/execution-metrics.json
+++ b/stats/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T08:53:18.380838Z",
+    "library": "org.jetbrains.exposed:exposed-core:1.0.0-beta-4",
+    "starting_commit": "ca925163b499ab193364099778f09831d16f89e6",
+    "ending_commit": "b3ab6fb65d4c33b83a32258ea802d518ffdb7661",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0.0-beta-4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4466,
+          "missed": 50240,
+          "ratio": 0.081636,
+          "total": 54706
+        },
+        "line": {
+          "covered": 710,
+          "missed": 6615,
+          "ratio": 0.096928,
+          "total": 7325
+        },
+        "method": {
+          "covered": 339,
+          "missed": 2727,
+          "ratio": 0.110568,
+          "total": 3066
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 339334,
+      "cached_input_tokens_used": 6289920,
+      "output_tokens_used": 29851,
+      "iterations": 6,
+      "cost_usd": 4.0405,
+      "generated_loc": 234,
+      "tested_library_loc": 710,
+      "metadata_entries": 5,
+      "code_coverage_percent": 9.69
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt",
+      "metadata_file": "metadata/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/stats.json
+++ b/stats/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.0.0-beta-4",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4466,
+        "missed" : 50240,
+        "ratio" : 0.081636,
+        "total" : 54706
+      },
+      "line" : {
+        "covered" : 710,
+        "missed" : 6615,
+        "ratio" : 0.096928,
+        "total" : 7325
+      },
+      "method" : {
+        "covered" : 339,
+        "missed" : 2727,
+        "ratio" : 0.110568,
+        "total" : 3066
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/.gitignore
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/gradle.properties
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jetbrains.exposed:exposed-core:1.0.0-beta-4
+library.version = 1.0.0-beta-4
+metadata.dir = org.jetbrains.exposed/exposed-core/1.0.0-beta-4/

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/settings.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jetbrains.exposed.exposed-core_tests'

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_exposed.exposed_core
+
+import org.junit.jupiter.api.Test
+
+class Exposed_coreTest {
+    @Test
+    fun test() {
+        println("This is just a placeholder, implement your test")
+    }
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.exposed.v1.core.Alias
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Index
+import org.jetbrains.exposed.v1.core.Join
 import org.jetbrains.exposed.v1.core.QueryBuilder
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder
 import org.jetbrains.exposed.v1.core.Table
@@ -53,6 +54,25 @@ public class ExposedCoreTest {
         assertThat(aliasedEmail.name).isEqualTo(Users.email.name)
         assertThat(aliasedEmail.table).isEqualTo(userAlias)
         assertThat(userAlias.originalColumn(aliasedEmail)).isEqualTo(Users.email)
+    }
+
+    @Test
+    fun joinsInferForeignKeysAndExposeCombinedFieldSets(): Unit {
+        val userMembershipJoin: Join = Users.innerJoin(Memberships)
+
+        assertThat(userMembershipJoin.columns).containsExactlyElementsOf(Users.columns + Memberships.columns)
+        assertThat(userMembershipJoin.fields).containsExactlyElementsOf(Users.fields + Memberships.fields)
+        assertThat(userMembershipJoin.alreadyInJoin(Memberships)).isTrue()
+        assertThat(userMembershipJoin.alreadyInJoin(Groups)).isFalse()
+
+        val userMembershipGroupJoin: Join = userMembershipJoin.innerJoin(Groups)
+
+        assertThat(userMembershipGroupJoin.columns)
+            .containsExactlyElementsOf(Users.columns + Memberships.columns + Groups.columns)
+        assertThat(userMembershipGroupJoin.fields)
+            .containsExactlyElementsOf(Users.fields + Memberships.fields + Groups.fields)
+        assertThat(userMembershipGroupJoin.alreadyInJoin(Memberships)).isTrue()
+        assertThat(userMembershipGroupJoin.alreadyInJoin(Groups)).isTrue()
     }
 
     @Test

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -10,9 +10,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.exposed.v1.core.Alias
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.DatabaseConfig
+import org.jetbrains.exposed.v1.core.ExperimentalKeywordApi
 import org.jetbrains.exposed.v1.core.Index
 import org.jetbrains.exposed.v1.core.Join
 import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Schema
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.Version
@@ -185,6 +188,62 @@ public class ExposedCoreTest {
         assertThat(version.covers("1.2.0")).isTrue()
         assertThat(version.covers("1.2.1")).isFalse()
         assertThat(Version.from("2").covers(1, 9, 9)).isTrue()
+    }
+
+    @Test
+    @OptIn(ExperimentalKeywordApi::class)
+    fun databaseConfigBuilderAppliesDefaultsCustomizationsAndValidation(): Unit {
+        val defaultConfig: DatabaseConfig = DatabaseConfig()
+
+        assertThat(defaultConfig.useNestedTransactions).isFalse()
+        assertThat(defaultConfig.defaultFetchSize).isNull()
+        assertThat(defaultConfig.defaultIsolationLevel).isEqualTo(-1)
+        assertThat(defaultConfig.defaultMaxAttempts).isEqualTo(3)
+        assertThat(defaultConfig.defaultMinRetryDelay).isZero()
+        assertThat(defaultConfig.defaultMaxRetryDelay).isZero()
+        assertThat(defaultConfig.defaultReadOnly).isFalse()
+        assertThat(defaultConfig.warnLongQueriesDuration).isNull()
+        assertThat(defaultConfig.maxEntitiesToStoreInCachePerEntity).isEqualTo(Int.MAX_VALUE)
+        assertThat(defaultConfig.keepLoadedReferencesOutOfTransaction).isFalse()
+        assertThat(defaultConfig.explicitDialect).isNull()
+        assertThat(defaultConfig.defaultSchema).isNull()
+        assertThat(defaultConfig.logTooMuchResultSetsThreshold).isZero()
+        assertThat(defaultConfig.preserveKeywordCasing).isTrue()
+
+        val schema = Schema("analytics")
+        val customConfig: DatabaseConfig = DatabaseConfig {
+            useNestedTransactions = true
+            defaultFetchSize = 64
+            defaultIsolationLevel = 8
+            defaultMaxAttempts = 2
+            defaultMinRetryDelay = 10L
+            defaultMaxRetryDelay = 20L
+            defaultReadOnly = true
+            warnLongQueriesDuration = 250L
+            maxEntitiesToStoreInCachePerEntity = 5
+            keepLoadedReferencesOutOfTransaction = true
+            defaultSchema = schema
+            logTooMuchResultSetsThreshold = 3
+            preserveKeywordCasing = false
+        }
+
+        assertThat(customConfig.useNestedTransactions).isTrue()
+        assertThat(customConfig.defaultFetchSize).isEqualTo(64)
+        assertThat(customConfig.defaultIsolationLevel).isEqualTo(8)
+        assertThat(customConfig.defaultMaxAttempts).isEqualTo(2)
+        assertThat(customConfig.defaultMinRetryDelay).isEqualTo(10L)
+        assertThat(customConfig.defaultMaxRetryDelay).isEqualTo(20L)
+        assertThat(customConfig.defaultReadOnly).isTrue()
+        assertThat(customConfig.warnLongQueriesDuration).isEqualTo(250L)
+        assertThat(customConfig.maxEntitiesToStoreInCachePerEntity).isEqualTo(5)
+        assertThat(customConfig.keepLoadedReferencesOutOfTransaction).isTrue()
+        assertThat(customConfig.defaultSchema).isEqualTo(schema)
+        assertThat(customConfig.logTooMuchResultSetsThreshold).isEqualTo(3)
+        assertThat(customConfig.preserveKeywordCasing).isFalse()
+
+        assertThatThrownBy { DatabaseConfig { defaultMaxAttempts = 0 } }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("defaultMaxAttempts")
     }
 }
 

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -6,11 +6,191 @@
  */
 package org_jetbrains_exposed.exposed_core
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.exposed.v1.core.Alias
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Index
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Version
+import org.jetbrains.exposed.v1.core.WindowFrameBound
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.append
+import org.jetbrains.exposed.v1.core.intLiteral
+import org.jetbrains.exposed.v1.core.intParam
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.stringParam
+import org.jetbrains.exposed.v1.exceptions.DuplicateColumnException
 import org.junit.jupiter.api.Test
 
-class Exposed_coreTest {
+public class ExposedCoreTest {
     @Test
-    fun test() {
-        println("This is just a placeholder, implement your test")
+    fun tableMetadataTracksColumnsKeysReferencesAndAliases(): Unit {
+        assertThat(Users.tableName).isEqualTo("app.users")
+        assertThat(Users.schemaName).isEqualTo("app")
+        assertThat(Users.columns.map { it.name })
+            .containsExactly("id", "email", "display_name", "status", "score", "active", "generated_token")
+        val primaryKeyColumns: List<Column<*>> = requireNotNull(Users.primaryKey).columns.toList()
+        assertThat(primaryKeyColumns).containsExactly(Users.id)
+        assertThat(Users.autoIncColumn).isEqualTo(Users.id)
+
+        val emailIndex: Index = Users.indices.single()
+        assertThat(emailIndex.customName).isEqualTo("ux_users_email")
+        assertThat(emailIndex.unique).isTrue()
+        assertThat(emailIndex.columns).containsExactly(Users.email)
+
+        assertThat(Memberships.user.referee).isEqualTo(Users.id)
+        assertThat(Memberships.group.referee).isEqualTo(Groups.id)
+        assertThat(Memberships.foreignKeys).hasSize(2)
+
+        val userAlias: Alias<Users> = Users.alias("u")
+        val aliasedEmail: Column<String> = userAlias[Users.email]
+        assertThat(userAlias.tableName).isEqualTo("u")
+        assertThat(userAlias.tableNameWithAlias).isEqualTo("app.users u")
+        assertThat(aliasedEmail.name).isEqualTo(Users.email.name)
+        assertThat(aliasedEmail.table).isEqualTo(userAlias)
+        assertThat(userAlias.originalColumn(aliasedEmail)).isEqualTo(Users.email)
     }
+
+    @Test
+    fun duplicateColumnNamesAreRejected(): Unit {
+        val table: Table = Table("duplicate_columns")
+        table.integer("id")
+
+        assertThatThrownBy { table.varchar("id", 16) }
+            .isInstanceOf(DuplicateColumnException::class.java)
+            .hasMessageContaining("id")
+            .hasMessageContaining("duplicate_columns")
+    }
+
+    @Test
+    fun columnDefaultsNullabilityAndGeneratedFlagsAreTracked(): Unit {
+        assertThat(Users.email.defaultValueFun == null).isTrue()
+        assertThat(Users.email.defaultValueInDb() == null).isTrue()
+        assertThat(Users.email.columnType.nullable).isFalse()
+
+        assertThat(Users.displayName.columnType.nullable).isTrue()
+        assertThat(Users.status.defaultValueFun?.invoke()).isEqualTo("active")
+        assertThat(Users.status.defaultValueInDb().toString()).isEqualTo("'active'")
+        assertThat(Users.score.defaultValueFun?.invoke()).isEqualTo(7)
+        assertThat(Users.score.defaultValueInDb() == null).isTrue()
+        assertThat(Users.active.defaultValueFun?.invoke()).isTrue()
+        assertThat(Users.active.defaultValueInDb()).isNotNull()
+
+        Users.generatedToken.defaultValueFun?.invoke().let { value: String? ->
+            assertThat(value).isEqualTo("generated")
+        }
+        assertThat(Users.generatedToken.isDatabaseGenerated()).isTrue()
+    }
+
+    @Test
+    fun columnTypesValidateAndFormatValues(): Unit {
+        assertThat(Users.id.columnType.valueFromDB("42")).isEqualTo(42)
+        assertThat(Users.email.columnType.valueFromDB(byteArrayOf(65, 66, 67))).isEqualTo("ABC")
+        assertThat(Users.email.columnType.valueToString("O'Reilly\nGuide")).isEqualTo("'O''Reilly\\nGuide'")
+        assertThat(Users.displayName.columnType.valueToString(null)).isEqualTo("NULL")
+
+        Users.email.columnType.validateValueBeforeUpdate("short@example.org")
+        assertThatThrownBy { Users.email.columnType.validateValueBeforeUpdate("x".repeat(129)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("exceeds length")
+
+        assertThatThrownBy { Users.email.columnType.valueToString(null) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("NULL in non-nullable column")
+    }
+
+    @Test
+    fun queryBuilderFormatsInlineSqlAndPreparedArguments(): Unit {
+        val inlineBuilder: QueryBuilder = QueryBuilder(prepared = false)
+        inlineBuilder.append(intLiteral(42), ", ", stringLiteral("O'Reilly"))
+
+        assertThat(inlineBuilder.toString()).isEqualTo("42, 'O''Reilly'")
+        assertThat(inlineBuilder.args).isEmpty()
+
+        val preparedBuilder: QueryBuilder = QueryBuilder(prepared = true)
+        preparedBuilder.append(intParam(7), ", ", stringParam("alpha"))
+
+        assertThat(preparedBuilder.toString()).isEqualTo("?, ?")
+        assertThat(preparedBuilder.args.map { it.second }).containsExactly(7, "alpha")
+    }
+
+    @Test
+    fun expressionDslBuildsComparisonListsAliasesCasesAndWindows(): Unit {
+        val comparison = with(SqlExpressionBuilder) {
+            (intLiteral(1) less intLiteral(3)) and (stringLiteral("kotlin") like "kot%")
+        }
+        assertThat(comparison.toString()).isEqualTo("(1 < 3) AND ('kotlin' LIKE 'kot%')")
+
+        val inList = with(SqlExpressionBuilder) { intLiteral(2) inList listOf(3, 1, 2) }
+        assertThat(inList.toString()).isEqualTo("2 IN (3, 1, 2)")
+
+        val arithmetic = with(SqlExpressionBuilder) { ((intLiteral(5) + 4) * intLiteral(2)) % 3 }
+        assertThat(arithmetic.toString()).isEqualTo("(((5 + 4) * 2) % 3)")
+
+        val caseExpression = with(SqlExpressionBuilder) {
+            case()
+                .When(intLiteral(1) eq 1, stringLiteral("one"))
+                .Else(stringLiteral("other"))
+        }
+        assertThat(caseExpression.toString()).isEqualTo("CASE WHEN 1 = 1 THEN 'one' ELSE 'other' END")
+
+        val coalesced = with(SqlExpressionBuilder) {
+            coalesce(stringLiteral("primary"), stringLiteral("fallback"), stringLiteral("last"))
+        }
+        assertThat(coalesced.toString()).isEqualTo("COALESCE('primary', 'fallback', 'last')")
+
+        val aliased = intLiteral(10).alias("ten")
+        assertThat(aliased.toString()).isEqualTo("10 ten")
+        assertThat(aliased.aliasOnlyExpression().toString()).isEqualTo("ten")
+
+        val window = with(SqlExpressionBuilder) {
+            rowNumber()
+                .over()
+                .partitionBy(stringLiteral("partition"))
+                .rows(WindowFrameBound.unboundedPreceding())
+        }
+        assertThat(window.toString()).isEqualTo("ROW_NUMBER() OVER(PARTITION BY 'partition' ROWS UNBOUNDED PRECEDING)")
+    }
+
+    @Test
+    fun versionParsingComparesSemanticComponents(): Unit {
+        val version: Version = Version.from("1.2.0-beta-4")
+
+        assertThat(version.toString()).isEqualTo("1.2.0")
+        assertThat(version.covers("1.1.9")).isTrue()
+        assertThat(version.covers("1.2.0")).isTrue()
+        assertThat(version.covers("1.2.1")).isFalse()
+        assertThat(Version.from("2").covers(1, 9, 9)).isTrue()
+    }
+}
+
+private object Users : Table("app.users") {
+    val id = integer("id").autoIncrement()
+    val email = varchar("email", 128).uniqueIndex("ux_users_email")
+    val displayName = varchar("display_name", 64).nullable()
+    val status = varchar("status", 32).default("active")
+    val score = integer("score").clientDefault { 7 }
+    val active = bool("active").default(true)
+    val generatedToken = varchar("generated_token", 32).clientDefault { "generated" }.databaseGenerated()
+
+    override val primaryKey = PrimaryKey(id, name = "pk_users")
+}
+
+private object Groups : Table("groups") {
+    val id = integer("id")
+    val name = varchar("name", 80)
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object Memberships : Table("memberships") {
+    val user = reference("user_id", Users.id)
+    val group = reference("group_id", Groups.id)
+    val role = varchar("role", 32).default("member")
+
+    override val primaryKey = PrimaryKey(user, group, name = "pk_memberships")
 }

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/user-code-filter.json
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jetbrains.exposed.v1.**"
+      "includeClasses" : "org.jetbrains.exposed.v1.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_exposed.exposed_core.**"
     }
   ]
 }

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/user-code-filter.json
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jetbrains.exposed.v1.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4499

This PR introduces tests and metadata for org.jetbrains.exposed:exposed-core:1.0.0-beta-4, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 339334
- Cached input tokens: 6289920
- Output tokens: 29851
- Metadata entries: 5
- Iterations: 6
- Library coverage percentage: 9.69
- Generated lines of code: 234
- Tested library lines of code: 710

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f733e9eb4b4ffa52254e317a09b56ee56aca9932`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 4466/54706 (8.16%)
- Line: 710/7325 (9.69%)
- Method: 339/3066 (11.06%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
