### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-funsuite_2.13:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-funsuite_2.13/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-funsuite_2.13/3.2.19/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
+      },
+      "bundle" : "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-funsuite_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-funsuite_2.13/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-javadoc.jar",
-    "description" : "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest on the JVM, where tests are registered as named functions rather than discovered as methods. It integrates with ScalaTest's assertions, fixtures, tagging, asynchronous suites, and reporting so Scala projects can write function-oriented unit tests.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-javadoc.jar",
+    "description": "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest on the JVM, where tests are registered as named functions rather than discovered as methods. It integrates with ScalaTest's assertions, fixtures, tagging, asynchronous suites, and reporting so Scala projects can write function-oriented unit tests.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.funsuite"
+    "allowed-packages": [
+      "org.scalatest.funsuite",
+      "org.scalatest"
     ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-funsuite_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-funsuite_2.13/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/funsuite-test/src/test/scala/org/scalatest/funsuite",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-funsuite_2.13/$version$/scalatest-funsuite_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest FunSuite provides the FunSuite testing style for ScalaTest on the JVM, where tests are registered as named functions rather than discovered as methods. It integrates with ScalaTest's assertions, fixtures, tagging, asynchronous suites, and reporting so Scala projects can write function-oriented unit tests.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.funsuite"
+    ]
+  }
+]

--- a/stats/org.scalatest/scalatest-funsuite_2.13/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-funsuite_2.13/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T22:15:22.907660Z",
+    "library": "org.scalatest:scalatest-funsuite_2.13:3.2.19",
+    "starting_commit": "288df8262ed975a107d64f883ac3bd5c84bf9c1e",
+    "ending_commit": "8b114b53b04a6430c2ef5f6c21356c5716b861c5",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 662,
+          "missed": 2229,
+          "ratio": 0.228987,
+          "total": 2891
+        },
+        "line": {
+          "covered": 59,
+          "missed": 124,
+          "ratio": 0.322404,
+          "total": 183
+        },
+        "method": {
+          "covered": 87,
+          "missed": 381,
+          "ratio": 0.185897,
+          "total": 468
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 139068,
+      "cached_input_tokens_used": 1510400,
+      "output_tokens_used": 15171,
+      "iterations": 4,
+      "cost_usd": 1.2103,
+      "generated_loc": 276,
+      "tested_library_loc": 59,
+      "metadata_entries": 1,
+      "code_coverage_percent": 32.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-funsuite_2.13/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-funsuite_2.13/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-funsuite_2.13/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 662,
+        "missed" : 2229,
+        "ratio" : 0.228987,
+        "total" : 2891
+      },
+      "line" : {
+        "covered" : 59,
+        "missed" : 124,
+        "ratio" : 0.322404,
+        "total" : 183
+      },
+      "method" : {
+        "covered" : 87,
+        "missed" : 381,
+        "ratio" : 0.185897,
+        "total" : 468
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-funsuite_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-funsuite_2.13:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-funsuite_2.13/3.2.19/

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-funsuite_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
@@ -10,7 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.scalatest.{Args, ConfigMap, Filter, Outcome, Reporter, Tag}
-import org.scalatest.events.{Event, InfoProvided, TestFailed, TestIgnored, TestPending, TestStarting, TestSucceeded}
+import org.scalatest.events.{Event, InfoProvided, TestCanceled, TestFailed, TestIgnored, TestPending, TestStarting, TestSucceeded}
 import org.scalatest.exceptions.{DuplicateTestNameException, TestRegistrationClosedException}
 import org.scalatest.funsuite.{AnyFunSuite, FixtureAnyFunSuite}
 
@@ -66,6 +66,25 @@ class Scalatest_funsuite_2_13Test {
     assertThat(succeeded.recordedEvents.collect { case event: InfoProvided => event.message }.asJava)
       .containsExactly("diagnostic details")
     assertThat(suite.executionLog.asJava).containsExactly("succeeded", "pending", "failed")
+  }
+
+  @Test
+  def anyFunSuiteReportsCanceledTestsAndContinuesTheSuite(): Unit = {
+    val suite: CancelingFunSuite = new CancelingFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(None, Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.executionLog.asJava).containsExactly("before", "cancel", "after")
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava)
+      .containsExactly("test before cancellation", "test after cancellation")
+
+    val canceledEvents: List[TestCanceled] = reporter.eventsOf[TestCanceled]
+    assertThat(canceledEvents.map(_.testName).asJava).containsExactly("canceled test")
+    assertThat(canceledEvents.head.message).contains("external service unavailable")
+    assertThat(reporter.eventsOf[TestFailed].asJava).isEmpty()
   }
 
   @Test
@@ -196,6 +215,23 @@ class OutcomeFunSuite extends AnyFunSuite {
   test("failing test") {
     executionLog += "failed"
     throw new IllegalStateException("intentional failure")
+  }
+}
+
+class CancelingFunSuite extends AnyFunSuite {
+  val executionLog: ListBuffer[String] = ListBuffer.empty
+
+  test("test before cancellation") {
+    executionLog += "before"
+  }
+
+  test("canceled test") {
+    executionLog += "cancel"
+    cancel("external service unavailable")
+  }
+
+  test("test after cancellation") {
+    executionLog += "after"
   }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_funsuite_2_13
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_funsuite_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
@@ -6,11 +6,263 @@
  */
 package org_scalatest.scalatest_funsuite_2_13
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.scalatest.{Args, ConfigMap, Filter, Outcome, Reporter, Tag}
+import org.scalatest.events.{Event, InfoProvided, TestFailed, TestIgnored, TestPending, TestStarting, TestSucceeded}
+import org.scalatest.exceptions.{DuplicateTestNameException, TestRegistrationClosedException}
+import org.scalatest.funsuite.{AnyFunSuite, FixtureAnyFunSuite}
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
 
 class Scalatest_funsuite_2_13Test {
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def anyFunSuiteRegistersAndRunsTestsInDeclarationOrder(): Unit = {
+    val suite: OrderedFunSuite = new OrderedFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(None, Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.testNames.toList.asJava).containsExactly("first test", "second test")
+    assertThat(suite.executionLog.asJava).containsExactly("first", "second")
+    assertThat(reporter.eventsOf[TestStarting].map(_.testName).asJava).containsExactly("first test", "second test")
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly("first test", "second test")
+  }
+
+  @Test
+  def anyFunSuiteCanRunASingleNamedTest(): Unit = {
+    val suite: OrderedFunSuite = new OrderedFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(Some("second test"), Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.executionLog.asJava).containsExactly("second")
+    assertThat(reporter.eventsOf[TestStarting].map(_.testName).asJava).containsExactly("second test")
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly("second test")
+  }
+
+  @Test
+  def anyFunSuiteReportsIgnoredPendingFailedAndRecordedInfoEvents(): Unit = {
+    val suite: OutcomeFunSuite = new OutcomeFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(None, Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isFalse()
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly("succeeds with info")
+    assertThat(reporter.eventsOf[TestIgnored].map(_.testName).asJava).containsExactly("ignored test")
+    assertThat(reporter.eventsOf[TestPending].map(_.testName).asJava).containsExactly("pending test")
+    assertThat(reporter.eventsOf[TestFailed].map(_.testName).asJava).containsExactly("failing test")
+
+    val succeeded: TestSucceeded = reporter.eventsOf[TestSucceeded].head
+    assertThat(succeeded.recordedEvents.collect { case event: InfoProvided => event.message }.asJava)
+      .containsExactly("diagnostic details")
+    assertThat(suite.executionLog.asJava).containsExactly("succeeded", "pending", "failed")
+  }
+
+  @Test
+  def anyFunSuiteAppliesTagsWhenCountingAndFilteringTests(): Unit = {
+    val suite: TaggedFunSuite = new TaggedFunSuite
+    val includeFastOnly: Filter = Filter(tagsToInclude = Some(Set(FastTag.name)), tagsToExclude = Set.empty)
+    val excludeDatabase: Filter = Filter(tagsToExclude = Set(DatabaseTag.name))
+    val reporter: RecordingReporter = new RecordingReporter
+
+    assertThat(suite.tags("fast test").asJava).containsExactly(FastTag.name)
+    assertThat(suite.tags("database test").asJava).containsExactly(DatabaseTag.name)
+    assertThat(suite.expectedTestCount(includeFastOnly)).isEqualTo(1)
+    assertThat(suite.expectedTestCount(excludeDatabase)).isEqualTo(1)
+
+    val status = suite.run(None, Args(reporter, filter = includeFastOnly))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.executionLog.asJava).containsExactly("fast")
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly("fast test")
+  }
+
+  @Test
+  def anyFunSuiteRegistersSharedTestsThroughTestsFor(): Unit = {
+    val suite: SharedBehaviorFunSuite = new SharedBehaviorFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(None, Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.testNames.toList.asJava).containsExactly(
+      "stack created with one element is non-empty",
+      "stack created with one element returns the top element"
+    )
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly(
+      "stack created with one element is non-empty",
+      "stack created with one element returns the top element"
+    )
+  }
+
+  @Test
+  def fixtureAnyFunSuiteProvidesFixtureAndConfigMapToEachTest(): Unit = {
+    val suite: FixtureBackedFunSuite = new FixtureBackedFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+    val args: Args = Args(reporter, configMap = ConfigMap("seed" -> "configured value"))
+
+    val status = suite.run(None, args)
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.events.asJava).containsExactly(
+      "create:uses fixture argument",
+      "test:configured value",
+      "cleanup:configured value",
+      "test:no-arg"
+    )
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly(
+      "uses fixture argument",
+      "uses no-arg fixture wrapper"
+    )
+  }
+
+  @Test
+  def anyFunSuiteRejectsDuplicateTestNames(): Unit = {
+    assertThrows(
+      classOf[DuplicateTestNameException],
+      () => new DuplicateNameFunSuite
+    )
+  }
+
+  @Test
+  def anyFunSuiteClosesRegistrationAfterRunStarts(): Unit = {
+    val suite: LateRegistrationFunSuite = new LateRegistrationFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+
+    val status = suite.run(None, Args(reporter))
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThrows(classOf[TestRegistrationClosedException], () => suite.registerAdditionalTest())
+  }
+}
+
+class RecordingReporter extends Reporter {
+  private val recordedEvents: ListBuffer[Event] = ListBuffer.empty
+
+  override def apply(event: Event): Unit = {
+    recordedEvents += event
+  }
+
+  def events: List[Event] = recordedEvents.toList
+
+  def eventsOf[A <: Event](implicit classTag: scala.reflect.ClassTag[A]): List[A] = {
+    events.collect { case event: A => event }
+  }
+}
+
+class OrderedFunSuite extends AnyFunSuite {
+  val executionLog: ListBuffer[String] = ListBuffer.empty
+
+  test("first test") {
+    executionLog += "first"
+  }
+
+  test("second test") {
+    executionLog += "second"
+  }
+}
+
+class OutcomeFunSuite extends AnyFunSuite {
+  val executionLog: ListBuffer[String] = ListBuffer.empty
+
+  test("succeeds with info") {
+    executionLog += "succeeded"
+    info("diagnostic details")
+  }
+
+  ignore("ignored test") {
+    executionLog += "ignored"
+  }
+
+  test("pending test") {
+    executionLog += "pending"
+    pending
+  }
+
+  test("failing test") {
+    executionLog += "failed"
+    throw new IllegalStateException("intentional failure")
+  }
+}
+
+object FastTag extends Tag("org.scalatest.examples.Fast")
+
+object DatabaseTag extends Tag("org.scalatest.examples.Database")
+
+class TaggedFunSuite extends AnyFunSuite {
+  val executionLog: ListBuffer[String] = ListBuffer.empty
+
+  test("fast test", FastTag) {
+    executionLog += "fast"
+  }
+
+  test("database test", DatabaseTag) {
+    executionLog += "database"
+  }
+}
+
+class SharedBehaviorFunSuite extends AnyFunSuite {
+  testsFor(nonEmptyStack("stack created with one element", List(1)))
+
+  private def nonEmptyStack(description: String, stack: List[Int]): Unit = {
+    test(s"$description is non-empty") {
+      assert(stack.nonEmpty)
+    }
+
+    test(s"$description returns the top element") {
+      assert(stack.head == 1)
+    }
+  }
+}
+
+class FixtureBackedFunSuite extends FixtureAnyFunSuite {
+  type FixtureParam = String
+
+  val events: ListBuffer[String] = ListBuffer.empty
+
+  override protected def withFixture(test: OneArgTest): Outcome = {
+    events += s"create:${test.name}"
+    val fixture: String = test.configMap("seed").asInstanceOf[String]
+    try {
+      test(fixture)
+    } finally {
+      events += s"cleanup:$fixture"
+    }
+  }
+
+  test("uses fixture argument") { fixture: String =>
+    events += s"test:$fixture"
+    assert(fixture == "configured value")
+  }
+
+  test("uses no-arg fixture wrapper") { () =>
+    events += "test:no-arg"
+  }
+}
+
+class DuplicateNameFunSuite extends AnyFunSuite {
+  test("duplicate") {}
+  test("duplicate") {}
+}
+
+class LateRegistrationFunSuite extends AnyFunSuite {
+  test("registered before run") {}
+
+  def registerAdditionalTest(): Unit = {
+    test("registered after run") {}
   }
 }

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_funsuite_2_13/Scalatest_funsuite_2_13Test.scala
@@ -149,6 +149,27 @@ class Scalatest_funsuite_2_13Test {
   }
 
   @Test
+  def anyFunSuiteAppliesNoArgFixtureAroundEachTest(): Unit = {
+    val suite: NoArgFixtureFunSuite = new NoArgFixtureFunSuite
+    val reporter: RecordingReporter = new RecordingReporter
+    val args: Args = Args(reporter, configMap = ConfigMap("mode" -> "fixture value"))
+
+    val status = suite.run(None, args)
+
+    assertThat(status.isCompleted).isTrue()
+    assertThat(status.succeeds()).isTrue()
+    assertThat(suite.events.asJava).containsExactly(
+      "before:first wrapped:fixture value",
+      "body:first",
+      "after:first wrapped",
+      "before:second wrapped:fixture value",
+      "body:second",
+      "after:second wrapped"
+    )
+    assertThat(reporter.eventsOf[TestSucceeded].map(_.testName).asJava).containsExactly("first wrapped", "second wrapped")
+  }
+
+  @Test
   def anyFunSuiteRejectsDuplicateTestNames(): Unit = {
     assertThrows(
       classOf[DuplicateTestNameException],
@@ -287,6 +308,27 @@ class FixtureBackedFunSuite extends FixtureAnyFunSuite {
 
   test("uses no-arg fixture wrapper") { () =>
     events += "test:no-arg"
+  }
+}
+
+class NoArgFixtureFunSuite extends AnyFunSuite {
+  val events: ListBuffer[String] = ListBuffer.empty
+
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    events += s"before:${test.name}:${test.configMap("mode")}"
+    try {
+      test()
+    } finally {
+      events += s"after:${test.name}"
+    }
+  }
+
+  test("first wrapped") {
+    events += "body:first"
+  }
+
+  test("second wrapped") {
+    events += "body:second"
   }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.funsuite.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.funsuite.**"
+      "includeClasses" : "org.scalatest.funsuite.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_funsuite_2_13.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5074

This PR introduces tests and metadata for org.scalatest:scalatest-funsuite_2.13:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 139068
- Cached input tokens: 1510400
- Output tokens: 15171
- Metadata entries: 1
- Iterations: 4
- Library coverage percentage: 32.24
- Generated lines of code: 276
- Tested library lines of code: 59

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `f242aa2b0f61de3a6f0f8706e1da0826d5cf33ec`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 662/2891 (22.90%)
- Line: 59/183 (32.24%)
- Method: 87/468 (18.59%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
