### PR TITLE
[GenAI] Mark org.jetbrains.compose.runtime:runtime as not for Native Image

### DIFF
--- a/metadata/org.jetbrains.compose.runtime/runtime/index.json
+++ b/metadata/org.jetbrains.compose.runtime/runtime/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.compose.runtime:runtime-desktop:1.7.3.",
+    "replacement": "org.jetbrains.compose.runtime:runtime-desktop:1.7.3"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #2644

This PR records `org.jetbrains.compose.runtime:runtime` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to org.jetbrains.compose.runtime:runtime-desktop:1.7.3.

Replacement guidance:
- org.jetbrains.compose.runtime:runtime-desktop:1.7.3

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a297c9297f77ec01586d25f1644c2564a502c5ac`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
