### PR TITLE
[GenAI] Mark org.junit.jupiter:junit-jupiter as not for Native Image

### DIFF
--- a/metadata/org.junit.jupiter/junit-jupiter/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no application/library JVM class files beyond module-info.class, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2173

This PR records `org.junit.jupiter:junit-jupiter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no application/library JVM class files beyond module-info.class, so there is no library code for native-image metadata.

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `a297c9297f77ec01586d25f1644c2564a502c5ac`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
