### PR TITLE
[GenAI] Add support for com.typesafe.play:play_2.13:2.9.10 using gpt-5.5

### DIFF
--- a/metadata/com.typesafe.play/play_2.13/2.9.10/reachability-metadata.json
+++ b/metadata/com.typesafe.play/play_2.13/2.9.10/reachability-metadata.json
@@ -1,0 +1,119 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "play.api.inject.Modules$"
+      },
+      "type" : "Module",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.inject.Modules$"
+      },
+      "type" : "ModulesTestConfiguredModule",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "play.api.Environment",
+            "play.api.Configuration"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.core.routing.HandlerInvokerFactory$"
+      },
+      "type" : "RelativeHandlerInvokerFactoryController",
+      "methods" : [
+        {
+          "name" : "show",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "application.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "application.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "application.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "reference.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "reference.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "reference.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "play/reference-overrides.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "version.conf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "version.json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.Configuration$"
+      },
+      "glob" : "version.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.i18n.DefaultMessagesApiProvider"
+      },
+      "glob" : "messages.en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.i18n.DefaultMessagesApiProvider"
+      },
+      "glob" : "messages.default"
+    }
+  ]
+}

--- a/metadata/com.typesafe.play/play_2.13/index.json
+++ b/metadata/com.typesafe.play/play_2.13/index.json
@@ -1,0 +1,24 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.9.10",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/play/play_2.13/$version$/play_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/playframework/playframework",
+    "test-code-url" : "https://github.com/playframework/playframework/tree/$version$/core/play/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/typesafe/play/play_2.13/$version$/play_2.13-$version$-javadoc.jar",
+    "description" : "Play Framework is a JVM web framework for building scalable, stateless applications in Java and Scala with asynchronous request handling, routing, controllers, templating, JSON, WebSocket, and asset support. This play_2.13 artifact provides the Scala 2.13 core Play APIs and runtime pieces used by Play applications and related Play modules.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "2.9.10"
+    ],
+    "allowed-packages" : [
+      "controllers",
+      "models",
+      "play",
+      "views"
+    ]
+  }
+]

--- a/stats/com.typesafe.play/play_2.13/2.9.10/execution-metrics.json
+++ b/stats/com.typesafe.play/play_2.13/2.9.10/execution-metrics.json
@@ -1,0 +1,68 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T05:38:05.446440Z",
+    "library": "com.typesafe.play:play_2.13:2.9.10",
+    "starting_commit": "76afd89a88104027139e6a93ad38a268c6dc31f8",
+    "ending_commit": "90d7155b6a9a3cbadc35e752dde9872d80d7bd97",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.9.10",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 36,
+            "totalCalls": 36
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 41,
+        "totalCalls": 41
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7116,
+          "missed": 156360,
+          "ratio": 0.043529,
+          "total": 163476
+        },
+        "line": {
+          "covered": 1080,
+          "missed": 11850,
+          "ratio": 0.083527,
+          "total": 12930
+        },
+        "method": {
+          "covered": 724,
+          "missed": 16796,
+          "ratio": 0.041324,
+          "total": 17520
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 440300,
+      "cached_input_tokens_used": 5008384,
+      "output_tokens_used": 70941,
+      "iterations": 18,
+      "cost_usd": 4.6324,
+      "generated_loc": 662,
+      "tested_library_loc": 1080,
+      "metadata_entries": 18,
+      "test_only_metadata_entries": 30,
+      "code_coverage_percent": 8.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/ModulesTest.scala",
+      "metadata_file": "metadata/com.typesafe.play/play_2.13/2.9.10/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.typesafe.play/play_2.13/2.9.10/stats.json
+++ b/stats/com.typesafe.play/play_2.13/2.9.10/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.9.10",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 36,
+          "totalCalls" : 36
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 41,
+      "totalCalls" : 41
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 7116,
+        "missed" : 156360,
+        "ratio" : 0.043529,
+        "total" : 163476
+      },
+      "line" : {
+        "covered" : 1080,
+        "missed" : 11850,
+        "ratio" : 0.083527,
+        "total" : 12930
+      },
+      "method" : {
+        "covered" : 724,
+        "missed" : 16796,
+        "ratio" : 0.041324,
+        "total" : 17520
+      }
+    }
+  } ]
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/.gitignore
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.typesafe.play:play_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/gradle.properties
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.typesafe.play:play_2.13:2.9.10
+library.version = 2.9.10
+metadata.dir = com.typesafe.play/play_2.13/2.9.10/

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/settings.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.typesafe.play.play_2.13_tests'

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,174 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "play.api.ApplicationLoader$"
+      },
+      "type" : "com_typesafe_play.play_2_13.JavaConfiguredApplicationLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.ApplicationLoader$"
+      },
+      "type" : "com_typesafe_play.play_2_13.ScalaConfiguredApplicationLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.LoggerConfigurator$"
+      },
+      "type" : "com_typesafe_play.play_2_13.TestLoggerConfigurator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.libs.reflect.MethodUtils"
+      },
+      "type" : "com_typesafe_play.play_2_13.ExactMatchingMethodTarget",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.libs.reflect.MethodUtils"
+      },
+      "type" : "com_typesafe_play.play_2_13.AssignableMatchingMethodTarget",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.mvc.PathBindable$$anon$12"
+      },
+      "type" : "com_typesafe_play.play_2_13.JavaBackedPathParameter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.mvc.QueryStringBindable$$anon$11"
+      },
+      "type" : "com_typesafe_play.play_2_13.JavaBackedQueryStringParameter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.http.EnabledFilters"
+      },
+      "type" : "com_typesafe_play.play_2_13.EnabledFiltersTestFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.utils.Reflect$"
+      },
+      "type" : "com_typesafe_play.play_2_13.ReflectDefaultConstructibleService",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.inject.NewInstanceInjector$"
+      },
+      "type" : "com_typesafe_play.play_2_13.NewInstanceConstructibleService",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.core.routing.HandlerInvokerFactory$"
+      },
+      "type" : "com_typesafe_play.play_2_13.DirectHandlerInvokerFactoryController",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "index",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.core.routing.HandlerInvokerFactory$"
+      },
+      "type" : "com_typesafe_play.play_2_13.RelativeHandlerInvokerFactoryController",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "show",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.core.routing.HandlerInvokerFactory$"
+      },
+      "type" : "com_typesafe_play.play_2_13.HandlerInvokerFactoryNoOpBodyParser",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "play.api.LoggerConfigurator$"
+      },
+      "glob" : "logger-configurator.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.i18n.DefaultMessagesApiProvider"
+      },
+      "glob" : "messages"
+    },
+    {
+      "condition" : {
+        "typeReached" : "play.api.mvc.Results$Status"
+      },
+      "glob" : "results-status-resource.txt"
+    }
+  ]
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/logger-configurator.properties
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/logger-configurator.properties
@@ -1,0 +1,1 @@
+play.logger.configurator=com_typesafe_play.play_2_13.TestLoggerConfigurator

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/messages
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/messages
@@ -1,0 +1,1 @@
+dynamic.access.coverage.message=Loaded by DefaultMessagesApiProvider

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/results-status-resource.txt
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/results-status-resource.txt
@@ -1,0 +1,1 @@
+status resource body

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/ModulesTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/ModulesTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+import java.io.File
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.Configuration
+import play.api.Environment
+import play.api.Mode
+import play.api.inject.Binding
+import play.api.inject.Modules
+
+class ModulesTest {
+  @Test
+  def locatesConfiguredAndDefaultModules(): Unit = {
+    ModulesTestConfiguredModule.constructorArgumentsSeen = false
+
+    val environment: Environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+    val settings: Map[String, Any] = Map(
+      "play.modules.enabled" -> Seq(classOf[ModulesTestConfiguredModule].getName)
+    )
+    val configuration: Configuration = Configuration.from(settings)
+
+    val modules: Seq[Any] = Modules.locate(environment, configuration)
+
+    assertThat(modules.exists(_.isInstanceOf[ModulesTestConfiguredModule])).isTrue
+    assertThat(modules.exists(_.isInstanceOf[Module])).isTrue
+    assertThat(ModulesTestConfiguredModule.constructorArgumentsSeen).isTrue
+  }
+}
+
+object ModulesTestConfiguredModule {
+  var constructorArgumentsSeen: Boolean = false
+}
+
+final class ModulesTestConfiguredModule(environment: Environment, configuration: Configuration)
+    extends play.api.inject.Module {
+  ModulesTestConfiguredModule.constructorArgumentsSeen = environment != null && configuration != null
+
+  override def bindings(
+      environment: Environment,
+      configuration: Configuration
+  ): scala.collection.Seq[Binding[_]] = Seq.empty
+}
+
+final class Module extends play.api.inject.Module {
+  override def bindings(
+      environment: Environment,
+      configuration: Configuration
+  ): scala.collection.Seq[Binding[_]] = Seq.empty
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ApplicationLoaderTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ApplicationLoaderTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.io.File
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import play.api.Application
+import play.api.ApplicationLoader
+import play.api.Environment
+import play.api.Mode
+
+class ApplicationLoaderTest {
+  private val LoaderKey: String = "play.application.loader"
+
+  @Test
+  def instantiatesConfiguredScalaApplicationLoader(): Unit = {
+    val loader: ApplicationLoader = ApplicationLoader(
+      contextFor(classOf[ScalaConfiguredApplicationLoader].getName)
+    )
+
+    assertThat(loader).isInstanceOf(classOf[ScalaConfiguredApplicationLoader])
+  }
+
+  @Test
+  def instantiatesConfiguredJavaApplicationLoader(): Unit = {
+    val context: ApplicationLoader.Context = contextFor(
+      classOf[JavaConfiguredApplicationLoader].getName
+    )
+    val loader: ApplicationLoader = ApplicationLoader(context)
+
+    assertThatThrownBy { () =>
+      loader.load(context)
+    }.isInstanceOf(classOf[UnsupportedOperationException])
+      .hasMessage("The Java ApplicationLoader was invoked through the Scala adapter")
+  }
+
+  private def contextFor(loaderClassName: String): ApplicationLoader.Context = {
+    val environment: Environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+    val settings: Map[String, AnyRef] = Map(LoaderKey -> loaderClassName)
+    ApplicationLoader.Context.create(environment, settings)
+  }
+}
+
+final class ScalaConfiguredApplicationLoader extends ApplicationLoader {
+  override def load(context: ApplicationLoader.Context): Application = {
+    throw new UnsupportedOperationException("The ApplicationLoader.apply tests only instantiate the loader")
+  }
+}
+
+final class JavaConfiguredApplicationLoader extends play.ApplicationLoader {
+  override def load(context: play.ApplicationLoader.Context): play.Application = {
+    throw new UnsupportedOperationException("The Java ApplicationLoader was invoked through the Scala adapter")
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/DefaultMessagesApiProviderTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/DefaultMessagesApiProviderTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.io.File
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.Configuration
+import play.api.Environment
+import play.api.Mode
+import play.api.http.HttpConfiguration
+import play.api.i18n.DefaultLangs
+import play.api.i18n.DefaultMessagesApiProvider
+import play.api.i18n.Lang
+import play.api.i18n.Langs
+import play.api.i18n.MessagesApi
+
+class DefaultMessagesApiProviderTest {
+  @Test
+  def loadsClasspathMessagesThroughConfiguredEnvironmentClassLoader(): Unit = {
+    val environment: Environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+    val configuration: Configuration = Configuration.reference
+    val langs: Langs = new DefaultLangs(Seq(Lang("en")))
+    val httpConfiguration: HttpConfiguration = HttpConfiguration.fromConfiguration(configuration, environment)
+
+    val messagesApi: MessagesApi = new DefaultMessagesApiProvider(
+      environment,
+      configuration,
+      langs,
+      httpConfiguration
+    ).get
+
+    assertThat(messagesApi("dynamic.access.coverage.message")(Lang("en"))).isEqualTo(
+      "Loaded by DefaultMessagesApiProvider"
+    )
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/EnabledFiltersTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/EnabledFiltersTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.io.File
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.Configuration
+import play.api.Environment
+import play.api.Mode
+import play.api.http.EnabledFilters
+import play.api.inject.NewInstanceInjector
+import play.api.inject.SimpleInjector
+import play.api.mvc.EssentialAction
+import play.api.mvc.EssentialFilter
+
+class EnabledFiltersTest {
+  @Test
+  def loadsConfiguredFilterClassAndRetrievesItFromInjector(): Unit = {
+    val filter: EnabledFiltersTestFilter = new EnabledFiltersTestFilter
+    val injector: SimpleInjector = new SimpleInjector(NewInstanceInjector)
+      .add(classOf[EnabledFiltersTestFilter], filter)
+    val environment: Environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
+    val configuration: Configuration = Configuration.from(
+      Map(
+        "play.filters.enabled" -> Seq(classOf[EnabledFiltersTestFilter].getName),
+        "play.filters.disabled" -> Seq.empty[String]
+      )
+    )
+
+    val enabledFilters: EnabledFilters = new EnabledFilters(environment, configuration, injector)
+
+    assertThat(enabledFilters.filters.size).isEqualTo(1)
+    assertThat(enabledFilters.filters.head).isSameAs(filter)
+  }
+}
+
+final class EnabledFiltersTestFilter extends EssentialFilter {
+  override def apply(next: EssentialAction): EssentialAction = next
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/HandlerInvokerFactoryTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/HandlerInvokerFactoryTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.util.concurrent.CompletionStage
+
+import akka.util.ByteString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.http.HttpConfiguration
+import play.api.routing.HandlerDef
+import play.core.j.JavaAction
+import play.core.j.JavaHandler
+import play.core.j.MappedJavaHandlerComponents
+import play.core.routing.HandlerInvokerFactory
+import play.http.ActionCreator
+import play.libs.F
+import play.libs.streams.Accumulator
+import play.mvc.Action
+import play.mvc.BodyParser
+import play.mvc.Http
+import play.mvc.Result
+import play.mvc.Results
+
+import scala.concurrent.ExecutionContext
+
+class HandlerInvokerFactoryTest {
+  @Test
+  def loadsJavaControllerClassFromControllerName(): Unit = {
+    val javaAction: JavaAction = javaActionFor(
+      HandlerDef(
+        classLoader = getClass.getClassLoader,
+        routerPackage = "",
+        controller = "_root_." + classOf[DirectHandlerInvokerFactoryController].getName,
+        method = "index",
+        parameterTypes = Seq.empty,
+        verb = "GET",
+        path = "/direct"
+      )
+    )
+
+    assertThat(javaAction.annotations.controller).isEqualTo(classOf[DirectHandlerInvokerFactoryController])
+    assertThat(javaAction.annotations.method.getName).isEqualTo("index")
+  }
+
+  @Test
+  def loadsJavaControllerClassRelativeToRouterPackageWhenControllerNameIsNotAbsolute(): Unit = {
+    val javaAction: JavaAction = javaActionFor(
+      HandlerDef(
+        classLoader = getClass.getClassLoader,
+        routerPackage = getClass.getPackageName,
+        controller = "RelativeHandlerInvokerFactoryController",
+        method = "show",
+        parameterTypes = Seq(classOf[String]),
+        verb = "GET",
+        path = "/relative/:id"
+      )
+    )
+
+    assertThat(javaAction.annotations.controller).isEqualTo(classOf[RelativeHandlerInvokerFactoryController])
+    assertThat(javaAction.annotations.method.getName).isEqualTo("show")
+  }
+
+  private def javaActionFor(handlerDef: HandlerDef): JavaAction = {
+    val handler: JavaHandler = HandlerInvokerFactory.wrapJava
+      .createInvoker(Results.ok("unused"), handlerDef)
+      .call(Results.ok("created"))
+      .asInstanceOf[JavaHandler]
+
+    handler.withComponents(handlerComponents).asInstanceOf[JavaAction]
+  }
+
+  private def handlerComponents: MappedJavaHandlerComponents = {
+    new MappedJavaHandlerComponents(actionCreator, HttpConfiguration(), ExecutionContext.global)
+      .addBodyParser(
+        classOf[HandlerInvokerFactoryNoOpBodyParser],
+        () => new HandlerInvokerFactoryNoOpBodyParser
+      )
+  }
+
+  private def actionCreator: ActionCreator = (_: Http.Request, _: java.lang.reflect.Method) =>
+    new Action.Simple {
+      override def call(request: Http.Request): CompletionStage[Result] = delegate.call(request)
+    }
+}
+
+class DirectHandlerInvokerFactoryController {
+  @BodyParser.Of(classOf[HandlerInvokerFactoryNoOpBodyParser])
+  def index(): Result = Results.ok("direct")
+}
+
+class RelativeHandlerInvokerFactoryController {
+  @BodyParser.Of(classOf[HandlerInvokerFactoryNoOpBodyParser])
+  def show(id: String): Result = Results.ok(id)
+}
+
+class HandlerInvokerFactoryNoOpBodyParser extends BodyParser[AnyRef] {
+  override def apply(request: Http.RequestHeader): Accumulator[ByteString, F.Either[Result, AnyRef]] = {
+    throw new AssertionError("This test only initializes the Java action annotations")
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/LoggerConfiguratorTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/LoggerConfiguratorTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.io.File
+import java.net.URL
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.slf4j.ILoggerFactory
+import org.slf4j.LoggerFactory
+import play.api.Configuration
+import play.api.Environment
+import play.api.LoggerConfigurator
+import play.api.Mode
+
+class LoggerConfiguratorTest {
+  @Test
+  def instantiatesConfiguredLoggerConfiguratorByClassName(): Unit = {
+    val configurator: Option[LoggerConfigurator] = LoggerConfigurator(
+      classOf[TestLoggerConfigurator].getName,
+      getClass.getClassLoader
+    )
+
+    assertThat(configurator.orNull).isInstanceOf(classOf[TestLoggerConfigurator])
+  }
+
+  @Test
+  def instantiatesLoggerConfiguratorDiscoveredFromResources(): Unit = {
+    val configurator: Option[LoggerConfigurator] = LoggerConfigurator(getClass.getClassLoader)
+
+    assertThat(configurator.orNull).isInstanceOf(classOf[TestLoggerConfigurator])
+  }
+}
+
+final class TestLoggerConfigurator extends LoggerConfigurator {
+  override def init(rootPath: File, mode: Mode): Unit = ()
+
+  override def configure(env: Environment): Unit = ()
+
+  override def configure(
+      env: Environment,
+      configuration: Configuration,
+      optionalProperties: Map[String, String]
+  ): Unit = ()
+
+  override def configure(properties: Map[String, String], config: Option[URL]): Unit = ()
+
+  override def loggerFactory: ILoggerFactory = LoggerFactory.getILoggerFactory
+
+  override def shutdown(): Unit = ()
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/MethodUtilsTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/MethodUtilsTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.lang.reflect.Method
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.libs.reflect.MethodUtils
+
+class MethodUtilsTest {
+  @Test
+  def findsAccessibleInterfaceMethodForNonPublicImplementation(): Unit = {
+    val implementationMethod: Method = classOf[PrivateInterfaceImplementation]
+      .getMethod("greet", classOf[String])
+
+    val accessibleMethod: Method = MethodUtils.getAccessibleMethod(implementationMethod)
+
+    assertThat(accessibleMethod).isNotNull
+    assertThat(accessibleMethod.getDeclaringClass).isEqualTo(classOf[PublicMethodUtilsGreeting])
+    assertThat(accessibleMethod.getName).isEqualTo("greet")
+  }
+
+  @Test
+  def findsAccessibleSuperclassMethodForNonPublicSubclass(): Unit = {
+    val implementationMethod: Method = classOf[PrivateSuperclassImplementation]
+      .getMethod("inheritedGreeting", classOf[String])
+
+    val accessibleMethod: Method = MethodUtils.getAccessibleMethod(implementationMethod)
+
+    assertThat(accessibleMethod).isNotNull
+    assertThat(accessibleMethod.getDeclaringClass).isEqualTo(classOf[PublicMethodUtilsSuperclass])
+    assertThat(accessibleMethod.getName).isEqualTo("inheritedGreeting")
+  }
+
+  @Test
+  def returnsExactPublicMethodWhenParameterTypesMatch(): Unit = {
+    val method: Method = MethodUtils.getMatchingAccessibleMethod(
+      classOf[ExactMatchingMethodTarget],
+      "echo",
+      classOf[String]
+    )
+
+    assertThat(method).isNotNull
+    assertThat(method.getDeclaringClass).isEqualTo(classOf[ExactMatchingMethodTarget])
+    assertThat(method.getParameterTypes.length).isEqualTo(1)
+    assertThat(method.getParameterTypes()(0)).isEqualTo(classOf[String])
+  }
+
+  @Test
+  def scansPublicMethodsToFindAssignableParameterMatch(): Unit = {
+    val method: Method = MethodUtils.getMatchingAccessibleMethod(
+      classOf[AssignableMatchingMethodTarget],
+      "describe",
+      classOf[Integer]
+    )
+
+    assertThat(method).isNotNull
+    assertThat(method.getDeclaringClass).isEqualTo(classOf[AssignableMatchingMethodTarget])
+    assertThat(method.getParameterTypes.length).isEqualTo(1)
+    assertThat(method.getParameterTypes()(0)).isEqualTo(classOf[Number])
+  }
+
+  private final class PrivateInterfaceImplementation extends PublicMethodUtilsGreeting {
+    override def greet(name: String): String = s"hello $name"
+  }
+
+  private final class PrivateSuperclassImplementation extends PublicMethodUtilsSuperclass {
+    override def inheritedGreeting(name: String): String = s"subclass $name"
+  }
+}
+
+trait PublicMethodUtilsGreeting {
+  def greet(name: String): String
+}
+
+class PublicMethodUtilsSuperclass {
+  def inheritedGreeting(name: String): String = s"superclass $name"
+}
+
+class ExactMatchingMethodTarget {
+  def echo(value: String): String = value
+}
+
+class AssignableMatchingMethodTarget {
+  def describe(value: Number): String = s"number $value"
+
+  def describe(value: AnyRef): String = s"object $value"
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/NewInstanceInjectorTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/NewInstanceInjectorTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.inject.BindingKey
+import play.api.inject.NewInstanceInjector
+
+class NewInstanceInjectorTest {
+  @Test
+  def createsInstanceFromClassToken(): Unit = {
+    val instance: NewInstanceConstructibleService = NewInstanceInjector.instanceOf(classOf[NewInstanceConstructibleService])
+
+    assertThat(instance.message).isEqualTo("created by NewInstanceInjector")
+  }
+
+  @Test
+  def createsInstanceFromBindingKey(): Unit = {
+    val key: BindingKey[NewInstanceConstructibleService] = BindingKey(classOf[NewInstanceConstructibleService])
+    val instance: NewInstanceConstructibleService = NewInstanceInjector.instanceOf(key)
+
+    assertThat(instance.message).isEqualTo("created by NewInstanceInjector")
+  }
+}
+
+final class NewInstanceConstructibleService {
+  def message: String = "created by NewInstanceInjector"
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/PathBindableAnonymous12Test.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/PathBindableAnonymous12Test.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.mvc.{PathBindable => ScalaPathBindable}
+
+class PathBindableAnonymous12Test {
+  @Test
+  def bindsJavaPathBindableUsingNoArgumentConstructor(): Unit = {
+    val binder: ScalaPathBindable[JavaBackedPathParameter] = implicitly[ScalaPathBindable[JavaBackedPathParameter]]
+
+    val result: Either[String, JavaBackedPathParameter] = binder.bind("slug", "play-framework")
+
+    assertThat(result.isRight).isTrue
+    val parameter: JavaBackedPathParameter = result.toOption.get
+    assertThat(parameter.boundKey).isEqualTo("slug")
+    assertThat(parameter.value).isEqualTo("play-framework")
+    assertThat(binder.unbind("slug", parameter)).isEqualTo("slug=play-framework")
+  }
+
+  @Test
+  def obtainsJavascriptUnbindFromJavaPathBindableUsingNoArgumentConstructor(): Unit = {
+    val binder: ScalaPathBindable[JavaBackedPathParameter] = implicitly[ScalaPathBindable[JavaBackedPathParameter]]
+
+    val javascriptUnbind: String = binder.javascriptUnbind
+
+    assertThat(javascriptUnbind).isEqualTo("function(k,v){return v.value;}")
+  }
+}
+
+final class JavaBackedPathParameter extends play.mvc.PathBindable[JavaBackedPathParameter] {
+  var boundKey: String = ""
+  var value: String = ""
+
+  override def bind(key: String, txt: String): JavaBackedPathParameter = {
+    boundKey = key
+    value = txt
+    this
+  }
+
+  override def unbind(key: String): String = s"$key=$value"
+
+  override def javascriptUnbind(): String = "function(k,v){return v.value;}"
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/QueryStringBindableAnonymous11Test.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/QueryStringBindableAnonymous11Test.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.util.Optional
+import java.util.{Map => JavaMap}
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.mvc.{QueryStringBindable => ScalaQueryStringBindable}
+
+class QueryStringBindableAnonymous11Test {
+  @Test
+  def bindsJavaQueryStringBindableUsingNoArgumentConstructor(): Unit = {
+    val binder: ScalaQueryStringBindable[JavaBackedQueryStringParameter] =
+      implicitly[ScalaQueryStringBindable[JavaBackedQueryStringParameter]]
+
+    val result: Option[Either[String, JavaBackedQueryStringParameter]] =
+      binder.bind("term", Map("term" -> Seq("graalvm")))
+
+    assertThat(result.isDefined).isTrue
+    assertThat(result.get.isRight).isTrue
+    val parameter: JavaBackedQueryStringParameter = result.get.toOption.get
+    assertThat(parameter.boundKey).isEqualTo("term")
+    assertThat(parameter.value).isEqualTo("graalvm")
+    assertThat(binder.unbind("term", parameter)).isEqualTo("term=graalvm")
+  }
+
+  @Test
+  def obtainsJavascriptUnbindFromJavaQueryStringBindableUsingNoArgumentConstructor(): Unit = {
+    val binder: ScalaQueryStringBindable[JavaBackedQueryStringParameter] =
+      implicitly[ScalaQueryStringBindable[JavaBackedQueryStringParameter]]
+
+    val javascriptUnbind: String = binder.javascriptUnbind
+
+    assertThat(javascriptUnbind).isEqualTo("function(k,v){return k + '=' + v.value;}")
+  }
+}
+
+final class JavaBackedQueryStringParameter extends play.mvc.QueryStringBindable[JavaBackedQueryStringParameter] {
+  var boundKey: String = ""
+  var value: String = ""
+
+  override def bind(
+      key: String,
+      data: JavaMap[String, Array[String]]
+  ): Optional[JavaBackedQueryStringParameter] = {
+    val values: Array[String] = data.get(key)
+    if (values == null || values.isEmpty) {
+      Optional.empty()
+    } else {
+      boundKey = key
+      value = values(0)
+      Optional.of(this)
+    }
+  }
+
+  override def unbind(key: String): String = s"$key=$value"
+
+  override def javascriptUnbind(): String = "function(k,v){return k + '=' + v.value;}"
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ReflectTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ReflectTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.utils.Reflect
+
+class ReflectTest {
+  @Test
+  def createsInstanceFromClassNameWithProvidedClassLoader(): Unit = {
+    val instance: ReflectConstructibleService = Reflect.createInstance[ReflectConstructibleService](
+      classOf[ReflectDefaultConstructibleService].getName,
+      getClass.getClassLoader
+    )
+
+    assertThat(instance.message).isEqualTo("created by Reflect")
+  }
+}
+
+trait ReflectConstructibleService {
+  def message: String
+}
+
+class ReflectDefaultConstructibleService extends ReflectConstructibleService {
+  override def message: String = "created by Reflect"
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ResourcesTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ResourcesTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.net.URI
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.nio.file.Paths
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.utils.Resources
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+class ResourcesTest {
+  @Test
+  def treatsGraalVmResourceUrlAsFileWhenOnlyNonSlashLookupResolves(): Unit = {
+    val resourcePath: String = "/play-resource-entry"
+    val classLoader: ResourcesTest.SingleResourceClassLoader = new ResourcesTest.SingleResourceClassLoader(resourcePath)
+    val url: URL = ResourcesTest.resourceUrl(resourcePath)
+
+    val isDirectory: Boolean = Resources.isDirectory(classLoader, url)
+
+    assertThat(isDirectory).isFalse
+    assertThat(classLoader.requestedResources).containsExactly(resourcePath, resourcePath + "/")
+  }
+}
+
+object ResourcesTest {
+  private val ResolvedResourceUrl: URL = Paths.get(".").toUri.toURL
+
+  private def resourceUrl(path: String): URL = {
+    URL.of(URI.create(s"resource:$path"), NoOpUrlStreamHandler)
+  }
+
+  final class SingleResourceClassLoader(resourcePath: String) extends ClassLoader(null) {
+    private val requests: ListBuffer[String] = ListBuffer.empty
+
+    override def getResource(name: String): URL = {
+      requests += name
+      if (name == resourcePath) ResolvedResourceUrl else null
+    }
+
+    def requestedResources: java.util.List[String] = requests.toSeq.asJava
+  }
+
+  private object NoOpUrlStreamHandler extends URLStreamHandler {
+    override protected def openConnection(url: URL): URLConnection = {
+      throw new UnsupportedOperationException("This test only inspects URL metadata")
+    }
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ResultsInnerStatusTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ResultsInnerStatusTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.http.FileMimeTypes
+import play.api.mvc.Results
+
+import scala.concurrent.ExecutionContext
+
+class ResultsInnerStatusTest {
+  @Test
+  def sendsClasspathResourceFromStatusResult(): Unit = {
+    implicit val executionContext: ExecutionContext = ExecutionContext.global
+    implicit val fileMimeTypes: FileMimeTypes = (name: String) =>
+      if (name.endsWith(".txt")) Some("text/plain") else None
+
+    val result = Results.Ok.sendResource(
+      resource = "results-status-resource.txt",
+      classLoader = getClass.getClassLoader,
+      inline = false
+    )
+
+    val contentDisposition: String = result.header.headers("Content-Disposition")
+
+    assertThat(result.header.status).isEqualTo(200)
+    assertThat(contentDisposition.contains("attachment")).isTrue
+    assertThat(contentDisposition.contains("results-status-resource.txt")).isTrue
+    assertThat(result.body.contentLength).isEqualTo(Some(20L))
+    assertThat(result.body.contentType).isEqualTo(Some("text/plain"))
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ScalaTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/ScalaTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import java.util.Arrays
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScalaTest {
+  @Test
+  def convertsScalaSeqToTypedJavaArray(): Unit = {
+    val values: scala.collection.immutable.Seq[String] = _root_.play.libs.Scala.toSeq(
+      Arrays.asList("alpha", "beta", "gamma")
+    )
+
+    val array: Array[String] = _root_.play.libs.Scala.asArray(classOf[String], values)
+
+    assertThat(array).containsExactly("alpha", "beta", "gamma")
+    assertThat(array.getClass.getComponentType).isEqualTo(classOf[String])
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/StatusHeaderTest.scala
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/scala/com_typesafe_play/play_2_13/StatusHeaderTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_2_13
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import play.api.http.FileMimeTypes
+import play.mvc.{FileMimeTypes => JavaFileMimeTypes}
+import play.mvc.Results
+
+import java.util.Optional
+
+class StatusHeaderTest {
+  @Test
+  def sendsResourceFromClassLoaderWithDownloadFilename(): Unit = {
+    val scalaFileMimeTypes: FileMimeTypes = (name: String) =>
+      if (name.endsWith(".txt")) Some("text/plain") else None
+    val fileMimeTypes: JavaFileMimeTypes = new JavaFileMimeTypes(scalaFileMimeTypes)
+
+    val result = Results
+      .status(200)
+      .sendResource(
+        "results-status-resource.txt",
+        getClass.getClassLoader,
+        false,
+        Optional.of("download.txt"),
+        fileMimeTypes
+      )
+
+    val contentDisposition: String = result.header("Content-Disposition").get()
+
+    assertThat(result.status()).isEqualTo(200)
+    assertThat(contentDisposition).contains("attachment")
+    assertThat(contentDisposition).contains("download.txt")
+    assertThat(result.contentType()).hasValue("text/plain")
+    assertThat(result.body().isKnownEmpty()).isFalse
+  }
+}

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/user-code-filter.json
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/user-code-filter.json
@@ -1,0 +1,22 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "controllers.**"
+    },
+    {
+      "includeClasses" : "models.**"
+    },
+    {
+      "includeClasses" : "play.**"
+    },
+    {
+      "includeClasses" : "views.**"
+    },
+    {
+      "includeClasses" : "com_typesafe_play.play_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #5419

## What does this PR do?

Adds reachability metadata and generated TCK coverage for `com.typesafe.play:play_2.13:2.9.10`.

This promotes the repaired preserved branch for #5419 after a local rerun. The promoted branch intentionally excludes the archived `human-intervention-logs` commits and carries only the reviewable metadata, index, stats, and generated tests.

Validation run locally:

```bash
./gradlew --no-daemon test nativeTest -Pcoordinates=com.typesafe.play:play_2.13:2.9.10 --stacktrace
```

Result: passed. Native Image built successfully and 24/24 native tests passed.

## Code sections where the PR accesses files, network, docker or some external service

- The Play tests read classpath test resources under `tests/src/com.typesafe.play/play_2.13/2.9.10/src/test/resources/`.
- No Docker or external service access is added by the test code.
