### PR TITLE
[GenAI] Test fix for org.codehaus.plexus:plexus-container-default:1.0-alpha-8 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/reachability-metadata.json
@@ -1,0 +1,1013 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "java.lang.Class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "java.lang.Object[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter"
+      },
+      "type" : "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.basic.DateConverter"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter"
+      },
+      "type" : "java.lang.Unknown"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter"
+      },
+      "type" : "java.util.ArrayList",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.basic.DateConverter"
+      },
+      "type" : "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.DefaultPlexusContainer",
+      "fields" : [
+        {
+          "name" : "componentComposerManager"
+        },
+        {
+          "name" : "componentDiscovererManager"
+        },
+        {
+          "name" : "componentFactoryManager"
+        },
+        {
+          "name" : "componentManagerManager"
+        },
+        {
+          "name" : "componentRepository"
+        },
+        {
+          "name" : "lifecycleHandlerManager"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.DefaultPlexusContainer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.PlexusContainerManager$1"
+      },
+      "type" : "org.codehaus.plexus.PlexusContainerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.SimplePlexusContainerManager",
+      "fields" : [
+        {
+          "name" : "plexusConfig"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.SimplePlexusContainerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.AbstractComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager",
+      "fields" : [
+        {
+          "name" : "componentComposers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultCompositionResolver",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscoverer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager",
+      "fields" : [
+        {
+          "name" : "componentDiscoverers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager",
+      "fields" : [
+        {
+          "name" : "defaultComponentFactory"
+        },
+        {
+          "name" : "defaultComponentFactoryId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.AbstractComponentManager",
+      "fields" : [
+        {
+          "name" : "id"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.AbstractComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager",
+      "fields" : [
+        {
+          "name" : "componentManagers"
+        },
+        {
+          "name" : "defaultComponentManagerId"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository",
+      "fields" : [
+        {
+          "name" : "compositionResolver"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.AbstractLifecycleHandler",
+      "fields" : [
+        {
+          "name" : "beginSegment"
+        },
+        {
+          "name" : "endSegment"
+        },
+        {
+          "name" : "id"
+        },
+        {
+          "name" : "name"
+        },
+        {
+          "name" : "resumeSegment"
+        },
+        {
+          "name" : "suspendSegment"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.AbstractLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.ComponentValueSetter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager",
+      "fields" : [
+        {
+          "name" : "defaultLifecycleHandlerId"
+        },
+        {
+          "name" : "lifecycleHandlers"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.AutoConfigurePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.CompositionPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ConfigurablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ContextualizePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.DisposePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogDisablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogEnablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ResumePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ServiceablePhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StartPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StopPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.SuspendPhase",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.xml.Xpp3Dom"
+      },
+      "type" : "org.codehaus.plexus.util.xml.Xpp3Dom[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.ComponentComposerManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.composition.ComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultCompositionResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.ComponentConfigurator$1"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.ComponentConfigurator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.discovery.ComponentDiscoverer$1"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.ComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.ComponentFactory$1"
+      },
+      "type" : "org.codehaus.plexus.component.factory.ComponentFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.AutoConfigurePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.CompositionPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ConfigurablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ContextualizePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.DisposePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogDisablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogEnablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ResumePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ServiceablePhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StartPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StopPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.SuspendPhase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.manager.ComponentManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ComponentManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.manager.ComponentManagerManager$1"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ComponentManagerManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.logging.LoggerManager$1"
+      },
+      "type" : "org.codehaus.plexus.logging.LoggerManager"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer"
+      },
+      "glob" : "META-INF/plexus/plexus.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "glob" : "org/codehaus/plexus/plexus-bootstrap.xml"
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-container-default/index.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.0-alpha-8",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/$version$/plexus-container-default-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-containers",
+    "test-code-url" : "N/A",
+    "documentation-url" : "N/A",
+    "description" : "Plexus Container Default is the original Plexus inversion-of-control container implementation used to discover, configure, compose, and manage Plexus components. It provides component descriptors, lifecycle handling, dependency injection, configuration conversion, logging hooks, and embeddable container APIs for Java applications.",
     "tested-versions" : [
       "1.0-alpha-8"
     ],

--- a/metadata/org.codehaus.plexus/plexus-container-default/index.json
+++ b/metadata/org.codehaus.plexus/plexus-container-default/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "org.codehaus.plexus"
     ]
+  },
+  {
+    "metadata-version" : "1.0-alpha-8",
+    "tested-versions" : [
+      "1.0-alpha-8"
+    ],
+    "allowed-packages" : [
+      "org.codehaus.plexus"
+    ]
   }
 ]

--- a/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-06": {
+    "timestamp": "2026-05-06T22:46:51.667494Z",
+    "library": "org.codehaus.plexus:plexus-container-default:1.0-alpha-8",
+    "starting_commit": "2c63a2f885c6e1006af90106ee2bedff474e9c50",
+    "ending_commit": "53240266168e3755c11cb8e4e66b8fad79f51ec9",
+    "previous_library": "org.codehaus.plexus:plexus-container-default:1.0-alpha-7",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.0-alpha-8",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.964912,
+            "coveredCalls": 55,
+            "totalCalls": 57
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.965517,
+        "coveredCalls": 56,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4026,
+          "missed": 7457,
+          "ratio": 0.350605,
+          "total": 11483
+        },
+        "line": {
+          "covered": 1017,
+          "missed": 1845,
+          "ratio": 0.355346,
+          "total": 2862
+        },
+        "method": {
+          "covered": 289,
+          "missed": 414,
+          "ratio": 0.411095,
+          "total": 703
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0-alpha-7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.964912,
+            "coveredCalls": 55,
+            "totalCalls": 57
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.965517,
+        "coveredCalls": 56,
+        "totalCalls": 58
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3971,
+          "missed": 7415,
+          "ratio": 0.348762,
+          "total": 11386
+        },
+        "line": {
+          "covered": 1006,
+          "missed": 1835,
+          "ratio": 0.354101,
+          "total": 2841
+        },
+        "method": {
+          "covered": 286,
+          "missed": 411,
+          "ratio": 0.41033,
+          "total": 697
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 231833,
+      "cached_input_tokens_used": 2637312,
+      "output_tokens_used": 26198,
+      "iterations": 6,
+      "cost_usd": 2.1046,
+      "tested_library_loc": 1017,
+      "metadata_entries": 176,
+      "test_only_metadata_entries": 8,
+      "previous_library_metadata_entries": 176,
+      "previous_library_test_only_metadata_entries": 8,
+      "code_coverage_percent": 35.53,
+      "previous_library_coverage_percent": 35.41
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/stats.json
+++ b/stats/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.0-alpha-8",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.964912,
+          "coveredCalls" : 55,
+          "totalCalls" : 57
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 0.965517,
+      "coveredCalls" : 56,
+      "totalCalls" : 58
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4026,
+        "missed" : 7457,
+        "ratio" : 0.350605,
+        "total" : 11483
+      },
+      "line" : {
+        "covered" : 1017,
+        "missed" : 1845,
+        "ratio" : 0.355346,
+        "total" : 2862
+      },
+      "method" : {
+        "covered" : 289,
+        "missed" : 414,
+        "ratio" : 0.411095,
+        "total" : 703
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-container-default:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-container-default:1.0-alpha-8
+library.version = 1.0-alpha-8
+metadata.dir = org.codehaus.plexus/plexus-container-default/1.0-alpha-8/

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-container-default_tests'

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractConfigurationConverterTest {
+    @Test
+    public void loadsImplementationHintsAndInstantiatesLoadedClasses() throws Exception {
+        ExposingConfigurationConverter converter = new ExposingConfigurationConverter();
+        ClassLoader classLoader = AbstractConfigurationConverterTest.class.getClassLoader();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("component");
+        configuration.setAttribute("implementation", ArrayList.class.getName());
+
+        Class implementation = converter.getImplementationClass(Object.class, configuration, classLoader);
+        Object instance = converter.instantiate(InstantiableComponent.class.getName(), classLoader);
+
+        assertSame(ArrayList.class, implementation);
+        assertTrue(instance instanceof InstantiableComponent);
+    }
+
+    public static final class InstantiableComponent {
+    }
+
+    private static final class ExposingConfigurationConverter extends AbstractConfigurationConverter {
+        private Class getImplementationClass(Class type, PlexusConfiguration configuration, ClassLoader classLoader)
+            throws ComponentConfigurationException {
+            return getClassForImplementationHint(type, configuration, classLoader);
+        }
+
+        private Object instantiate(String className, ClassLoader classLoader) throws ComponentConfigurationException {
+            return instantiateObject(className, classLoader);
+        }
+
+        @Override
+        public boolean canConvert(Class type) {
+            return false;
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -7,6 +7,7 @@
 package org_codehaus_plexus.plexus_container_default;
 
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
@@ -56,6 +57,13 @@ public class AbstractConfigurationConverterTest {
         public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
                                         Class baseType, ClassLoader classLoader,
                                         ExpressionEvaluator expressionEvaluator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener) {
             throw new UnsupportedOperationException();
         }
     }

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ArrayConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ArrayConverterTest {
+    @Test
+    public void convertsArrayElementsResolvedByClassNameBasePackageAndComponentType() throws Exception {
+        ExposingArrayConverter converter = new ExposingArrayConverter();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("items");
+        addChild(configuration, "java.lang.String", "resolved from fully qualified element name");
+        addChild(configuration, "string", "resolved from base package");
+        addChild(configuration, "unknown", "resolved from array component type");
+
+        Object value = converter.fromConfiguration(
+            new DefaultConverterLookup(),
+            configuration,
+            String[].class,
+            String.class,
+            ArrayConverterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+
+        assertArrayEquals(
+            new String[] {
+                "resolved from fully qualified element name",
+                "resolved from base package",
+                "resolved from array component type"
+            },
+            (String[]) value
+        );
+    }
+
+    @Test
+    public void createsDefaultListCollection() {
+        ExposingArrayConverter converter = new ExposingArrayConverter();
+
+        Collection collection = converter.defaultCollection(ArrayList.class);
+
+        assertTrue(collection instanceof ArrayList);
+        assertTrue(collection.isEmpty());
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    private static final class ExposingArrayConverter extends ArrayConverter {
+        private Collection defaultCollection(Class collectionType) {
+            return getDefaultCollection(collectionType);
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
+import org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CollectionConverterTest {
+    @Test
+    public void recognizesCollectionsButNotMaps() {
+        CollectionConverter converter = new CollectionConverter();
+
+        assertTrue(converter.canConvert(ArrayList.class));
+        assertFalse(converter.canConvert(Map.class));
+    }
+
+    @Test
+    public void createsConcreteCollectionAndResolvesChildrenByClassNameAndBasePackage() throws Exception {
+        CollectionConverter converter = new CollectionConverter();
+        DefaultConverterLookup converterLookup = new DefaultConverterLookup();
+        converterLookup.registerConverter(new NamedElementConverter());
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("items");
+        addChild(configuration, "java.lang.String", "loaded from fully qualified child element");
+        addChild(configuration, "collectionConverterTest$NamedElement", "loaded from base package child element");
+
+        Object value = converter.fromConfiguration(
+            converterLookup,
+            configuration,
+            ArrayList.class,
+            CollectionConverterTest.class,
+            CollectionConverterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+
+        assertTrue(value instanceof ArrayList);
+        Collection collection = (Collection) value;
+        assertEquals(2, collection.size());
+        assertTrue(collection.contains("loaded from fully qualified child element"));
+        assertTrue(collection.contains(new NamedElement("loaded from base package child element")));
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    public static final class NamedElement {
+        private final String value;
+
+        private NamedElement(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof NamedElement)) {
+                return false;
+            }
+            NamedElement that = (NamedElement) other;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+
+    private static final class NamedElementConverter implements ConfigurationConverter {
+        @Override
+        public boolean canConvert(Class type) {
+            return NamedElement.class.equals(type);
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator)
+            throws ComponentConfigurationException {
+            try {
+                return new NamedElement((String) expressionEvaluator.evaluate(configuration.getValue(null)));
+            } catch (ExpressionEvaluationException e) {
+                throw new ComponentConfigurationException("Could not create named element", e);
+            }
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -7,6 +7,7 @@
 package org_codehaus_plexus.plexus_container_default;
 
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
 import org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
@@ -107,6 +108,14 @@ public class CollectionConverterTest {
             } catch (ExpressionEvaluationException e) {
                 throw new ComponentConfigurationException("Could not create named element", e);
             }
+        }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener)
+            throws ComponentConfigurationException {
+            return fromConfiguration(converterLookup, configuration, type, baseType, classLoader, expressionEvaluator);
         }
     }
 

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.composition.ComponentComposer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentComposerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentComposer.class.getName(), ComponentComposer.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentComposerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.composition.ComponentComposerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentComposerManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentComposerManager.class.getName(), ComponentComposerManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentConfiguratorAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentConfiguratorAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentConfiguratorAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentConfigurator.class.getName(), ComponentConfigurator.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentDiscovererAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentDiscovererAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.discovery.ComponentDiscoverer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentDiscovererAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentDiscoverer.class.getName(), ComponentDiscoverer.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentFactoryAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentFactoryAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.factory.ComponentFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentFactoryAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentFactory.class.getName(), ComponentFactory.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.manager.ComponentManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentManager.class.getName(), ComponentManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentManagerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.manager.ComponentManagerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentManagerManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(ComponentManagerManager.class.getName(), ComponentManagerManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/ComponentValueSetterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.component.configurator.converters.ComponentValueSetter;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentValueSetterTest {
+    @Test
+    public void configuresPrivateFieldWhenNoSetterExists() throws Exception {
+        FieldOnlyComponent component = new FieldOnlyComponent();
+
+        configure(component, "configuredValue", "field value");
+
+        assertEquals("field value", component.getConfiguredValue());
+    }
+
+    @Test
+    public void configuresUsingSetterWhenSetterExists() throws Exception {
+        SetterOnlyComponent component = new SetterOnlyComponent();
+
+        configure(component, "configuredValue", "setter value");
+
+        assertEquals("setter value", component.getAssignedValue());
+    }
+
+    private static void configure(Object component, String fieldName, String value) throws Exception {
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration(fieldName);
+        configuration.setValue(value);
+
+        ComponentValueSetter setter = new ComponentValueSetter(fieldName, component, new DefaultConverterLookup());
+        setter.configure(
+            configuration,
+            ComponentValueSetterTest.class.getClassLoader(),
+            new LiteralExpressionEvaluator()
+        );
+    }
+
+    public static final class FieldOnlyComponent {
+        private String configuredValue;
+
+        public String getConfiguredValue() {
+            return configuredValue;
+        }
+    }
+
+    public static final class SetterOnlyComponent {
+        private String assignedValue;
+
+        public void setConfiguredValue(String configuredValue) {
+            assignedValue = configuredValue;
+        }
+
+        public String getAssignedValue() {
+            return assignedValue;
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/DefaultPlexusContainerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.logging.console.ConsoleLoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultPlexusContainerTest {
+    private static final String BOOTSTRAP_CONFIGURATION = """
+        <plexus>
+          <resources/>
+          <components/>
+          <component-repository implementation="org.codehaus.plexus.component.repository.DefaultComponentRepository"/>
+          <lifecycle-handler-manager implementation="org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager">
+            <lifecycle-handlers>
+              <lifecycle-handler implementation="org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler">
+                <id>plexus</id>
+                <name>Plexus</name>
+              </lifecycle-handler>
+            </lifecycle-handlers>
+          </lifecycle-handler-manager>
+          <component-manager-manager
+              implementation="org.codehaus.plexus.component.manager.DefaultComponentManagerManager">
+            <component-managers/>
+            <default-component-manager-id>singleton</default-component-manager-id>
+          </component-manager-manager>
+          <component-discoverer-manager
+              implementation="org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager">
+            <component-discoverers/>
+            <listeners/>
+          </component-discoverer-manager>
+          <component-factory-manager
+              implementation="org.codehaus.plexus.component.factory.DefaultComponentFactoryManager"/>
+          <component-composer-manager
+              implementation="org.codehaus.plexus.component.composition.DefaultComponentComposerManager">
+            <component-composers/>
+          </component-composer-manager>
+          <system-properties/>
+          <load-on-start/>
+        </plexus>
+        """;
+
+    @Test
+    void initializeAssignsLoggerForPlexusContainerRole() throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        DefaultPlexusContainer container = new DefaultPlexusContainer();
+        ClassWorld classWorld = new ClassWorld();
+        ClassRealm coreRealm = classWorld.newRealm("test.core", new BootstrapConfigurationClassLoader());
+
+        try {
+            container.setClassWorld(classWorld);
+            container.setCoreRealm(coreRealm);
+            container.setLoggerManager(new ConsoleLoggerManager("fatal"));
+
+            container.initialize();
+
+            assertThat(container.isInitialized()).isTrue();
+            assertThat(container.getLogger()).isNotNull();
+            assertThat(container.getContext().get(PlexusConstants.PLEXUS_KEY)).isSameAs(container);
+            assertThat(container.getLogger().getName()).contains(PlexusContainer.class.getName());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            if (container.isInitialized()) {
+                container.dispose();
+            }
+        }
+    }
+
+    private static final class BootstrapConfigurationClassLoader extends ClassLoader {
+        private BootstrapConfigurationClassLoader() {
+            super(DefaultPlexusContainerTest.class.getClassLoader());
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (DefaultPlexusContainer.BOOTSTRAP_CONFIGURATION.equals(name)) {
+                return new ByteArrayInputStream(BOOTSTRAP_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.FieldComponentComposer;
+import org.codehaus.plexus.component.composition.UndefinedComponentComposerException;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentInstantiationException;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class FieldComponentComposerTest {
+    @Test
+    public void assignsRequirementsToAllSupportedFieldShapes() throws Exception {
+        FieldComponentComposer composer = new FieldComponentComposer();
+        ComponentWithAllFieldKinds component = new ComponentWithAllFieldKinds();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor componentDescriptor = descriptor(ComponentWithAllFieldKinds.class.getName());
+
+        Object[] arrayDependency = new Object[] {"nested dependency" };
+        List<String> listDependencies = new ArrayList<>();
+        listDependencies.add("list dependency");
+        Map<String, String> mapDependencies = new HashMap<>();
+        mapDependencies.put("key", "map dependency");
+        Map<String, String> setSourceDependencies = new HashMap<>();
+        setSourceDependencies.put("set-key", "set dependency");
+        Dependency ordinaryDependency = new Dependency();
+
+        String arrayRole = "arrayRole";
+        String mapRole = "mapRole";
+        String listRole = "listRole";
+        String setRole = "setRole";
+        String ordinaryRole = Dependency.class.getName();
+
+        container.addList(arrayRole, listOf(arrayDependency));
+        container.addList(listRole, listDependencies);
+        container.addMap(mapRole, mapDependencies);
+        container.addMap(setRole, setSourceDependencies);
+        container.addComponent(ordinaryRole, ordinaryDependency);
+
+        componentDescriptor.addRequirement(requirement(arrayRole, "arrayDependencies"));
+        componentDescriptor.addRequirement(requirement(mapRole, "mapDependencies"));
+        componentDescriptor.addRequirement(requirement(listRole, "listDependencies"));
+        componentDescriptor.addRequirement(requirement(setRole, "setDependencies"));
+        componentDescriptor.addRequirement(requirement(ordinaryRole, "ordinaryDependency"));
+
+        List assignedDescriptors = composer.assembleComponent(component, componentDescriptor, container);
+
+        assertEquals(5, assignedDescriptors.size());
+        assertEquals(1, component.arrayDependencies.length);
+        assertSame(arrayDependency, component.arrayDependencies[0]);
+        assertSame(mapDependencies, component.mapDependencies);
+        assertSame(listDependencies, component.listDependencies);
+        assertEquals(setSourceDependencies.entrySet(), component.setDependencies);
+        assertSame(ordinaryDependency, component.ordinaryDependency);
+    }
+
+    @Test
+    public void findsRequirementFieldByRoleUsingThreadContextClassLoader() throws Exception {
+        ExposingFieldComponentComposer composer = new ExposingFieldComponentComposer();
+        ComponentDescriptor descriptor = descriptor(DerivedComponent.class.getName());
+        ComponentRequirement requirement = requirement(Dependency.class.getName(), null);
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+        Thread.currentThread().setContextClassLoader(FieldComponentComposerTest.class.getClassLoader());
+        try {
+            Field field = composer.findField(new DerivedComponent(), descriptor, requirement);
+
+            assertEquals("inheritedDependency", field.getName());
+            assertSame(BaseComponent.class, field.getDeclaringClass());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static ComponentRequirement requirement(String role, String fieldName) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldName(fieldName);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    public static final class Dependency {
+    }
+
+    public static class BaseComponent {
+        private Dependency inheritedDependency;
+    }
+
+    public static final class DerivedComponent extends BaseComponent {
+    }
+
+    public static final class ComponentWithAllFieldKinds {
+        private Object[] arrayDependencies;
+
+        private Map mapDependencies;
+
+        private List listDependencies;
+
+        private Set setDependencies;
+
+        private Dependency ordinaryDependency;
+    }
+
+    private static final class ExposingFieldComponentComposer extends FieldComponentComposer {
+        private Field findField(Object component, ComponentDescriptor descriptor, ComponentRequirement requirement)
+            throws CompositionException {
+            return findMatchingField(component, descriptor, requirement, null);
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addComponent(String key, Object component) {
+            components.put(key, component);
+            descriptors.put(key, descriptor(key));
+        }
+
+        private void addList(String role, List dependencies) {
+            lists.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isStarted() {
+            return true;
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public Object createComponentInstance(ComponentDescriptor componentDescriptor)
+            throws ComponentInstantiationException, ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void composeComponent(Object component, ComponentDescriptor componentDescriptor)
+            throws CompositionException, UndefinedComponentComposerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public ClassRealm getComponentRealm(String componentKey) {
+            return null;
+        }
+
+        @Override
+        public void setLoggerManager(LoggerManager loggerManager) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,6 +176,11 @@ public class FieldComponentComposerTest {
         }
 
         @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
             if (component == null) {
@@ -226,6 +232,10 @@ public class FieldComponentComposerTest {
         @Override
         public boolean hasChildContainer(String name) {
             return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
         }
 
         @Override

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/JavaComponentFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.factory.java.JavaComponentFactory;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaComponentFactoryTest {
+    @Test
+    void createsComponentImplementationWithDefaultConstructor() throws Exception {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(SampleComponent.class.getName());
+        descriptor.setImplementation(SampleComponent.class.getName());
+
+        ClassWorld classWorld = new ClassWorld();
+        ClassRealm realm = classWorld.newRealm(
+            "java-component-factory-test",
+            JavaComponentFactoryTest.class.getClassLoader()
+        );
+
+        Object component = new JavaComponentFactory().newInstance(descriptor, realm, null);
+
+        assertThat(component).isInstanceOf(SampleComponent.class);
+        assertThat(((SampleComponent) component).message()).isEqualTo("created by JavaComponentFactory");
+    }
+
+    public static class SampleComponent {
+        public String message() {
+            return "created by JavaComponentFactory";
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/LoggerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/LoggerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LoggerManagerAnonymous1Test {
+    @Test
+    public void exposesInterfaceRoleName() {
+        assertEquals(LoggerManager.class.getName(), LoggerManager.ROLE);
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.MapOrientedComponentComposer;
+import org.codehaus.plexus.component.composition.UndefinedComponentComposerException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentInstantiationException;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MapOrientedComponentComposerTest {
+    @Test
+    public void rejectsComponentsThatAreNotMapOriented() {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        Object component = nonMapOrientedComponentSelectedAtRuntime();
+
+        CompositionException exception = assertThrows(
+            CompositionException.class,
+            () -> composer.assembleComponent(component, null, null)
+        );
+
+        assertTrue(exception.getMessage().contains(component.getClass().getName()));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+    }
+
+    @Test
+    public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
+        MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
+        RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor descriptor = descriptor(RecordingMapOrientedComponent.class.getName());
+
+        Object hintedDependency = new Object();
+        Object singleDependency = new Object();
+        Object fallbackDependency = new Object();
+        Map<String, Object> mappedDependencies = new HashMap<>();
+        mappedDependencies.put("mapped", new Object());
+        List<Object> listedDependencies = new ArrayList<>();
+        listedDependencies.add(new Object());
+        listedDependencies.add(new Object());
+
+        container.addComponent("hintedRolehint", hintedDependency);
+        container.addComponent("singleRole", singleDependency);
+        container.addComponent("fallbackRole", fallbackDependency);
+        container.addMap("mapRole", mappedDependencies);
+        container.addList("setRole", listedDependencies);
+
+        ComponentRequirement hinted = requirement("hintedRole", null);
+        hinted.setRoleHint("hint");
+        ComponentRequirement single = requirement("singleRole", "single");
+        ComponentRequirement mapped = requirement("mapRole", "map");
+        ComponentRequirement set = requirement("setRole", "set");
+        ComponentRequirement fallback = requirement("fallbackRole", "unexpected");
+
+        descriptor.addRequirement(hinted);
+        descriptor.addRequirement(single);
+        descriptor.addRequirement(mapped);
+        descriptor.addRequirement(set);
+        descriptor.addRequirement(fallback);
+
+        List assignedDescriptors = composer.assembleComponent(component, descriptor, container);
+
+        assertEquals(5, assignedDescriptors.size());
+        assertSame(hintedDependency, component.valueFor(hinted));
+        assertSame(singleDependency, component.valueFor(single));
+        assertSame(mappedDependencies, component.valueFor(mapped));
+        assertSame(fallbackDependency, component.valueFor(fallback));
+        assertEquals(new HashSet<>(listedDependencies), component.valueFor(set));
+    }
+
+    private static Object nonMapOrientedComponentSelectedAtRuntime() {
+        Object[] candidates = new Object[] {new Object(), "not a map-oriented component" };
+        return candidates[(int) (System.nanoTime() & 1L)];
+    }
+
+    private static ComponentRequirement requirement(String role, String mappingType) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldMappingType(mappingType);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    private static final class RecordingMapOrientedComponent implements MapOrientedComponent {
+        private final Map<ComponentRequirement, Object> values = new HashMap<>();
+
+        @Override
+        public void addComponentRequirement(ComponentRequirement requirementDescriptor, Object requirementValue)
+            throws ComponentConfigurationException {
+            values.put(requirementDescriptor, requirementValue);
+        }
+
+        @Override
+        public void setComponentConfiguration(Map componentConfiguration) throws ComponentConfigurationException {
+        }
+
+        private Object valueFor(ComponentRequirement requirement) {
+            return values.get(requirement);
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addComponent(String key, Object component) {
+            components.put(key, component);
+            descriptors.put(key, descriptor(key));
+        }
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        private void addList(String role, List dependencies) {
+            lists.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isStarted() {
+            return true;
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public Object createComponentInstance(ComponentDescriptor componentDescriptor)
+            throws ComponentInstantiationException, ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void composeComponent(Object component, ComponentDescriptor componentDescriptor)
+            throws CompositionException, UndefinedComponentComposerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public ClassRealm getComponentRealm(String componentKey) {
+            return null;
+        }
+
+        @Override
+        public void setLoggerManager(LoggerManager loggerManager) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -25,11 +25,17 @@ import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.File;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,9 +46,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentComposerTest {
     @Test
-    public void rejectsComponentsThatAreNotMapOriented() {
+    @Order(1)
+    public void rejectsComponentsThatAreNotMapOriented() throws Exception {
+        clearCompilerGeneratedClassCache();
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         Object component = nonMapOrientedComponentSelectedAtRuntime();
 
@@ -52,10 +61,11 @@ public class MapOrientedComponentComposerTest {
         );
 
         assertTrue(exception.getMessage().contains(component.getClass().getName()));
-        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertTrue(exception.getMessage().contains("org.codehaus.plexus.component.MapOrientedComponent"));
     }
 
     @Test
+    @Order(2)
     public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -98,6 +108,19 @@ public class MapOrientedComponentComposerTest {
         assertSame(mappedDependencies, component.valueFor(mapped));
         assertSame(fallbackDependency, component.valueFor(fallback));
         assertEquals(new HashSet<>(listedDependencies), component.valueFor(set));
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+            MapOrientedComponentComposer.class,
+            MethodHandles.lookup()
+        );
+        VarHandle classCache = lookup.findStaticVarHandle(
+            MapOrientedComponentComposer.class,
+            "class$org$codehaus$plexus$component$MapOrientedComponent",
+            Class.class
+        );
+        classCache.set(null);
     }
 
     private static Object nonMapOrientedComponentSelectedAtRuntime() {
@@ -168,6 +191,11 @@ public class MapOrientedComponentComposerTest {
         }
 
         @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
             if (component == null) {
@@ -219,6 +247,10 @@ public class MapOrientedComponentComposerTest {
         @Override
         public boolean hasChildContainer(String name) {
             return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
         }
 
         @Override

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.MapOrientedComponent;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MapOrientedComponentConfiguratorTest {
+    @Test
+    public void rejectsComponentsThatDoNotAcceptMapConfiguration() throws Exception {
+        clearCompilerGeneratedClassCache();
+        MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        Object component = nonMapOrientedComponentSelectedAtRuntime();
+
+        ComponentConfigurationException exception = assertThrows(
+            ComponentConfigurationException.class,
+            () -> configurator.configureComponent(component, new XmlPlexusConfiguration("configuration"), null, null)
+        );
+
+        assertTrue(exception.getMessage().contains("can only process implementations"));
+        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+    }
+
+    @Test
+    public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
+        MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
+        RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("configuration");
+        addChild(configuration, "host", "localhost");
+        addChild(configuration, "port", "8080");
+
+        configurator.configureComponent(component, configuration, testRealm());
+
+        assertEquals("localhost", component.configuration.get("host"));
+        assertEquals("8080", component.configuration.get("port"));
+    }
+
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+            MapOrientedComponentConfigurator.class,
+            MethodHandles.lookup()
+        );
+        VarHandle classCache = lookup.findStaticVarHandle(
+            MapOrientedComponentConfigurator.class,
+            "class$org$codehaus$plexus$component$MapOrientedComponent",
+            Class.class
+        );
+        classCache.set(null);
+    }
+
+    private static Object nonMapOrientedComponentSelectedAtRuntime() {
+        Object[] candidates = new Object[] {new Object(), "not map oriented" };
+        return candidates[(int) (System.nanoTime() & 1L)];
+    }
+
+    private static ClassRealm testRealm() throws Exception {
+        ClassWorld classWorld = new ClassWorld();
+        return classWorld.newRealm(
+            "map-oriented-component-configurator-test",
+            MapOrientedComponentConfiguratorTest.class.getClassLoader()
+        );
+    }
+
+    private static void addChild(XmlPlexusConfiguration parent, String name, String value) {
+        XmlPlexusConfiguration child = new XmlPlexusConfiguration(name);
+        child.setValue(value);
+        parent.addChild(child);
+    }
+
+    private static final class RecordingMapOrientedComponent implements MapOrientedComponent {
+        private Map configuration;
+
+        @Override
+        public void addComponentRequirement(ComponentRequirement requirementDescriptor, Object requirementValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setComponentConfiguration(Map componentConfiguration) {
+            configuration = componentConfiguration;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -13,20 +13,45 @@ import org.codehaus.plexus.component.configurator.ComponentConfigurationExceptio
 import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
+import java.lang.invoke.MethodType;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentConfiguratorTest {
     @Test
+    @Order(1)
+    public void resolvesMapOrientedComponentTypeThroughCompilerGeneratedClassLiteralHelper() throws Exception {
+        MethodHandle classLiteralHelper = MethodHandles.privateLookupIn(
+            MapOrientedComponentConfigurator.class,
+            MethodHandles.lookup()
+        ).findStatic(
+            MapOrientedComponentConfigurator.class,
+            "class$",
+            MethodType.methodType(Class.class, String.class)
+        );
+
+        Class<?> resolvedType = invokeClassLiteralHelper(
+            classLiteralHelper,
+            mapOrientedComponentTypeNameSelectedAtRuntime()
+        );
+
+        assertEquals(MapOrientedComponent.class, resolvedType);
+    }
+
+    @Test
+    @Order(2)
     public void rejectsComponentsThatDoNotAcceptMapConfiguration() throws Exception {
-        clearCompilerGeneratedClassCache();
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         Object component = nonMapOrientedComponentSelectedAtRuntime();
 
@@ -40,6 +65,7 @@ public class MapOrientedComponentConfiguratorTest {
     }
 
     @Test
+    @Order(3)
     public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -53,17 +79,19 @@ public class MapOrientedComponentConfiguratorTest {
         assertEquals("8080", component.configuration.get("port"));
     }
 
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-            MapOrientedComponentConfigurator.class,
-            MethodHandles.lookup()
-        );
-        VarHandle classCache = lookup.findStaticVarHandle(
-            MapOrientedComponentConfigurator.class,
-            "class$org$codehaus$plexus$component$MapOrientedComponent",
-            Class.class
-        );
-        classCache.set(null);
+    private static Class<?> invokeClassLiteralHelper(MethodHandle classLiteralHelper, String typeName) throws Exception {
+        try {
+            return (Class<?>) classLiteralHelper.invoke(typeName);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String mapOrientedComponentTypeNameSelectedAtRuntime() {
+        String[] nameParts = new String[] {"org.codehaus.plexus.component.", "MapOrientedComponent" };
+        return nameParts[0] + nameParts[1];
     }
 
     private static Object nonMapOrientedComponentSelectedAtRuntime() {

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/PlexusContainerManagerAnonymous1Test.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/PlexusContainerManagerAnonymous1Test.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.plexus.PlexusContainerManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlexusContainerManagerAnonymous1Test {
+    @Test
+    void roleUsesThePlexusContainerManagerTypeName() {
+        assertThat(PlexusContainerManager.ROLE).isEqualTo(PlexusContainerManager.class.getName());
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.composition.CompositionException;
+import org.codehaus.plexus.component.composition.SetterComponentComposer;
+import org.codehaus.plexus.component.composition.UndefinedComponentComposerException;
+import org.codehaus.plexus.component.discovery.ComponentDiscoveryListener;
+import org.codehaus.plexus.component.factory.ComponentInstantiationException;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.component.repository.ComponentRequirement;
+import org.codehaus.plexus.component.repository.exception.ComponentLifecycleException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.component.repository.exception.ComponentRepositoryException;
+import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SetterComponentComposerTest {
+    @Test
+    public void assignsArrayAndMapRequirementsThroughBeanSetters() throws Exception {
+        SetterComponentComposer composer = new SetterComponentComposer();
+        ComponentWithSetterDependencies component = new ComponentWithSetterDependencies();
+        RecordingPlexusContainer container = new RecordingPlexusContainer();
+        ComponentDescriptor componentDescriptor = descriptor(ComponentWithSetterDependencies.class.getName());
+
+        String arrayRole = "arrayRole";
+        String mapRole = "mapRole";
+        Map<String, Object> emptyArrayDependencies = new HashMap<>();
+        Map<String, String> mapDependencies = new HashMap<>();
+        mapDependencies.put("key", "map dependency");
+
+        container.addMap(arrayRole, emptyArrayDependencies);
+        container.addMap(mapRole, mapDependencies);
+
+        componentDescriptor.addRequirement(requirement(arrayRole, "arrayDependencies"));
+        componentDescriptor.addRequirement(requirement(mapRole, "mapDependencies"));
+
+        List assignedDescriptors = composer.assembleComponent(component, componentDescriptor, container);
+
+        assertEquals(2, assignedDescriptors.size());
+        assertEquals(0, component.arrayDependencies.length);
+        assertSame(mapDependencies, component.mapDependencies);
+    }
+
+    private static ComponentRequirement requirement(String role, String fieldName) {
+        ComponentRequirement requirement = new ComponentRequirement();
+        requirement.setRole(role);
+        requirement.setFieldName(fieldName);
+        return requirement;
+    }
+
+    private static ComponentDescriptor descriptor(String role) {
+        ComponentDescriptor descriptor = new ComponentDescriptor();
+        descriptor.setRole(role);
+        descriptor.setImplementation(role);
+        return descriptor;
+    }
+
+    private static List<Object> listOf(Object value) {
+        List<Object> values = new ArrayList<>();
+        values.add(value);
+        return values;
+    }
+
+    public static final class ComponentWithSetterDependencies {
+        private Object[] arrayDependencies;
+
+        private Map mapDependencies;
+
+        public void setArrayDependencies(Object[] arrayDependencies) {
+            this.arrayDependencies = arrayDependencies;
+        }
+
+        public void setMapDependencies(Map mapDependencies) {
+            this.mapDependencies = mapDependencies;
+        }
+    }
+
+    private static final class RecordingPlexusContainer implements PlexusContainer {
+        private final Map<String, Object> components = new HashMap<>();
+
+        private final Map<String, List> lists = new HashMap<>();
+
+        private final Map<String, Map> maps = new HashMap<>();
+
+        private final Map<String, ComponentDescriptor> descriptors = new HashMap<>();
+
+        private void addMap(String role, Map dependencies) {
+            maps.put(role, dependencies);
+            descriptors.put(role, descriptor(role));
+        }
+
+        @Override
+        public Object lookup(String componentKey) throws ComponentLookupException {
+            Object component = components.get(componentKey);
+            if (component == null) {
+                throw new ComponentLookupException("Missing component: " + componentKey);
+            }
+            return component;
+        }
+
+        @Override
+        public Object lookup(String role, String roleHint) throws ComponentLookupException {
+            return lookup(role + roleHint);
+        }
+
+        @Override
+        public Map lookupMap(String role) throws ComponentLookupException {
+            Map dependencies = maps.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing map: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public List lookupList(String role) throws ComponentLookupException {
+            List dependencies = lists.get(role);
+            if (dependencies == null) {
+                throw new ComponentLookupException("Missing list: " + role);
+            }
+            return dependencies;
+        }
+
+        @Override
+        public ComponentDescriptor getComponentDescriptor(String componentKey) {
+            return descriptors.get(componentKey);
+        }
+
+        @Override
+        public Map getComponentDescriptorMap(String role) {
+            Map<String, ComponentDescriptor> descriptorMap = new HashMap<>();
+            descriptorMap.put(role, descriptors.get(role));
+            return descriptorMap;
+        }
+
+        @Override
+        public List getComponentDescriptorList(String role) {
+            return listOf(descriptors.get(role));
+        }
+
+        @Override
+        public boolean hasChildContainer(String name) {
+            return false;
+        }
+
+        @Override
+        public PlexusContainer getChildContainer(String name) {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(String name, List classpathJars, Map context)
+            throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlexusContainer createChildContainer(
+            String name,
+            List classpathJars,
+            Map context,
+            List discoveryListeners
+        ) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addComponentDescriptor(ComponentDescriptor componentDescriptor)
+            throws ComponentRepositoryException {
+            descriptors.put(componentDescriptor.getComponentKey(), componentDescriptor);
+        }
+
+        @Override
+        public void release(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(Map components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void releaseAll(List components) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasComponent(String componentKey) {
+            return components.containsKey(componentKey);
+        }
+
+        @Override
+        public boolean hasComponent(String role, String roleHint) {
+            return hasComponent(role + roleHint);
+        }
+
+        @Override
+        public void suspend(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void resume(Object component) throws ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void initialize() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public void start() throws PlexusContainerException {
+        }
+
+        @Override
+        public boolean isStarted() {
+            return true;
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public Context getContext() {
+            return null;
+        }
+
+        @Override
+        public void setParentPlexusContainer(PlexusContainer parentContainer) {
+        }
+
+        @Override
+        public void addContextValue(Object key, Object value) {
+        }
+
+        @Override
+        public void setConfigurationResource(Reader configuration) throws PlexusConfigurationResourceException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger getLogger() {
+            return null;
+        }
+
+        @Override
+        public Object createComponentInstance(ComponentDescriptor componentDescriptor)
+            throws ComponentInstantiationException, ComponentLifecycleException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void composeComponent(Object component, ComponentDescriptor componentDescriptor)
+            throws CompositionException, UndefinedComponentComposerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeComponentDiscoveryListener(ComponentDiscoveryListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarRepository(File repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addJarResource(File resource) throws PlexusContainerException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ClassRealm getContainerRealm() {
+            return null;
+        }
+
+        @Override
+        public ClassRealm getComponentRealm(String componentKey) {
+            return null;
+        }
+
+        @Override
+        public void setLoggerManager(LoggerManager loggerManager) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LoggerManager getLoggerManager() {
+            return null;
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +112,11 @@ public class SetterComponentComposerTest {
         }
 
         @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
+        @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
             if (component == null) {
@@ -162,6 +168,10 @@ public class SetterComponentComposerTest {
         @Override
         public boolean hasChildContainer(String name) {
             return false;
+        }
+
+        @Override
+        public void removeChildContainer(String name) {
         }
 
         @Override

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SimplePlexusContainerManagerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_container_default;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.classworlds.ClassWorld;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.SimplePlexusContainerManager;
+import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.codehaus.plexus.context.DefaultContext;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SimplePlexusContainerManagerTest {
+    private static final String MANAGED_CONFIGURATION_RESOURCE = "simple-manager-managed-plexus.xml";
+
+    private static final String BOOTSTRAP_CONFIGURATION = """
+        <plexus/>
+        """;
+
+    private static final String MALFORMED_MANAGED_CONFIGURATION = """
+        <plexus>
+        """;
+
+    @Test
+    public void initializeLoadsManagedContainerConfigurationFromContextClassLoader() throws Exception {
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        ResourceBackedClassLoader resourceBackedClassLoader = new ResourceBackedClassLoader(originalContextClassLoader);
+        SimplePlexusContainerManager manager = new SimplePlexusContainerManager();
+
+        configureManager(manager);
+        manager.contextualize(contextWithParentContainer());
+        Thread.currentThread().setContextClassLoader(resourceBackedClassLoader);
+
+        try {
+            assertThatThrownBy(manager::initialize)
+                .isInstanceOf(InitializationException.class)
+                .hasMessage("Error initializing container");
+            assertThat(resourceBackedClassLoader.wasManagedConfigurationRequested()).isTrue();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+            disposeIfInitialized(manager);
+        }
+    }
+
+    private static void configureManager(SimplePlexusContainerManager manager) throws Exception {
+        XmlPlexusConfiguration configuration = new XmlPlexusConfiguration("configuration");
+        XmlPlexusConfiguration plexusConfig = new XmlPlexusConfiguration("plexus-config");
+        plexusConfig.setValue(MANAGED_CONFIGURATION_RESOURCE);
+        configuration.addChild(plexusConfig);
+
+        ClassWorld classWorld = new ClassWorld();
+        ClassRealm realm = classWorld.newRealm(
+            "simple-plexus-container-manager-test",
+            SimplePlexusContainerManagerTest.class.getClassLoader()
+        );
+        new BasicComponentConfigurator().configureComponent(manager, configuration, new LiteralExpressionEvaluator(), realm);
+    }
+
+    private static DefaultContext contextWithParentContainer() {
+        DefaultContext context = new DefaultContext();
+        context.put(PlexusConstants.PLEXUS_KEY, new DefaultPlexusContainer());
+        return context;
+    }
+
+    private static void disposeIfInitialized(SimplePlexusContainerManager manager) {
+        PlexusContainer[] managedContainers = manager.getManagedContainers();
+        if (managedContainers.length == 1
+            && managedContainers[0] != null
+            && managedContainers[0].isInitialized()) {
+            manager.stop();
+        }
+    }
+
+    private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
+        @Override
+        public Object evaluate(String expression) throws ExpressionEvaluationException {
+            return expression;
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return file;
+        }
+    }
+
+    private static final class ResourceBackedClassLoader extends ClassLoader {
+        private boolean managedConfigurationRequested;
+
+        private ResourceBackedClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (DefaultPlexusContainer.BOOTSTRAP_CONFIGURATION.equals(name)) {
+                return streamFor(BOOTSTRAP_CONFIGURATION);
+            }
+            if (MANAGED_CONFIGURATION_RESOURCE.equals(name)) {
+                managedConfigurationRequested = true;
+                return streamFor(MALFORMED_MANAGED_CONFIGURATION);
+            }
+            return super.getResourceAsStream(name);
+        }
+
+        private boolean wasManagedConfigurationRequested() {
+            return managedConfigurationRequested;
+        }
+
+        private static ByteArrayInputStream streamFor(String value) {
+            return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.AbstractConfigurationConverterTest$InstantiableComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.FieldComponentComposerTest$ComponentWithAllFieldKinds"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.FieldComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.FieldComponentComposerTest$Dependency[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.composition.SetterComponentComposer"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.SetterComponentComposerTest$ComponentWithSetterDependenciesCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.ComponentValueSetterTest$FieldOnlyComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.util.ReflectionUtils"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.ComponentValueSetterTest$SetterOnlyComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory"
+      },
+      "type" : "org_codehaus_plexus.plexus_container_default.JavaComponentFactoryTest$SampleComponent"
+    }
+  ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.codehaus.plexus.**"
+    },
+    {
+      "includeClasses" : "org_codehaus_plexus.plexus_container_default.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6218

This PR provides test fixes and new metadata for org.codehaus.plexus:plexus-container-default:1.0-alpha-8, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 231833
- Cached input tokens: 2637312
- Output tokens: 26198
- Metadata entries: 176
- Test-only metadata entries: 8
- Iterations: 6
- Library coverage percentage: 35.53
- Previous library version metadata entries: 176
- Previous library version test-only metadata entries: 8
- Previous library version coverage percentage: 35.41

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 56/58 covered calls (96.55%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 56/58 covered calls (96.55%)

**Reflection:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 55/57 covered calls (96.49%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 55/57 covered calls (96.49%)

**Resources:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 1/1 covered calls (100.00%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 3971/11386 (34.88%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 4026/11483 (35.06%)

**Line:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 1006/2841 (35.41%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 1017/2862 (35.53%)

**Method:**
- org.codehaus.plexus:plexus-container-default:1.0-alpha-7: 286/697 (41.03%)
- org.codehaus.plexus:plexus-container-default:1.0-alpha-8: 289/703 (41.11%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
index c426faeae6..ca3cbf16ed 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/AbstractConfigurationConverterTest.java
@@ -7,6 +7,7 @@
 package org_codehaus_plexus.plexus_container_default;
 
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
@@ -58,5 +59,12 @@ public class AbstractConfigurationConverterTest {
                                         ExpressionEvaluator expressionEvaluator) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener) {
+            throw new UnsupportedOperationException();
+        }
     }
 }
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
index 07a7492cc5..ba01ac3f28 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/CollectionConverterTest.java
@@ -7,6 +7,7 @@
 package org_codehaus_plexus.plexus_container_default;
 
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
 import org.codehaus.plexus.component.configurator.converters.ConfigurationConverter;
 import org.codehaus.plexus.component.configurator.converters.composite.CollectionConverter;
 import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
@@ -108,6 +109,14 @@ public class CollectionConverterTest {
                 throw new ComponentConfigurationException("Could not create named element", e);
             }
         }
+
+        @Override
+        public Object fromConfiguration(ConverterLookup converterLookup, PlexusConfiguration configuration, Class type,
+                                        Class baseType, ClassLoader classLoader,
+                                        ExpressionEvaluator expressionEvaluator, ConfigurationListener listener)
+            throws ComponentConfigurationException {
+            return fromConfiguration(converterLookup, configuration, type, baseType, classLoader, expressionEvaluator);
+        }
     }
 
     private static final class LiteralExpressionEvaluator implements ExpressionEvaluator {
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
index 421179c1a7..f326bb5ec0 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/FieldComponentComposerTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +175,11 @@ public class FieldComponentComposerTest {
             descriptors.put(role, descriptor(role));
         }
 
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
         @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
@@ -228,6 +234,10 @@ public class FieldComponentComposerTest {
             return false;
         }
 
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
         @Override
         public PlexusContainer getChildContainer(String name) {
             return null;
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
index 58b0b731d0..7e4594bab9 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentComposerTest.java
@@ -25,11 +25,17 @@ import org.codehaus.plexus.configuration.PlexusConfigurationResourceException;
 import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.LoggerManager;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.File;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,9 +46,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentComposerTest {
     @Test
-    public void rejectsComponentsThatAreNotMapOriented() {
+    @Order(1)
+    public void rejectsComponentsThatAreNotMapOriented() throws Exception {
+        clearCompilerGeneratedClassCache();
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         Object component = nonMapOrientedComponentSelectedAtRuntime();
 
@@ -52,10 +61,11 @@ public class MapOrientedComponentComposerTest {
         );
 
         assertTrue(exception.getMessage().contains(component.getClass().getName()));
-        assertTrue(exception.getMessage().contains(MapOrientedComponent.class.getName()));
+        assertTrue(exception.getMessage().contains("org.codehaus.plexus.component.MapOrientedComponent"));
     }
 
     @Test
+    @Order(2)
     public void addsMappedRequirementsToMapOrientedComponents() throws Exception {
         MapOrientedComponentComposer composer = new MapOrientedComponentComposer();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -100,6 +110,19 @@ public class MapOrientedComponentComposerTest {
         assertEquals(new HashSet<>(listedDependencies), component.valueFor(set));
     }
 
+    private static void clearCompilerGeneratedClassCache() throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+            MapOrientedComponentComposer.class,
+            MethodHandles.lookup()
+        );
+        VarHandle classCache = lookup.findStaticVarHandle(
+            MapOrientedComponentComposer.class,
+            "class$org$codehaus$plexus$component$MapOrientedComponent",
+            Class.class
+        );
+        classCache.set(null);
+    }
+
     private static Object nonMapOrientedComponentSelectedAtRuntime() {
         Object[] candidates = new Object[] {new Object(), "not a map-oriented component" };
         return candidates[(int) (System.nanoTime() & 1L)];
@@ -167,6 +190,11 @@ public class MapOrientedComponentComposerTest {
             descriptors.put(role, descriptor(role));
         }
 
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
         @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
@@ -221,6 +249,10 @@ public class MapOrientedComponentComposerTest {
             return false;
         }
 
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
         @Override
         public PlexusContainer getChildContainer(String name) {
             return null;
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
index 575380c71a..4d7e3e3615 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/MapOrientedComponentConfiguratorTest.java
@@ -13,20 +13,45 @@ import org.codehaus.plexus.component.configurator.ComponentConfigurationExceptio
 import org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator;
 import org.codehaus.plexus.component.repository.ComponentRequirement;
 import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
+import java.lang.invoke.MethodType;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MapOrientedComponentConfiguratorTest {
     @Test
+    @Order(1)
+    public void resolvesMapOrientedComponentTypeThroughCompilerGeneratedClassLiteralHelper() throws Exception {
+        MethodHandle classLiteralHelper = MethodHandles.privateLookupIn(
+            MapOrientedComponentConfigurator.class,
+            MethodHandles.lookup()
+        ).findStatic(
+            MapOrientedComponentConfigurator.class,
+            "class$",
+            MethodType.methodType(Class.class, String.class)
+        );
+
+        Class<?> resolvedType = invokeClassLiteralHelper(
+            classLiteralHelper,
+            mapOrientedComponentTypeNameSelectedAtRuntime()
+        );
+
+        assertEquals(MapOrientedComponent.class, resolvedType);
+    }
+
+    @Test
+    @Order(2)
     public void rejectsComponentsThatDoNotAcceptMapConfiguration() throws Exception {
-        clearCompilerGeneratedClassCache();
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         Object component = nonMapOrientedComponentSelectedAtRuntime();
 
@@ -40,6 +65,7 @@ public class MapOrientedComponentConfiguratorTest {
     }
 
     @Test
+    @Order(3)
     public void passesConvertedConfigurationMapToMapOrientedComponent() throws Exception {
         MapOrientedComponentConfigurator configurator = new MapOrientedComponentConfigurator();
         RecordingMapOrientedComponent component = new RecordingMapOrientedComponent();
@@ -53,17 +79,19 @@ public class MapOrientedComponentConfiguratorTest {
         assertEquals("8080", component.configuration.get("port"));
     }
 
-    private static void clearCompilerGeneratedClassCache() throws Exception {
-        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
-            MapOrientedComponentConfigurator.class,
-            MethodHandles.lookup()
-        );
-        VarHandle classCache = lookup.findStaticVarHandle(
-            MapOrientedComponentConfigurator.class,
-            "class$org$codehaus$plexus$component$MapOrientedComponent",
-            Class.class
-        );
-        classCache.set(null);
+    private static Class<?> invokeClassLiteralHelper(MethodHandle classLiteralHelper, String typeName) throws Exception {
+        try {
+            return (Class<?>) classLiteralHelper.invoke(typeName);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String mapOrientedComponentTypeNameSelectedAtRuntime() {
+        String[] nameParts = new String[] {"org.codehaus.plexus.component.", "MapOrientedComponent" };
+        return nameParts[0] + nameParts[1];
     }
 
     private static Object nonMapOrientedComponentSelectedAtRuntime() {
diff --git 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
index 6ac54b5a4e..d68be141ee 100644
--- 1/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-7/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
+++ 2/tests/src/org.codehaus.plexus/plexus-container-default/1.0-alpha-8/src/test/java/org_codehaus_plexus/plexus_container_default/SetterComponentComposerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,11 @@ public class SetterComponentComposerTest {
             descriptors.put(role, descriptor(role));
         }
 
+        @Override
+        public Date getCreationDate() {
+            return new Date(0L);
+        }
+
         @Override
         public Object lookup(String componentKey) throws ComponentLookupException {
             Object component = components.get(componentKey);
@@ -164,6 +170,10 @@ public class SetterComponentComposerTest {
             return false;
         }
 
+        @Override
+        public void removeChildContainer(String name) {
+        }
+
         @Override
         public PlexusContainer getChildContainer(String name) {
             return null;

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
