### PR TITLE
[GenAI] Mark org.jetbrains.kotlinx:atomicfu as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.kotlinx/atomicfu/index.json
+++ b/metadata/org.jetbrains.kotlinx/atomicfu/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata and no JVM class files; Gradle module metadata redirects JVM variants to org.jetbrains.kotlinx:atomicfu-jvm:0.19.0.",
+    "replacement": "org.jetbrains.kotlinx:atomicfu-jvm:0.19.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2659

This PR records `org.jetbrains.kotlinx:atomicfu` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata and no JVM class files; Gradle module metadata redirects JVM variants to org.jetbrains.kotlinx:atomicfu-jvm:0.19.0.

Replacement guidance:
- org.jetbrains.kotlinx:atomicfu-jvm:0.19.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `9c576cc7973ce058ca8729aadfd2172dfde2b9a1`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
