### PR TITLE
[GenAI] Add support for org.eclipse.jetty:jetty-alpn-client:11.0.12 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-alpn-client/11.0.12/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/11.0.12/reachability-metadata.json
@@ -1,0 +1,102 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Boolean",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Byte",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Double",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Float",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Integer",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Long",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.Short",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "11.0.12",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
-    "repository-url" : "https://github.com/jetty/jetty.project",
-    "test-code-url" : "N/A",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
-    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "11.0.12",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url": "https://github.com/jetty/jetty.project",
+    "test-code-url": "N/A",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description": "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
+    "tested-versions": [
       "11.0.12"
     ],
-    "allowed-packages" : [
-      "org.eclipse.jetty.alpn.client"
+    "allowed-packages": [
+      "org.eclipse.jetty.alpn.client",
+      "org.eclipse.jetty.util"
     ]
   }
 ]

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "11.0.12",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
+    "tested-versions" : [
+      "11.0.12"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.alpn.client"
+    ]
+  }
+]

--- a/stats/org.eclipse.jetty/jetty-alpn-client/11.0.12/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/11.0.12/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T21:28:54.058295Z",
+    "library": "org.eclipse.jetty:jetty-alpn-client:11.0.12",
+    "starting_commit": "7ea24761015ed09a4f591b8c8b38f96915acf7c1",
+    "ending_commit": "86747643994f9fb64feeeeb010f8887cb30b559d",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "11.0.12",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 65,
+          "missed": 117,
+          "ratio": 0.357143,
+          "total": 182
+        },
+        "line": {
+          "covered": 18,
+          "missed": 28,
+          "ratio": 0.391304,
+          "total": 46
+        },
+        "method": {
+          "covered": 5,
+          "missed": 2,
+          "ratio": 0.714286,
+          "total": 7
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 136388,
+      "cached_input_tokens_used": 1092096,
+      "output_tokens_used": 15686,
+      "iterations": 3,
+      "cost_usd": 1.0166,
+      "generated_loc": 206,
+      "tested_library_loc": 18,
+      "metadata_entries": 14,
+      "code_coverage_percent": 39.13
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-alpn-client/11.0.12/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-alpn-client/11.0.12/stats.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/11.0.12/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "11.0.12",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 65,
+        "missed" : 117,
+        "ratio" : 0.357143,
+        "total" : 182
+      },
+      "line" : {
+        "covered" : 18,
+        "missed" : 28,
+        "ratio" : 0.391304,
+        "total" : 46
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 2,
+        "ratio" : 0.714286,
+        "total" : 7
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-alpn-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-alpn-client:11.0.12
+library.version = 11.0.12
+metadata.dir = org.eclipse.jetty/jetty-alpn-client/11.0.12/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-alpn-client_tests'

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_alpn_client;
+
+import org.junit.jupiter.api.Test;
+
+class Jetty_alpn_clientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -6,11 +6,201 @@
  */
 package org_eclipse_jetty.jetty_alpn_client;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.alpn.client.ALPNClientConnection;
+import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
+import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
 import org.junit.jupiter.api.Test;
 
-class Jetty_alpn_clientTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class Jetty_alpn_clientTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+    private static final List<String> PROTOCOLS = List.of("h2", "http/1.1");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void clientConnectionExposesSslEngineAndConfiguredProtocols() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        SSLEngine sslEngine = newClientEngine();
+        Map<String, Object> context = new HashMap<>();
+        ALPNClientConnection connection = new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                sslEngine,
+                context,
+                PROTOCOLS);
+
+        assertThat(connection.getSSLEngine()).isSameAs(sslEngine);
+        assertThat(connection.getProtocols()).containsExactly("h2", "http/1.1");
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolIsRecordedWithoutImmediatelyReplacingTheConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        context.put("test.name", "selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection");
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("http/1.1");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("http/1.1");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void selectedProtocolOnFillableUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void onFillableKeepsWaitingWhenNegotiationHasNotCompletedAndNoBytesAreAvailable() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isFillInterested()).isTrue();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void closeShutsDownEndPointOutput() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.close();
+
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
+    void clientConnectionFactoryRejectsEmptyProtocolListBeforeLookingUpProcessors() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        List.of()))
+                .withMessage("ALPN protocol list cannot be empty");
+    }
+
+    @Test
+    void clientConnectionFactoryReportsMissingProcessorWhenNoClientAlpnProcessorServiceIsPresent() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        PROTOCOLS))
+                .withMessage("No Client ALPNProcessors!");
+    }
+
+    private static ALPNClientConnection newAlpnConnection(
+            EndPoint endPoint,
+            ClientConnectionFactory connectionFactory,
+            Map<String, Object> context) throws Exception {
+        return new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                newClientEngine(),
+                context,
+                PROTOCOLS);
+    }
+
+    private static SSLEngine newClientEngine() throws Exception {
+        SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine("localhost", 443);
+        sslEngine.setUseClientMode(true);
+        return sslEngine;
+    }
+
+    private static final class TestClientConnectionFactory implements ClientConnectionFactory {
+        private final List<EndPoint> seenEndPoints = new ArrayList<>();
+        private final List<Map<String, Object>> seenContexts = new ArrayList<>();
+        private final List<RecordingConnection> createdConnections = new ArrayList<>();
+
+        @Override
+        public Connection newConnection(EndPoint endPoint, Map<String, Object> context) throws IOException {
+            seenEndPoints.add(endPoint);
+            seenContexts.add(context);
+            RecordingConnection connection = new RecordingConnection(endPoint);
+            createdConnections.add(connection);
+            return connection;
+        }
+    }
+
+    private static final class RecordingConnection extends AbstractConnection {
+        private boolean opened;
+
+        private RecordingConnection(EndPoint endPoint) {
+            super(endPoint, DIRECT_EXECUTOR);
+        }
+
+        @Override
+        public void onOpen() {
+            super.onOpen();
+            opened = true;
+        }
+
+        @Override
+        public void onFillable() {
+        }
     }
 }

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -152,6 +152,24 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
+    void failedProtocolConnectionCreationClosesEndPoint() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        ClientConnectionFactory failingConnectionFactory = (ignoredEndPoint, ignoredContext) -> {
+            throw new IOException("Unable to create protocol connection");
+        };
+        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
     void clientConnectionFactoryRejectsEmptyProtocolListBeforeLookingUpProcessors() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new ALPNClientConnectionFactory(

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -120,6 +120,25 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
+    void endOfInputCompletesNegotiationAndUpgradesToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+        endPoint.addInputEOF();
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
     void closeShutsDownEndPointOutput() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
         TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.jetty.alpn.client.**"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.jetty.alpn.client.**"
+      "includeClasses" : "org.eclipse.jetty.alpn.client.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_jetty.jetty_alpn_client.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #1511

This PR introduces tests and metadata for org.eclipse.jetty:jetty-alpn-client:11.0.12, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 136388
- Cached input tokens: 1092096
- Output tokens: 15686
- Metadata entries: 14
- Iterations: 3
- Library coverage percentage: 39.13
- Generated lines of code: 206
- Tested library lines of code: 18

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0e560ab7b0e9e75b7295e5e58041c48c2451aaba`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 65/182 (35.71%)
- Line: 18/46 (39.13%)
- Method: 5/7 (71.43%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
