### PR TITLE
Remove redundant Maven coordinates issue fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_support_new_library.yml
+++ b/.github/ISSUE_TEMPLATE/01_support_new_library.yml
@@ -1,6 +1,6 @@
 name: "📚 Support a new library"
 description: Submit a request to add support for a third-party library
-title: "Support for {maven_coordinates}"
+title: "Support for <groupId>:<artifactId>:<version>"
 labels:
   - library-new-request
   - priority
@@ -9,15 +9,6 @@ body:
     attributes:
       value: |
         Provide the Maven coordinates for the library you need supported.
-
-  - type: input
-    id: maven_coordinates
-    attributes:
-      label: Full Maven coordinates
-      description: Include the version that you need. The system might support older versions so more people can benefit.
-      placeholder: groupId:artifactId:version
-    validations:
-      required: true
 
   - type: textarea
     id: reason

--- a/.github/ISSUE_TEMPLATE/02_update_existing_library.yml
+++ b/.github/ISSUE_TEMPLATE/02_update_existing_library.yml
@@ -1,6 +1,6 @@
 name: "🛠️ Update an existing library"
 description: Report a problem or request improvements for a library that is already supported
-title: "Update existing library: {maven_coordinates}"
+title: "Update existing library: <groupId>:<artifactId>:<version>"
 labels:
   - library-update-request
   - priority
@@ -9,15 +9,6 @@ body:
     attributes:
       value: |
         Use this form to report issues or request fixes for libraries that already have support in this repository.
-
-  - type: input
-    id: maven_coordinates
-    attributes:
-      label: Full Maven coordinates
-      description: Include a version that is failing for you.
-      placeholder: groupId:artifactId:version
-    validations:
-      required: true
 
   - type: textarea
     id: details

--- a/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
+++ b/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
@@ -17,7 +17,7 @@
 //     - `CREATE_PATH`, `SUPPORTED_PATH`, `ORDER_GA`
 //
 // Behavior notes:
-//   - Existing open issues are matched by requested Maven coordinates in the issue body or title
+//   - Existing open issues are matched by requested Maven coordinates in the issue title
 //   - When a reusable issue targets a newer version, automation rewrites it to the older version
 //     requested by the current plan so blocker creation stays conservative
 //   - Duplicate "blocked by" links are treated as a successful no-op
@@ -122,12 +122,8 @@ function buildIssueTitle(ga, version) {
 /**
  * Builds the standardized issue body used for newly created dependency issues.
  */
-function buildIssueBody(ga, version) {
+function buildIssueBody() {
   return [
-    '### Full Maven coordinates',
-    '',
-    `${ga}:${version}`,
-    '',
     '_This issue was created by automation._'
   ].join('\n');
 }
@@ -156,72 +152,18 @@ function buildCreatedIssueLabels(context) {
 }
 
 /**
- * Extracts the requested Maven coordinates from the standard issue body template.
+ * Extracts the requested Maven coordinates from an issue title.
  */
-function extractCoordinatesFromIssueBody(body) {
-  const lines = String(body || '')
-    .replace(/\r/g, '')
-    .split('\n');
-  let foundHeader = false;
-
-  for (const line of lines) {
-    if (foundHeader) {
-      if (line.trim() === '') {
-        continue;
-      }
-      return line.trim();
-    }
-
-    if (/^###[ \t]+Full Maven coordinates[ \t]*$/.test(line)) {
-      foundHeader = true;
-    }
-  }
-
-  return null;
+function extractCoordinatesFromIssueTitle(title) {
+  const match = String(title || '').match(/([^:\s]+:[^:\s]+:[^\s]+)/);
+  return match ? match[1] : null;
 }
 
 /**
- * Parses requested coordinates from an existing issue body first, then from its title.
+ * Parses requested coordinates from an existing issue title.
  */
 function parseRequestedCoordinatesFromIssue(issue) {
-  const bodyCoordinates = extractCoordinatesFromIssueBody(issue?.body);
-  const parsedBodyCoordinates = parseGAV(bodyCoordinates);
-  if (parsedBodyCoordinates) {
-    return parsedBodyCoordinates;
-  }
-
-  const titleMatch = String(issue?.title || '').match(/^Support for ([^:\s]+:[^:\s]+:[^\s]+)$/);
-  if (!titleMatch) {
-    return null;
-  }
-
-  return parseGAV(titleMatch[1]);
-}
-
-/**
- * Rewrites the coordinates section of an existing issue body to a requested version.
- */
-function updateIssueBodyCoordinates(body, ga, version) {
-  const lines = String(body || '')
-    .replace(/\r/g, '')
-    .split('\n');
-  let foundHeader = false;
-
-  for (let index = 0; index < lines.length; index++) {
-    if (foundHeader) {
-      if (lines[index].trim() === '') {
-        continue;
-      }
-      lines[index] = `${ga}:${version}`;
-      return lines.join('\n');
-    }
-
-    if (/^###[ \t]+Full Maven coordinates[ \t]*$/.test(lines[index])) {
-      foundHeader = true;
-    }
-  }
-
-  return buildIssueBody(ga, version);
+  return parseGAV(extractCoordinatesFromIssueTitle(issue?.title));
 }
 
 /**
@@ -898,7 +840,7 @@ module.exports = async function openDependencyIssuesAndLinkBlockers({ github, co
 
     const version = toCreate.get(ga);
     const title = buildIssueTitle(ga, version);
-    const body = buildIssueBody(ga, version);
+    const body = buildIssueBody();
     const reusableIssue = reusableIssueByGA.get(ga);
     let issueNumber = null;
 
@@ -907,16 +849,13 @@ module.exports = async function openDependencyIssuesAndLinkBlockers({ github, co
       const existingVersion = reusableIssue.requestedCoordinates.version;
 
       if (compareVersions(version, existingVersion) < 0) {
-        const updatedBody = updateIssueBodyCoordinates(reusableIssue.issue.body, ga, version);
         await github.rest.issues.update({
           owner,
           repo,
           issue_number: issueNumber,
-          title,
-          body: updatedBody
+          title
         });
         reusableIssue.issue.title = title;
-        reusableIssue.issue.body = updatedBody;
         reusableIssue.requestedCoordinates = parseGAV(`${ga}:${version}`);
         console.log(
           `Reused issue #${issueNumber} for ${ga} and updated it from version ${existingVersion} to older version ${version}.`

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -32,24 +32,12 @@ jobs:
             ).filter(Boolean);
             const hasLibraryNewRequestLabel = labelNames.includes("library-new-request");
 
-            function extractCoordinatesFromBody(body) {
-              const lines = String(body || "").replace(/\r/g, "").split("\n");
-              let foundHeader = false;
-              for (const line of lines) {
-                if (foundHeader) {
-                  if (line.trim() === "") {
-                    continue;
-                  }
-                  return line.trim();
-                }
-                if (/^###[ \t]+Full Maven coordinates[ \t]*$/.test(line)) {
-                  foundHeader = true;
-                }
-              }
-              return null;
+            function extractCoordinatesFromTitle(title) {
+              const match = String(title || "").match(/([^:\s]+:[^:\s]+:[^\s]+)/);
+              return match ? match[1] : null;
             }
 
-            const coords = extractCoordinatesFromBody(issue.body);
+            const coords = extractCoordinatesFromTitle(issue.title);
             const hasLibraryRequestTitle = Boolean(coords) && issue.title === `Support for ${coords}`;
             const isUnlabeledLibraryRequest = labelNames.length === 0 && hasLibraryRequestTitle;
             if (isUnlabeledLibraryRequest) {
@@ -75,15 +63,14 @@ jobs:
         if: ${{ steps.classify.outputs.should_triage == 'true' }}
         id: extract
         env:
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           set -Eeuo pipefail
-          # Normalize CRLF and capture the first non-empty line that follows the "Full Maven coordinates" header
-          COORDS="$(printf '%s\n' "$ISSUE_BODY" | tr -d '\r' | awk '
-            f { if ($0 ~ /^[[:space:]]*$/) next; print; exit }
-            /^###[[:space:]]+Full Maven coordinates[[:space:]]*$/ { f=1 }
-          ')"
-          COORDS="$(echo "$COORDS" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [[ "$ISSUE_TITLE" =~ ([^[:space:]:]+:[^[:space:]:]+:[^[:space:]]+) ]]; then
+            COORDS="${BASH_REMATCH[1]}"
+          else
+            COORDS=""
+          fi
           echo "coords=$COORDS" >> "$GITHUB_OUTPUT"
 
       - name: "Validate coordinates format"
@@ -108,7 +95,7 @@ jobs:
             const repo = context.repo.repo;
             const issue_number = context.issue.number;
             const coords = "${{ steps.extract.outputs.coords }}";
-            const reason = `Full Maven coordinates format is invalid: '${coords}'.`;
+            const reason = `Maven coordinates in the issue title are invalid: '${coords}'.`;
             const body = [
               "Automated triage: " + reason,
               "",
@@ -124,7 +111,7 @@ jobs:
               "org.hibernate.orm:hibernate-core:1.2.3",
               "```",
               "",
-              "This issue will be closed. Please open a new issue with the correct format under the '### Full Maven coordinates' section.",
+              "This issue will be closed. Please open a new issue with the correct format in the issue title.",
               "Reopening will not re-run automation; maintainers will review manually."
             ].join("\n");
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
@@ -142,21 +129,9 @@ jobs:
             const coords = "${{ steps.extract.outputs.coords }}";
             const exactTitle = `Support for ${coords}`;
 
-            function extractCoordinatesFromBody(body) {
-              const lines = (body || "").replace(/\r/g, "").split("\n");
-              let foundHeader = false;
-              for (const line of lines) {
-                if (foundHeader) {
-                  if (line.trim() === "") {
-                    continue;
-                  }
-                  return line.trim();
-                }
-                if (/^###[ \t]+Full Maven coordinates[ \t]*$/.test(line)) {
-                  foundHeader = true;
-                }
-              }
-              return null;
+            function extractCoordinatesFromTitle(title) {
+              const match = String(title || "").match(/([^:\s]+:[^:\s]+:[^\s]+)/);
+              return match ? match[1] : null;
             }
 
             const openIssues = await github.paginate(github.rest.issues.listForRepo, {
@@ -170,7 +145,7 @@ jobs:
               if (issue.pull_request || issue.number === issue_number) {
                 return false;
               }
-              return issue.title === exactTitle || extractCoordinatesFromBody(issue.body) === coords;
+              return issue.title === exactTitle || extractCoordinatesFromTitle(issue.title) === coords;
             });
 
             if (!duplicateIssue) {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -54,9 +54,9 @@ Workflows for style and security:
 
 [.github/workflows/triage-new-issues.yml](../.github/workflows/triage-new-issues.yml) runs when a GitHub issue is opened. It ignores pull requests and only proceeds for new-library requests.
 
-For normal user-created issues, the `library-new-request` label from the issue template makes the workflow eligible for triage. For automated issues created by native-build-tools without labels, such as issues opened by non-maintainers, the workflow first checks whether the issue has no labels, uses the standard `Support for groupId:artifactId:version` title, and contains a `### Full Maven coordinates` section. If it matches that shape, the workflow adds `library-new-request` and `priority` before continuing.
+For normal user-created issues, the `library-new-request` label from the issue template makes the workflow eligible for triage. For automated issues created by native-build-tools without labels, such as issues opened by non-maintainers, the workflow first checks whether the issue has no labels and uses the standard `Support for groupId:artifactId:version` title. If it matches that shape, the workflow adds `library-new-request` and `priority` before continuing.
 
-Once eligible, the workflow extracts the requested Maven coordinates, validates the `groupId:artifactId:version` format, closes invalid requests, closes duplicate exact-coordinate requests, and closes requests for versions already supported by the repository. If the request remains eligible, it generates a deps.dev dependency graph and opens or reuses `library-new-request` issues for unsupported transitive dependencies, linking them as blockers of the original request.
+Once eligible, the workflow extracts the requested Maven coordinates from the issue title, validates the `groupId:artifactId:version` format, closes invalid requests, closes duplicate exact-coordinate requests, and closes requests for versions already supported by the repository. If the request remains eligible, it generates a deps.dev dependency graph and opens or reuses `library-new-request` issues for unsupported transitive dependencies, linking them as blockers of the original request.
 
 ## Native Build Tools snapshot setup
 


### PR DESCRIPTION
### Summary
- Remove the `Full Maven coordinates` input from the new-library and library-update issue templates.
- Resolve request coordinates from issue titles in triage and dependency issue automation.
- Update CI documentation for the title-based coordinate flow.

### Testing
- `node --check ../.github/workflows/scripts/open-dependency-issues-and-link-blockers.js`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts path }' ../.github/ISSUE_TEMPLATE/01_support_new_library.yml ../.github/ISSUE_TEMPLATE/02_update_existing_library.yml ../.github/workflows/triage-new-issues.yml`
- `git diff --check -- ../.github/ISSUE_TEMPLATE/01_support_new_library.yml ../.github/ISSUE_TEMPLATE/02_update_existing_library.yml ../.github/workflows/triage-new-issues.yml ../.github/workflows/scripts/open-dependency-issues-and-link-blockers.js ../docs/CI.md`

Fixes #6134