### PR TITLE
[GenAI] Mark org.scala-js:scalajs-stubs_2.13 as not for Native Image

### DIFF
--- a/metadata/org.scala-js/scalajs-stubs_2.13/index.json
+++ b/metadata/org.scala-js/scalajs-stubs_2.13/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Scala.js artifact; it is not a JVM library consumed by native-image."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4992

This PR records `org.scala-js:scalajs-stubs_2.13` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Scala.js artifact; it is not a JVM library consumed by native-image.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `755520bffb5b8616224b6d6c88d1ced23438b819`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
