### PR TITLE
Run library version verification every six hours

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -2,7 +2,7 @@ name: "Verify compatibility with latest library versions"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -60,7 +60,7 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [CI.md](CI.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
-- Schedule-driven: full metadata sweep, new-library-version compatibility (daily), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
+- Schedule-driven: full metadata sweep, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every two weeks, scheduled coverage publication.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
 


### PR DESCRIPTION
## Summary
- run the latest-library-version compatibility workflow every six hours instead of daily
- update the functional spec CI cadence wording to match

## Testing
- Not run; GitHub Actions cron/docs-only change.

Fixes #6113