### PR TITLE
[Forge] Fix and harden Gradle bootstrap discovery

### DIFF
--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -29,6 +29,7 @@ REVIEW_MODEL="${FORGE_REVIEW_MODEL:-gpt-5.4}"
 USER_REQUESTED_ONLY="${FORGE_USER_REQUESTED_ISSUES_ONLY:-0}"
 WORK_STRATEGY_NAME="${FORGE_STRATEGY_NAME:-dynamic_access_main_sources_pi_gpt-5.6-sol}"
 GITHUB_RATE_LIMIT_EXIT_CODE=75
+GRADLE_BOOTSTRAP_EXIT_CODE=76
 MAX_PARALLELISM=4
 RUN_ONCE=0
 REQUEST_STOP=0
@@ -368,6 +369,13 @@ run_step() {
 
     if [[ "$status" -eq "$GITHUB_RATE_LIMIT_EXIT_CODE" ]]; then
         log "Skipping remaining work because the GitHub API limit is exhausted."
+        return 0
+    fi
+
+    # §FS-shared-infrastructure-bootstrap-failure: a shared Gradle bootstrap outage
+    # is host-wide, so skip the rest of this cycle and retry after the normal sleep.
+    if [[ "$status" -eq "$GRADLE_BOOTSTRAP_EXIT_CODE" ]]; then
+        log "Skipping remaining work because the shared Gradle bootstrap failed; retrying after sleep."
         return 0
     fi
 

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -508,7 +508,14 @@ isolated Gradle user home keep bootstrap from failing in the first place:
   download deterministically, after a full connect timeout. The file is linked
   rather than copied so host credentials are not duplicated into a shared
   temporary directory. An explicit Gradle user home chosen by an operator is
-  taken as given and left alone.
+  taken as given and left alone. Inheritance is deliberately wholesale rather
+  than filtered to proxy keys: a Forge run should behave the way `./gradlew`
+  behaves for a developer on that host, and filtering would mean writing a copy,
+  which is exactly what would duplicate a host proxy password into a shared
+  temporary directory. The accepted cost is precedence — a Gradle user home
+  `gradle.properties` outranks the repository's own, so a host that sets keys
+  like `org.gradle.java.home` overrides repository intent for Forge runs. Hosts
+  are expected to keep that file to host concerns such as proxy configuration.
 - **One cache per checkout.** Forge keys the Gradle user home on the checkout's
   common git directory, so every linked issue worktree of one checkout shares a
   single plugin and dependency cache and resolves the root build's plugins once

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -425,8 +425,10 @@ CI-equivalent verification (compile, test, native-test, and finalization gates),
 which includes the rare case of an agent timeout. A workflow failure is
 **external** — and must not get the label — only when it surfaces as a typed
 exception from the dependency boundary Forge itself crosses: GitHub (`gh`: rate
-limits and 5xx/network) as `GitHubError` / `GitHubRateLimitExceeded`, and remote
-git operations (push/pull/fetch/clone/ls-remote) as `GitTransportError`. Maven
+limits and 5xx/network) as `GitHubError` / `GitHubRateLimitExceeded`, remote
+git operations (push/pull/fetch/clone/ls-remote) as `GitTransportError`, and a
+Gradle build that never left configuration as `GradleBootstrapFailure`
+(§FS-shared-infrastructure-bootstrap-failure). Maven
 Central and Docker registry failures have no such boundary — Gradle owns them
 inside `./gradlew test` and they reach Forge only as an opaque CI-check `rc != 0`,
 indistinguishable from a real test failure once the in-workflow retries have run —
@@ -434,7 +436,8 @@ so they are not special-cased and fall through to the safe logical default. When
 failure is external, Forge takes no issue action: it applies no
 `human-intervention` label and posts no comment, and silently releases the issue
 claim (status back to `Todo`, assignees cleared) so the issue is retried later.
-Rate limits additionally stop the current run for retry after reset.
+Rate limits and shared bootstrap failures additionally stop the current run for
+a later retry.
 
 The label can appear on issues or pull requests. On an issue, it means Forge
 could not safely produce a PR-ready result and posted enough diagnostics for a
@@ -455,6 +458,61 @@ automated intervention changed the working tree and the local CI-equivalent
 verification still passed. That status should not by itself add the
 `human-intervention` label unless the result also meets one of the policy cases
 above.
+
+### FS-shared-infrastructure-bootstrap-failure: Shared infrastructure bootstrap failure
+
+A Gradle invocation that fails while configuring the root build has not reached
+any library-specific work yet, so its failure says nothing about the claimed
+library. Forge must not charge such a failure to whichever issue happened to be
+in flight: doing so turns one host-wide outage into as many `human-intervention`
+items as there are queued issues, which is the opposite of draining the queue
+(§GOAL-improve-automation-first).
+
+Artifact metadata discovery is the first Gradle invocation of a new-library run
+and therefore where shared bootstrap breakage surfaces. Forge runs it with
+`--no-daemon` and records one structured entry per attempt — attempt name, exit
+code, rendered command, and full output — in the discovery log, so an operator
+can separate a bootstrap outage from a library failure without rerunning.
+
+Forge recognizes two bootstrap failure shapes. Both are decidable from the Gradle
+output alone precisely because the build never left configuration:
+
+- The root build's Spotless plugin cannot be resolved from Maven Local or the
+  Gradle plugin repositories.
+- The Gradle wrapper distribution download fails or times out.
+
+Either shape is retried exactly once, after a short delay, with
+`--stacktrace --info --refresh-dependencies`, so a stale or partial cache entry
+is refetched and the second attempt leaves a diagnosable log. A succeeding retry
+makes the run continue normally, with nothing recorded about the outage beyond
+the attempt log.
+
+When the retry also fails on a bootstrap shape, Forge raises
+`GradleBootstrapFailure`, a typed external failure
+(§FS-human-intervention-policy): the issue claim goes back to `Todo` with
+assignees cleared, no `human-intervention` label or comment is applied, and no
+failed work is preserved. Because the cause is host-wide rather than per-issue,
+Forge also stops the current run rather than claiming the next issue, reverting
+every still-active claim first, and exits with a dedicated status so the do-work
+loop reports the outage and retries after its normal sleep (§DW-do-work-loop) —
+the same shape as a rate-limit stop.
+
+Detection and retry are the safety net, not the fix. Two properties of the
+isolated Gradle user home keep bootstrap from failing in the first place:
+
+- **Host configuration is inherited.** Isolating Gradle *state* must not discard
+  host Gradle *configuration*. Forge links the host `gradle.properties` into the
+  isolated home, because on a host that reaches Maven Central and the Gradle
+  plugin repository only through an HTTP proxy, that file carries the proxy
+  settings — and an isolated home without it fails every plugin and distribution
+  download deterministically, after a full connect timeout. The file is linked
+  rather than copied so host credentials are not duplicated into a shared
+  temporary directory. An explicit Gradle user home chosen by an operator is
+  taken as given and left alone.
+- **One cache per checkout.** Forge keys the Gradle user home on the checkout's
+  common git directory, so every linked issue worktree of one checkout shares a
+  single plugin and dependency cache and resolves the root build's plugins once
+  per checkout instead of once per issue.
 
 ### FS-human-intervention-resolution: Human intervention resolution
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -98,6 +98,7 @@ from utility_scripts.repo_path_resolver import (
     require_complete_reachability_repo,
     resolve_repo_roots,
 )
+from utility_scripts.source_context import GradleBootstrapFailure
 from utility_scripts.stage_logger import log_failure_banner, log_stage, log_success_banner
 from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
@@ -223,6 +224,7 @@ LATEST_EA_GRAALVM_ENV_VAR = "GRAALVM_HOME_LATEST_EA"
 INTERRUPT_EXIT_CODES = {130, -int(signal.SIGINT)}
 INTERRUPT_REASON_CTRL_C = "Ctrl+C interrupt"
 INTERRUPT_REASON_SHUTDOWN = "shutdown request"
+INTERRUPT_REASON_GRADLE_BOOTSTRAP = "Gradle bootstrap infrastructure failure"
 SHUTDOWN_SIGNAL_POLL_SECONDS = 5.0
 
 _user_interrupt_requested = threading.Event()
@@ -4128,8 +4130,11 @@ def run_claimed_issue(
             strategy_name,
             keep_tests_without_dynamic_access,
         )
+    except GradleBootstrapFailure:
+        raise
     except KeyboardInterrupt:
-        mark_user_interrupt_requested()
+        if not is_user_interrupt_requested():
+            mark_user_interrupt_requested()
         raise
     except Exception as exc:
         if is_user_interrupt_requested():
@@ -4454,11 +4459,29 @@ def process_claimed_issue_lifecycle(
                 file=sys.stderr,
             )
         return handled
+    except GradleBootstrapFailure as exc:
+        if not lifecycle_completed:
+            mark_user_interrupt_requested(INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+            revert_claimed_issue(claimed_issue, INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+            log_failure_banner(
+                format_issue_result_message(
+                    claimed_issue,
+                    (
+                        "Workflow stopped on shared Gradle bootstrap infrastructure failure; "
+                        "the issue claim was reverted without failed-work preservation or "
+                        "human-intervention follow-up."
+                    ),
+                ),
+                file=sys.stderr,
+            )
+            raise KeyboardInterrupt from exc
+        raise
     except BaseException as exc:
         if not lifecycle_completed:
             if is_interrupt_exception(exc) or is_user_interrupt_requested():
-                mark_user_interrupt_requested()
-                revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
+                if not is_user_interrupt_requested():
+                    mark_user_interrupt_requested()
+                revert_claimed_issue(claimed_issue, get_user_interrupt_reason())
                 raise
             else:
                 try:
@@ -4478,8 +4501,9 @@ def process_claimed_issue_lifecycle(
                         file=sys.stderr,
                     )
                 except KeyboardInterrupt:
-                    mark_user_interrupt_requested()
-                    revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
+                    if not is_user_interrupt_requested():
+                        mark_user_interrupt_requested()
+                    revert_claimed_issue(claimed_issue, get_user_interrupt_reason())
                     raise
                 return False
         raise
@@ -5347,13 +5371,13 @@ def process_issues_with_label(
     except KeyboardInterrupt:
         if is_shutdown_requested():
             mark_shutdown_requested()
-        else:
+        elif not is_user_interrupt_requested():
             mark_user_interrupt_requested()
         interrupt_reason = get_user_interrupt_reason()
         interrupt_message = (
             f"Shutdown requested via {describe_active_shutdown_signal_path()}"
             if interrupt_reason == INTERRUPT_REASON_SHUTDOWN
-            else "Ctrl+C received"
+            else f"{interrupt_reason} detected"
         )
         print(
             f"\n[{interrupt_message}. Reverting all active claimed issues before exit.]",

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -186,6 +186,7 @@ from utility_scripts.repo_path_resolver import (
     require_complete_reachability_repo,
     resolve_repo_roots,
 )
+from utility_scripts.source_context import GradleBootstrapFailure
 from utility_scripts.stage_logger import log_failure_banner, log_stage, log_success_banner
 from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
@@ -221,6 +222,7 @@ ISSUE_SEARCH_CACHE_FILENAME = "issue-search-cache-v2.json"
 ISSUE_SEARCH_CACHE_LOCK_FILENAME = "issue-search-cache-v1.lock"
 DEFAULT_ISSUE_SEARCH_CACHE_TTL_SECONDS = 10 * 60
 GITHUB_RATE_LIMIT_EXIT_CODE = 75
+GRADLE_BOOTSTRAP_EXIT_CODE = 76
 FIXTURE_E2E_LOG_DIRNAME = "fixture-e2e-logs"
 FIXTURE_RUN_LOG_FILENAME = "run.log"
 FIXTURE_PUBLICATION_FILENAME = "publication.md"
@@ -321,7 +323,8 @@ PUBLICATION_METRICS_EXTRA_KEYS: tuple[str, ...] = (
 # A workflow failure is logical (driver/core/CI-check) and gets `human-intervention`
 # by default. The only exception is an external dependency failure, which surfaces
 # as a typed exception at the Python boundary that issues it: GitHub (`gh`) as
-# `GitHubError` / `GitHubRateLimitExceeded`, and remote git as `GitTransportError`.
+# `GitHubError` / `GitHubRateLimitExceeded`, remote git as `GitTransportError`, and
+# a Gradle build that never left configuration as `GradleBootstrapFailure`.
 # Maven Central and Docker registry failures have no such boundary (Gradle owns
 # them inside `./gradlew test`); they fall through to the safe logical default.
 # §FS-human-intervention-policy
@@ -348,6 +351,7 @@ LATEST_EA_GRAALVM_ENV_VAR = "GRAALVM_HOME_LATEST_EA"
 INTERRUPT_EXIT_CODES = {130, -int(signal.SIGINT)}
 INTERRUPT_REASON_CTRL_C = "Ctrl+C interrupt"
 INTERRUPT_REASON_SHUTDOWN = "shutdown request"
+INTERRUPT_REASON_GRADLE_BOOTSTRAP = "Gradle bootstrap infrastructure failure"
 SHUTDOWN_SIGNAL_POLL_SECONDS = 5.0
 
 _user_interrupt_requested = threading.Event()
@@ -545,6 +549,17 @@ def mark_user_interrupt_requested(reason: str = INTERRUPT_REASON_CTRL_C) -> None
     _user_interrupt_requested.set()
 
 
+def preserve_user_interrupt_reason(reason: str = INTERRUPT_REASON_CTRL_C) -> None:
+    """Mark the run as unwinding without overwriting an already recorded reason.
+
+    Unwinding passes several handlers, and the first one to fire knows why the
+    run is stopping; later ones must not relabel a shared bootstrap stop as a
+    Ctrl+C (§FS-shared-infrastructure-bootstrap-failure).
+    """
+    if not is_user_interrupt_requested():
+        mark_user_interrupt_requested(reason)
+
+
 def clear_user_interrupt_requested() -> None:
     """Clear the shutdown marker before starting a new top-level run."""
     global _user_interrupt_reason
@@ -566,6 +581,11 @@ def get_user_interrupt_reason() -> str:
 def is_shutdown_request_interrupt() -> bool:
     """Return True when the current run is stopping because of the shared marker."""
     return is_user_interrupt_requested() and get_user_interrupt_reason() == INTERRUPT_REASON_SHUTDOWN
+
+
+def is_gradle_bootstrap_interrupt() -> bool:
+    """Return True when the run is stopping on a shared Gradle bootstrap outage."""
+    return is_user_interrupt_requested() and get_user_interrupt_reason() == INTERRUPT_REASON_GRADLE_BOOTSTRAP
 
 
 def mark_shutdown_requested() -> None:
@@ -3303,15 +3323,17 @@ def _load_dynamic_access_snapshot_from_report(claimed_issue: ClaimedIssue) -> Dy
 def is_external_failure_exception(exc: BaseException | None) -> bool:
     """Return True when a workflow exception is an external dependency failure.
 
-    GitHub (rate-limit or transient) and git transport surface as typed exceptions
-    (`GitHubError` / `GitTransportError`). An external failure releases the issue
-    claim for retry without `human-intervention`, while any other exception
-    (including agent timeouts) is logical. The cause/context chain is walked so a
-    wrapped external error is still recognized. §FS-human-intervention-policy
+    GitHub (rate-limit or transient), git transport, and shared Gradle bootstrap
+    outages surface as typed exceptions (`GitHubError` / `GitTransportError` /
+    `GradleBootstrapFailure`). An external failure releases the issue claim for
+    retry without `human-intervention`, while any other exception (including agent
+    timeouts) is logical. The cause/context chain is walked so a wrapped external
+    error is still recognized.
+    §FS-human-intervention-policy, §FS-shared-infrastructure-bootstrap-failure
     """
     error: BaseException | None = exc
     while error is not None:
-        if isinstance(error, (GitHubError, GitTransportError)):
+        if isinstance(error, (GitHubError, GitTransportError, GradleBootstrapFailure)):
             return True
         error = error.__cause__ or error.__context__
     return False
@@ -6324,8 +6346,10 @@ def run_claimed_issue(
             strategy_name,
             keep_tests_without_dynamic_access,
         )
+    except GradleBootstrapFailure:
+        raise
     except KeyboardInterrupt:
-        mark_user_interrupt_requested()
+        preserve_user_interrupt_reason()
         raise
     except Exception as exc:
         if is_user_interrupt_requested():
@@ -7208,7 +7232,7 @@ def handle_completed_run(run_result: WorkflowRunResult) -> bool:
         )
         return True
     except KeyboardInterrupt:
-        mark_user_interrupt_requested()
+        preserve_user_interrupt_reason()
         raise
     except Exception as exc:
         print(
@@ -7259,11 +7283,27 @@ def process_claimed_issue_lifecycle(
                 file=sys.stderr,
             )
         return handled
+    except GradleBootstrapFailure as exc:
+        if not lifecycle_completed:
+            mark_user_interrupt_requested(INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+            revert_claimed_issue(claimed_issue, INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+            log_failure_banner(
+                format_issue_result_message(
+                    claimed_issue,
+                    (
+                        "Run stopped on a shared Gradle bootstrap failure; the issue claim was "
+                        "reverted without failed-work preservation or human-intervention follow-up."
+                    ),
+                ),
+                file=sys.stderr,
+            )
+            raise KeyboardInterrupt from exc
+        raise
     except BaseException as exc:
         if not lifecycle_completed:
             if is_interrupt_exception(exc) or is_user_interrupt_requested():
-                mark_user_interrupt_requested()
-                revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
+                preserve_user_interrupt_reason()
+                revert_claimed_issue(claimed_issue, get_user_interrupt_reason())
                 raise
             else:
                 try:
@@ -7284,8 +7324,8 @@ def process_claimed_issue_lifecycle(
                         file=sys.stderr,
                     )
                 except KeyboardInterrupt:
-                    mark_user_interrupt_requested()
-                    revert_claimed_issue(claimed_issue, "Ctrl+C interrupt")
+                    preserve_user_interrupt_reason()
+                    revert_claimed_issue(claimed_issue, get_user_interrupt_reason())
                     raise
                 return False
         raise
@@ -8254,12 +8294,12 @@ def process_issues_with_label(
         if is_shutdown_requested():
             mark_shutdown_requested()
         else:
-            mark_user_interrupt_requested()
+            preserve_user_interrupt_reason()
         interrupt_reason = get_user_interrupt_reason()
         interrupt_message = (
             f"Shutdown requested via {describe_active_shutdown_signal_path()}"
             if interrupt_reason == INTERRUPT_REASON_SHUTDOWN
-            else "Ctrl+C received"
+            else f"{interrupt_reason} detected"
         )
         print(
             f"\n[{interrupt_message}. Reverting all active claimed issues before exit.]",
@@ -8743,13 +8783,19 @@ def main() -> None:
         if is_shutdown_requested():
             mark_shutdown_requested()
         else:
-            mark_user_interrupt_requested()
+            preserve_user_interrupt_reason()
         if is_shutdown_request_interrupt():
             print(
                 f"\nRun stopped because the Forge stop marker exists at {describe_active_shutdown_signal_path()}.",
                 file=sys.stderr,
             )
             sys.exit(0)
+        if is_gradle_bootstrap_interrupt():
+            log_failure_banner(
+                "Shared Gradle bootstrap failed after retry. Stop current run and retry later.",
+                file=sys.stderr,
+            )
+            sys.exit(GRADLE_BOOTSTRAP_EXIT_CODE)
         print("\nERROR: Run interrupted by Ctrl+C.", file=sys.stderr)
         sys.exit(130)
     except GitHubRateLimitExceeded as exc:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -5486,7 +5486,7 @@ def invoke_pipeline(
         )
     rc = invocation.runner(invocation.argv)
     if is_interrupt_exit_code(rc):
-        mark_user_interrupt_requested()
+        preserve_user_interrupt_reason()
         raise KeyboardInterrupt
     if rc != 0:
         print(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -2032,6 +2032,90 @@ class InterruptHandlingTests(unittest.TestCase):
         handle_failed_claimed_issue.assert_called_once()
         cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
 
+    def test_gradle_bootstrap_failure_reverts_claim_without_human_intervention_follow_up(self) -> None:
+        claimed_issue = _claimed_issue()
+        failure = forge_metadata.GradleBootstrapFailure(claimed_issue.issue_coordinates, "/tmp/discover.log")
+
+        with patch.object(forge_metadata, "run_claimed_issue", side_effect=failure), \
+                patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                patch.object(forge_metadata, "revert_claimed_issue") as revert_claimed_issue, \
+                patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
+            with self.assertRaises(KeyboardInterrupt):
+                forge_metadata.process_claimed_issue_lifecycle(
+                    claimed_issue,
+                    strategy_name=None,
+                    keep_tests_without_dynamic_access=False,
+                    canonical_metrics_repo_path="/tmp/metrics",
+                )
+
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+        handle_completed_run.assert_not_called()
+        handle_failed_claimed_issue.assert_not_called()
+        revert_claimed_issue.assert_called_once_with(
+            claimed_issue,
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+        cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
+
+    def test_gradle_bootstrap_failure_stops_issue_queue(self) -> None:
+        claimed_issue = _claimed_issue()
+        issue = {
+            "number": 1412,
+            "title": "Add support for org.example:lib:1.0.0",
+            "labels": [],
+            "assignees": [],
+        }
+        failure = forge_metadata.GradleBootstrapFailure(claimed_issue.issue_coordinates, "/tmp/discover.log")
+
+        with patch.object(forge_metadata, "is_shutdown_requested", return_value=False), \
+                patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                patch.object(
+                    forge_metadata,
+                    "get_prioritized_issues_with_label",
+                    return_value=([issue], 0, 1, True, False),
+                ), \
+                patch.object(forge_metadata, "get_cached_issue_claim_skips", return_value={}), \
+                patch.object(
+                    forge_metadata,
+                    "resolve_next_issue_claim_candidate_batch",
+                    return_value=[(issue, _preflight(), None)],
+                ), \
+                patch.object(
+                    forge_metadata,
+                    "claim_issue_for_processing",
+                    return_value=claimed_issue,
+                ) as claim_issue_for_processing, \
+                patch.object(forge_metadata, "run_claimed_issue", side_effect=failure), \
+                patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                patch.object(forge_metadata, "revert_claimed_issue"), \
+                patch.object(forge_metadata, "cleanup_issue_workspace"):
+            with self.assertRaises(KeyboardInterrupt):
+                forge_metadata.process_issues_with_label(
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    2,
+                    0,
+                    "/tmp/reachability",
+                    "/tmp/metrics",
+                    None,
+                    False,
+                    "automation-user",
+                    1,
+                    environment_already_validated=True,
+                )
+
+        claim_issue_for_processing.assert_called_once()
+        handle_completed_run.assert_not_called()
+        handle_failed_claimed_issue.assert_not_called()
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+
     def test_failed_run_analysis_uses_fallback_when_worktree_is_invalid(self) -> None:
         claimed_issue = _claimed_issue()
         candidate = forge_metadata.HumanInterventionCandidate(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import dataclasses
 import io
 import json
 import os
@@ -147,6 +148,11 @@ def _claimed_issue(label: str = forge_metadata.LABEL_LIBRARY_NEW) -> forge_metad
         scratch_metrics_repo_path="/tmp/metrics-worktree",
         issue_coordinates="org.example:lib:1.0.0",
     )
+
+
+def _claimed_issue_in(base_path: str, label: str = forge_metadata.LABEL_LIBRARY_NEW) -> forge_metadata.ClaimedIssue:
+    """Build a claimed issue whose base checkout path exists on disk."""
+    return dataclasses.replace(_claimed_issue(label), base_reachability_metadata_path=base_path)
 
 
 def _dynamic_access_report(class_names: list[str]) -> DynamicAccessCoverageReport:
@@ -2767,9 +2773,11 @@ class FailedRunFollowUpTests(unittest.TestCase):
 class InterruptHandlingTests(unittest.TestCase):
     def setUp(self) -> None:
         forge_metadata.clear_user_interrupt_requested()
+        self._original_cwd = os.getcwd()
 
     def tearDown(self) -> None:
         forge_metadata.clear_user_interrupt_requested()
+        os.chdir(self._original_cwd)
 
     def test_interrupt_return_code_from_workflow_raises_keyboard_interrupt(self) -> None:
         claimed_issue = _claimed_issue()
@@ -2786,28 +2794,29 @@ class InterruptHandlingTests(unittest.TestCase):
         require_graalvm_home.assert_not_called()
 
     def test_interrupted_failed_workflow_skips_human_intervention_handling(self) -> None:
-        claimed_issue = _claimed_issue()
+        with tempfile.TemporaryDirectory() as repo_path:
+            claimed_issue = _claimed_issue_in(repo_path)
 
-        def interrupted_run(*_args):
-            forge_metadata.mark_user_interrupt_requested()
-            return forge_metadata.WorkflowRunResult(
-                claimed_issue=claimed_issue,
-                success=False,
-                started_at=123.0,
-            )
-
-        with patch.object(forge_metadata, "run_claimed_issue", side_effect=interrupted_run), \
-                patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
-                patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
-                patch.object(forge_metadata, "revert_claimed_issue") as revert_claimed_issue, \
-                patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
-            with self.assertRaises(KeyboardInterrupt):
-                forge_metadata.process_claimed_issue_lifecycle(
-                    claimed_issue,
-                    strategy_name=None,
-                    keep_tests_without_dynamic_access=False,
-                    canonical_metrics_repo_path="/tmp/metrics",
+            def interrupted_run(*_args):
+                forge_metadata.mark_user_interrupt_requested()
+                return forge_metadata.WorkflowRunResult(
+                    claimed_issue=claimed_issue,
+                    success=False,
+                    started_at=123.0,
                 )
+
+            with patch.object(forge_metadata, "run_claimed_issue", side_effect=interrupted_run), \
+                    patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                    patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                    patch.object(forge_metadata, "revert_claimed_issue") as revert_claimed_issue, \
+                    patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
+                with self.assertRaises(KeyboardInterrupt):
+                    forge_metadata.process_claimed_issue_lifecycle(
+                        claimed_issue,
+                        strategy_name=None,
+                        keep_tests_without_dynamic_access=False,
+                        canonical_metrics_repo_path="/tmp/metrics",
+                    )
 
         handle_completed_run.assert_not_called()
         handle_failed_claimed_issue.assert_not_called()
@@ -2815,18 +2824,19 @@ class InterruptHandlingTests(unittest.TestCase):
         cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
 
     def test_unhandled_system_exit_is_failed_issue_not_queue_stopper(self) -> None:
-        claimed_issue = _claimed_issue()
+        with tempfile.TemporaryDirectory() as repo_path:
+            claimed_issue = _claimed_issue_in(repo_path)
 
-        with patch.object(forge_metadata, "run_claimed_issue", side_effect=SystemExit(1)), \
-                patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
-                patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
-                patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
-            handled = forge_metadata.process_claimed_issue_lifecycle(
-                claimed_issue,
-                strategy_name=None,
-                keep_tests_without_dynamic_access=False,
-                canonical_metrics_repo_path="/tmp/metrics",
-            )
+            with patch.object(forge_metadata, "run_claimed_issue", side_effect=SystemExit(1)), \
+                    patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                    patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                    patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
+                handled = forge_metadata.process_claimed_issue_lifecycle(
+                    claimed_issue,
+                    strategy_name=None,
+                    keep_tests_without_dynamic_access=False,
+                    canonical_metrics_repo_path="/tmp/metrics",
+                )
 
         self.assertFalse(handled)
         handle_completed_run.assert_not_called()
@@ -2887,6 +2897,109 @@ class InterruptHandlingTests(unittest.TestCase):
 
         post_issue_comment.assert_not_called()
         add_issue_label.assert_not_called()
+
+    def test_gradle_bootstrap_failure_is_classified_as_external(self) -> None:
+        failure = forge_metadata.GradleBootstrapFailure("org.example:lib:1.0.0", "/tmp/discover.log")
+
+        wrapped = RuntimeError("wrapped")
+        wrapped.__cause__ = failure
+
+        self.assertTrue(forge_metadata.is_external_failure_exception(failure))
+        self.assertTrue(forge_metadata.is_external_failure_exception(wrapped))
+
+    def test_preserved_interrupt_reason_survives_later_generic_handlers(self) -> None:
+        forge_metadata.mark_user_interrupt_requested(forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+        forge_metadata.preserve_user_interrupt_reason()
+
+        self.assertTrue(forge_metadata.is_gradle_bootstrap_interrupt())
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+
+    def test_gradle_bootstrap_failure_reverts_claim_without_human_intervention_follow_up(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            claimed_issue = _claimed_issue_in(repo_path)
+            failure = forge_metadata.GradleBootstrapFailure(claimed_issue.issue_coordinates, "/tmp/discover.log")
+
+            with patch.object(forge_metadata, "run_claimed_issue", side_effect=failure), \
+                    patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                    patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                    patch.object(forge_metadata, "revert_claimed_issue") as revert_claimed_issue, \
+                    patch.object(forge_metadata, "cleanup_issue_workspace") as cleanup_issue_workspace:
+                with self.assertRaises(KeyboardInterrupt):
+                    forge_metadata.process_claimed_issue_lifecycle(
+                        claimed_issue,
+                        strategy_name=None,
+                        keep_tests_without_dynamic_access=False,
+                        canonical_metrics_repo_path="/tmp/metrics",
+                    )
+
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+        handle_completed_run.assert_not_called()
+        handle_failed_claimed_issue.assert_not_called()
+        revert_claimed_issue.assert_called_once_with(
+            claimed_issue,
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
+        cleanup_issue_workspace.assert_called_once_with(claimed_issue, "/tmp/metrics")
+
+    def test_gradle_bootstrap_failure_stops_the_issue_queue(self) -> None:
+        issues = [
+            {
+                "number": issue_number,
+                "title": f"Add support for org.example:lib{issue_number}:1.0.0",
+                "labels": [],
+                "assignees": [],
+            }
+            for issue_number in range(1, 4)
+        ]
+
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as lock_root:
+            claimed_issue = _claimed_issue_in(repo_path)
+            failure = forge_metadata.GradleBootstrapFailure(claimed_issue.issue_coordinates, "/tmp/discover.log")
+
+            with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
+                    patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                    patch.object(
+                        forge_metadata,
+                        "get_prioritized_issues_with_label",
+                        return_value=(issues, _scan_state(len(issues), exhausted=True)),
+                    ), \
+                    patch.object(forge_metadata, "get_issue_claim_preflights_or_empty"), \
+                    patch.object(
+                        forge_metadata,
+                        "claim_issue_for_processing",
+                        return_value=claimed_issue,
+                    ) as claim_issue_for_processing, \
+                    patch.object(forge_metadata, "run_claimed_issue", side_effect=failure), \
+                    patch.object(forge_metadata, "handle_completed_run") as handle_completed_run, \
+                    patch.object(forge_metadata, "handle_failed_claimed_issue") as handle_failed_claimed_issue, \
+                    patch.object(forge_metadata, "revert_claimed_issue"), \
+                    patch.object(forge_metadata, "cleanup_issue_workspace"):
+                with self.assertRaises(KeyboardInterrupt):
+                    forge_metadata.process_issues_with_label(
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                        len(issues),
+                        0,
+                        "/tmp/reachability",
+                        "/tmp/metrics",
+                        None,
+                        False,
+                        "automation-user",
+                        1,
+                    )
+
+        claim_issue_for_processing.assert_called_once()
+        handle_completed_run.assert_not_called()
+        handle_failed_claimed_issue.assert_not_called()
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP,
+        )
 
     def test_process_issues_with_label_skips_queue_when_shutdown_requested(self) -> None:
         with patch.object(forge_metadata, "is_shutdown_requested", return_value=True), \

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -2898,6 +2898,37 @@ class InterruptHandlingTests(unittest.TestCase):
         post_issue_comment.assert_not_called()
         add_issue_label.assert_not_called()
 
+    def test_no_unwind_path_relabels_a_recorded_bootstrap_stop_as_ctrl_c(self) -> None:
+        """A concurrent worker observing the interrupt must not reset the reason.
+
+        With parallelism > 1 one issue can record the bootstrap stop while another
+        worker unwinds through a generic interrupt handler; the main loop would then
+        revert the remaining claims, and exit, under the wrong reason.
+        """
+        claimed_issue = _claimed_issue()
+        forge_metadata.mark_user_interrupt_requested(forge_metadata.INTERRUPT_REASON_GRADLE_BOOTSTRAP)
+
+        with patch.object(forge_metadata, "run_add_new_library_support_workflow", return_value=130), \
+                patch.object(forge_metadata, "require_claimed_issue_worktree"), \
+                patch.object(forge_metadata, "run_library_preparation_preflight", return_value=None), \
+                patch.object(forge_metadata, "prepare_dynamic_access_chunking", return_value=None), \
+                patch.object(forge_metadata, "create_or_load_run_continuation_marker", return_value=None), \
+                patch.object(forge_metadata, "load_continuation_marker", return_value=None), \
+                patch.object(forge_metadata, "record_library_update_route_in_marker"):
+            with self.assertRaises(KeyboardInterrupt):
+                forge_metadata.invoke_pipeline(claimed_issue, None, False)
+
+        self.assertTrue(forge_metadata.is_gradle_bootstrap_interrupt())
+
+    def test_ctrl_c_is_still_recorded_when_no_reason_was_set(self) -> None:
+        forge_metadata.preserve_user_interrupt_reason()
+
+        self.assertTrue(forge_metadata.is_user_interrupt_requested())
+        self.assertEqual(
+            forge_metadata.get_user_interrupt_reason(),
+            forge_metadata.INTERRUPT_REASON_CTRL_C,
+        )
+
     def test_gradle_bootstrap_failure_is_classified_as_external(self) -> None:
         failure = forge_metadata.GradleBootstrapFailure("org.example:lib:1.0.0", "/tmp/discover.log")
 

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -4,6 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -26,6 +27,26 @@ class GradleEnvironmentTests(unittest.TestCase):
             self.assertEqual(os.path.dirname(os.path.dirname(gradle_home)), tempfile.gettempdir())
             self.assertEqual(os.path.basename(os.path.dirname(gradle_home)), "metadata-forge-gradle")
             self.assertEqual(gradle_home, equivalent_gradle_home)
+
+    def test_git_worktrees_share_gradle_home_with_main_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = os.path.join(temp_dir, "repo")
+            worktree_path = os.path.join(temp_dir, "linked")
+            os.makedirs(repo_path)
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_path, check=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_path, check=True)
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as readme_file:
+                readme_file.write("test\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
+            subprocess.run(["git", "commit", "-m", "initial"], cwd=repo_path, check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(["git", "worktree", "add", worktree_path], cwd=repo_path, check=True, stdout=subprocess.DEVNULL)
+
+            with patch.dict(os.environ, {}, clear=True):
+                main_gradle_home = gradle_user_home_for_repo(repo_path)
+                worktree_gradle_home = gradle_user_home_for_repo(worktree_path)
+
+            self.assertEqual(main_gradle_home, worktree_gradle_home)
 
     def test_command_environment_preserves_base_env_and_sets_gradle_user_home(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -197,6 +197,18 @@ class GradleEnvironmentTests(unittest.TestCase):
             linked_properties = os.path.join(inner_env["GRADLE_USER_HOME"], "gradle.properties")
             self.assertEqual(os.path.realpath(linked_properties), os.path.realpath(host_properties))
 
+    def test_host_home_on_an_unrelated_volume_is_not_rejected(self) -> None:
+        """`commonpath` raises across Windows drives; that must not escape."""
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as inherited_home:
+            host_properties = _write_gradle_properties(inherited_home)
+
+            with patch.dict(os.environ, {}, clear=True), \
+                    patch.object(os.path, "commonpath", side_effect=ValueError("different drives")):
+                env = gradle_command_environment(repo_path, {"GRADLE_USER_HOME": inherited_home})
+
+            linked_properties = os.path.join(env["GRADLE_USER_HOME"], "gradle.properties")
+            self.assertEqual(os.path.realpath(linked_properties), os.path.realpath(host_properties))
+
     def test_explicit_gradle_home_override_skips_host_properties_sharing(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, \
                 tempfile.TemporaryDirectory() as host_home, \

--- a/forge/tests/test_gradle_environment.py
+++ b/forge/tests/test_gradle_environment.py
@@ -4,6 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -11,9 +12,61 @@ from unittest.mock import patch
 from utility_scripts.gradle_environment import (
     FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV,
     FORGE_GRADLE_USER_HOME_ENV,
+    _resolve_git_common_dir,
     gradle_command_environment,
     gradle_user_home_for_repo,
 )
+
+
+def _init_git_repo_with_worktree(repo_path: str, worktree_path: str) -> None:
+    os.makedirs(repo_path)
+    _run_git(repo_path, "init", "-b", "main")
+    _run_git(repo_path, "config", "user.email", "test@example.com")
+    _run_git(repo_path, "config", "user.name", "Test User")
+    with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as readme_file:
+        readme_file.write("test\n")
+    _run_git(repo_path, "add", "README.md")
+    _run_git(repo_path, "commit", "-m", "initial")
+    _run_git(repo_path, "worktree", "add", worktree_path)
+
+
+def _run_git(cwd: str, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _write_host_gradle_properties(home: str) -> str:
+    """Write `gradle.properties` into the default `~/.gradle` of a fake home."""
+    return _write_gradle_properties(os.path.join(home, ".gradle"))
+
+
+def _write_gradle_properties(gradle_home: str) -> str:
+    """Write a `gradle.properties` carrying the settings Forge must inherit."""
+    os.makedirs(gradle_home, exist_ok=True)
+    properties_path = os.path.join(gradle_home, "gradle.properties")
+    with open(properties_path, "w", encoding="utf-8") as properties_file:
+        properties_file.write("systemProp.https.proxyHost=proxy.test\nsystemProp.https.proxyPort=80\n")
+    return properties_path
+
+
+def _git_common_dir(cwd: str) -> str:
+    """Return `git rev-parse --git-common-dir` as the oracle for the filesystem walk."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    common_dir = result.stdout.strip()
+    if not os.path.isabs(common_dir):
+        common_dir = os.path.join(cwd, common_dir)
+    return os.path.realpath(common_dir)
 
 
 class GradleEnvironmentTests(unittest.TestCase):
@@ -27,6 +80,46 @@ class GradleEnvironmentTests(unittest.TestCase):
             self.assertEqual(os.path.dirname(os.path.dirname(gradle_home)), tempfile.gettempdir())
             self.assertEqual(os.path.basename(os.path.dirname(gradle_home)), "metadata-forge-gradle")
             self.assertEqual(gradle_home, equivalent_gradle_home)
+
+    def test_linked_worktrees_share_gradle_home_with_main_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = os.path.join(temp_dir, "repo")
+            worktree_path = os.path.join(temp_dir, "linked")
+            _init_git_repo_with_worktree(repo_path, worktree_path)
+
+            with patch.dict(os.environ, {}, clear=True):
+                main_gradle_home = gradle_user_home_for_repo(repo_path)
+                worktree_gradle_home = gradle_user_home_for_repo(worktree_path)
+
+            self.assertEqual(main_gradle_home, worktree_gradle_home)
+
+    def test_common_dir_resolution_matches_git_rev_parse(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = os.path.join(temp_dir, "repo")
+            worktree_path = os.path.join(temp_dir, "linked")
+            nested_path = os.path.join(worktree_path, "nested", "dir")
+            _init_git_repo_with_worktree(repo_path, worktree_path)
+            os.makedirs(nested_path)
+
+            for path in (repo_path, worktree_path, nested_path):
+                self.assertEqual(_resolve_git_common_dir(path), _git_common_dir(path), path)
+
+    def test_paths_outside_a_checkout_fall_back_to_the_path_itself(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertIsNone(_resolve_git_common_dir(temp_dir))
+
+    def test_unrelated_checkouts_do_not_share_gradle_home(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first_repo = os.path.join(temp_dir, "first")
+            second_repo = os.path.join(temp_dir, "second")
+            _init_git_repo_with_worktree(first_repo, os.path.join(temp_dir, "first-linked"))
+            _init_git_repo_with_worktree(second_repo, os.path.join(temp_dir, "second-linked"))
+
+            with patch.dict(os.environ, {}, clear=True):
+                first_gradle_home = gradle_user_home_for_repo(first_repo)
+                second_gradle_home = gradle_user_home_for_repo(second_repo)
+
+            self.assertNotEqual(first_gradle_home, second_gradle_home)
 
     def test_command_environment_preserves_base_env_and_sets_gradle_user_home(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
@@ -51,6 +144,70 @@ class GradleEnvironmentTests(unittest.TestCase):
             self.assertNotEqual(first_env["GRADLE_USER_HOME"], second_env["GRADLE_USER_HOME"])
             self.assertEqual(os.path.realpath(first_dists), expected_dists)
             self.assertEqual(os.path.realpath(second_dists), expected_dists)
+
+    def test_isolated_home_inherits_host_gradle_properties(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as host_home:
+            host_properties = _write_host_gradle_properties(host_home)
+
+            with patch.dict(os.environ, {"HOME": host_home}, clear=True):
+                env = gradle_command_environment(repo_path)
+
+            linked_properties = os.path.join(env["GRADLE_USER_HOME"], "gradle.properties")
+            self.assertTrue(os.path.islink(linked_properties))
+            self.assertEqual(os.path.realpath(linked_properties), os.path.realpath(host_properties))
+
+    def test_host_gradle_properties_sharing_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as host_home:
+            _write_host_gradle_properties(host_home)
+
+            with patch.dict(os.environ, {"HOME": host_home}, clear=True):
+                first_env = gradle_command_environment(repo_path)
+                second_env = gradle_command_environment(repo_path)
+
+            self.assertEqual(first_env["GRADLE_USER_HOME"], second_env["GRADLE_USER_HOME"])
+            self.assertTrue(os.path.islink(os.path.join(second_env["GRADLE_USER_HOME"], "gradle.properties")))
+
+    def test_missing_host_gradle_properties_is_not_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as host_home:
+            with patch.dict(os.environ, {"HOME": host_home}, clear=True):
+                env = gradle_command_environment(repo_path)
+
+            self.assertFalse(os.path.exists(os.path.join(env["GRADLE_USER_HOME"], "gradle.properties")))
+
+    def test_inherited_gradle_user_home_supplies_host_properties(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, \
+                tempfile.TemporaryDirectory() as inherited_home, \
+                tempfile.TemporaryDirectory() as empty_home:
+            host_properties = _write_gradle_properties(inherited_home)
+
+            with patch.dict(os.environ, {"HOME": empty_home}, clear=True):
+                env = gradle_command_environment(repo_path, {"GRADLE_USER_HOME": inherited_home})
+
+            linked_properties = os.path.join(env["GRADLE_USER_HOME"], "gradle.properties")
+            self.assertEqual(os.path.realpath(linked_properties), os.path.realpath(host_properties))
+
+    def test_forge_home_inherited_from_an_outer_call_is_not_treated_as_host_config(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as host_home:
+            host_properties = _write_host_gradle_properties(host_home)
+
+            with patch.dict(os.environ, {"HOME": host_home}, clear=True):
+                outer_env = gradle_command_environment(repo_path)
+                inner_env = gradle_command_environment(repo_path, dict(outer_env))
+
+            linked_properties = os.path.join(inner_env["GRADLE_USER_HOME"], "gradle.properties")
+            self.assertEqual(os.path.realpath(linked_properties), os.path.realpath(host_properties))
+
+    def test_explicit_gradle_home_override_skips_host_properties_sharing(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, \
+                tempfile.TemporaryDirectory() as host_home, \
+                tempfile.TemporaryDirectory() as gradle_home:
+            _write_host_gradle_properties(host_home)
+
+            with patch.dict(os.environ, {"HOME": host_home, FORGE_GRADLE_USER_HOME_ENV: gradle_home}, clear=True):
+                env = gradle_command_environment(repo_path)
+
+            self.assertEqual(env["GRADLE_USER_HOME"], gradle_home)
+            self.assertFalse(os.path.exists(os.path.join(gradle_home, "gradle.properties")))
 
     def test_explicit_gradle_distributions_override_is_honored(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as gradle_dists:

--- a/forge/tests/test_source_context.py
+++ b/forge/tests/test_source_context.py
@@ -1,0 +1,157 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts.source_context import (
+    GradleBootstrapFailure,
+    discover_artifact_metadata,
+)
+
+
+class SourceContextDiscoveryTests(unittest.TestCase):
+    def test_discover_artifact_metadata_uses_no_daemon(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            log_path = os.path.join(repo, "discover.log")
+            completed = subprocess.CompletedProcess([], 0, stdout="success\n")
+
+            with (
+                patch("utility_scripts.source_context.require_complete_reachability_repo"),
+                patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+                patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+                patch("utility_scripts.source_context.subprocess.run", return_value=completed) as run,
+            ):
+                discover_artifact_metadata(repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            run.assert_called_once()
+            command = run.call_args.args[0]
+            self.assertEqual(command[:3], ["./gradlew", "--no-daemon", "discoverArtifactMetadata"])
+            self.assertIn("--coordinates=org.example:demo:1.0.0", command)
+            self.assertIn("--agent-command=/bin/true", command)
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                log_content = log_file.read()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("success", log_content)
+
+    def test_discover_artifact_metadata_retries_spotless_plugin_bootstrap_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            log_path = os.path.join(repo, "discover.log")
+            first = subprocess.CompletedProcess(
+                [],
+                1,
+                stdout=(
+                    "Plugin [id: 'com.diffplug.spotless', version: '6.3.0'] was not found\n"
+                    "could not resolve plugin artifact "
+                    "'com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.3.0'\n"
+                    "Searched in the following repositories:\n"
+                    "  Gradle Central Plugin Repository\n"
+                ),
+            )
+            second = subprocess.CompletedProcess([], 0, stdout="retry success\n")
+
+            with (
+                patch("utility_scripts.source_context.require_complete_reachability_repo"),
+                patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+                patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+                patch("utility_scripts.source_context.time.sleep") as sleep,
+                patch("utility_scripts.source_context.subprocess.run", side_effect=[first, second]) as run,
+            ):
+                discover_artifact_metadata(repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(run.call_count, 2)
+            retry_command = run.call_args_list[1].args[0]
+            self.assertIn("--stacktrace", retry_command)
+            self.assertIn("--info", retry_command)
+            self.assertIn("--refresh-dependencies", retry_command)
+            sleep.assert_called_once()
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                log_content = log_file.read()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("[forge] Gradle discovery attempt: diagnostic-retry", log_content)
+            self.assertIn("retry success", log_content)
+
+    def test_discover_artifact_metadata_raises_bootstrap_failure_when_retry_is_exhausted(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            log_path = os.path.join(repo, "discover.log")
+            failed = subprocess.CompletedProcess(
+                [],
+                1,
+                stdout=(
+                    "Plugin [id: 'com.diffplug.spotless', version: '6.3.0'] was not found\n"
+                    "could not resolve plugin artifact "
+                    "'com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.3.0'\n"
+                    "Searched in the following repositories:\n"
+                    "  Gradle Central Plugin Repository\n"
+                ),
+            )
+
+            with (
+                patch("utility_scripts.source_context.require_complete_reachability_repo"),
+                patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+                patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+                patch("utility_scripts.source_context.time.sleep"),
+                patch("utility_scripts.source_context.subprocess.run", side_effect=[failed, failed]) as run,
+            ):
+                with self.assertRaises(GradleBootstrapFailure) as raised:
+                    discover_artifact_metadata(repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(run.call_count, 2)
+            self.assertEqual(raised.exception.coordinate, "org.example:demo:1.0.0")
+            self.assertEqual(raised.exception.log_path, log_path)
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                log_content = log_file.read()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("[forge] Gradle discovery attempt: diagnostic-retry", log_content)
+
+    def test_discover_artifact_metadata_retries_gradle_wrapper_download_bootstrap_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            log_path = os.path.join(repo, "discover.log")
+            first = subprocess.CompletedProcess(
+                [],
+                1,
+                stdout=(
+                    "Downloading https://services.gradle.org/distributions/gradle-8.14.3-bin.zip\n"
+                    "Exception in thread \"main\" java.net.SocketTimeoutException: Read timed out\n"
+                ),
+            )
+            second = subprocess.CompletedProcess([], 0, stdout="retry success\n")
+
+            with (
+                patch("utility_scripts.source_context.require_complete_reachability_repo"),
+                patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+                patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+                patch("utility_scripts.source_context.time.sleep"),
+                patch("utility_scripts.source_context.subprocess.run", side_effect=[first, second]) as run,
+            ):
+                discover_artifact_metadata(repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(run.call_count, 2)
+
+    def test_discover_artifact_metadata_does_not_retry_non_bootstrap_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            log_path = os.path.join(repo, "discover.log")
+            failed = subprocess.CompletedProcess([], 1, stdout="compileJava failed\n")
+
+            with (
+                patch("utility_scripts.source_context.require_complete_reachability_repo"),
+                patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+                patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+                patch("utility_scripts.source_context.subprocess.run", return_value=failed) as run,
+            ):
+                with self.assertRaises(SystemExit):
+                    discover_artifact_metadata(repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            run.assert_called_once()
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                log_content = log_file.read()
+            self.assertNotIn("diagnostic-retry", log_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_source_context.py
+++ b/forge/tests/test_source_context.py
@@ -3,13 +3,48 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import contextlib
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
 
-from utility_scripts.source_context import SourceArtifactContext, prepare_source_contexts
+from utility_scripts.source_context import (
+    GradleBootstrapFailure,
+    SourceArtifactContext,
+    _is_gradle_bootstrap_failure,
+    discover_artifact_metadata,
+    prepare_source_contexts,
+)
+
+SPOTLESS_BOOTSTRAP_OUTPUT = (
+    "Plugin [id: 'com.diffplug.spotless', version: '6.3.0'] was not found\n"
+    "could not resolve plugin artifact "
+    "'com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.3.0'\n"
+    "Searched in the following repositories:\n"
+    "  Gradle Central Plugin Repository\n"
+)
+WRAPPER_DOWNLOAD_FAILURE_OUTPUT = (
+    "Downloading https://services.gradle.org/distributions/gradle-8.14.3-bin.zip\n"
+    'Exception in thread "main" java.net.SocketTimeoutException: Read timed out\n'
+)
+# Observed verbatim from a wrapper bootstrap against an unreachable
+# services.gradle.org: the message is "Connect timed out", not "Connection".
+WRAPPER_CONNECT_TIMEOUT_OUTPUT = (
+    "Downloading https://services.gradle.org/distributions/gradle-9.1.0-bin.zip\n"
+    "\n"
+    'Exception in thread "main" java.io.IOException: Downloading from '
+    "https://services.gradle.org/distributions/gradle-9.1.0-bin.zip failed: timeout (10000ms)\n"
+    "\tat org.gradle.wrapper.Install.forceFetch(SourceFile:4)\n"
+    "\tat org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)\n"
+    "Caused by: java.net.SocketTimeoutException: Connect timed out\n"
+)
+WRAPPER_DOWNLOAD_SUCCESS_OUTPUT = (
+    "Downloading https://services.gradle.org/distributions/gradle-9.1.0-bin.zip\n"
+    "BUILD SUCCESSFUL in 42s\n"
+)
 
 
 class SourceContextTests(unittest.TestCase):
@@ -46,6 +81,115 @@ class SourceContextTests(unittest.TestCase):
                 )
 
             self.assertEqual(downloaded_urls, ["https://example.test/demo-1.0.1-sources.jar"])
+
+
+class DiscoverArtifactMetadataTests(unittest.TestCase):
+    def test_discovery_runs_without_daemon_and_logs_the_attempt(self) -> None:
+        with _discovery_harness([subprocess.CompletedProcess([], 0, stdout="success\n")]) as harness:
+            discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            harness.run.assert_called_once()
+            command = harness.run.call_args.args[0]
+            self.assertEqual(command[:3], ["./gradlew", "--no-daemon", "discoverArtifactMetadata"])
+            self.assertIn("--coordinates=org.example:demo:1.0.0", command)
+            self.assertIn("--agent-command=/bin/true", command)
+            log_content = harness.read_log()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("[forge] Exit code: 0", log_content)
+            self.assertIn("success", log_content)
+
+    def test_spotless_plugin_bootstrap_failure_is_retried_with_dependency_refresh(self) -> None:
+        attempts = [
+            subprocess.CompletedProcess([], 1, stdout=SPOTLESS_BOOTSTRAP_OUTPUT),
+            subprocess.CompletedProcess([], 0, stdout="retry success\n"),
+        ]
+        with _discovery_harness(attempts) as harness:
+            discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(harness.run.call_count, 2)
+            retry_command = harness.run.call_args_list[1].args[0]
+            self.assertIn("--stacktrace", retry_command)
+            self.assertIn("--info", retry_command)
+            self.assertIn("--refresh-dependencies", retry_command)
+            harness.sleep.assert_called_once()
+            log_content = harness.read_log()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("[forge] Gradle discovery attempt: diagnostic-retry", log_content)
+            self.assertIn("retry success", log_content)
+
+    def test_wrapper_download_bootstrap_failure_is_retried(self) -> None:
+        attempts = [
+            subprocess.CompletedProcess([], 1, stdout=WRAPPER_DOWNLOAD_FAILURE_OUTPUT),
+            subprocess.CompletedProcess([], 0, stdout="retry success\n"),
+        ]
+        with _discovery_harness(attempts) as harness:
+            discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(harness.run.call_count, 2)
+
+    def test_wrapper_connect_timeout_is_recognized_as_a_bootstrap_failure(self) -> None:
+        attempts = [
+            subprocess.CompletedProcess([], 1, stdout=WRAPPER_CONNECT_TIMEOUT_OUTPUT),
+            subprocess.CompletedProcess([], 0, stdout="retry success\n"),
+        ]
+        with _discovery_harness(attempts) as harness:
+            discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(harness.run.call_count, 2)
+
+    def test_downloaded_distribution_alone_is_not_a_bootstrap_failure(self) -> None:
+        self.assertFalse(_is_gradle_bootstrap_failure(WRAPPER_DOWNLOAD_SUCCESS_OUTPUT))
+        self.assertFalse(_is_gradle_bootstrap_failure("compileJava FAILED\n"))
+        self.assertFalse(_is_gradle_bootstrap_failure(None))
+
+    def test_exhausted_bootstrap_retry_raises_gradle_bootstrap_failure(self) -> None:
+        failed = subprocess.CompletedProcess([], 1, stdout=SPOTLESS_BOOTSTRAP_OUTPUT)
+        with _discovery_harness([failed, failed]) as harness:
+            with self.assertRaises(GradleBootstrapFailure) as raised:
+                discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            self.assertEqual(harness.run.call_count, 2)
+            self.assertEqual(raised.exception.coordinate, "org.example:demo:1.0.0")
+            self.assertEqual(raised.exception.log_path, harness.log_path)
+            log_content = harness.read_log()
+            self.assertIn("[forge] Gradle discovery attempt: initial", log_content)
+            self.assertIn("[forge] Gradle discovery attempt: diagnostic-retry", log_content)
+
+    def test_library_failure_is_not_retried_and_stays_a_library_failure(self) -> None:
+        failed = subprocess.CompletedProcess([], 1, stdout="compileJava failed\n")
+        with _discovery_harness([failed]) as harness:
+            with self.assertRaises(SystemExit):
+                discover_artifact_metadata(harness.repo, "org.example:demo:1.0.0", agent_command="/bin/true")
+
+            harness.run.assert_called_once()
+            self.assertNotIn("diagnostic-retry", harness.read_log())
+
+
+class _DiscoveryHarness:
+    def __init__(self, repo: str, log_path: str, run, sleep) -> None:
+        self.repo = repo
+        self.log_path = log_path
+        self.run = run
+        self.sleep = sleep
+
+    def read_log(self) -> str:
+        with open(self.log_path, "r", encoding="utf-8") as log_file:
+            return log_file.read()
+
+
+@contextlib.contextmanager
+def _discovery_harness(attempts: list[subprocess.CompletedProcess]):
+    """Run discovery against stubbed Gradle attempts in a throwaway repo."""
+    with tempfile.TemporaryDirectory() as repo:
+        log_path = os.path.join(repo, "discover.log")
+        with (
+            patch("utility_scripts.source_context.require_complete_reachability_repo"),
+            patch("utility_scripts.source_context.build_task_log_path", return_value=log_path),
+            patch("utility_scripts.source_context.gradle_command_environment", return_value={"ENV": "1"}),
+            patch("utility_scripts.source_context.time.sleep") as sleep,
+            patch("utility_scripts.source_context.subprocess.run", side_effect=attempts) as run,
+        ):
+            yield _DiscoveryHarness(repo, log_path, run, sleep)
 
 
 if __name__ == "__main__":

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import subprocess
 import tempfile
 
 FORGE_GRADLE_USER_HOME_ENV = "FORGE_GRADLE_USER_HOME"
@@ -14,12 +15,12 @@ _GRADLE_USER_HOME_ROOT = "metadata-forge-gradle"
 
 
 def gradle_user_home_for_repo(repo_path: str) -> str:
-    """Return the isolated Gradle user home for a reachability-metadata worktree."""
+    """Return the Forge Gradle user home for a reachability-metadata checkout."""
     return _resolve_gradle_user_home(repo_path, os.environ.get(FORGE_GRADLE_USER_HOME_ENV))
 
 
 def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None = None) -> dict[str, str]:
-    """Return an environment that keeps Gradle daemons scoped to one worktree."""
+    """Return an environment that keeps Gradle state scoped to one local clone."""
     env = dict(os.environ if base_env is None else base_env)
     _align_graalvm_java_home(env)
     gradle_user_home = _resolve_gradle_user_home(repo_path, env.get(FORGE_GRADLE_USER_HOME_ENV))
@@ -48,5 +49,35 @@ def _resolve_gradle_user_home(repo_path: str, override: str | None) -> str:
     if override:
         return os.path.abspath(os.path.expanduser(override))
 
-    repo_id = hashlib.sha256(os.path.realpath(repo_path).encode("utf-8")).hexdigest()[:16]
+    repo_id = hashlib.sha256(_gradle_cache_identity(repo_path).encode("utf-8")).hexdigest()[:16]
     return os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT, repo_id)
+
+
+def _gradle_cache_identity(repo_path: str) -> str:
+    git_common_dir = _resolve_git_common_dir(repo_path)
+    if git_common_dir:
+        return git_common_dir
+    return os.path.realpath(repo_path)
+
+
+def _resolve_git_common_dir(repo_path: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    git_common_dir = result.stdout.strip()
+    if not git_common_dir:
+        return None
+    if not os.path.isabs(git_common_dir):
+        git_common_dir = os.path.join(repo_path, git_common_dir)
+    return os.path.realpath(git_common_dir)

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -174,7 +174,13 @@ def _resolve_host_gradle_home(gradle_user_home: str, env: dict[str, str]) -> str
 
 
 def _is_within(path: str, root: str) -> bool:
-    return os.path.commonpath([os.path.realpath(path), os.path.realpath(root)]) == os.path.realpath(root)
+    resolved_root = os.path.realpath(root)
+    try:
+        return os.path.commonpath([os.path.realpath(path), resolved_root]) == resolved_root
+    except ValueError:
+        # Windows raises when the two paths live on different drives, which is
+        # itself proof that `path` is not under `root`.
+        return False
 
 
 def _share_gradle_wrapper_distributions(gradle_user_home: str, override: str | None) -> None:

--- a/forge/utility_scripts/gradle_environment.py
+++ b/forge/utility_scripts/gradle_environment.py
@@ -13,15 +13,17 @@ FORGE_GRADLE_USER_HOME_ENV = "FORGE_GRADLE_USER_HOME"
 FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV = "FORGE_GRADLE_DISTRIBUTIONS_HOME"
 _GRADLE_USER_HOME_ROOT = "metadata-forge-gradle"
 _GRADLE_DISTRIBUTIONS_DIR = "wrapper-dists"
+_GRADLE_PROPERTIES_FILENAME = "gradle.properties"
+_DEFAULT_HOST_GRADLE_HOME_DIR = ".gradle"
 
 
 def gradle_user_home_for_repo(repo_path: str) -> str:
-    """Return the isolated Gradle user home for a reachability-metadata worktree."""
+    """Return the Forge Gradle user home for a reachability-metadata checkout."""
     return _resolve_gradle_user_home(repo_path, os.environ.get(FORGE_GRADLE_USER_HOME_ENV))
 
 
 def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None = None) -> dict[str, str]:
-    """Return an environment that keeps Gradle daemons scoped to one worktree."""
+    """Return an environment that keeps Gradle state scoped to one checkout."""
     env = dict(os.environ if base_env is None else base_env)
     _align_graalvm_java_home(env)
     user_home_override = env.get(FORGE_GRADLE_USER_HOME_ENV)
@@ -29,6 +31,7 @@ def gradle_command_environment(repo_path: str, base_env: dict[str, str] | None =
     os.makedirs(gradle_user_home, exist_ok=True)
     if not user_home_override:
         _share_gradle_wrapper_distributions(gradle_user_home, env.get(FORGE_GRADLE_DISTRIBUTIONS_HOME_ENV))
+        _share_host_gradle_properties(gradle_user_home, env)
     env["GRADLE_USER_HOME"] = gradle_user_home
     return env
 
@@ -53,8 +56,125 @@ def _resolve_gradle_user_home(repo_path: str, override: str | None) -> str:
     if override:
         return os.path.abspath(os.path.expanduser(override))
 
-    repo_id = hashlib.sha256(os.path.realpath(repo_path).encode("utf-8")).hexdigest()[:16]
+    repo_id = hashlib.sha256(_gradle_cache_identity(repo_path).encode("utf-8")).hexdigest()[:16]
     return os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT, repo_id)
+
+
+def _gradle_cache_identity(repo_path: str) -> str:
+    """Return the cache key shared by every linked worktree of one checkout.
+
+    Keying on the common git directory lets all issue worktrees of a checkout
+    resolve the root build's plugins once instead of once per issue
+    (§FS-shared-infrastructure-bootstrap-failure).
+    """
+    return _resolve_git_common_dir(repo_path) or os.path.realpath(repo_path)
+
+
+def _resolve_git_common_dir(repo_path: str) -> str | None:
+    """Return the `.git` directory shared by a checkout and its linked worktrees.
+
+    Read from the filesystem, the way `git rev-parse --git-common-dir` resolves
+    it, so building a Gradle environment never shells out.
+    """
+    git_dir = _resolve_git_dir(repo_path)
+    if git_dir is None:
+        return None
+    common_dir = _read_git_pointer_file(os.path.join(git_dir, "commondir"))
+    if common_dir is None:
+        return os.path.realpath(git_dir)
+    if not os.path.isabs(common_dir):
+        common_dir = os.path.join(git_dir, common_dir)
+    return os.path.realpath(common_dir)
+
+
+def _resolve_git_dir(repo_path: str) -> str | None:
+    """Return the git directory of the checkout containing `repo_path`."""
+    current = os.path.realpath(repo_path)
+    while True:
+        git_path = os.path.join(current, ".git")
+        if os.path.isdir(git_path):
+            return git_path
+        if os.path.isfile(git_path):
+            return _resolve_linked_git_dir(current, git_path)
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def _resolve_linked_git_dir(repo_path: str, git_file_path: str) -> str | None:
+    pointer = _read_git_pointer_file(git_file_path, prefix="gitdir:")
+    if pointer is None:
+        return None
+    if not os.path.isabs(pointer):
+        pointer = os.path.join(repo_path, pointer)
+    return pointer
+
+
+def _read_git_pointer_file(path: str, prefix: str | None = None) -> str | None:
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as pointer_file:
+            content = pointer_file.read()
+    except OSError:
+        return None
+    for line in content.splitlines():
+        candidate = line.strip()
+        if prefix is not None:
+            if not candidate.startswith(prefix):
+                continue
+            candidate = candidate[len(prefix):].strip()
+        if candidate:
+            return candidate
+    return None
+
+
+def _share_host_gradle_properties(gradle_user_home: str, env: dict[str, str]) -> None:
+    """Link the host's `gradle.properties` into the isolated Gradle user home.
+
+    Isolating Gradle state must not discard host Gradle configuration. On a host
+    that reaches Maven Central and the Gradle plugin repository only through an
+    HTTP proxy, that file carries the proxy settings, and an isolated home
+    without it fails every plugin and distribution download during root-build
+    configuration (§FS-shared-infrastructure-bootstrap-failure).
+    """
+    host_properties = _resolve_host_gradle_properties(gradle_user_home, env)
+    if host_properties is None:
+        return
+
+    link_path = os.path.join(gradle_user_home, _GRADLE_PROPERTIES_FILENAME)
+    if os.path.islink(link_path) or os.path.exists(link_path):
+        return
+
+    # Linked rather than copied so host credentials in the file are not duplicated
+    # into a shared temporary directory.
+    try:
+        os.symlink(host_properties, link_path)
+    except OSError:
+        return
+
+
+def _resolve_host_gradle_properties(gradle_user_home: str, env: dict[str, str]) -> str | None:
+    host_home = _resolve_host_gradle_home(gradle_user_home, env)
+    host_properties = os.path.join(host_home, _GRADLE_PROPERTIES_FILENAME)
+    return host_properties if os.path.isfile(host_properties) else None
+
+
+def _resolve_host_gradle_home(gradle_user_home: str, env: dict[str, str]) -> str:
+    forge_homes_root = os.path.join(tempfile.gettempdir(), _GRADLE_USER_HOME_ROOT)
+    inherited_home = env.get("GRADLE_USER_HOME")
+    if inherited_home:
+        inherited_home = os.path.abspath(os.path.expanduser(inherited_home))
+        # An inherited value pointing at a Forge home is this layer's own output
+        # from an outer call, not host configuration.
+        if not _is_within(inherited_home, forge_homes_root) and inherited_home != gradle_user_home:
+            return inherited_home
+    return os.path.join(os.path.expanduser("~"), _DEFAULT_HOST_GRADLE_HOME_DIR)
+
+
+def _is_within(path: str, root: str) -> bool:
+    return os.path.commonpath([os.path.realpath(path), os.path.realpath(root)]) == os.path.realpath(root)
 
 
 def _share_gradle_wrapper_distributions(gradle_user_home: str, override: str | None) -> None:

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -5,10 +5,12 @@
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import tarfile
+import time
 import urllib.parse
 import urllib.request
 import zipfile
@@ -48,6 +50,18 @@ TEST_FILE_EXTENSIONS_BY_LANGUAGE = {
     "scala": (".scala",),
 }
 DEFAULT_TEST_FILE_EXTENSIONS = TEST_FILE_EXTENSIONS_BY_LANGUAGE[DEFAULT_TEST_LANGUAGE]
+GRADLE_BOOTSTRAP_RETRY_DELAY_SECONDS = 5
+
+
+class GradleBootstrapFailure(RuntimeError):
+    """Raised when shared Gradle bootstrap infrastructure prevents discovery."""
+
+    def __init__(self, coordinate: str, log_path: str):
+        self.coordinate = coordinate
+        self.log_path = log_path
+        super().__init__(
+            f"Gradle bootstrap failed for {coordinate}. See {display_log_path(log_path)} for details."
+        )
 
 
 @dataclass(frozen=True)
@@ -173,30 +187,133 @@ def discover_artifact_metadata(
     log_path = build_task_log_path("discover-artifact-metadata", coordinate, "discover_artifact_metadata.log")
     log_path_display = display_log_path(log_path)
     log_stage("discover-artifact-metadata", f"Discovering artifact metadata for {coordinate}; output: {log_path_display}")
-    command = [
-        "./gradlew",
-        "discoverArtifactMetadata",
-        f"--coordinates={coordinate}",
-        f"--agent-command={agent_command}",
-    ]
-    result = subprocess.run(
-        command,
-        cwd=reachability_repo_path,
-        env=gradle_command_environment(reachability_repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
-    )
-    with open(log_path, "w", encoding="utf-8") as log_file:
-        log_file.write(result.stdout)
+    command = _discover_artifact_metadata_command(coordinate, agent_command)
+    command_env = gradle_command_environment(reachability_repo_path)
+    result = _run_gradle_discovery_command(command, reachability_repo_path, command_env)
+    log_entries = [_format_gradle_attempt_log("initial", command, result)]
+    _write_gradle_attempt_logs(log_path, log_entries)
+
+    if result.returncode != 0 and _is_gradle_bootstrap_failure(result.stdout):
+        retry_command = _discover_artifact_metadata_command(coordinate, agent_command, diagnostics=True)
+        log_stage(
+            "discover-artifact-metadata",
+            (
+                "Gradle bootstrap failed for {coordinate}; retrying once "
+                "with dependency refresh and diagnostic logging"
+            ).format(coordinate=coordinate),
+        )
+        time.sleep(GRADLE_BOOTSTRAP_RETRY_DELAY_SECONDS)
+        result = _run_gradle_discovery_command(retry_command, reachability_repo_path, command_env)
+        log_entries.append(_format_gradle_attempt_log("diagnostic-retry", retry_command, result))
+        _write_gradle_attempt_logs(log_path, log_entries)
+
     if result.returncode != 0:
+        if _is_gradle_bootstrap_failure(result.stdout):
+            print(
+                f"ERROR: Gradle bootstrap failed for {coordinate}. See {log_path_display} for details.",
+                file=sys.stderr,
+            )
+            raise GradleBootstrapFailure(coordinate, log_path)
         print(
             f"ERROR: discoverArtifactMetadata failed for {coordinate}. See {log_path_display} for details.",
             file=sys.stderr,
         )
         raise SystemExit(1)
     log_stage("discover-artifact-metadata", f"Artifact metadata discovered for {coordinate}")
+
+
+def _discover_artifact_metadata_command(
+        coordinate: str,
+        agent_command: str,
+        diagnostics: bool = False,
+) -> list[str]:
+    command = ["./gradlew", "--no-daemon"]
+    if diagnostics:
+        command.extend(["--stacktrace", "--info", "--refresh-dependencies"])
+    command.extend([
+        "discoverArtifactMetadata",
+        f"--coordinates={coordinate}",
+        f"--agent-command={agent_command}",
+    ])
+    return command
+
+
+def _run_gradle_discovery_command(
+        command: list[str],
+        reachability_repo_path: str,
+        command_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=reachability_repo_path,
+        env=command_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+
+def _format_gradle_attempt_log(
+        attempt_name: str,
+        command: list[str],
+        result: subprocess.CompletedProcess[str],
+) -> str:
+    rendered_command = " ".join(shlex.quote(part) for part in command)
+    output = result.stdout or ""
+    if output and not output.endswith("\n"):
+        output += "\n"
+    return (
+        f"[forge] Gradle discovery attempt: {attempt_name}\n"
+        f"[forge] Exit code: {result.returncode}\n"
+        f"$ {rendered_command}\n\n"
+        f"{output}"
+    )
+
+
+def _write_gradle_attempt_logs(log_path: str, log_entries: list[str]) -> None:
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write("\n\n".join(log_entries))
+
+
+def _is_gradle_bootstrap_failure(output: str | None) -> bool:
+    return (
+        _is_spotless_plugin_bootstrap_failure(output)
+        or _is_gradle_wrapper_download_failure(output)
+    )
+
+
+def _is_spotless_plugin_bootstrap_failure(output: str | None) -> bool:
+    if not output:
+        return False
+    normalized = output.lower()
+    return (
+        "com.diffplug.spotless" in normalized
+        and (
+            "could not resolve plugin artifact" in normalized
+            or "plugin [id: 'com.diffplug.spotless'" in normalized
+        )
+        and (
+            "was not found" in normalized
+            or "gradle central plugin repository" in normalized
+            or "plugin repositories" in normalized
+        )
+    )
+
+
+def _is_gradle_wrapper_download_failure(output: str | None) -> bool:
+    if not output:
+        return False
+    normalized = output.lower()
+    return (
+        "services.gradle.org/distributions/gradle-" in normalized
+        and (
+            "read timed out" in normalized
+            or "connection timed out" in normalized
+            or "connection reset" in normalized
+            or "could not install gradle distribution" in normalized
+        )
+    )
 
 
 def prepare_source_contexts(

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -14,10 +14,12 @@ starts.
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import tarfile
+import time
 import urllib.parse
 import urllib.request
 import zipfile
@@ -57,6 +59,39 @@ TEST_FILE_EXTENSIONS_BY_LANGUAGE = {
     "scala": (".scala",),
 }
 DEFAULT_TEST_FILE_EXTENSIONS = TEST_FILE_EXTENSIONS_BY_LANGUAGE[DEFAULT_TEST_LANGUAGE]
+GRADLE_BOOTSTRAP_RETRY_DELAY_SECONDS = 5
+# A wrapper failure is only ever reported alongside the distribution URL it was
+# fetching, so that URL is the narrowing guard and the markers below only have to
+# separate a failed fetch from a successful one.
+GRADLE_DISTRIBUTION_URL_MARKER = "services.gradle.org/distributions/gradle-"
+GRADLE_WRAPPER_DOWNLOAD_FAILURE_MARKERS = (
+    "org.gradle.wrapper.install",
+    "could not install gradle distribution",
+    "sockettimeoutexception",
+    "unknownhostexception",
+    "read timed out",
+    "connect timed out",
+    "connection timed out",
+    "connection reset",
+    "connection refused",
+)
+
+
+class GradleBootstrapFailure(RuntimeError):
+    """Raised when shared Gradle bootstrap infrastructure prevents discovery.
+
+    A configuration-time Gradle failure is host-wide, not a property of the
+    claimed library, so the control plane releases the claim without
+    `human-intervention` and stops the run
+    (§FS-shared-infrastructure-bootstrap-failure).
+    """
+
+    def __init__(self, coordinate: str, log_path: str):
+        self.coordinate = coordinate
+        self.log_path = log_path
+        super().__init__(
+            f"Gradle bootstrap failed for {coordinate}. See {display_log_path(log_path)} for details."
+        )
 
 
 @dataclass(frozen=True)
@@ -208,34 +243,136 @@ def discover_artifact_metadata(
         coordinate: str,
         agent_command: str = DEFAULT_POPULATE_AGENT_COMMAND,
 ) -> None:
+    """Discover artifact metadata, separating bootstrap outages from library failures.
+
+    This is the first Gradle invocation of a new-library run, so a shared
+    bootstrap outage surfaces here. It is retried once with a dependency refresh
+    and, if still failing, reported as `GradleBootstrapFailure` rather than as
+    this library's failure (§FS-shared-infrastructure-bootstrap-failure).
+    """
     require_complete_reachability_repo(reachability_repo_path)
     log_path = build_task_log_path("discover-artifact-metadata", coordinate, "discover_artifact_metadata.log")
     log_path_display = display_log_path(log_path)
     log_stage("discover-artifact-metadata", f"Discovering artifact metadata for {coordinate}; output: {log_path_display}")
-    command = [
-        "./gradlew",
-        "discoverArtifactMetadata",
-        f"--coordinates={coordinate}",
-        f"--agent-command={agent_command}",
-    ]
-    result = subprocess.run(
-        command,
-        cwd=reachability_repo_path,
-        env=gradle_command_environment(reachability_repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
-    )
-    with open(log_path, "w", encoding="utf-8") as log_file:
-        log_file.write(result.stdout)
+    command = _discover_artifact_metadata_command(coordinate, agent_command)
+    command_env = gradle_command_environment(reachability_repo_path)
+    result = _run_gradle_discovery_command(command, reachability_repo_path, command_env)
+    attempt_logs = [_format_gradle_attempt_log("initial", command, result)]
+    _write_gradle_attempt_logs(log_path, attempt_logs)
+
+    if result.returncode != 0 and _is_gradle_bootstrap_failure(result.stdout):
+        retry_command = _discover_artifact_metadata_command(coordinate, agent_command, diagnostics=True)
+        log_stage(
+            "discover-artifact-metadata",
+            (
+                f"Gradle bootstrap failed for {coordinate}; retrying once with "
+                "dependency refresh and diagnostic logging"
+            ),
+        )
+        time.sleep(GRADLE_BOOTSTRAP_RETRY_DELAY_SECONDS)
+        result = _run_gradle_discovery_command(retry_command, reachability_repo_path, command_env)
+        attempt_logs.append(_format_gradle_attempt_log("diagnostic-retry", retry_command, result))
+        _write_gradle_attempt_logs(log_path, attempt_logs)
+
     if result.returncode != 0:
+        if _is_gradle_bootstrap_failure(result.stdout):
+            print(
+                f"ERROR: Gradle bootstrap failed for {coordinate}. See {log_path_display} for details.",
+                file=sys.stderr,
+            )
+            raise GradleBootstrapFailure(coordinate, log_path)
         print(
             f"ERROR: discoverArtifactMetadata failed for {coordinate}. See {log_path_display} for details.",
             file=sys.stderr,
         )
         raise SystemExit(1)
     log_stage("discover-artifact-metadata", f"Artifact metadata discovered for {coordinate}")
+
+
+def _discover_artifact_metadata_command(
+        coordinate: str,
+        agent_command: str,
+        diagnostics: bool = False,
+) -> list[str]:
+    command = ["./gradlew", "--no-daemon"]
+    if diagnostics:
+        command.extend(["--stacktrace", "--info", "--refresh-dependencies"])
+    command.extend([
+        "discoverArtifactMetadata",
+        f"--coordinates={coordinate}",
+        f"--agent-command={agent_command}",
+    ])
+    return command
+
+
+def _run_gradle_discovery_command(
+        command: list[str],
+        reachability_repo_path: str,
+        command_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=reachability_repo_path,
+        env=command_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+
+def _format_gradle_attempt_log(
+        attempt_name: str,
+        command: list[str],
+        result: subprocess.CompletedProcess[str],
+) -> str:
+    rendered_command = " ".join(shlex.quote(part) for part in command)
+    output = result.stdout or ""
+    if output and not output.endswith("\n"):
+        output += "\n"
+    return (
+        f"[forge] Gradle discovery attempt: {attempt_name}\n"
+        f"[forge] Exit code: {result.returncode}\n"
+        f"$ {rendered_command}\n\n"
+        f"{output}"
+    )
+
+
+def _write_gradle_attempt_logs(log_path: str, attempt_logs: list[str]) -> None:
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write("\n\n".join(attempt_logs))
+
+
+def _is_gradle_bootstrap_failure(output: str | None) -> bool:
+    """Return True when Gradle failed before leaving root-build configuration."""
+    return _is_spotless_plugin_bootstrap_failure(output) or _is_gradle_wrapper_download_failure(output)
+
+
+def _is_spotless_plugin_bootstrap_failure(output: str | None) -> bool:
+    if not output:
+        return False
+    normalized = output.lower()
+    return (
+        "com.diffplug.spotless" in normalized
+        and (
+            "could not resolve plugin artifact" in normalized
+            or "plugin [id: 'com.diffplug.spotless'" in normalized
+        )
+        and (
+            "was not found" in normalized
+            or "gradle central plugin repository" in normalized
+            or "plugin repositories" in normalized
+        )
+    )
+
+
+def _is_gradle_wrapper_download_failure(output: str | None) -> bool:
+    if not output:
+        return False
+    normalized = output.lower()
+    if GRADLE_DISTRIBUTION_URL_MARKER not in normalized:
+        return False
+    return any(marker in normalized for marker in GRADLE_WRAPPER_DOWNLOAD_FAILURE_MARKERS)
 
 
 def prepare_source_contexts(


### PR DESCRIPTION
## What does this PR do?

Forge issue runs stopped in `discover-artifact-metadata` while configuring the root Gradle build because `com.diffplug.spotless` could not be resolved from Maven Local or the Gradle plugin repositories. Each stop was charged to whichever library happened to be in flight, so one host-wide condition produced many unrelated `human-intervention` items.

**Root cause (found while validating this PR, and now fixed):** Forge isolates the Gradle *user home* but did not carry over host Gradle *configuration*. On a host that reaches Maven Central and the Gradle plugin repository only through an HTTP proxy, `~/.gradle/gradle.properties` carries the proxy settings — so an isolated home without it fails every plugin and distribution download **deterministically**, after a full connect timeout. Reproduced on a clean checkout: a cold isolated Forge Gradle home failed the Spotless plugin resolution after `BUILD FAILED in 6m 7s`; with the host `gradle.properties` present, the same discovery is `BUILD SUCCESSFUL in 35s`.

The PR therefore fixes the cause and keeps a safety net for the transient case:

- links the host `gradle.properties` into the isolated Gradle user home — linked rather than copied so host credentials are not duplicated into a shared temporary directory; an explicit `FORGE_GRADLE_USER_HOME` is taken as given and left alone. Inheritance is deliberately wholesale rather than filtered to proxy keys, so a Forge run behaves the way `./gradlew` behaves for a developer on that host; filtering would require writing a copy, which is precisely what would duplicate a host proxy password into a shared temp dir. The accepted cost is precedence: a Gradle user home `gradle.properties` outranks the repository's own, so a host that sets keys like `org.gradle.java.home` overrides repository intent for Forge runs. Hosts are expected to keep that file to host concerns such as proxy configuration.
- keys the Gradle user home on the checkout's common git directory (resolved from the filesystem the way `git rev-parse --git-common-dir` does, so building an environment never shells out), so all linked issue worktrees of a checkout share one plugin/dependency cache
- runs discovery through `./gradlew --no-daemon` and records structured per-attempt logs (attempt name, exit code, rendered command, output)
- detects Spotless plugin and Gradle wrapper distribution bootstrap failures and retries once with `--stacktrace --info --refresh-dependencies`
- raises `GradleBootstrapFailure` after the retry is exhausted. It is a **typed external failure**, so the existing external-failure boundary releases the claim with no `human-intervention` label, no comment, and no failed-work preservation; because the cause is host-wide, the run also stops after reverting still-active claims and exits with a dedicated status that the do-work loop retries after its normal sleep — the same shape as a rate-limit stop.

This is a rebase and redesign of the original May version of this PR onto current `master`, which has since grown a typed external-failure boundary and an explicit human-intervention classification policy. The stop now flows through that boundary and reports its own reason and exit code instead of masquerading as a Ctrl+C.

Spec: new `FS-shared-infrastructure-bootstrap-failure`, plus the third typed external boundary added to `FS-human-intervention-policy`.

## Validation

- `PYTHONPATH=forge python -m pytest forge/tests -q` → **363 passed**, 3 failures that are pre-existing on `master` (`test_library_update_passes_issue_requested_metadata_context_to_workflow`, `test_fixture_issue_listing_can_exclude_non_user_authors`, `test_validate_no_scaffold_placeholders_rejects_placeholder_text`). `master` itself reports 5 failures / 340 passed; two of those were `InterruptHandlingTests` cases that assumed a pre-existing `/tmp/reachability` directory, which this PR makes environment-independent.
- `grund check` → clean (only the two pre-existing `outdated grund init block` warnings on `AGENTS.md` and `forge/AGENTS.md`).
- Real Gradle runs, full failure path: initial `--no-daemon` attempt failed with the exact `Plugin [id: 'com.diffplug.spotless', version: '6.3.0'] was not found` error, was classified as a bootstrap failure, retried with `--stacktrace --info --refresh-dependencies`, and raised `GradleBootstrapFailure` with both attempts in one structured log.
- Real Gradle run, fixed path: after the `gradle.properties` link, `discover_artifact_metadata` for `org.postgresql:postgresql:42.7.3` succeeded through a cold isolated Forge Gradle home in one attempt.
- Filesystem common-dir resolution is asserted equal to `git rev-parse --git-common-dir` for a checkout, a linked worktree, and a nested subdirectory; also verified against this repo's real Forge worktrees.
- The `Connect timed out` wrapper-download message observed from a real failing bootstrap is kept as a test fixture — the original pattern only matched `Connection timed out` and missed it.

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/gradle_environment.py` reads `.git` / `commondir` pointer files to derive the Gradle cache identity, and symlinks the host `gradle.properties` into the isolated Gradle user home.
- `forge/utility_scripts/source_context.py` runs `./gradlew discoverArtifactMetadata` and may access Gradle plugin/dependency repositories during bootstrap and the diagnostic retry.

## Open question

- **Fixture E2E not completed.** Per `CLAUDE.md` I ran the hermetic fixture E2E (`--fixture-testing --issue-number 9101`). It got through fixture routing, isolated worktree setup, library preflight, and dispatch, then failed for two environmental reasons unrelated to this change: a leftover worktree from an earlier run still holds `ai/vjovanov/add-lib-support-com.google.http-client-google-http-client-1.42.2` (`git switch -C` → exit 128), and the agent workspace has hit its spend cap, so both the preflight and the failure analysis returned errors. A clean fixture E2E needs the stale worktree pruned and agent budget available. Worth noting the run did show the generic failure path still behaving correctly around the new `GradleBootstrapFailure` clause: the `CalledProcessError` was classified as logical and went through failed-work preservation.
- **Follow-up on the affected issues.** This PR intentionally does not remove `human-intervention` from the originally affected issues (#2166, #2631, #2740, #3603, #3689, #5400, #5434, #5467, #5471, #5474, #5476, #5478, #5480, #5483, #5490, #5493, #5505, #5507, #5510, #5511). The follow-up is to rerun representative ones after this lands and clear the label only where discovery now passes.
