### PR TITLE
[GenAI] Add support for org.scodec:scodec-bits_3:1.1.27 using gpt-5.5

### DIFF
--- a/metadata/org.scodec/scodec-bits_3/1.1.27/reachability-metadata.json
+++ b/metadata/org.scodec/scodec-bits_3/1.1.27/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "scodec.bits.ByteVector"
+      },
+      "type": "scodec.bits.ByteVector",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.bits.BitVector"
+      },
+      "type": "scodec.bits.BitVector",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.bits.crc$"
+      },
+      "type": "scodec.bits.crc$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.bits.BitVector$Suspend"
+      },
+      "type": "scodec.bits.BitVector$Suspend",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scodec/scodec-bits_3/index.json
+++ b/metadata/org.scodec/scodec-bits_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.1.27",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-bits_3/$version$/scodec-bits_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scodec/scodec-bits",
+    "test-code-url" : "https://github.com/scodec/scodec-bits/tree/v$version$/core",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scodec/scodec-bits_3/$version$/scodec-bits_3-$version$-javadoc.jar",
+    "description" : "scodec-bits is a Scala library that provides persistent BitVector and ByteVector data types for working with bits and bytes. It supports efficient slicing and concatenation, lazy byte access, base encodings, and hexadecimal or binary string interpolators for binary data manipulation.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.1.27"
+    ],
+    "allowed-packages" : [
+      "scodec.bits"
+    ]
+  }
+]

--- a/stats/org.scodec/scodec-bits_3/1.1.27/execution-metrics.json
+++ b/stats/org.scodec/scodec-bits_3/1.1.27/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T09:02:25.033504Z",
+    "library": "org.scodec:scodec-bits_3:1.1.27",
+    "starting_commit": "b2d0d752bd31152c9757523ad1fdd180b0dd7003",
+    "ending_commit": "6a4b8d4db073b04d4bbbd349c30534f8dc62d8d6",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1.27",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8962,
+          "missed": 9313,
+          "ratio": 0.490397,
+          "total": 18275
+        },
+        "line": {
+          "covered": 1279,
+          "missed": 716,
+          "ratio": 0.641103,
+          "total": 1995
+        },
+        "method": {
+          "covered": 520,
+          "missed": 710,
+          "ratio": 0.422764,
+          "total": 1230
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 173861,
+      "cached_input_tokens_used": 2196480,
+      "output_tokens_used": 20517,
+      "iterations": 4,
+      "cost_usd": 1.7137,
+      "generated_loc": 229,
+      "tested_library_loc": 1279,
+      "metadata_entries": 8,
+      "code_coverage_percent": 64.11
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala",
+      "metadata_file": "metadata/org.scodec/scodec-bits_3/1.1.27/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scodec/scodec-bits_3/1.1.27/stats.json
+++ b/stats/org.scodec/scodec-bits_3/1.1.27/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1.27",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8962,
+        "missed" : 9313,
+        "ratio" : 0.490397,
+        "total" : 18275
+      },
+      "line" : {
+        "covered" : 1279,
+        "missed" : 716,
+        "ratio" : 0.641103,
+        "total" : 1995
+      },
+      "method" : {
+        "covered" : 520,
+        "missed" : 710,
+        "ratio" : 0.422764,
+        "total" : 1230
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/.gitignore
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/gradle.properties
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scodec:scodec-bits_3:1.1.27
+library.version = 1.1.27
+metadata.dir = org.scodec/scodec-bits_3/1.1.27/

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/settings.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scodec.scodec-bits_3_tests'

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -140,6 +140,50 @@ class Scodec_bits_3Test {
   }
 
   @Test
+  def vectorsSupportBoundedAcquisitionAndConsumption(): Unit = {
+    val packet: ByteVector = ByteVector(3, 0x66, 0x6f, 0x6f, 0xff)
+
+    assertEquals(Right(ByteVector(3, 0x66)), packet.acquire(2L))
+    assertTrue(packet.acquire(6L).isLeft)
+
+    val lengthResult: (ByteVector, Int) = expectRight(packet.consume(1L) { lengthBytes =>
+      Right(lengthBytes.toInt(signed = false))
+    })
+    assertEquals("666f6fff", lengthResult._1.toHex)
+    assertEquals(3, lengthResult._2)
+
+    val payloadResult: (ByteVector, String) = expectRight(lengthResult._1.consume(lengthResult._2.toLong) { payloadBytes =>
+      Right(expectRight(payloadBytes.decodeAscii))
+    })
+    assertEquals(ByteVector(0xff), payloadResult._1)
+    assertEquals("foo", payloadResult._2)
+
+    var decoderCalled: Boolean = false
+    val failedByteConsume: Either[String, (ByteVector, Unit)] = packet.consume(6L) { _ =>
+      decoderCalled = true
+      Right(())
+    }
+    assertTrue(failedByteConsume.isLeft)
+    assertFalse(decoderCalled)
+
+    val bits: BitVector = BitVector.fromValidBin("101110101111")
+    assertEquals(Right(BitVector.fromValidBin("101")), bits.acquire(3L))
+
+    val tagResult: (BitVector, Long) = expectRight(bits.consume(3L) { tag =>
+      Right(tag.populationCount)
+    })
+    assertEquals("110101111", tagResult._1.toBin)
+    assertEquals(2L, tagResult._2)
+
+    val fieldResult: (BitVector, Int) = expectRight(tagResult._1.consume(5L) { field =>
+      Right(field.toInt(signed = false))
+    })
+    assertEquals("1111", fieldResult._1.toBin)
+    assertEquals(26, fieldResult._2)
+    assertTrue(tagResult._1.consume(20L)(_ => Right(())).isLeft)
+  }
+
+  @Test
   def bitVectorSupportsBitLevelConstructionTransformsAndParsing(): Unit = {
     val bits: BitVector = BitVector.fromValidBin("0b101_0011")
 

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
-import scodec.bits.{Bases, BitVector, ByteOrdering, ByteVector, crc}
+import scodec.bits.{Bases, BitVector, ByteOrdering, ByteVector, bin, crc, hex}
 
 class Scodec_bits_3Test {
   @Test
@@ -124,6 +124,19 @@ class Scodec_bits_3Test {
     assertEquals(None, ByteVector.fromHex("not hex"))
     assertTrue(ByteVector.fromHexDescriptive("01xz").isLeft)
     assertTrue(ByteVector.fromBase64Descriptive("%%%%").isLeft)
+  }
+
+  @Test
+  def literalInterpolatorsCreateByteAndBitVectors(): Unit = {
+    val bytes: ByteVector = hex"deadbeef"
+    val bits: BitVector = bin"1010101010"
+
+    assertEquals(4L, bytes.size)
+    assertEquals("deadbeef", bytes.toHex)
+    assertEquals(ByteVector(0xde, 0xad, 0xbe, 0xef), bytes)
+    assertEquals(10L, bits.size)
+    assertEquals("1010101010", bits.toBin)
+    assertEquals(5L, bits.populationCount)
   }
 
   @Test

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -6,11 +6,205 @@
  */
 package org_scodec.scodec_bits_3
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.channels.Channels
+import java.util.UUID
+
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.Test
+import scodec.bits.{Bases, BitVector, ByteOrdering, ByteVector, crc}
 
 class Scodec_bits_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def byteVectorSupportsCollectionStyleEditingAndQueries(): Unit = {
+    val bytes: ByteVector = ByteVector(1, 2, 3, 4, 5)
+
+    assertEquals(5L, bytes.size)
+    assertEquals(5L, bytes.length)
+    assertFalse(bytes.isEmpty)
+    assertTrue(bytes.nonEmpty)
+    assertEquals(1.toByte, bytes(0L))
+    assertEquals(Some(3.toByte), bytes.lift(2L))
+    assertEquals(None, bytes.lift(-1L))
+    assertEquals("0102030405", bytes.toHex)
+    assertEquals("0102030405", ByteVector.concat(List(ByteVector(1, 2), ByteVector(3), ByteVector(4, 5))).toHex)
+
+    assertEquals("0102090405", bytes.update(2L, 9.toByte).toHex)
+    assertEquals("010209030405", bytes.insert(2L, 9.toByte).toHex)
+    assertEquals("01020908030405", bytes.splice(2L, ByteVector(9, 8)).toHex)
+    assertEquals("010a0b0c05", bytes.patch(1L, ByteVector(0x0a, 0x0b, 0x0c)).toHex)
+    assertEquals("010203", bytes.take(3L).toHex)
+    assertEquals("0405", bytes.drop(3L).toHex)
+    assertEquals("020304", bytes.slice(1L, 4L).toHex)
+    assertEquals("030405", bytes.takeRight(3L).toHex)
+    assertEquals("0102", bytes.dropRight(3L).toHex)
+    assertEquals("0504030201", bytes.reverse.toHex)
+
+    assertTrue(bytes.startsWith(ByteVector(1, 2)))
+    assertTrue(bytes.endsWith(ByteVector(4, 5)))
+    assertTrue(bytes.containsSlice(ByteVector(3, 4)))
+    assertEquals(2L, bytes.indexOfSlice(ByteVector(3, 4)))
+    assertEquals(List("0102", "0304", "05"), bytes.grouped(2L).map(_.toHex).toList)
+    assertEquals("0203040506", bytes.map(b => (b + 1).toByte).toHex)
+    assertEquals("fefdfcfbfa", bytes.xor(ByteVector.high(5L)).toHex)
+
+    val copiedToStream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    bytes.copyToStream(copiedToStream)
+    assertArrayEquals(Array[Byte](1, 2, 3, 4, 5), copiedToStream.toByteArray)
+
+    val destination: ByteBuffer = ByteBuffer.allocate(3)
+    assertEquals(3, bytes.copyToBuffer(destination))
+    assertArrayEquals(Array[Byte](1, 2, 3), destination.array())
+
+    assertThrows(classOf[IndexOutOfBoundsException], () => {
+      bytes(5L)
+      ()
+    })
   }
+
+  @Test
+  def byteVectorDistinguishesCopiesFromViewsAndBuffers(): Unit = {
+    val backing: Array[Byte] = Array[Byte](1, 2, 3, 4)
+    val copied: ByteVector = ByteVector(backing)
+    val viewed: ByteVector = ByteVector.view(backing)
+    backing(0) = 9.toByte
+
+    assertEquals("01020304", copied.toHex)
+    assertEquals("09020304", viewed.toHex)
+    assertArrayEquals(Array[Byte](1, 2, 3, 4), copied.toArray)
+
+    val sourceBuffer: ByteBuffer = ByteBuffer.wrap(Array[Byte](10, 11, 12, 13))
+    sourceBuffer.position(1)
+    sourceBuffer.limit(3)
+    val copiedFromBuffer: ByteVector = ByteVector(sourceBuffer)
+    val viewedFromBuffer: ByteVector = ByteVector.view(sourceBuffer)
+
+    assertEquals("0b0c", copiedFromBuffer.toHex)
+    assertEquals("0b0c", viewedFromBuffer.toHex)
+    assertTrue(copiedFromBuffer.toByteBuffer.isReadOnly)
+    assertEquals("0b0c", copiedFromBuffer.toBitVector.toHex)
+
+    val generated: ByteVector = ByteVector.viewI(i => (i * 3 + 1).toInt, 4L)
+    assertEquals("0104070a", generated.toHex)
+    val buffered: ByteVector = (ByteVector(1, 2).buffer :+ 3.toByte) ++ ByteVector(4, 5, 6)
+    assertEquals("010203040506", buffered.unbuffer.toHex)
+    assertEquals("000000", ByteVector.low(3L).toHex)
+    assertEquals("ffffff", ByteVector.high(3L).toHex)
+  }
+
+  @Test
+  def byteVectorEncodesNumbersStringsUuidsAndBases(): Unit = {
+    val uuid: UUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+    val text: String = "scodec bits \u2713"
+    val utf8: ByteVector = expectRight(ByteVector.encodeUtf8(text))
+    val ascii: ByteVector = expectRight(ByteVector.encodeAscii("ASCII"))
+
+    assertEquals("01020304", ByteVector.fromInt(0x01020304).toHex)
+    assertEquals("04030201", ByteVector.fromInt(0x01020304, ordering = ByteOrdering.LittleEndian).toHex)
+    assertEquals("0102030405060708", ByteVector.fromLong(0x0102030405060708L).toHex)
+    assertEquals(0x01020304, ByteVector.fromInt(0x01020304).toInt(signed = false))
+    assertEquals(0x01020304, ByteVector.fromInt(0x01020304, ordering = ByteOrdering.LittleEndian).toInt(signed = false, ordering = ByteOrdering.LittleEndian))
+    assertEquals(uuid, ByteVector.fromUUID(uuid).toUUID)
+    assertEquals(ByteOrdering.BigEndian, ByteOrdering.fromJava(ByteOrder.BIG_ENDIAN))
+    assertEquals(ByteOrdering.LittleEndian, ByteOrdering.fromJava(ByteOrder.LITTLE_ENDIAN))
+
+    assertEquals(text, expectRight(utf8.decodeUtf8))
+    assertEquals("ASCII", expectRight(ascii.decodeAscii))
+    assertEquals(utf8, ByteVector.fromValidHex("0x" + utf8.toHex))
+    assertEquals(utf8, ByteVector.fromValidBin(utf8.toBin))
+    assertEquals(utf8, ByteVector.fromValidBase32(utf8.toBase32))
+    assertEquals(utf8, ByteVector.fromValidBase58(utf8.toBase58))
+    assertEquals(utf8, ByteVector.fromValidBase64(utf8.toBase64))
+    assertEquals(utf8, ByteVector.fromValidBase64(utf8.toBase64NoPad, Bases.Alphabets.Base64NoPad))
+    assertEquals(utf8, ByteVector.fromValidBase64(utf8.toBase64Url, Bases.Alphabets.Base64Url))
+    assertEquals(utf8, ByteVector.fromValidBase64(utf8.toBase64UrlNoPad, Bases.Alphabets.Base64UrlNoPad))
+    assertEquals(utf8.toHex.toUpperCase, utf8.toHex(Bases.Alphabets.HexUppercase))
+
+    assertEquals(None, ByteVector.fromHex("not hex"))
+    assertTrue(ByteVector.fromHexDescriptive("01xz").isLeft)
+    assertTrue(ByteVector.fromBase64Descriptive("%%%%").isLeft)
+  }
+
+  @Test
+  def bitVectorSupportsBitLevelConstructionTransformsAndParsing(): Unit = {
+    val bits: BitVector = BitVector.fromValidBin("0b101_0011")
+
+    assertEquals(7L, bits.size)
+    assertEquals("1010011", bits.toBin)
+    assertEquals("a6", bits.toHex)
+    assertEquals(4L, bits.populationCount)
+    assertTrue(bits.startsWith(BitVector.fromValidBin("101")))
+    assertTrue(bits.endsWith(BitVector.fromValidBin("011")))
+    assertEquals(2L, bits.indexOfSlice(BitVector.fromValidBin("100")))
+    assertEquals(List("101", "001", "1"), bits.grouped(3L).map(_.toBin).toList)
+
+    assertEquals("1100011", bits.set(1L).clear(2L).toBin)
+    assertEquals("10110011", bits.insert(3L, true).toBin)
+    assertEquals("1000011", bits.patch(2L, BitVector.low(2L)).toBin)
+    assertEquals("0001010011", bits.padLeft(10L).toBin)
+    assertEquals("1010011000", bits.padRight(10L).toBin)
+    assertEquals("1100101", bits.reverse.toBin)
+    assertEquals("1001110", bits.rotateLeft(2L).toBin)
+    assertEquals("1110100", bits.rotateRight(2L).toBin)
+    assertEquals("0101100", bits.xor(BitVector.high(7L)).toBin)
+    assertEquals("1010011", bits.force.toBin)
+
+    assertEquals("10101010", BitVector.bits(List(true, false, true, false, true, false, true, false)).toBin)
+    assertEquals("11111", BitVector.high(5L).toBin)
+    assertEquals("00000", BitVector.low(5L).toBin)
+    assertEquals("3412", BitVector.fromShort(0x1234.toShort, ordering = ByteOrdering.LittleEndian).toHex)
+    assertEquals(0x1234, BitVector.fromShort(0x1234.toShort).toInt(signed = false))
+    assertEquals(BitVector.fromValidHex("abc"), BitVector.fromValidBin("101010111100"))
+    assertEquals(None, BitVector.fromBin("10201"))
+    assertTrue(BitVector.fromBase32Descriptive("*").isLeft)
+  }
+
+  @Test
+  def bitVectorReadsBoundedStreamsChannelsAndLazyUnfolds(): Unit = {
+    val streamBytes: Array[Byte] = Array[Byte](1, 2, 3, 4, 5)
+    val input: ByteArrayInputStream = new ByteArrayInputStream(streamBytes)
+    try {
+      assertEquals("0102030405", BitVector.fromInputStream(input, chunkSizeInBytes = 2).force.toHex)
+    } finally {
+      input.close()
+    }
+
+    val channelInput: ByteArrayInputStream = new ByteArrayInputStream(Array[Byte](6, 7, 8, 9))
+    val channel = Channels.newChannel(channelInput)
+    try {
+      assertEquals("06070809", BitVector.fromChannel(channel, chunkSizeInBytes = 2, direct = true).force.toHex)
+    } finally {
+      channel.close()
+      channelInput.close()
+    }
+
+    val unfolded: BitVector = BitVector.unfold(0) { index =>
+      if (index >= 4) None else Some((BitVector.fromByte((index + 1).toByte), index + 1))
+    }
+    assertEquals("01020304", unfolded.force.toHex)
+  }
+
+  @Test
+  def compressionDigestsAndCrcsRoundTripDeterministically(): Unit = {
+    val payload: ByteVector = expectRight(ByteVector.encodeAscii("123456789"))
+    val abc: ByteVector = expectRight(ByteVector.encodeAscii("abc"))
+    val compressed: ByteVector = payload.deflate()
+    val compressedBits: BitVector = payload.bits.deflate()
+
+    assertEquals(payload, expectRight(compressed.inflate()))
+    assertEquals(payload.bits, expectRight(compressedBits.inflate()))
+    assertEquals(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      abc.digest("SHA-256").toHex
+    )
+    assertEquals("cbf43926", crc.crc32(payload.bits).toHex)
+    assertEquals("e3069283", crc.crc32c(payload.bits).toHex)
+  }
+
+  private def expectRight[L, R](either: Either[L, R]): R =
+    either match {
+      case Right(value) => value
+      case Left(error)  => throw new AssertionError(s"Expected Right, got Left($error)")
+    }
 }

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/src/test/scala/org_scodec/scodec_bits_3/Scodec_bits_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scodec.scodec_bits_3
+
+import org.junit.jupiter.api.Test
+
+class Scodec_bits_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "scodec.bits.**"
+      "includeClasses" : "scodec.bits.**"
+    },
+    {
+      "includeClasses" : "org_scodec.scodec_bits_3.**"
     }
   ]
 }

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/user-code-filter.json
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "scodec.bits.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4881

This PR introduces tests and metadata for org.scodec:scodec-bits_3:1.1.27, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 173861
- Cached input tokens: 2196480
- Output tokens: 20517
- Metadata entries: 8
- Iterations: 4
- Library coverage percentage: 64.11
- Generated lines of code: 229
- Tested library lines of code: 1279

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ac36403f6ad02940b89d9a5751d6c2f67d260186`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 8962/18275 (49.04%)
- Line: 1279/1995 (64.11%)
- Method: 520/1230 (42.28%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
