### PR TITLE
[GenAI] Add support for org.scala-lang.modules:scala-xml_3:2.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.scala-lang.modules/scala-xml_3/2.1.0/reachability-metadata.json
+++ b/metadata/org.scala-lang.modules/scala-xml_3/2.1.0/reachability-metadata.json
@@ -1,0 +1,37 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "scala.xml.XML$"
+      },
+      "type": "scala.xml.XML$",
+      "fields": [
+        {
+          "name": "0bitmap$2"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.parsing.FactoryAdapter"
+      },
+      "type": "scala.xml.parsing.FactoryAdapter",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.PrettyPrinter"
+      },
+      "type": "scala.xml.PrettyPrinter",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.scala-lang.modules/scala-xml_3/index.json
+++ b/metadata/org.scala-lang.modules/scala-xml_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_3/$version$/scala-xml_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scala/scala-xml",
+    "test-code-url" : "https://github.com/scala/scala-xml/tree/v$version$/jvm/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_3/$version$/scala-xml_3-$version$-javadoc.jar",
+    "description" : "scala-xml is the standard Scala XML library, providing XML node, attribute, namespace, parsing, printing, and DTD utilities for Scala programs. The scala-xml_3 artifact is the Scala 3 JVM build, usable with Scala XML literals and ordinary JVM code that needs XML construction or processing.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.1.0"
+    ],
+    "allowed-packages" : [
+      "scala.xml"
+    ]
+  }
+]

--- a/stats/org.scala-lang.modules/scala-xml_3/2.1.0/execution-metrics.json
+++ b/stats/org.scala-lang.modules/scala-xml_3/2.1.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T15:45:34.042239Z",
+    "library": "org.scala-lang.modules:scala-xml_3:2.1.0",
+    "starting_commit": "a2f388ea3e837bf7027b3abe29a21791c246d62b",
+    "ending_commit": "ac8759113d60e06b21031f80a2324981d4a59bab",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8384,
+          "missed": 18307,
+          "ratio": 0.314113,
+          "total": 26691
+        },
+        "line": {
+          "covered": 951,
+          "missed": 1460,
+          "ratio": 0.394442,
+          "total": 2411
+        },
+        "method": {
+          "covered": 562,
+          "missed": 1808,
+          "ratio": 0.237131,
+          "total": 2370
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 216088,
+      "cached_input_tokens_used": 2078720,
+      "output_tokens_used": 24732,
+      "iterations": 7,
+      "cost_usd": 1.7814,
+      "generated_loc": 245,
+      "tested_library_loc": 951,
+      "metadata_entries": 6,
+      "code_coverage_percent": 39.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala",
+      "metadata_file": "metadata/org.scala-lang.modules/scala-xml_3/2.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scala-lang.modules/scala-xml_3/2.1.0/stats.json
+++ b/stats/org.scala-lang.modules/scala-xml_3/2.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8384,
+        "missed" : 18307,
+        "ratio" : 0.314113,
+        "total" : 26691
+      },
+      "line" : {
+        "covered" : 951,
+        "missed" : 1460,
+        "ratio" : 0.394442,
+        "total" : 2411
+      },
+      "method" : {
+        "covered" : 562,
+        "missed" : 1808,
+        "ratio" : 0.237131,
+        "total" : 2370
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/.gitignore
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scala-lang.modules:scala-xml_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/gradle.properties
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scala-lang.modules:scala-xml_3:2.1.0
+library.version = 2.1.0
+metadata.dir = org.scala-lang.modules/scala-xml_3/2.1.0/

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/settings.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scala-lang.modules.scala-xml_3_tests'

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scala_lang_modules.scala_xml_3
+
+import org.junit.jupiter.api.Test
+
+class Scala_xml_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
@@ -6,11 +6,210 @@
  */
 package org_scala_lang_modules.scala_xml_3
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+
+import java.io.StringReader
+import java.io.StringWriter
+import scala.jdk.CollectionConverters._
+import scala.xml.Comment
+import scala.xml.Elem
+import scala.xml.MinimizeMode
+import scala.xml.NamespaceBinding
+import scala.xml.Node
+import scala.xml.NodeBuffer
+import scala.xml.Null
+import scala.xml.PCData
+import scala.xml.PrefixedAttribute
+import scala.xml.PrettyPrinter
+import scala.xml.ProcInstr
+import scala.xml.Text
+import scala.xml.TopScope
+import scala.xml.UnprefixedAttribute
+import scala.xml.Utility
+import scala.xml.XML
+import scala.xml.dtd.DocType
+import scala.xml.dtd.PublicID
+import scala.xml.dtd.SystemID
+import scala.xml.transform.RewriteRule
+import scala.xml.transform.RuleTransformer
+
+final class RenameTitleElementRule extends RewriteRule {
+  override def transform(node: Node): scala.collection.Seq[Node] = {
+    node match {
+      case element: Elem if element.label == "title" => scala.collection.immutable.Seq(element.copy(label = "name"))
+      case other => scala.collection.immutable.Seq(other)
+    }
+  }
+}
 
 class Scala_xml_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def parsesNavigatesAndFiltersXmlDocuments(): Unit = {
+    val document: Elem = XML
+      .loadString(
+        """
+          |<catalog>
+          |  <book id="b-1" category="fiction">
+          |    <title>Neverwhere</title>
+          |    <author>Neil Gaiman</author>
+          |    <tags><tag>urban</tag><tag>fantasy</tag></tags>
+          |  </book>
+          |  <book id="b-2" category="non-fiction">
+          |    <title>The Design of Everyday Things</title>
+          |    <author>Don Norman</author>
+          |  </book>
+          |  <magazine id="m-1"><title>Scala Times</title></magazine>
+          |</catalog>
+          |""".stripMargin
+      )
+      .asInstanceOf[Elem]
+
+    val directBooks: scala.xml.NodeSeq = document \ "book"
+    val allTitles: List[String] = (document \\ "title").map(_.text.trim).toList
+    val fictionBook: Node = directBooks.find(node => (node \@ "category") == "fiction").get
+
+    assertThat(document.label).isEqualTo("catalog")
+    assertThat(directBooks.map(_ \@ "id").toList.asJava).containsExactly("b-1", "b-2")
+    assertThat(allTitles.asJava).containsExactly("Neverwhere", "The Design of Everyday Things", "Scala Times")
+    assertThat((fictionBook \ "tags" \\ "tag").map(_.text).toList.asJava).containsExactly("urban", "fantasy")
+    assertThat(fictionBook.attribute("category").map(_.text)).isEqualTo(Some("fiction"))
+    assertThat((document \\ "missing").isEmpty).isTrue
+  }
+
+  @Test
+  def preservesNamespacesAndNamespacedAttributes(): Unit = {
+    val root: Elem = XML
+      .loadString(
+        """
+          |<root xmlns:h="urn:html" xmlns:f="urn:furniture" h:id="root-1" plain="value">
+          |  <h:table><h:tr><h:td>cell</h:td></h:tr></h:table>
+          |  <f:table><f:name>African Coffee Table</f:name><f:width unit="cm">80</f:width></f:table>
+          |</root>
+          |""".stripMargin
+      )
+      .asInstanceOf[Elem]
+
+    val htmlTable: Node = (root \ "table").find(_.prefix == "h").get
+    val furnitureTable: Node = (root \ "table").find(_.prefix == "f").get
+    val htmlCell: Node = (root \\ "td").head
+    val furnitureWidth: Node = (furnitureTable \ "width").head
+
+    assertThat(root.getNamespace("h")).isEqualTo("urn:html")
+    assertThat(root.getNamespace("f")).isEqualTo("urn:furniture")
+    assertThat(root.attribute("plain").map(_.text)).isEqualTo(Some("value"))
+    assertThat(root.attribute("urn:html", "id").map(_.text)).isEqualTo(Some("root-1"))
+    assertThat(htmlTable.namespace).isEqualTo("urn:html")
+    assertThat(htmlCell.namespace).isEqualTo("urn:html")
+    assertThat(furnitureTable.namespace).isEqualTo("urn:furniture")
+    assertThat(furnitureWidth.attribute("unit").map(_.text)).isEqualTo(Some("cm"))
+  }
+
+  @Test
+  def constructsCopiesAndUpdatesElementsWithAttributes(): Unit = {
+    val scope: NamespaceBinding = NamespaceBinding("sku", "urn:sku", TopScope)
+    val attributes = new PrefixedAttribute(
+      "sku",
+      "id",
+      "A-1",
+      new UnprefixedAttribute("kind", "keyboard", Null)
+    )
+    val item: Elem = Elem("sku", "item", attributes, scope, false, Text("standard keyboard"))
+    val stockedItem: Elem = (item % new UnprefixedAttribute("stock", "5", Null))
+      .copy(child = scala.collection.immutable.Seq(Text("mechanical keyboard")))
+    val inventory: Elem = Elem(null, "inventory", Null, TopScope, false, stockedItem)
+
+    assertThat(stockedItem.prefix).isEqualTo("sku")
+    assertThat(stockedItem.namespace).isEqualTo("urn:sku")
+    assertThat(stockedItem.attribute("urn:sku", "id").map(_.text)).isEqualTo(Some("A-1"))
+    assertThat(stockedItem.attribute("kind").map(_.text)).isEqualTo(Some("keyboard"))
+    assertThat(stockedItem.attribute("stock").map(_.text)).isEqualTo(Some("5"))
+    assertThat(stockedItem.text).isEqualTo("mechanical keyboard")
+    assertThat((inventory \ "item").head.text).isEqualTo("mechanical keyboard")
+    assertThat(inventory.toString()).contains("xmlns:sku=\"urn:sku\"")
+  }
+
+  @Test
+  def trimsPrettyPrintsEscapesAndWritesXml(): Unit = {
+    val raw: Elem = XML
+      .loadString(
+        """
+          |<message text="5 &lt; 7 &amp; &quot;quoted&quot;">
+          |  Hello &lt;xml&gt; &amp; Scala
+          |  <empty></empty>
+          |</message>
+          |""".stripMargin
+      )
+      .asInstanceOf[Elem]
+    val trimmed: Node = Utility.trim(raw)
+    val pretty: String = new PrettyPrinter(width = 80, step = 2).format(trimmed)
+    val writer = new StringWriter()
+
+    XML.write(writer, trimmed, "UTF-8", true, null, MinimizeMode.Never)
+
+    assertThat(Utility.escape("5 < 7 & Scala")).isEqualTo("5 &lt; 7 &amp; Scala")
+    assertThat(trimmed.text.trim).isEqualTo("Hello <xml> & Scala")
+    assertThat(pretty).contains("Hello &lt;xml&gt; &amp; Scala")
+    assertThat(pretty).contains("text=\"5 &lt; 7 &amp; &quot;quoted&quot;\"")
+    assertThat(writer.toString).startsWith("<?xml version='1.0' encoding='UTF-8'?>")
+    assertThat(writer.toString).contains("<empty></empty>")
+  }
+
+  @Test
+  def serializesProcessingInstructionsCommentsCDataAndDoctypes(): Unit = {
+    val buffer = new NodeBuffer()
+    buffer &+ new ProcInstr("xml-stylesheet", "type=\"text/css\" href=\"style.css\"")
+    buffer &+ new Comment("generated by scala-xml")
+    buffer &+ new PCData("raw <markup> & data")
+
+    val article: Elem = Elem(null, "article", Null, TopScope, false, buffer.toSeq*)
+    val doctype = DocType("article", SystemID("article.dtd"), scala.collection.immutable.Seq.empty)
+    val writer = new StringWriter()
+
+    XML.write(writer, article, "UTF-8", false, doctype, MinimizeMode.Default)
+
+    val serialized: String = writer.toString
+    assertThat(article.child.map(_.label).toList.asJava).containsExactly("#PI", "#REM", "#PCDATA")
+    assertThat(serialized).startsWith("<!DOCTYPE article SYSTEM \"article.dtd\">")
+    assertThat(serialized).contains("<?xml-stylesheet type=\"text/css\" href=\"style.css\"?>")
+    assertThat(serialized).contains("<!--generated by scala-xml-->")
+    assertThat(serialized).contains("<![CDATA[raw <markup> & data]]>")
+  }
+
+  @Test
+  def formatsPublicDoctypesAndLoadsFromReaders(): Unit = {
+    val doctype = DocType(
+      "html",
+      PublicID("-//W3C//DTD XHTML 1.0 Strict//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"),
+      scala.collection.immutable.Seq.empty
+    )
+    val writer = new StringWriter()
+    val page: Elem = XML.load(new StringReader("<html><body><p>Hello</p></body></html>")).asInstanceOf[Elem]
+
+    XML.write(writer, page, "UTF-8", true, doctype, MinimizeMode.Default)
+
+    assertThat(page.label).isEqualTo("html")
+    assertThat((page \\ "p").text).isEqualTo("Hello")
+    assertThat(doctype.toString).contains("PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"")
+    assertThat(writer.toString).contains("<!DOCTYPE html PUBLIC")
+    assertThat(writer.toString).contains("<p>Hello</p>")
+  }
+
+  @Test
+  def transformsTreesWithRewriteRules(): Unit = {
+    val catalog: Node = XML.loadString(
+      """
+        |<catalog>
+        |  <book><title>Neverwhere</title><author>Neil Gaiman</author></book>
+        |  <magazine><title>Scala Times</title></magazine>
+        |</catalog>
+        |""".stripMargin
+    )
+    val transformer = new RuleTransformer(new RenameTitleElementRule())
+    val transformed: Elem = transformer.transform(catalog).head.asInstanceOf[Elem]
+
+    assertThat((transformed \\ "title").isEmpty).isTrue
+    assertThat((transformed \\ "name").map(_.text.trim).toList.asJava).containsExactly("Neverwhere", "Scala Times")
+    assertThat((transformed \\ "author").text.trim).isEqualTo("Neil Gaiman")
   }
 }

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
@@ -14,6 +14,7 @@ import java.io.StringWriter
 import scala.io.Source
 import scala.jdk.CollectionConverters._
 import scala.xml.Comment
+import scala.xml.Document
 import scala.xml.Elem
 import scala.xml.MinimizeMode
 import scala.xml.NamespaceBinding
@@ -30,8 +31,11 @@ import scala.xml.UnprefixedAttribute
 import scala.xml.Utility
 import scala.xml.XML
 import scala.xml.dtd.DocType
+import scala.xml.dtd.IntDef
+import scala.xml.dtd.ParsedEntityDecl
 import scala.xml.dtd.PublicID
 import scala.xml.dtd.SystemID
+import scala.xml.parsing.ConstructingParser
 import scala.xml.parsing.XhtmlParser
 import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
@@ -215,6 +219,36 @@ class Scala_xml_3Test {
       assertThat(scriptContent).isInstanceOf(classOf[PCData])
       assertThat(scriptContent.text).isEqualTo("if (a < b && c > d) render();")
       assertThat(div.toString()).contains("<![CDATA[if (a < b && c > d) render();]]>")
+    } finally {
+      source.close()
+    }
+  }
+
+  @Test
+  def constructsDocumentsWithXmlDeclarationsAndInternalDtds(): Unit = {
+    val source: Source = Source.fromString(
+      """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        |<!DOCTYPE note [
+        |  <!ENTITY greeting "Hello">
+        |]>
+        |<note priority="high"><to>Alice</to><from>Bob</from><body>&greeting;, Alice</body></note>""".stripMargin
+    )
+
+    try {
+      val document: Document = ConstructingParser.fromSource(source, preserveWS = false).document()
+      val parsedEntity = document.dtd.decls.collectFirst {
+        case declaration: ParsedEntityDecl if declaration.name == "greeting" => declaration
+      }.get
+
+      assertThat(document.version).isEqualTo(Some("1.0"))
+      assertThat(document.encoding).isEqualTo(Some("UTF-8"))
+      assertThat(document.standAlone).isEqualTo(Some(true))
+      assertThat(document.docElem.label).isEqualTo("note")
+      assertThat((document.docElem \ "to").text).isEqualTo("Alice")
+      assertThat((document.docElem \ "from").text).isEqualTo("Bob")
+      assertThat((document.docElem \ "body").text).isEqualTo("Hello, Alice")
+      assertThat(document.docElem.attribute("priority").map(_.text)).isEqualTo(Some("high"))
+      assertThat(parsedEntity.entdef).isEqualTo(IntDef("Hello"))
     } finally {
       source.close()
     }

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/src/test/scala/org_scala_lang_modules/scala_xml_3/Scala_xml_3Test.scala
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test
 
 import java.io.StringReader
 import java.io.StringWriter
+import scala.io.Source
 import scala.jdk.CollectionConverters._
 import scala.xml.Comment
 import scala.xml.Elem
@@ -31,6 +32,7 @@ import scala.xml.XML
 import scala.xml.dtd.DocType
 import scala.xml.dtd.PublicID
 import scala.xml.dtd.SystemID
+import scala.xml.parsing.XhtmlParser
 import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
 
@@ -193,6 +195,29 @@ class Scala_xml_3Test {
     assertThat(doctype.toString).contains("PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"")
     assertThat(writer.toString).contains("<!DOCTYPE html PUBLIC")
     assertThat(writer.toString).contains("<p>Hello</p>")
+  }
+
+  @Test
+  def parsesXhtmlEntitiesAndPreservesCDataBlocks(): Unit = {
+    val source: Source = Source.fromString(
+      """<div>
+        |  <p>Scala&nbsp;XML &copy;</p>
+        |  <script><![CDATA[if (a < b && c > d) render();]]></script>
+        |</div>""".stripMargin
+    )
+
+    try {
+      val parsed: scala.xml.NodeSeq = XhtmlParser(source)
+      val div: Elem = parsed.head.asInstanceOf[Elem]
+      val scriptContent: Node = (div \ "script").head.child.head
+
+      assertThat((div \ "p").text).isEqualTo("Scala\u00a0XML ©")
+      assertThat(scriptContent).isInstanceOf(classOf[PCData])
+      assertThat(scriptContent.text).isEqualTo("if (a < b && c > d) render();")
+      assertThat(div.toString()).contains("<![CDATA[if (a < b && c > d) render();]]>")
+    } finally {
+      source.close()
+    }
   }
 
   @Test

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/user-code-filter.json
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "scala.xml.**"
+    }
+  ]
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/user-code-filter.json
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "scala.xml.**"
+      "includeClasses" : "scala.xml.**"
+    },
+    {
+      "includeClasses" : "org_scala_lang_modules.scala_xml_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2241

This PR introduces tests and metadata for org.scala-lang.modules:scala-xml_3:2.1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 216088
- Cached input tokens: 2078720
- Output tokens: 24732
- Metadata entries: 6
- Iterations: 7
- Library coverage percentage: 39.44
- Generated lines of code: 245
- Tested library lines of code: 951

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 8384/26691 (31.41%)
- Line: 951/2411 (39.44%)
- Method: 562/2370 (23.71%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
