### PR TITLE
[Forge] Handle discovery metadata-version drift

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java
@@ -161,7 +161,7 @@ public class DiscoverArtifactMetadata extends DefaultTask {
                 Mark "not-for-native-image": true only for certain cases such as Android-only AAR/tooling artifacts, Scala.js artifacts, Kotlin Native/JS/Wasm artifacts, or artifacts with no JVM class files.
                 If you set "not-for-native-image": true, also set "reason" to a short evidence-based explanation and set "replacement" when there is an obvious JVM replacement artifact.
                 If the artifact might still be usable from JVM code, leave "not-for-native-image", "reason", and "replacement" absent.
-                The sources URL, the test suite URL, and the documentation URL must render to the entry metadata-version "%s" when "$version$" is replaced with "%s".
+                The sources URL, the test suite URL, and the documentation URL must render to the metadata index version "%s" when "$version$" is replaced with "%s".
                 The source, test suite, and documentation URLs should point to the right tag of the library.
                 If we have these source of these artifacts on maven, that should be prefered.
                 If there are tests on maven that should also be prefered.
@@ -169,6 +169,8 @@ public class DiscoverArtifactMetadata extends DefaultTask {
 
                 Update this file directly:
                 - File: %s
+                - Use only these top-level JSON keys: "coordinates", "repository-url", "source-code-url", "test-code-url", "documentation-url", "description", "language", "not-for-native-image", "reason", and "replacement".
+                - Do not add "metadata-version"; the metadata index version is derived from the coordinate version later.
                 - Set "coordinates" to "%s".
                 - Set "repository-url" to the discovered repository root URL.
                 - Set "source-code-url", "test-code-url", and "documentation-url" to the discovered values with "$version$" replacing version "%s".

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/DiscoveredArtifactMetadata.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/DiscoveredArtifactMetadata.java
@@ -6,11 +6,13 @@
  */
 package org.graalvm.internal.tck.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Build-local discovered metadata for a single library coordinate.
  */
+@JsonIgnoreProperties("metadata-version")
 public record DiscoveredArtifactMetadata(
         String coordinates,
         @JsonProperty("source-code-url")

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadataTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadataTests.java
@@ -51,12 +51,47 @@ class DiscoverArtifactMetadataTests {
                 .contains("{ \"name\": \"groovy\", \"version\": \"<groovy major.minor, e.g. 4.0>\" }")
                 .contains("{ \"name\": \"scala\", \"version\": \"3\" }")
                 .contains("If the library is not language-specific, leave the \"language\" field absent.")
-                .contains("The sources URL, the test suite URL, and the documentation URL must render to the entry metadata-version \"3.1.0\" when \"$version$\" is replaced with \"3.1.0\".")
+                .contains("The sources URL, the test suite URL, and the documentation URL must render to the metadata index version \"3.1.0\" when \"$version$\" is replaced with \"3.1.0\".")
                 .contains("Update this file directly:")
+                .contains("Use only these top-level JSON keys: \"coordinates\", \"repository-url\", \"source-code-url\", \"test-code-url\", \"documentation-url\", \"description\", \"language\", \"not-for-native-image\", \"reason\", and \"replacement\".")
+                .contains("Do not add \"metadata-version\"; the metadata index version is derived from the coordinate version later.")
                 .contains("Set \"coordinates\" to \"io.ktor:ktor-server-core-jvm:3.1.0\".")
                 .contains("Set \"source-code-url\", \"test-code-url\", and \"documentation-url\" to the discovered values with \"$version$\" replacing version \"3.1.0\".")
                 .contains("build/discovered-artifact-metadata/io.ktor-ktor-server-core-jvm-3.1.0.json");
         assertThat(tempDir.resolve("build/agent-artifact-discovery-logs")).doesNotExist();
+    }
+
+    @Test
+    void runAcceptsRedundantMetadataVersionFromAgent() throws IOException, InterruptedException {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        DiscoverArtifactMetadata task = project.getTasks().create("discoverArtifactMetadata", DiscoverArtifactMetadata.class);
+        task.setCoordinatesOption("io.ktor:ktor-server-core-jvm:3.1.0");
+
+        Path discoveryFile = tempDir.resolve("build/discovered-artifact-metadata/io.ktor-ktor-server-core-jvm-3.1.0.json");
+        Path agentScript = tempDir.resolve("write-discovery-json.sh");
+        Files.writeString(agentScript, """
+                #!/bin/sh
+                cat > '%s' <<'JSON'
+                {
+                  "coordinates": "io.ktor:ktor-server-core-jvm:3.1.0",
+                  "metadata-version": "3.1.0",
+                  "source-code-url": "https://github.com/ktorio/ktor/tree/$version$",
+                  "repository-url": "https://github.com/ktorio/ktor",
+                  "test-code-url": "https://github.com/ktorio/ktor/tree/$version$/ktor-server",
+                  "documentation-url": "https://github.com/ktorio/ktor/tree/$version$/README.md",
+                  "description": "Ktor server core provides the central APIs for building asynchronous JVM server applications. It supplies routing, pipeline, and application abstractions used by Ktor server integrations."
+                }
+                JSON
+                """.formatted(discoveryFile.toString()), StandardCharsets.UTF_8);
+        assertThat(agentScript.toFile().setExecutable(true)).isTrue();
+
+        task.setAgentCommandOption(agentScript.toString());
+
+        task.run();
+
+        assertThat(discoveryFile).exists();
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Root cause: the external artifact-discovery agent could write build-local discovery JSON with a top-level `"metadata-version"` field. That was plausible because the prompt said `entry metadata-version` and repository index examples contain `"metadata-version"`, but the build-local discovery file is read back through strict Jackson binding to `DiscoveredArtifactMetadata`, which does not model that field. The result was `UnrecognizedPropertyException` in `:discoverArtifactMetadata` before scaffold generation, metadata generation, tests, stats, or Native Image execution.

This PR fixes the discovery contract narrowly:

- clarifies that URL checks target the derived metadata index version, not a discovery-file field
- lists the allowed top-level discovery JSON keys and explicitly tells the agent not to add `"metadata-version"`
- accepts only the redundant `"metadata-version"` field when rereading `DiscoveredArtifactMetadata`, while keeping other unknown discovery-file properties strict
- adds a regression test that runs the post-agent `DiscoverArtifactMetadata.run()` path against an agent script that writes a discovery file containing `"metadata-version"`

GitHub human-intervention items addressed:

- Addresses #4865 for `com.softwaremill.sttp.tapir:tapir-json-circe_3:1.11.25`
- Addresses #5322 for `org.jetbrains.exposed:exposed-dao:1.2.0`

Validation:

- `git diff --check origin/master...HEAD` passed on the clean PR branch
- `./gradlew -p tests/tck-build-logic --no-daemon test --tests org.graalvm.internal.tck.harness.tasks.DiscoverArtifactMetadataTests --stacktrace` passed on the clean PR branch with `BUILD SUCCESSFUL in 9s`
- reviewed fix-pass validation also passed the full `tests/tck-build-logic` suite after the binding change
- reviewed Forge reruns passed `discoverArtifactMetadata` for both affected coordinates using `codex -a never exec -s danger-full-access`, and both reruns completed without the `Unrecognized field "metadata-version"` failure

The original issue labels are intentionally left for post-merge Forge rerun cleanup: after this PR lands, rerun the affected issues on the fixed Forge code and remove `human-intervention` only from items whose discovery reruns pass; later library-specific failures should be handled as narrower follow-up classes.

## Code sections where the PR accesses files, network, docker or some external service

- `tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/DiscoverArtifactMetadata.java` writes and reads build-local discovery JSON and runs the configured external artifact-discovery agent command. That agent command can access the network depending on the Forge invocation.
- `tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/DiscoveredArtifactMetadata.java` controls Jackson binding for the build-local discovery JSON file.