### PR TITLE
[GenAI] Mark org.jetbrains.compose.foundation:foundation as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.compose.foundation/foundation/index.json
+++ b/metadata/org.jetbrains.compose.foundation/foundation/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM desktop variants to org.jetbrains.compose.foundation:foundation-desktop:1.7.3.",
+    "replacement": "org.jetbrains.compose.foundation:foundation-desktop:1.7.3"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2661

This PR records `org.jetbrains.compose.foundation:foundation` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM desktop variants to org.jetbrains.compose.foundation:foundation-desktop:1.7.3.

Replacement guidance:
- org.jetbrains.compose.foundation:foundation-desktop:1.7.3

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9c576cc7973ce058ca8729aadfd2172dfde2b9a1`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
