### PR TITLE
[GenAI] Add support for org.scodec:scodec-bits_3:1.1.34 using gpt-5.5

### DIFF
--- a/metadata/org.scodec/scodec-bits_3/1.1.34/reachability-metadata.json
+++ b/metadata/org.scodec/scodec-bits_3/1.1.34/reachability-metadata.json
@@ -1,0 +1,59 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "scodec.bits.ByteVector"
+      },
+      "type" : "scodec.bits.ByteVector",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.bits.BitVector"
+      },
+      "type" : "scodec.bits.BitVector",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.bits.crc$"
+      },
+      "type" : "scodec.bits.crc$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.bits.BitVector$Suspend"
+      },
+      "type" : "scodec.bits.BitVector$Suspend",
+      "fields" : [
+        {
+          "name" : "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "scodec.bits.HexDumpFormat"
+      },
+      "type" : "scodec.bits.HexDumpFormat",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scodec/scodec-bits_3/index.json
+++ b/metadata/org.scodec/scodec-bits_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.1.34",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-bits_3/1.1.34/scodec-bits_3-1.1.34-sources.jar",
+    "repository-url" : "https://github.com/scodec/scodec-bits",
+    "test-code-url" : "https://github.com/scodec/scodec-bits/tree/v1.1.34/core/jvm/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-bits_3/1.1.34/scodec-bits_3-1.1.34-javadoc.jar",
+    "description" : "scodec-bits provides persistent Scala data types for representing and manipulating bits and bytes. It centers on BitVector and ByteVector, offering collection-like operations, lazy constructors, string interpolators, and conversions for binary, hexadecimal, and base64 data.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.1.34"
+    ],
+    "allowed-packages" : [
+      "scodec.bits"
+    ]
+  }
+]

--- a/stats/org.scodec/scodec-bits_3/1.1.34/execution-metrics.json
+++ b/stats/org.scodec/scodec-bits_3/1.1.34/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T09:03:24.069380Z",
+    "library": "org.scodec:scodec-bits_3:1.1.34",
+    "starting_commit": "dae06710e7e8638c1b880ccbeb9e9bdfd37fa1fe",
+    "ending_commit": "d30ce5ee0ec36e4ebb8af06f54c26b99597240f0",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1.34",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10917,
+          "missed": 8981,
+          "ratio": 0.548648,
+          "total": 19898
+        },
+        "line": {
+          "covered": 1559,
+          "missed": 671,
+          "ratio": 0.699103,
+          "total": 2230
+        },
+        "method": {
+          "covered": 620,
+          "missed": 720,
+          "ratio": 0.462687,
+          "total": 1340
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 317402,
+      "cached_input_tokens_used": 2384896,
+      "output_tokens_used": 20204,
+      "iterations": 7,
+      "cost_usd": 1.7985,
+      "generated_loc": 241,
+      "tested_library_loc": 1559,
+      "metadata_entries": 10,
+      "code_coverage_percent": 69.91
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala",
+      "metadata_file": "metadata/org.scodec/scodec-bits_3/1.1.34/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scodec/scodec-bits_3/1.1.34/stats.json
+++ b/stats/org.scodec/scodec-bits_3/1.1.34/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1.34",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10917,
+        "missed" : 8981,
+        "ratio" : 0.548648,
+        "total" : 19898
+      },
+      "line" : {
+        "covered" : 1559,
+        "missed" : 671,
+        "ratio" : 0.699103,
+        "total" : 2230
+      },
+      "method" : {
+        "covered" : 620,
+        "missed" : 720,
+        "ratio" : 0.462687,
+        "total" : 1340
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/.gitignore
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/gradle.properties
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scodec:scodec-bits_3:1.1.34
+library.version = 1.1.34
+metadata.dir = org.scodec/scodec-bits_3/1.1.34/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/settings.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scodec.scodec-bits_3_tests'

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -215,6 +215,28 @@ final class Scodec_bits_3Test {
   }
 
   @Test
+  def vectorsConsumePrefixesWithRemainingDataAndFailures(): Unit = {
+    val bytes = ByteVector.fromValidHex("010203aabb")
+    val byteResult: Either[String, (ByteVector, String)] = bytes.consume(3) { prefix =>
+      Right(prefix.reverse.toHex)
+    }
+    val byteRejection: Either[String, (ByteVector, String)] = bytes.consume(2) { _ =>
+      Left("prefix rejected")
+    }
+    val bits = BitVector.fromValidBin("101_0110011")
+
+    assertThat(byteResult).isEqualTo(Right((ByteVector.fromValidHex("aabb"), "030201")))
+    assertThat(byteRejection).isEqualTo(Left("prefix rejected"))
+    assertThat(bytes.consume(99)(_ => Right("unreachable")).isLeft).isTrue()
+    val bitResult: Either[String, (BitVector, String)] = bits.consume(3) { prefix =>
+      Right(prefix.toBin)
+    }
+
+    assertThat(bitResult).isEqualTo(Right((BitVector.fromValidBin("0110011"), "101")))
+    assertThat(bits.consume(99)(_ => Right("unreachable")).isLeft).isTrue()
+  }
+
+  @Test
   def crcFunctionsSupportKnownVectorsAndIncrementalBuilders(): Unit = {
     val message = ByteVector.encodeAscii("123456789").getOrElse(ByteVector.empty).bits
     val split = message.splitAt(32)

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -15,6 +15,7 @@ import scodec.bits.*
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
+import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
@@ -148,6 +149,28 @@ final class Scodec_bits_3Test {
     assertThat(edited.grouped(4).map(_.toBin).toList.asJava).containsExactly("0111", "1000", "0111")
     assertThat(edited.compare(BitVector.fromValidBin("01111001000"))).isLessThan(0)
     assertThat(edited.acquire(99).isLeft).isTrue()
+  }
+
+  @Test
+  def bitVectorReadsFromJavaStreamsAndChannels(): Unit = {
+    val expected: BitVector = ByteVector.fromValidHex("0123456789abcdef").bits
+    val inputStream: ByteArrayInputStream = new ByteArrayInputStream(expected.toByteArray)
+    val channelStream: ByteArrayInputStream = new ByteArrayInputStream(expected.toByteArray)
+    val channel = Channels.newChannel(channelStream)
+
+    try {
+      val fromInputStream: BitVector = BitVector.fromInputStream(inputStream, 2).force
+      val fromChannel: BitVector = BitVector.fromChannel(channel, 3).force
+
+      assertThat(fromInputStream).isEqualTo(expected)
+      assertThat(fromInputStream.toHex).isEqualTo("0123456789abcdef")
+      assertThat(fromChannel).isEqualTo(expected)
+      assertThat(fromChannel.toHex).isEqualTo("0123456789abcdef")
+    } finally {
+      channel.close()
+      channelStream.close()
+      inputStream.close()
+    }
   }
 
   @Test

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -6,11 +6,219 @@
  */
 package org_scodec.scodec_bits_3
 
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.jupiter.api.Test
+import scodec.bits.*
 
-class Scodec_bits_3Test {
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
+
+final class Scodec_bits_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def byteVectorSupportsPersistentCollectionOperationsAndViews(): Unit = {
+    val copied = ByteVector(Array[Byte](0x10, 0x20, 0x30))
+    val source = Array[Byte](0x01, 0x02, 0x03, 0x04)
+    val viewed = ByteVector.view(source, 1, 2)
+    source(1) = 0x7f.toByte
+
+    val vector = (copied ++ viewed)
+      .insert(1, 0x11.toByte)
+      .patch(3, ByteVector.fromValidHex("aabb"))
+      .update(0, 0x0f.toByte)
+
+    assertThat(copied.toHex).isEqualTo("102030")
+    assertThat(viewed.toHex).isEqualTo("7f03")
+    assertThat(vector.toHex).isEqualTo("0f1120aabb03")
+    assertThat(vector.size).isEqualTo(6L)
+    assertThat(vector.headOption).isEqualTo(Some(0x0f.toByte))
+    assertThat(vector.lastOption).isEqualTo(Some(0x03.toByte))
+    assertThat(vector.lift(99)).isEqualTo(None)
+    assertThat(vector.slice(2, 6).toHex).isEqualTo("20aabb03")
+    assertThat(vector.takeWhile(_ != 0xaa.toByte).toHex).isEqualTo("0f1120")
+    assertThat(vector.dropWhile(_ != 0xaa.toByte).toHex).isEqualTo("aabb03")
+    assertThat(vector.indexOfSlice(ByteVector.fromValidHex("aabb"))).isEqualTo(3L)
+    assertThat(vector.containsSlice(ByteVector.fromValidHex("bb03"))).isTrue()
+    assertThat(vector.startsWith(ByteVector.fromValidHex("0f11"))).isTrue()
+    assertThat(vector.endsWith(ByteVector.fromValidHex("bb03"))).isTrue()
+    assertThat(vector.grouped(3).map(_.toHex).toList.asJava).containsExactly("0f1120", "aabb03")
+    assertThat(vector.compare(ByteVector.fromValidHex("0f1120aabb037f04"))).isLessThan(0)
+  }
+
+  @Test
+  def byteVectorConvertsToAndFromStreamsBuffersNumbersAndText(): Unit = {
+    val uuid = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+    val fromBufferSource = ByteBuffer.wrap(Array[Byte](9, 8, 7, 6, 5))
+    fromBufferSource.position(1)
+    fromBufferSource.limit(4)
+
+    val vector = ByteVector.fromUUID(uuid) ++ ByteVector(fromBufferSource)
+    val output = new ByteArrayOutputStream()
+    vector.copyToStream(output)
+    val copyTarget = Array.fill[Byte](6)(0.toByte)
+    vector.copyToArray(copyTarget, 1, 14, 4)
+    val inputStream = vector.takeRight(3).toInputStream
+
+    try {
+      assertThat(ByteVector.fromUUID(uuid).toUUID).isEqualTo(uuid)
+      assertThat(ByteVector(fromBufferSource).toHex).isEqualTo("080706")
+      assertThat(output.toByteArray).isEqualTo(vector.toArray)
+      assertThat(copyTarget).isEqualTo(Array[Byte](0, 0xee.toByte, 0xff.toByte, 8, 7, 0))
+      assertThat(inputStream.read()).isEqualTo(8)
+      assertThat(inputStream.read()).isEqualTo(7)
+      assertThat(inputStream.read()).isEqualTo(6)
+      assertThat(inputStream.read()).isEqualTo(-1)
+      assertThat(ByteVector.fromShort(0x1234.toShort).toHex).isEqualTo("1234")
+      assertThat(ByteVector.fromInt(0x01020304, ordering = ByteOrdering.LittleEndian).toHex).isEqualTo("04030201")
+      assertThat(ByteVector.fromLong(0x0102030405060708L, size = 6).toHex).isEqualTo("030405060708")
+      assertThat(ByteVector.encodeUtf8("scodec ✓").map(_.decodeUtf8)).isEqualTo(Right(Right("scodec ✓")))
+      assertThat(ByteVector.fromValidHex("ff").toInt(signed = false)).isEqualTo(255)
+      assertThat(ByteVector.fromValidHex("ff").toInt(signed = true)).isEqualTo(-1)
+    } finally {
+      inputStream.close()
+      output.close()
+    }
+  }
+
+  @Test
+  def byteVectorBaseEncodingsValidateRoundTripsAndFailures(): Unit = {
+    val data = ByteVector.encodeAscii("hello world").getOrElse(ByteVector.empty)
+
+    assertThat(data.toHex).isEqualTo("68656c6c6f20776f726c64")
+    assertThat(ByteVector.fromValidHex("0x6865 6c6c_6f").decodeAscii).isEqualTo(Right("hello"))
+    assertThat(data.toBin.take(16)).isEqualTo("0110100001100101")
+    assertThat(ByteVector.fromValidBin("0b01101000_01101001").decodeAscii).isEqualTo(Right("hi"))
+    assertThat(data.toBase32).isEqualTo("NBSWY3DPEB3W64TMMQ======")
+    assertThat(ByteVector.fromValidBase32(data.toBase32)).isEqualTo(data)
+    assertThat(data.toBase58).isEqualTo("StV1DL6CwTryKyV")
+    assertThat(ByteVector.fromValidBase58(data.toBase58)).isEqualTo(data)
+    assertThat(data.toBase64).isEqualTo("aGVsbG8gd29ybGQ=")
+    assertThat(data.toBase64NoPad).isEqualTo("aGVsbG8gd29ybGQ")
+    assertThat(data.toBase64Url).isEqualTo("aGVsbG8gd29ybGQ=")
+    assertThat(ByteVector.fromValidBase64(data.toBase64)).isEqualTo(data)
+    assertThat(ByteVector.fromHex("not-hex")).isEqualTo(None)
+    assertThat(ByteVector.fromBase64Descriptive("****").isLeft).isTrue()
+    assertThatThrownBy(new ThrowingCallable {
+      override def call(): Unit = ByteVector.fromValidBin("01012")
+    }).isInstanceOf(classOf[IllegalArgumentException])
+  }
+
+  @Test
+  def byteVectorBitwiseCompressionHashingAndHexDumpAreDeterministic(): Unit = {
+    val payload = ByteVector.encodeUtf8("native image friendly compression payload").getOrElse(ByteVector.empty)
+    val mask = ByteVector.high(payload.size)
+    val compressed = payload.deflate()
+
+    assertThat((payload xor mask).xor(mask)).isEqualTo(payload)
+    assertThat((payload and mask)).isEqualTo(payload)
+    assertThat((payload or ByteVector.low(payload.size))).isEqualTo(payload)
+    assertThat((~ByteVector.fromValidHex("00ff")).toHex).isEqualTo("ff00")
+    assertThat(ByteVector.fromValidHex("1234").shiftLeft(4).toHex).isEqualTo("2340")
+    assertThat(ByteVector.fromValidHex("1234").shiftRight(4, signExtension = false).toHex).isEqualTo("0123")
+    assertThat(payload.rotateLeft(12).rotateRight(12)).isEqualTo(payload)
+    assertThat(compressed.inflate()).isEqualTo(Right(payload))
+    assertThat(payload.sha1.toHex).isEqualTo("d6b08e66ee45e3b11941301a6ed6aaaf9d224f7e")
+    assertThat(payload.sha256.toHex).isEqualTo("774f0482bed346fe644341ea00cf3d466a7710a111e993ff5a0fbbcf70e31d50")
+    assertThat(HexDumpFormat.NoAscii.withAnsi(false).withDataColumnWidthInBytes(4).render(ByteVector.fromValidHex("000102030405")))
+      .isEqualTo("00000000  00 01 02 03  04 05  \n")
+  }
+
+  @Test
+  def bitVectorSupportsUnalignedUpdatesSlicingAndOrdering(): Unit = {
+    val bits = BitVector.fromValidBin("1011_0010") ++ BitVector.fromValidHex("f").take(3)
+    val edited = bits.clear(0).set(1).insert(4, true).patch(6, BitVector.fromValidBin("000"))
+
+    assertThat(bits.size).isEqualTo(11L)
+    assertThat(bits.toBin).isEqualTo("10110010111")
+    assertThat(edited.toBin).isEqualTo("011110000111")
+    assertThat(edited.populationCount).isEqualTo(7L)
+    assertThat(edited.head).isFalse()
+    assertThat(edited.last).isTrue()
+    assertThat(edited.lift(100)).isEqualTo(None)
+    assertThat(edited.splitAt(5)._1.toBin).isEqualTo("01111")
+    assertThat(edited.splitAt(5)._2.toBin).isEqualTo("0000111")
+    assertThat(edited.indexOfSlice(BitVector.fromValidBin("000"))).isEqualTo(5L)
+    assertThat(edited.startsWith(BitVector.fromValidBin("011"))).isTrue()
+    assertThat(edited.endsWith(BitVector.fromValidBin("111"))).isTrue()
+    assertThat(edited.grouped(4).map(_.toBin).toList.asJava).containsExactly("0111", "1000", "0111")
+    assertThat(edited.compare(BitVector.fromValidBin("01111001000"))).isLessThan(0)
+    assertThat(edited.acquire(99).isLeft).isTrue()
+  }
+
+  @Test
+  def bitVectorConvertsNumbersWithSignednessAndByteOrdering(): Unit = {
+    val uuid = UUID.fromString("10203040-5060-7080-90a0-b0c0d0e0f001")
+    val littleEndianInt = BitVector.fromInt(0x01020304, ordering = ByteOrdering.LittleEndian)
+    val thirteenBits = BitVector.fromInt(0x1abc, size = 13)
+
+    assertThat(littleEndianInt.toHex).isEqualTo("04030201")
+    assertThat(littleEndianInt.toInt(ordering = ByteOrdering.LittleEndian)).isEqualTo(0x01020304)
+    assertThat(BitVector.fromByte(0xff.toByte, size = 4).toByte(signed = true)).isEqualTo(-1.toByte)
+    assertThat(BitVector.fromByte(0xff.toByte, size = 4).toByte(signed = false)).isEqualTo(15.toByte)
+    assertThat(thirteenBits.toBin).isEqualTo("1101010111100")
+    assertThat(thirteenBits.sliceToInt(1, 8, signed = false)).isEqualTo(0xab)
+    assertThat(BitVector.fromLong(0x0102030405060708L, size = 40).toLong(signed = false)).isEqualTo(0x0405060708L)
+    assertThat(BitVector.fromUUID(uuid).toUUID).isEqualTo(uuid)
+    assertThat(BitVector.encodeUtf8("bits").map(_.decodeUtf8)).isEqualTo(Right(Right("bits")))
+    assertThat(BitVector.fromValidHex("abc").toBin).isEqualTo("101010111100")
+  }
+
+  @Test
+  def bitVectorBitwiseReverseShiftRotateAndLazyConstructionWorkTogether(): Unit = {
+    val vector = BitVector.unfold(0) { index =>
+      if (index < 4) Some((BitVector.fromByte((0xf0 + index).toByte), index + 1))
+      else None
+    }
+    val forced = vector.force
+
+    assertThat(forced.toHex).isEqualTo("f0f1f2f3")
+    assertThat(forced.reverse.toBin.take(8)).isEqualTo("11001111")
+    assertThat(forced.reverseByteOrder.toHex).isEqualTo("f3f2f1f0")
+    assertThat(forced.reverseByteOrder.invertReverseByteOrder).isEqualTo(forced)
+    assertThat(forced.reverseBitOrder.toHex).isEqualTo("0f8f4fcf")
+    assertThat((forced & BitVector.fromValidHex("0f0f0f0f")).toHex).isEqualTo("00010203")
+    assertThat((forced | BitVector.fromValidHex("0f0f0f0f")).toHex).isEqualTo("ffffffff")
+    assertThat((forced ^ BitVector.fromValidHex("ffffffff")).toHex).isEqualTo("0f0e0d0c")
+    assertThat((~forced).toHex).isEqualTo("0f0e0d0c")
+    assertThat(forced.shiftLeft(4).toHex).isEqualTo("0f1f2f30")
+    assertThat(forced.shiftRight(4, signExtension = false).toHex).isEqualTo("0f0f1f2f")
+    assertThat(forced.rotateLeft(8).toHex).isEqualTo("f1f2f3f0")
+    assertThat(forced.rotateRight(8).toHex).isEqualTo("f3f0f1f2")
+  }
+
+  @Test
+  def crcFunctionsSupportKnownVectorsAndIncrementalBuilders(): Unit = {
+    val message = ByteVector.encodeAscii("123456789").getOrElse(ByteVector.empty).bits
+    val split = message.splitAt(32)
+    val crc32BuilderResult = crc.crc32Builder.updated(split._1).updated(split._2).result
+    val customCrc8 = crc(
+      poly = BitVector.fromValidHex("07"),
+      initial = BitVector.low(8),
+      reflectInput = false,
+      reflectOutput = false,
+      finalXor = BitVector.low(8)
+    )
+
+    assertThat(crc.crc32(message).toHex).isEqualTo("cbf43926")
+    assertThat(crc32BuilderResult.toHex).isEqualTo("cbf43926")
+    assertThat(crc.crc32c(message).toHex).isEqualTo("e3069283")
+    assertThat(crc.int32(0x04c11db7, 0xffffffff, reflectInput = true, reflectOutput = true, 0xffffffff)(message))
+      .isEqualTo(0xcbf43926)
+    assertThat(customCrc8(message).toHex).isEqualTo("f4")
+  }
+
+  @Test
+  def scalaThreeInterpolatorsProduceValidatedVectors(): Unit = {
+    val bytes = hex"de ad be ef"
+    val bits = bin"1010_111"
+
+    assertThat(bytes).isEqualTo(ByteVector.fromValidHex("deadbeef"))
+    assertThat(bits).isEqualTo(BitVector.fromValidBin("1010111"))
+    assertThat((bytes.bits.take(4) ++ bits).toBin).isEqualTo("11011010111")
   }
 }

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scodec.scodec_bits_3
+
+import org.junit.jupiter.api.Test
+
+class Scodec_bits_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "scodec.bits.**"
+    }
+  ]
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.34/user-code-filter.json
@@ -1,10 +1,10 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "scodec.bits.**"
+      "includeClasses" : "scodec.bits.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #6097

This PR introduces tests and metadata for org.scodec:scodec-bits_3:1.1.34, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 317402
- Cached input tokens: 2384896
- Output tokens: 20204
- Metadata entries: 10
- Iterations: 7
- Library coverage percentage: 69.91
- Generated lines of code: 241
- Tested library lines of code: 1559

### Metadata Forge

- Forge monitored branch: `origin/fix/staged-native-metadata-final-merge`
- Forge branch: `fix/staged-native-metadata-final-merge`
- Forge commit hash: `2bb9805187faf113803567761454b1e2b1e1819e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 10917/19898 (54.86%)
- Line: 1559/2230 (69.91%)
- Method: 620/1340 (46.27%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
