### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-mustmatchers_2.13:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-mustmatchers_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_2.13/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-javadoc.jar",
-    "description" : "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-javadoc.jar",
+    "description": "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.matchers.must"
+    "allowed-packages": [
+      "org.scalatest.matchers.must",
+      "org.scalatest"
     ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-mustmatchers_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-mustmatchers_2.13/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/scalatest-test/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.13/$version$/scalatest-mustmatchers_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest Must Matchers provides the must-style matcher syntax for ScalaTest assertions on the JVM. It supplies the org.scalatest.matchers.must.Matchers API, allowing tests to express expectations such as values must equal, include, contain, start with, or satisfy custom matchers.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.matchers.must"
+    ]
+  }
+]

--- a/stats/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T17:57:30.741609Z",
+    "library": "org.scalatest:scalatest-mustmatchers_2.13:3.2.19",
+    "starting_commit": "04f252c980168a56dc9405a6316fefe2d38ef32f",
+    "ending_commit": "1346b050bf4c026b4d78f57c3b288ca10f38244f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1126,
+          "missed": 16895,
+          "ratio": 0.062483,
+          "total": 18021
+        },
+        "line": {
+          "covered": 126,
+          "missed": 1468,
+          "ratio": 0.079046,
+          "total": 1594
+        },
+        "method": {
+          "covered": 80,
+          "missed": 1356,
+          "ratio": 0.05571,
+          "total": 1436
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 116706,
+      "cached_input_tokens_used": 690688,
+      "output_tokens_used": 18314,
+      "iterations": 4,
+      "cost_usd": 0.8947,
+      "generated_loc": 245,
+      "tested_library_loc": 126,
+      "metadata_entries": 1,
+      "code_coverage_percent": 7.9
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1126,
+        "missed" : 16895,
+        "ratio" : 0.062483,
+        "total" : 18021
+      },
+      "line" : {
+        "covered" : 126,
+        "missed" : 1468,
+        "ratio" : 0.079046,
+        "total" : 1594
+      },
+      "method" : {
+        "covered" : 80,
+        "missed" : 1356,
+        "ratio" : 0.05571,
+        "total" : 1436
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-mustmatchers_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-mustmatchers_2.13:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-mustmatchers_2.13/3.2.19/

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-mustmatchers_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
@@ -134,6 +134,33 @@ class Scalatest_mustmatchers_2_13Test extends Matchers {
   }
 
   @Test
+  def mustDslSupportsPartialFunctionDefinedAtMatchers(): Unit = {
+    val routeStatuses: PartialFunction[String, ServiceStatus] = {
+      case route if route.startsWith("/services/") =>
+        val serviceName: String = route.stripPrefix("/services/")
+        ServiceStatus(
+          name = serviceName,
+          active = true,
+          endpoint = s"https://$serviceName.example.test",
+          replicas = 2
+        )
+    }
+
+    routeStatuses must be definedAt ("/services/metadata")
+    routeStatuses must not be definedAt ("/health")
+
+    val metadataStatus: ServiceStatus = routeStatuses("/services/metadata")
+    assertEquals("metadata", metadataStatus.name)
+    assertTrue(metadataStatus.active)
+
+    val failure: TestFailedException = expectTestFailure {
+      routeStatuses must be definedAt ("/metrics")
+    }
+    assertTrue(failure.getMessage.contains("was not defined at"))
+    assertTrue(failure.getMessage.contains("/metrics"))
+  }
+
+  @Test
   def customMatchersIntegrateWithMustSyntaxAndExposeMatchResults(): Unit = {
     val evenNumber: Matcher[Int] = Matcher { (value: Int) =>
       MatchResult(

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
@@ -6,11 +6,220 @@
  */
 package org_scalatest.scalatest_mustmatchers_2_13
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.BeMatcher
+import org.scalatest.matchers.BePropertyMatchResult
+import org.scalatest.matchers.BePropertyMatcher
+import org.scalatest.matchers.HavePropertyMatchResult
+import org.scalatest.matchers.HavePropertyMatcher
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.must.Matchers
 
-class Scalatest_mustmatchers_2_13Test {
+final case class ServiceStatus(name: String, active: Boolean, endpoint: String, replicas: Int)
+
+class Scalatest_mustmatchers_2_13Test extends Matchers {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def mustDslSupportsEqualityIdentityAndNumericMatchers(): Unit = {
+    val serviceName: String = "metadata-forge"
+    val alias: String = serviceName
+    val measuredLatency: Double = 98.6
+
+    serviceName mustBe "metadata-forge"
+    serviceName must equal("metadata-forge")
+    alias must be theSameInstanceAs serviceName
+    measuredLatency must be(98.7 +- 0.2)
+    7 must be > 3
+    7 must be >= 7
+    7 must be < 11
+    7 must be <= 7
+    serviceName must not be empty
+
+    val failure: TestFailedException = expectTestFailure {
+      measuredLatency must be(100.0 +- 0.1)
+    }
+    assertTrue(failure.getMessage.contains("98.6"))
+    assertTrue(failure.getMessage.contains("100.0"))
+  }
+
+  @Test
+  def mustDslSupportsStringAndRegexMatchers(): Unit = {
+    val description: String = "ScalaTest must matchers exercise integration paths"
+
+    description must startWith("ScalaTest")
+    description must endWith("paths")
+    description must include("must matchers")
+    description must fullyMatch regex ("ScalaTest must matchers exercise integration paths")
+    description must include regex ("must [a-z]+ers")
+    description must (startWith("Scala") and include("integration"))
+    description must (endWith("paths") or endWith("routes"))
+    description must not include ("deprecated")
+
+    val failure: TestFailedException = expectTestFailure {
+      description must startWith("JUnit")
+    }
+    assertTrue(failure.getMessage.contains("JUnit"))
+  }
+
+  @Test
+  def mustDslSupportsCollectionArrayAndMapMatchers(): Unit = {
+    val numbers: List[Int] = List(1, 2, 3, 4, 5)
+    val orderedLabels: Vector[String] = Vector("discover", "exercise", "verify")
+    val labelArray: Array[String] = Array("alpha", "beta", "gamma")
+    val settings: Map[String, Int] = Map("port" -> 8080, "workers" -> 4)
+
+    numbers must contain(3)
+    numbers must contain allOf (1, 3, 5)
+    numbers must contain atLeastOneOf (0, 4, 9)
+    numbers must contain noneOf (7, 8, 9)
+    numbers must contain theSameElementsAs List(5, 4, 3, 2, 1)
+    numbers must contain inOrder (1, 2, 3)
+    numbers must have size 5
+    numbers must have length 5
+
+    orderedLabels must contain inOrderOnly ("discover", "exercise", "verify")
+    labelArray must contain theSameElementsInOrderAs Seq("alpha", "beta", "gamma")
+    settings must contain key ("port")
+    settings must contain value (4)
+    settings must contain("workers" -> 4)
+
+    val failure: TestFailedException = expectTestFailure {
+      numbers must contain only (1, 2, 3)
+    }
+    assertTrue(failure.getMessage.contains("4"))
+    assertTrue(failure.getMessage.contains("5"))
+  }
+
+  @Test
+  def mustDslSupportsOptionEitherAndInspectionMatchers(): Unit = {
+    val optionalPort: Option[Int] = Some(8443)
+    val missingPort: Option[Int] = None
+    val results: List[Either[String, Int]] = List(Right(1), Right(2), Right(3))
+    val replicatedCounts: Vector[Int] = Vector(3, 4, 5, 6)
+
+    optionalPort must contain(8443)
+    missingPort mustBe empty
+    results must contain only (Right(1), Right(2), Right(3))
+    all(replicatedCounts) must be >= 3
+    atLeast(2, replicatedCounts) must be > 4
+    atMost(2, replicatedCounts) must be <= 4
+    exactly(1, replicatedCounts) must be(6)
+    between(2, 3, replicatedCounts) must be >= 5
+    every(List("agent", "builder", "runner")) must fullyMatch regex ("[a-z]+")
+
+    val failure: TestFailedException = expectTestFailure {
+      all(replicatedCounts) must be < 6
+    }
+    assertTrue(failure.getMessage.contains("6"))
+  }
+
+  @Test
+  def mustDslSupportsExceptionMatchers(): Unit = {
+    an[IllegalArgumentException] must be thrownBy {
+      parsePositive("-4")
+    }
+    noException must be thrownBy {
+      parsePositive("12")
+    }
+
+    val failure: IllegalArgumentException = the[IllegalArgumentException] thrownBy {
+      parsePositive("0")
+    }
+    failure must have message "value must be positive: 0"
+  }
+
+  @Test
+  def customMatchersIntegrateWithMustSyntaxAndExposeMatchResults(): Unit = {
+    val evenNumber: Matcher[Int] = Matcher { (value: Int) =>
+      MatchResult(
+        value % 2 == 0,
+        s"$value was not even",
+        s"$value was even"
+      )
+    }
+    val stableIdentifier: BeMatcher[String] = BeMatcher { (value: String) =>
+      MatchResult(
+        value.matches("[a-z][a-z0-9_]*"),
+        s"$value was not a stable identifier",
+        s"$value was a stable identifier"
+      )
+    }
+
+    12 must evenNumber
+    "worker_17" must be(stableIdentifier)
+    "Worker-17" must not be (stableIdentifier)
+
+    val directResult: MatchResult = evenNumber(11)
+    assertFalse(directResult.matches)
+    assertEquals("11 was not even", directResult.rawFailureMessage)
+
+    val failure: TestFailedException = expectTestFailure {
+      11 must evenNumber
+    }
+    assertTrue(failure.getMessage.contains("11 was not even"))
+  }
+
+  @Test
+  def propertyMatchersIntegrateWithMustBeAndMustHaveSyntax(): Unit = {
+    val active: BePropertyMatcher[ServiceStatus] = new BePropertyMatcher[ServiceStatus] {
+      override def apply(left: ServiceStatus): BePropertyMatchResult = {
+        BePropertyMatchResult(left.active, "active")
+      }
+    }
+    val endpoint: HavePropertyMatcher[ServiceStatus, String] = new HavePropertyMatcher[ServiceStatus, String] {
+      override def apply(left: ServiceStatus): HavePropertyMatchResult[String] = {
+        HavePropertyMatchResult(
+          left.endpoint == "https://metadata.example.test",
+          "endpoint",
+          "https://metadata.example.test",
+          left.endpoint
+        )
+      }
+    }
+    val replicas: HavePropertyMatcher[ServiceStatus, Int] = new HavePropertyMatcher[ServiceStatus, Int] {
+      override def apply(left: ServiceStatus): HavePropertyMatchResult[Int] = {
+        HavePropertyMatchResult(left.replicas == 3, "replicas", 3, left.replicas)
+      }
+    }
+    val healthyService: ServiceStatus = ServiceStatus(
+      name = "reachability-metadata",
+      active = true,
+      endpoint = "https://metadata.example.test",
+      replicas = 3
+    )
+
+    healthyService must be(active)
+    healthyService must have(endpoint)
+    healthyService must have(replicas)
+    healthyService must have(endpoint, replicas)
+
+    val failure: TestFailedException = expectTestFailure {
+      healthyService.copy(replicas = 2) must have(replicas)
+    }
+    assertTrue(failure.getMessage.contains("replicas"))
+    assertTrue(failure.getMessage.contains("3"))
+    assertTrue(failure.getMessage.contains("2"))
+  }
+
+  private def parsePositive(input: String): Int = {
+    val parsed: Int = input.toInt
+    if (parsed <= 0) {
+      throw new IllegalArgumentException(s"value must be positive: $input")
+    }
+    parsed
+  }
+
+  private def expectTestFailure(action: => Unit): TestFailedException = {
+    org.junit.jupiter.api.Assertions.assertThrows(
+      classOf[TestFailedException],
+      new Executable {
+        override def execute(): Unit = action
+      }
+    )
   }
 }

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
@@ -134,6 +134,32 @@ class Scalatest_mustmatchers_2_13Test extends Matchers {
   }
 
   @Test
+  def mustDslSupportsPatternAndTypeMatchers(): Unit = {
+    val metadataStatus: ServiceStatus = ServiceStatus(
+      name = "metadata",
+      active = true,
+      endpoint = "https://metadata.example.test",
+      replicas = 3
+    )
+
+    metadataStatus mustBe a [ServiceStatus]
+    metadataStatus.endpoint mustBe a [String]
+    metadataStatus must not be a [String]
+    metadataStatus must matchPattern {
+      case ServiceStatus("metadata", true, endpoint, replicas)
+        if endpoint.startsWith("https://") && replicas >= 3 =>
+    }
+
+    val failure: TestFailedException = expectTestFailure {
+      metadataStatus must matchPattern {
+        case ServiceStatus("metrics", true, _, _) =>
+      }
+    }
+    assertTrue(failure.getMessage.contains("ServiceStatus"))
+    assertTrue(failure.getMessage.contains("did not match"))
+  }
+
+  @Test
   def mustDslSupportsPartialFunctionDefinedAtMatchers(): Unit = {
     val routeStatuses: PartialFunction[String, ServiceStatus] = {
       case route if route.startsWith("/services/") =>

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_mustmatchers_2_13/Scalatest_mustmatchers_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_mustmatchers_2_13
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_mustmatchers_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.matchers.must.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.matchers.must.**"
+      "includeClasses" : "org.scalatest.matchers.must.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_mustmatchers_2_13.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5081

This PR introduces tests and metadata for org.scalatest:scalatest-mustmatchers_2.13:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 116706
- Cached input tokens: 690688
- Output tokens: 18314
- Metadata entries: 1
- Iterations: 4
- Library coverage percentage: 7.9
- Generated lines of code: 245
- Tested library lines of code: 126

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `d7921ec95f73156f19f56f5fd70a8303346bbe93`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1126/18021 (6.25%)
- Line: 126/1594 (7.90%)
- Method: 80/1436 (5.57%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
