### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-shouldmatchers_2.13:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
+      },
+      "bundle" : "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-shouldmatchers_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_2.13/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test/scala/org/scalatest",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest Should Matchers provides the should matcher syntax for expressing assertions in ScalaTest suites. It lets tests compare values, inspect collections and properties, and build readable expectations using ScalaTest's matcher DSL.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.matchers.should"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-shouldmatchers_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-shouldmatchers_2.13/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test/scala/org/scalatest",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-javadoc.jar",
-    "description" : "ScalaTest Should Matchers provides the should matcher syntax for expressing assertions in ScalaTest suites. It lets tests compare values, inspect collections and properties, and build readable expectations using ScalaTest's matcher DSL.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test/scala/org/scalatest",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-shouldmatchers_2.13/$version$/scalatest-shouldmatchers_2.13-$version$-javadoc.jar",
+    "description": "ScalaTest Should Matchers provides the should matcher syntax for expressing assertions in ScalaTest suites. It lets tests compare values, inspect collections and properties, and build readable expectations using ScalaTest's matcher DSL.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.matchers.should"
+    "allowed-packages": [
+      "org.scalatest.matchers.should",
+      "org.scalatest"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T17:12:57.698749Z",
+    "library": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.19",
+    "starting_commit": "344280bcb3e9b0b965a34d7d861cb81c95bc4c7c",
+    "ending_commit": "aa07d8464e40275c17810627b4dbb163a56a120b",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 862,
+          "missed": 17164,
+          "ratio": 0.04782,
+          "total": 18026
+        },
+        "line": {
+          "covered": 101,
+          "missed": 1494,
+          "ratio": 0.063323,
+          "total": 1595
+        },
+        "method": {
+          "covered": 62,
+          "missed": 1375,
+          "ratio": 0.043145,
+          "total": 1437
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 72672,
+      "cached_input_tokens_used": 354304,
+      "output_tokens_used": 10667,
+      "iterations": 5,
+      "cost_usd": 0.4972,
+      "generated_loc": 133,
+      "tested_library_loc": 101,
+      "metadata_entries": 1,
+      "code_coverage_percent": 6.33
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 862,
+        "missed" : 17164,
+        "ratio" : 0.04782,
+        "total" : 18026
+      },
+      "line" : {
+        "covered" : 101,
+        "missed" : 1494,
+        "ratio" : 0.063323,
+        "total" : 1595
+      },
+      "method" : {
+        "covered" : 62,
+        "missed" : 1375,
+        "ratio" : 0.043145,
+        "total" : 1437
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-shouldmatchers_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-shouldmatchers_2.13:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-shouldmatchers_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
@@ -8,6 +8,9 @@ package org_scalatest.scalatest_shouldmatchers_2_13
 
 import java.util
 
+import scala.util.Success
+import scala.util.Try
+
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.scalatest.exceptions.TestFailedException
@@ -93,6 +96,17 @@ class Scalatest_shouldmatchers_2_13Test extends Matchers {
     atMost(1, statusLines) should include("ERROR")
     exactly(2, statusLines) should startWith("20")
     no(statusLines) should endWith("PENDING")
+  }
+
+  @Test
+  def matchesValuesWithPatternMatching(): Unit = {
+    val parsedNumber: Try[Int] = Try("42".toInt)
+    val response: Either[String, (String, Int)] = Right(("created", 201))
+    val measurements: Vector[Int] = Vector(1, 2, 3, 5)
+
+    parsedNumber should matchPattern { case Success(42) => }
+    response should matchPattern { case Right(("created", status: Int)) if status >= 200 && status < 300 => }
+    measurements should matchPattern { case Vector(1, 2, _*) => }
   }
 
   @Test

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
@@ -110,6 +110,22 @@ class Scalatest_shouldmatchers_2_13Test extends Matchers {
   }
 
   @Test
+  def matchesThrownExceptionsAndCapturedMessages(): Unit = {
+    val failure: IllegalArgumentException = the[IllegalArgumentException] thrownBy {
+      throw new IllegalArgumentException("invalid port", new NumberFormatException("not numeric"))
+    }
+
+    an[IllegalStateException] should be thrownBy {
+      throw new IllegalStateException("service unavailable")
+    }
+    noException should be thrownBy {
+      List(1, 2, 3).sum
+    }
+    failure should have message "invalid port"
+    failure.getCause shouldBe a[NumberFormatException]
+  }
+
+  @Test
   def supportsCustomPublicMatchersAndNegation(): Unit = {
     val bePalindrome: Matcher[String] = Matcher { (left: String) =>
       val normalized: String = left.filter(_.isLetterOrDigit).toLowerCase

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_shouldmatchers_2_13
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_shouldmatchers_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_shouldmatchers_2_13/Scalatest_shouldmatchers_2_13Test.scala
@@ -6,11 +6,120 @@
  */
 package org_scalatest.scalatest_shouldmatchers_2_13
 
-import org.junit.jupiter.api.Test
+import java.util
 
-class Scalatest_shouldmatchers_2_13Test {
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.should.Matchers
+
+class Scalatest_shouldmatchers_2_13Test extends Matchers {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def matchesEqualityOrderingTypesAndNumericTolerance(): Unit = {
+    val computedTotal: Int = List(2, 3, 5).sum
+    val observedRatio: Double = 22.0 / 7.0
+    val thrown: Throwable = new IllegalArgumentException("invalid input")
+
+    computedTotal shouldBe 10
+    computedTotal should (be >= 10 and be < 20)
+    computedTotal should not be 11
+    observedRatio shouldBe (3.142 +- 0.001)
+    Vector(1, 2, 3, 4) shouldBe sorted
+    thrown shouldBe a[RuntimeException]
   }
+
+  @Test
+  def matchesStringsWithSubstringPrefixSuffixAndRegexGroups(): Unit = {
+    val message: String = "order-123: shipped to Vienna"
+
+    message should startWith("order-")
+    message should include("shipped")
+    message should endWith("Vienna")
+    "order-123" should fullyMatch regex ("order-(\\d+)" withGroup "123")
+    "scala" should not fullyMatch regex("java-[0-9]+")
+  }
+
+  @Test
+  def matchesScalaCollectionsWithElementAndSequenceConstraints(): Unit = {
+    val colors: List[String] = List("red", "green", "blue", "green")
+    val orderedNumbers: Vector[Int] = Vector(1, 2, 3, 4, 5)
+
+    colors should contain("red")
+    colors should contain allOf("red", "blue")
+    colors should contain atLeastOneOf("purple", "green")
+    colors should contain noneOf("black", "white")
+    colors should contain only("red", "green", "blue")
+    orderedNumbers should contain inOrder(2, 3, 5)
+    orderedNumbers should contain theSameElementsAs Vector(5, 4, 3, 2, 1)
+    orderedNumbers should have length 5
+    colors.toSet should have size 3
+  }
+
+  @Test
+  def matchesOptionsArraysMapsAndJavaCollections(): Unit = {
+    val configured: Option[String] = Some("enabled")
+    val absent: Option[String] = None
+    val byteValues: Array[Byte] = Array[Byte](1, 2, 3)
+    val scalaMap: Map[String, Int] = Map("http" -> 80, "https" -> 443)
+    val javaList: util.ArrayList[String] = new util.ArrayList[String]()
+    javaList.add("alpha")
+    javaList.add("beta")
+    val javaMap: util.HashMap[String, Int] = new util.HashMap[String, Int]()
+    javaMap.put("retries", 3)
+    javaMap.put("timeoutSeconds", 5)
+
+    configured shouldBe defined
+    configured should contain("enabled")
+    absent shouldBe empty
+    byteValues should contain theSameElementsInOrderAs Array[Byte](1, 2, 3)
+    scalaMap should contain key "https"
+    scalaMap should contain value 80
+    javaList should contain("beta")
+    javaList should have length 2
+    javaMap should contain key "retries"
+    javaMap should contain value 5
+  }
+
+  @Test
+  def appliesMatchersAcrossCollectionsWithQuantifiers(): Unit = {
+    val evenNumbers: List[Int] = List(2, 4, 6, 8)
+    val statusLines: List[String] = List("200 OK", "201 CREATED", "500 ERROR")
+
+    all(evenNumbers) should be < 10
+    all(evenNumbers.map(_ % 2)) shouldBe 0
+    atLeast(2, evenNumbers) should be > 4
+    atMost(1, statusLines) should include("ERROR")
+    exactly(2, statusLines) should startWith("20")
+    no(statusLines) should endWith("PENDING")
+  }
+
+  @Test
+  def supportsCustomPublicMatchersAndNegation(): Unit = {
+    val bePalindrome: Matcher[String] = Matcher { (left: String) =>
+      val normalized: String = left.filter(_.isLetterOrDigit).toLowerCase
+      MatchResult(
+        normalized == normalized.reverse,
+        s"$left was not a palindrome",
+        s"$left was a palindrome"
+      )
+    }
+
+    "Never odd or even" should bePalindrome
+    "ScalaTest" should not(bePalindrome)
+  }
+
+  @Test
+  def reportsMatcherFailuresAsTestFailedExceptions(): Unit = {
+    val failure: TestFailedException = expectMatcherFailure {
+      List(1, 2, 3) should contain only(1, 2)
+    }
+
+    failure.getMessage should not be empty
+    failure.failedCodeFileName shouldBe Some("Scalatest_shouldmatchers_2_13Test.scala")
+  }
+
+  private def expectMatcherFailure(assertion: => Unit): TestFailedException =
+    Assertions.assertThrows(classOf[TestFailedException], () => assertion)
 }

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.matchers.should.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.matchers.should.**"
+      "includeClasses" : "org.scalatest.matchers.should.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_shouldmatchers_2_13.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5083

This PR introduces tests and metadata for org.scalatest:scalatest-shouldmatchers_2.13:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 72672
- Cached input tokens: 354304
- Output tokens: 10667
- Metadata entries: 1
- Iterations: 5
- Library coverage percentage: 6.33
- Generated lines of code: 133
- Tested library lines of code: 101

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `5eb40d7709dbbf741a598523b2fbedd24c55d625`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 862/18026 (4.78%)
- Line: 101/1595 (6.33%)
- Method: 62/1437 (4.31%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
