### PR TITLE
Block blocked issues by default

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -123,7 +123,7 @@ GITHUB_API_MAX_PAGE_SIZE = 100
 GITHUB_SEARCH_MAX_RESULTS = 1000
 PRIORITY_BLOCKING_LIBRARY_THRESHOLD = 10
 PRIORITY_BLOCKING_ISSUE_QUERY_CHUNK_SIZE = 25
-DEFAULT_TAKE_BLOCKED_ISSUES = True
+DEFAULT_TAKE_BLOCKED_ISSUES = False
 # GitHub validates GraphQL node cost against worst-case first values; 5 issues can exceed 500k here.
 ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE = 4
 ISSUE_CLAIM_CACHE_VERSION = 1
@@ -5306,8 +5306,8 @@ def process_issues_with_label(
                     ):
                         continue
                     claim_kwargs: dict[str, bool] = {}
-                    if not take_blocked_issues:
-                        claim_kwargs["take_blocked_issues"] = False
+                    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+                        claim_kwargs["take_blocked_issues"] = take_blocked_issues
                     claimed_issue = claim_issue_for_processing(
                         issue,
                         label,
@@ -5383,6 +5383,7 @@ def process_work_queues(
         keep_tests_without_dynamic_access_override: bool = False,
         parallelism_default: int = DEFAULT_PARALLELISM,
         random_offset_override: bool | None = None,
+        take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
     queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
@@ -5432,6 +5433,9 @@ def process_work_queues(
                 "issue-scan",
                 f"Selected random start offset {issue_scan_offset} for label '{queue_config.label}'",
             )
+        claim_kwargs: dict[str, bool] = {}
+        if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+            claim_kwargs["take_blocked_issues"] = take_blocked_issues
         process_issues_with_label(
             queue_config.label,
             queue_config.limit,
@@ -5443,6 +5447,7 @@ def process_work_queues(
             authenticated_user,
             parallelism,
             environment_already_validated=True,
+            **claim_kwargs,
         )
 
     for review_queue_config in review_queue_configs:
@@ -5577,7 +5582,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="take_blocked_issues",
         action="store_true",
         default=DEFAULT_TAKE_BLOCKED_ISSUES,
-        help="Claim issues even when GitHub shows open blocking issues. Defaults to enabled.",
+        help="Claim issues even when GitHub shows open blocking issues. Defaults to disabled.",
     )
 
     args = parser.parse_args(argv)
@@ -5607,8 +5612,8 @@ def process_single_issue(
     log_stage("issue-scan", f"Issue #{issue_number} matched pipeline label: {label}")
 
     claim_kwargs: dict[str, bool] = {}
-    if not take_blocked_issues:
-        claim_kwargs["take_blocked_issues"] = False
+    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+        claim_kwargs["take_blocked_issues"] = take_blocked_issues
     claimed_issue = claim_issue_for_processing(
         issue,
         label,
@@ -5645,8 +5650,8 @@ def process_large_library_continuation(
     verify_large_library_previous_part_merged(state)
     issue, label = get_issue_by_number(state.issue_number)
     claim_kwargs: dict[str, bool] = {}
-    if not take_blocked_issues:
-        claim_kwargs["take_blocked_issues"] = False
+    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+        claim_kwargs["take_blocked_issues"] = take_blocked_issues
     claimed_issue = claim_issue_for_processing(
         issue,
         label,
@@ -5698,6 +5703,7 @@ def main() -> None:
                 args.keep_tests_without_dynamic_access,
                 args.parallelism,
                 random_offset_override=args.random_offset,
+                take_blocked_issues=args.take_blocked_issues,
             )
         elif args.review_pr is not None:
             authenticated_user = resolve_authenticated_user()

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -225,7 +225,7 @@ DEFAULT_ISSUE_SCAN_BATCH_SIZE = 25
 ISSUE_SCAN_PROGRESS_LOG_INTERVAL = 100
 GITHUB_API_MAX_PAGE_SIZE = 100
 GITHUB_SEARCH_MAX_RESULTS = 1000
-DEFAULT_TAKE_BLOCKED_ISSUES = True
+DEFAULT_TAKE_BLOCKED_ISSUES = False
 # GitHub validates GraphQL node cost against worst-case first values; 5 issues can exceed 500k here.
 ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE = 4
 ISSUE_CLAIM_CACHE_VERSION = 1
@@ -8293,8 +8293,8 @@ def process_issues_with_label(
                         continue
 
                     claim_kwargs: dict[str, bool] = {}
-                    if not take_blocked_issues:
-                        claim_kwargs["take_blocked_issues"] = False
+                    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+                        claim_kwargs["take_blocked_issues"] = take_blocked_issues
                     claimed_issue = claim_issue_for_processing(
                         issue,
                         label,
@@ -8372,6 +8372,7 @@ def process_work_queues(
         random_offset_override: bool | None = None,
         user_requested_only_override: bool | None = None,
         priority_override: str | None = None,
+        take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
     queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
@@ -8387,6 +8388,9 @@ def process_work_queues(
     priority_kwargs: dict[str, str] = {}
     if priority_override is not None:
         priority_kwargs["priority"] = priority_override
+    claim_kwargs: dict[str, bool] = {}
+    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+        claim_kwargs["take_blocked_issues"] = take_blocked_issues
     enabled_issue_queues = [queue_config for queue_config in queue_configs if queue_config.limit > 0]
 
     if is_shutdown_requested():
@@ -8456,6 +8460,7 @@ def process_work_queues(
             user_requested_only=user_requested_only,
             environment_already_validated=True,
             **priority_kwargs,
+            **claim_kwargs,
         )
 
     for review_queue_config in review_queue_configs:
@@ -8622,7 +8627,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="take_blocked_issues",
         action="store_true",
         default=DEFAULT_TAKE_BLOCKED_ISSUES,
-        help="Claim issues even when GitHub shows open blocking issues. Defaults to enabled.",
+        help="Claim issues even when GitHub shows open blocking issues. Defaults to disabled.",
     )
 
     args = parser.parse_args(argv)
@@ -8697,8 +8702,8 @@ def process_single_issue(
             )
 
     claim_kwargs: dict[str, bool] = {}
-    if not take_blocked_issues:
-        claim_kwargs["take_blocked_issues"] = False
+    if take_blocked_issues != DEFAULT_TAKE_BLOCKED_ISSUES:
+        claim_kwargs["take_blocked_issues"] = take_blocked_issues
     claimed_issue = claim_issue_for_processing(
         issue,
         label,
@@ -8803,6 +8808,7 @@ def main() -> None:
                 random_offset_override=args.random_offset,
                 user_requested_only_override=args.user_requested_only,
                 priority_override=args.priority,
+                take_blocked_issues=args.take_blocked_issues,
             )
         elif args.review_pr is not None:
             authenticated_user = resolve_authenticated_user()

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -378,6 +378,16 @@ class IssueClaimPreflightTests(unittest.TestCase):
             )
         )
 
+    def test_open_blocker_preflight_allows_issue_when_override_is_enabled(self) -> None:
+        issue = {"number": 1412, "labels": []}
+        self.assertFalse(
+            forge_metadata.should_skip_issue_from_preflight(
+                issue,
+                _preflight(open_blockers=(1392,)),
+                take_blocked_issues=True,
+            )
+        )
+
     def test_incomplete_preflight_falls_back_to_fresh_checks(self) -> None:
         issue = {"number": 1412, "labels": []}
         self.assertFalse(
@@ -1160,6 +1170,17 @@ class WorkQueueSchedulerTests(unittest.TestCase):
         self.assertTrue(random_args.random_offset)
         self.assertFalse(no_random_args.random_offset)
 
+    def test_take_blocked_issues_is_disabled_by_default(self) -> None:
+        default_args = forge_metadata.parse_args(["--label", forge_metadata.LABEL_LIBRARY_NEW])
+        override_args = forge_metadata.parse_args([
+            "--label",
+            forge_metadata.LABEL_LIBRARY_NEW,
+            "--take-blocked-issues",
+        ])
+
+        self.assertFalse(default_args.take_blocked_issues)
+        self.assertTrue(override_args.take_blocked_issues)
+
     def test_review_label_environment_overrides_default_review_queues(self) -> None:
         env = {
             "FORGE_REVIEW_LABEL": forge_metadata.LABEL_PR_LIBRARY_BULK_UPDATE,
@@ -1257,6 +1278,41 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             environment_already_validated=True,
         )
         process_reviews.assert_not_called()
+
+    def test_process_work_queues_forwards_take_blocked_issues_override(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "1",
+            "FORGE_REVIEW_LIMIT": "0",
+            "FORGE_WORK_LABEL": forge_metadata.LABEL_LIBRARY_NEW,
+        }
+
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                patch.object(forge_metadata, "process_issues_with_label", return_value=0) as process_issues:
+            forge_metadata.process_work_queues(
+                "/tmp/reachability",
+                "/tmp/metrics",
+                "automation-user",
+                take_blocked_issues=True,
+            )
+
+        process_issues.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            1,
+            0,
+            "/tmp/reachability",
+            "/tmp/metrics",
+            forge_metadata.DEFAULT_WORK_QUEUE_STRATEGY_NAME,
+            False,
+            "automation-user",
+            forge_metadata.DEFAULT_PARALLELISM,
+            environment_already_validated=True,
+            take_blocked_issues=True,
+        )
 
     def test_process_work_queues_resolves_auth_for_review_only_queue(self) -> None:
         env = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -757,6 +757,16 @@ class IssueClaimPreflightTests(unittest.TestCase):
             )
         )
 
+    def test_open_blocker_preflight_allows_issue_when_override_is_enabled(self) -> None:
+        issue = {"number": 1412, "labels": []}
+        self.assertFalse(
+            forge_metadata.should_skip_issue_from_preflight(
+                issue,
+                _preflight(open_blockers=(1392,)),
+                take_blocked_issues=True,
+            )
+        )
+
     def test_incomplete_preflight_falls_back_to_fresh_checks(self) -> None:
         issue = {"number": 1412, "labels": []}
         self.assertFalse(
@@ -1405,7 +1415,6 @@ class IssueClaimPreflightTests(unittest.TestCase):
             "/tmp/reachability",
             "/tmp/metrics",
             "automation-user",
-            take_blocked_issues=False,
         )
         get_open_blocking_issue_numbers.assert_not_called()
         get_issue_assignees.assert_not_called()
@@ -1698,6 +1707,17 @@ class WorkQueueSchedulerTests(unittest.TestCase):
         self.assertTrue(random_args.random_offset)
         self.assertFalse(no_random_args.random_offset)
 
+    def test_take_blocked_issues_is_disabled_by_default(self) -> None:
+        default_args = forge_metadata.parse_args(["--label", forge_metadata.LABEL_LIBRARY_NEW])
+        override_args = forge_metadata.parse_args([
+            "--label",
+            forge_metadata.LABEL_LIBRARY_NEW,
+            "--take-blocked-issues",
+        ])
+
+        self.assertFalse(default_args.take_blocked_issues)
+        self.assertTrue(override_args.take_blocked_issues)
+
     def test_issue_queue_modes_accept_priority_tiers(self) -> None:
         for priority in forge_metadata.PRIORITY_CHOICES:
             with self.subTest(priority=priority):
@@ -1870,6 +1890,42 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             forge_metadata.DEFAULT_PARALLELISM,
             user_requested_only=True,
             environment_already_validated=True,
+        )
+
+    def test_process_work_queues_forwards_take_blocked_issues_override(self) -> None:
+        env = {
+            "FORGE_JAVAC_WORK_LIMIT": "0",
+            "FORGE_JAVA_RUN_WORK_LIMIT": "0",
+            "FORGE_NI_RUN_WORK_LIMIT": "0",
+            "FORGE_LIBRARY_UPDATE_WORK_LIMIT": "0",
+            "FORGE_WORK_LIMIT": "1",
+            "FORGE_REVIEW_LIMIT": "0",
+            "FORGE_WORK_LABEL": forge_metadata.LABEL_LIBRARY_NEW,
+        }
+
+        with patch.dict(os.environ, env, clear=True), \
+                patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                patch.object(forge_metadata, "process_issues_with_label", return_value=0) as process_issues:
+            forge_metadata.process_work_queues(
+                "/tmp/reachability",
+                "/tmp/metrics",
+                "automation-user",
+                take_blocked_issues=True,
+            )
+
+        process_issues.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            1,
+            0,
+            "/tmp/reachability",
+            "/tmp/metrics",
+            forge_metadata.DEFAULT_WORK_QUEUE_STRATEGY_NAME,
+            False,
+            "automation-user",
+            forge_metadata.DEFAULT_PARALLELISM,
+            user_requested_only=False,
+            environment_already_validated=True,
+            take_blocked_issues=True,
         )
 
     def test_process_work_queues_resolves_auth_for_review_only_queue(self) -> None:


### PR DESCRIPTION
### Summary
- Default Forge issue claiming now skips issues that have open GitHub `Blocked by` dependencies.
- Keep `--take-blocked-issues` as the explicit override and forward it through run-work-queues.
- Add tests for the default, override, and work-queue forwarding behavior.

### Hold before merge
This draft should only be merged after tomorrow, May 7, 2026, or after reaching 1000 covered libraries.

### Testing
- `.venv/bin/python -m unittest tests.test_forge_metadata`
- `git diff --check`

Fixes #6111