### PR TITLE
[GenAI] Add support for com.squareup.moshi:moshi-kotlin:1.15.2 using gpt-5.5

### DIFF
--- a/metadata/com.squareup.moshi/moshi-kotlin/1.15.2/reachability-metadata.json
+++ b/metadata/com.squareup.moshi/moshi-kotlin/1.15.2/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "glob" : "META-INF/*.kotlin_module"
+    }
+  ]
+}

--- a/metadata/com.squareup.moshi/moshi-kotlin/index.json
+++ b/metadata/com.squareup.moshi/moshi-kotlin/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.15.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/moshi/moshi-kotlin/$version$/moshi-kotlin-$version$-sources.jar",
+    "repository-url" : "https://github.com/square/moshi",
+    "test-code-url" : "https://github.com/square/moshi/tree/$version$/moshi-kotlin/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/squareup/moshi/moshi-kotlin/$version$/moshi-kotlin-$version$-javadoc.jar",
+    "description" : "Moshi is a JSON library for Android, Java, and Kotlin that converts Java and Kotlin objects to and from JSON. The moshi-kotlin artifact adds Kotlin reflection support through KotlinJsonAdapterFactory, honoring Kotlin nullability and default parameter values when binding JSON.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "1.8"
+    },
+    "tested-versions" : [
+      "1.15.2"
+    ],
+    "allowed-packages" : [
+      "com.squareup.moshi"
+    ]
+  }
+]

--- a/stats/com.squareup.moshi/moshi-kotlin/1.15.2/execution-metrics.json
+++ b/stats/com.squareup.moshi/moshi-kotlin/1.15.2/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T15:45:58.794380Z",
+    "library": "com.squareup.moshi:moshi-kotlin:1.15.2",
+    "starting_commit": "ce60d3aa2237a22bb7093956b532b23c56b495b2",
+    "ending_commit": "1d2b80c6daa4a5accb44818ffae347363a91f99e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.15.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 733,
+          "missed": 377,
+          "ratio": 0.66036,
+          "total": 1110
+        },
+        "line": {
+          "covered": 132,
+          "missed": 35,
+          "ratio": 0.790419,
+          "total": 167
+        },
+        "method": {
+          "covered": 16,
+          "missed": 9,
+          "ratio": 0.64,
+          "total": 25
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 71982,
+      "cached_input_tokens_used": 461312,
+      "output_tokens_used": 15904,
+      "iterations": 3,
+      "cost_usd": 0.7078,
+      "generated_loc": 256,
+      "tested_library_loc": 132,
+      "metadata_entries": 1,
+      "test_only_metadata_entries": 32,
+      "code_coverage_percent": 79.04
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt",
+      "metadata_file": "metadata/com.squareup.moshi/moshi-kotlin/1.15.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.squareup.moshi/moshi-kotlin/1.15.2/stats.json
+++ b/stats/com.squareup.moshi/moshi-kotlin/1.15.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.15.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 733,
+        "missed" : 377,
+        "ratio" : 0.66036,
+        "total" : 1110
+      },
+      "line" : {
+        "covered" : 132,
+        "missed" : 35,
+        "ratio" : 0.790419,
+        "total" : 167
+      },
+      "method" : {
+        "covered" : 16,
+        "missed" : 9,
+        "ratio" : 0.64,
+        "total" : 25
+      }
+    }
+  } ]
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/.gitignore
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.squareup.moshi:moshi-kotlin:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/gradle.properties
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.squareup.moshi:moshi-kotlin:1.15.2
+library.version = 1.15.2
+metadata.dir = com.squareup.moshi/moshi-kotlin/1.15.2/

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/settings.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.squareup.moshi.moshi-kotlin_tests'

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
@@ -6,11 +6,188 @@
  */
 package com_squareup_moshi.moshi_kotlin
 
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
-class Moshi_kotlinTest {
+public class MoshiKotlinTest {
+    private val moshi: Moshi = Moshi.Builder()
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+
     @Test
-    fun test() {
-        println("This is just a placeholder, implement your test")
+    fun readsKotlinPrimaryConstructorWithJsonNamesNullabilityAndDefaults(): Unit {
+        val adapter = moshi.adapter(UserProfile::class.java)
+
+        val profile = adapter.fromJson(
+            """
+            {
+              "user_id": 7,
+              "name": "Ada Lovelace",
+              "unknown_from_service": true
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(profile).isEqualTo(
+            UserProfile(
+                userId = 7,
+                name = "Ada Lovelace",
+                nicknames = emptyList(),
+                settings = AccountSettings(),
+                email = null,
+                enabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun writesNestedKotlinObjectsUsingDeclarationOrderAndJsonNames(): Unit {
+        val adapter = moshi.adapter(UserProfile::class.java)
+        val profile = UserProfile(
+            userId = 8,
+            name = "Grace Hopper",
+            nicknames = listOf("Amazing Grace", "grandma COBOL"),
+            settings = AccountSettings(newsletters = true, theme = "navy"),
+            email = "grace@example.test",
+            enabled = false,
+        )
+
+        assertThat(adapter.toJson(profile)).isEqualTo(
+            """
+            {"user_id":8,"name":"Grace Hopper","nicknames":["Amazing Grace","grandma COBOL"],"settings":{"newsletters":true,"theme":"navy"},"email":"grace@example.test","enabled":false}
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun serializesExplicitNullsForNullableKotlinPropertiesWhenRequested(): Unit {
+        val adapter = moshi.adapter(UserProfile::class.java).serializeNulls()
+        val profile = UserProfile(userId = 9, name = "Katherine Johnson")
+
+        assertThat(adapter.toJson(profile)).isEqualTo(
+            """
+            {"user_id":9,"name":"Katherine Johnson","nicknames":[],"settings":{"newsletters":false,"theme":"light"},"email":null,"enabled":true}
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun rejectsNullAndMissingValuesForNonNullableKotlinProperties(): Unit {
+        val adapter = moshi.adapter(RequiredBooking::class.java)
+
+        assertThatThrownBy { adapter.fromJson("""{"guest":null,"nights":2}""") }
+            .isInstanceOf(JsonDataException::class.java)
+            .hasMessageContaining("guest")
+            .hasMessageContaining("null")
+
+        assertThatThrownBy { adapter.fromJson("""{"nights":2}""") }
+            .isInstanceOf(JsonDataException::class.java)
+            .hasMessageContaining("guest")
+            .hasMessageContaining("missing")
+    }
+
+    @Test
+    fun ignoresPropertiesMarkedWithJsonIgnoreAndAppliesTheirDefaults(): Unit {
+        val adapter = moshi.adapter(AuditEntry::class.java)
+
+        val entry = adapter.fromJson(
+            """
+            {
+              "event_id": "evt-1",
+              "actor": "system",
+              "localOnlyNote": "must not be read"
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(entry).isEqualTo(
+            AuditEntry(
+                eventId = "evt-1",
+                actor = "system",
+                localOnlyNote = "created locally",
+            ),
+        )
+        assertThat(adapter.toJson(entry)).isEqualTo("""{"event_id":"evt-1","actor":"system"}""")
+    }
+
+    @Test
+    fun readsAndWritesKotlinClassesContainingCollectionsMapsEnumsAndNestedObjects(): Unit {
+        val adapter = moshi.adapter(IncidentReport::class.java)
+        val json =
+            """
+            {
+              "severity": "HIGH",
+              "entries": [
+                {"event_id":"evt-2","actor":"scheduler"},
+                {"event_id":"evt-3","actor":"operator"}
+              ],
+              "countsByActor": {
+                "scheduler": 1,
+                "operator": 1
+              }
+            }
+            """.trimIndent()
+
+        val report = adapter.fromJson(json)
+
+        assertThat(report).isEqualTo(
+            IncidentReport(
+                severity = Severity.HIGH,
+                entries = listOf(
+                    AuditEntry(eventId = "evt-2", actor = "scheduler"),
+                    AuditEntry(eventId = "evt-3", actor = "operator"),
+                ),
+                countsByActor = mapOf("scheduler" to 1, "operator" to 1),
+            ),
+        )
+        assertThat(adapter.toJson(report)).isEqualTo(
+            """
+            {"severity":"HIGH","entries":[{"event_id":"evt-2","actor":"scheduler"},{"event_id":"evt-3","actor":"operator"}],"countsByActor":{"scheduler":1,"operator":1}}
+            """.trimIndent(),
+        )
     }
 }
+
+public data class UserProfile(
+    @Json(name = "user_id")
+    val userId: Long,
+    val name: String,
+    val nicknames: List<String> = emptyList(),
+    val settings: AccountSettings = AccountSettings(),
+    val email: String? = null,
+    val enabled: Boolean = true,
+)
+
+public data class AccountSettings(
+    val newsletters: Boolean = false,
+    val theme: String = "light",
+)
+
+public data class RequiredBooking(
+    val guest: String,
+    val nights: Int,
+)
+
+public data class AuditEntry(
+    @Json(name = "event_id")
+    val eventId: String,
+    val actor: String,
+    @Json(ignore = true)
+    val localOnlyNote: String = "created locally",
+)
+
+public enum class Severity {
+    LOW,
+    HIGH,
+}
+
+public data class IncidentReport(
+    val severity: Severity,
+    val entries: List<AuditEntry>,
+    val countsByActor: Map<String, Int>,
+)

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_moshi.moshi_kotlin
+
+import org.junit.jupiter.api.Test
+
+class Moshi_kotlinTest {
+    @Test
+    fun test() {
+        println("This is just a placeholder, implement your test")
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
@@ -7,9 +7,14 @@
 package com_squareup_moshi.moshi_kotlin
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.lang.reflect.Type
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -151,6 +156,32 @@ public class MoshiKotlinTest {
             """.trimIndent(),
         )
     }
+
+    @Test
+    fun appliesJsonQualifierAnnotationsOnKotlinConstructorProperties(): Unit {
+        val qualifiedMoshi = Moshi.Builder()
+            .add(NormalizedChannelStringAdapterFactory)
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+        val adapter = qualifiedMoshi.adapter(SupportTicket::class.java)
+
+        val ticket = adapter.fromJson(
+            """
+            {
+              "channel": "email",
+              "summary": "Needs HELP"
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(ticket).isEqualTo(
+            SupportTicket(
+                channel = "EMAIL",
+                summary = "Needs HELP",
+            ),
+        )
+        assertThat(adapter.toJson(ticket)).isEqualTo("""{"channel":"email","summary":"Needs HELP"}""")
+    }
 }
 
 public data class UserProfile(
@@ -191,3 +222,32 @@ public data class IncidentReport(
     val entries: List<AuditEntry>,
     val countsByActor: Map<String, Int>,
 )
+
+@JsonQualifier
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class NormalizedChannel
+
+public data class SupportTicket(
+    @NormalizedChannel
+    val channel: String,
+    val summary: String,
+)
+
+public object NormalizedChannelStringAdapterFactory : JsonAdapter.Factory {
+    override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        if (type != String::class.java || annotations.none { it is NormalizedChannel }) {
+            return null
+        }
+        return NormalizedChannelStringAdapter
+    }
+}
+
+public object NormalizedChannelStringAdapter : JsonAdapter<String>() {
+    override fun fromJson(reader: JsonReader): String {
+        return reader.nextString().uppercase()
+    }
+
+    override fun toJson(writer: JsonWriter, value: String?) {
+        writer.value(requireNotNull(value) { "channel == null" }.lowercase())
+    }
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/kotlin/com_squareup_moshi/moshi_kotlin/Moshi_kotlinTest.kt
@@ -182,6 +182,40 @@ public class MoshiKotlinTest {
         )
         assertThat(adapter.toJson(ticket)).isEqualTo("""{"channel":"email","summary":"Needs HELP"}""")
     }
+
+    @Test
+    fun readsAndWritesMutableKotlinPropertiesDeclaredOutsidePrimaryConstructor(): Unit {
+        val adapter = moshi.adapter(NotificationEnvelope::class.java)
+
+        val envelope = adapter.fromJson(
+            """
+            {
+              "messageId": "msg-1",
+              "title": "Maintenance window",
+              "delivered": true,
+              "labels": ["ops", "scheduled"]
+            }
+            """.trimIndent(),
+        )
+
+        assertThat(envelope?.messageId).isEqualTo("msg-1")
+        assertThat(envelope?.title).isEqualTo("Maintenance window")
+        assertThat(envelope?.delivered).isTrue()
+        assertThat(envelope?.labels).containsExactly("ops", "scheduled")
+
+        val updatedEnvelope = NotificationEnvelope(messageId = "msg-2").apply {
+            title = "Incident resolved"
+            delivered = false
+            labels = listOf("support", "resolved")
+        }
+
+        val json = adapter.toJson(updatedEnvelope)
+
+        assertThat(json).contains("\"messageId\":\"msg-2\"")
+        assertThat(json).contains("\"title\":\"Incident resolved\"")
+        assertThat(json).contains("\"delivered\":false")
+        assertThat(json).contains("\"labels\":[\"support\",\"resolved\"]")
+    }
 }
 
 public data class UserProfile(
@@ -232,6 +266,14 @@ public data class SupportTicket(
     val channel: String,
     val summary: String,
 )
+
+public class NotificationEnvelope(
+    val messageId: String,
+) {
+    public lateinit var title: String
+    public var delivered: Boolean = false
+    public var labels: List<String> = emptyList()
+}
 
 public object NormalizedChannelStringAdapterFactory : JsonAdapter.Factory {
     override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,81 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.AccountSettings",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.AuditEntry",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.IncidentReport",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.NormalizedChannel"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.NotificationEnvelope",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.RequiredBooking",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.Severity",
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.SupportTicket",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory"
+      },
+      "type" : "com_squareup_moshi.moshi_kotlin.UserProfile",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true,
+      "allDeclaredFields" : true
+    }
+  ]
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/user-code-filter.json
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.squareup.moshi.**"
+    }
+  ]
+}

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/user-code-filter.json
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.squareup.moshi.**"
+      "includeClasses" : "com.squareup.moshi.**"
+    },
+    {
+      "includeClasses" : "com_squareup_moshi.moshi_kotlin.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4491

This PR introduces tests and metadata for com.squareup.moshi:moshi-kotlin:1.15.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 71982
- Cached input tokens: 461312
- Output tokens: 15904
- Metadata entries: 1
- Test-only metadata entries: 32
- Iterations: 3
- Library coverage percentage: 79.04
- Generated lines of code: 256
- Tested library lines of code: 132

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `ad80a18794957e4ef5413fe686532bedf35a255e`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 733/1110 (66.04%)
- Line: 132/167 (79.04%)
- Method: 16/25 (64.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
