### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-featurespec_2.13:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-featurespec_2.13/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/3.2.19/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalatest.Resources$"
+      },
+      "bundle" : "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
@@ -1,21 +1,22 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.2.19",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-sources.jar",
-    "repository-url" : "https://github.com/scalatest/scalatest",
-    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-javadoc.jar",
-    "description" : "ScalaTest FeatureSpec provides the FeatureSpec and AsyncFeatureSpec testing style for organizing ScalaTest suites around named features and scenarios. It supplies synchronous, asynchronous, and fixture-based specs for behavior-driven Scala tests while integrating with ScalaTest's assertions, matchers, reporting, and runner infrastructure.",
-    "language" : {
-      "name" : "scala",
-      "version" : "2"
+    "latest": true,
+    "metadata-version": "3.2.19",
+    "source-code-url": "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-sources.jar",
+    "repository-url": "https://github.com/scalatest/scalatest",
+    "test-code-url": "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-javadoc.jar",
+    "description": "ScalaTest FeatureSpec provides the FeatureSpec and AsyncFeatureSpec testing style for organizing ScalaTest suites around named features and scenarios. It supplies synchronous, asynchronous, and fixture-based specs for behavior-driven Scala tests while integrating with ScalaTest's assertions, matchers, reporting, and runner infrastructure.",
+    "language": {
+      "name": "scala",
+      "version": "2"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.19"
     ],
-    "allowed-packages" : [
-      "org.scalatest.featurespec"
+    "allowed-packages": [
+      "org.scalatest.featurespec",
+      "org.scalatest"
     ]
   }
 ]

--- a/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
+++ b/metadata/org.scalatest/scalatest-featurespec_2.13/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/featurespec-test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest-featurespec_2.13/$version$/scalatest-featurespec_2.13-$version$-javadoc.jar",
+    "description" : "ScalaTest FeatureSpec provides the FeatureSpec and AsyncFeatureSpec testing style for organizing ScalaTest suites around named features and scenarios. It supplies synchronous, asynchronous, and fixture-based specs for behavior-driven Scala tests while integrating with ScalaTest's assertions, matchers, reporting, and runner infrastructure.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.featurespec"
+    ]
+  }
+]

--- a/stats/org.scalatest/scalatest-featurespec_2.13/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-featurespec_2.13/3.2.19/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-06": {
+    "timestamp": "2026-05-06T22:50:22.460946Z",
+    "library": "org.scalatest:scalatest-featurespec_2.13:3.2.19",
+    "starting_commit": "be760ec666472ee8985a1f61b44225769893441c",
+    "ending_commit": "0e4c6e7110e295519fb0b0443a3133ef64b82117",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1454,
+          "missed": 2712,
+          "ratio": 0.349016,
+          "total": 4166
+        },
+        "line": {
+          "covered": 134,
+          "missed": 107,
+          "ratio": 0.556017,
+          "total": 241
+        },
+        "method": {
+          "covered": 189,
+          "missed": 416,
+          "ratio": 0.312397,
+          "total": 605
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 131195,
+      "cached_input_tokens_used": 991744,
+      "output_tokens_used": 19116,
+      "iterations": 4,
+      "cost_usd": 1.0694,
+      "generated_loc": 237,
+      "tested_library_loc": 134,
+      "metadata_entries": 1,
+      "code_coverage_percent": 55.6
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-featurespec_2.13/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-featurespec_2.13/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-featurespec_2.13/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1454,
+        "missed" : 2712,
+        "ratio" : 0.349016,
+        "total" : 4166
+      },
+      "line" : {
+        "covered" : 134,
+        "missed" : 107,
+        "ratio" : 0.556017,
+        "total" : 241
+      },
+      "method" : {
+        "covered" : 189,
+        "missed" : 416,
+        "ratio" : 0.312397,
+        "total" : 605
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-featurespec_2.13:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-featurespec_2.13/3.2.19/

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-featurespec_2.13_tests'

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -24,6 +24,7 @@ import org.scalatest.Suite
 import org.scalatest.Tag
 import org.scalatest.events.Event
 import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
 import org.scalatest.events.TestSucceeded
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.featurespec.AsyncFeatureSpec
@@ -61,6 +62,20 @@ class Scalatest_featurespec_2_13Test {
     assert(result.succeeded)
     assert(suite.executed.toSet == Set("addition", "multiplication"))
     assert(succeededEvents(result.events).map(_.testName).toSet == Set(additionTestName, multiplicationTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+  }
+
+  @Test
+  def anyFeatureSpecReportsPendingScenariosWithoutFailingTheSuite(): Unit = {
+    val suite: PendingScenarioFeatureSpec = new PendingScenarioFeatureSpec
+    val pendingTestName: String = findTestName(suite, "captures an unfinished payment workflow")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("pending"))
+    assert(pendingEvents(result.events).map(_.testName) == Vector(pendingTestName))
+    assert(succeededEvents(result.events).isEmpty)
     assert(ignoredEvents(result.events).isEmpty)
   }
 
@@ -138,6 +153,17 @@ class Scalatest_featurespec_2_13Test {
     }
   }
 
+  final class PendingScenarioFeatureSpec extends AnyFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Pending payment workflow") {
+      Scenario("captures an unfinished payment workflow") {
+        executed = executed :+ "pending"
+        pending
+      }
+    }
+  }
+
   final class TextFixtureFeatureSpec extends FixtureAnyFeatureSpec {
     type FixtureParam = String
 
@@ -208,6 +234,9 @@ class Scalatest_featurespec_2_13Test {
 
   private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
     events.collect { case event: TestIgnored => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
 
   private final class RecordingReporter extends Reporter {
     private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_featurespec_2_13
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_featurespec_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -18,11 +18,13 @@ import scala.util.Try
 import org.junit.jupiter.api.Test
 import org.scalatest.Args
 import org.scalatest.FutureOutcome
+import org.scalatest.GivenWhenThen
 import org.scalatest.Outcome
 import org.scalatest.Reporter
 import org.scalatest.Suite
 import org.scalatest.Tag
 import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
 import org.scalatest.events.TestIgnored
 import org.scalatest.events.TestPending
 import org.scalatest.events.TestSucceeded
@@ -105,6 +107,23 @@ class Scalatest_featurespec_2_13Test {
     assert(suite.fixtureNames.asScala.toVector == Vector(scenarioTestName))
     assert(suite.observedFixtures.asScala.toVector == Vector("async-feature-spec"))
     assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+  }
+
+  @Test
+  def anyFeatureSpecPublishesGivenWhenThenMessages(): Unit = {
+    val suite: CheckoutNarrativeFeatureSpec = new CheckoutNarrativeFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "describes checkout steps")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed == Vector("narrative"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+    assert(recordedInfoMessages(result.events) == Vector(
+      "Given a cart containing a guide",
+      "When the customer checks out",
+      "Then the order summary contains the guide"
+    ))
   }
 
   final class ShoppingCartFeatureSpec extends AnyFeatureSpec {
@@ -209,6 +228,20 @@ class Scalatest_featurespec_2_13Test {
     }
   }
 
+  final class CheckoutNarrativeFeatureSpec extends AnyFeatureSpec with GivenWhenThen {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Checkout narrative") {
+      Scenario("describes checkout steps") {
+        Given("a cart containing a guide")
+        When("the customer checks out")
+        Then("the order summary contains the guide")
+        executed = executed :+ "narrative"
+        assert(Vector("guide").mkString(",") == "guide")
+      }
+    }
+  }
+
   private def findTestName(suite: Suite, fragment: String): String = {
     suite.testNames.find(_.contains(fragment)).getOrElse {
       throw new AssertionError(s"Could not find test name containing '$fragment'")
@@ -237,6 +270,11 @@ class Scalatest_featurespec_2_13Test {
 
   private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
     events.collect { case event: TestPending => event }
+
+  private def recordedInfoMessages(events: Vector[Event]): Vector[String] =
+    succeededEvents(events).flatMap { event: TestSucceeded =>
+      event.recordedEvents.collect { case info: InfoProvided => info.message }.toVector
+    }
 
   private final class RecordingReporter extends Reporter {
     private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/src/test/scala/org_scalatest/scalatest_featurespec_2_13/Scalatest_featurespec_2_13Test.scala
@@ -6,11 +6,219 @@
  */
 package org_scalatest.scalatest_featurespec_2_13
 
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
 import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.FutureOutcome
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.Event
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestSucceeded
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.featurespec.AsyncFeatureSpec
+import org.scalatest.featurespec.FixtureAnyFeatureSpec
+import org.scalatest.featurespec.FixtureAsyncFeatureSpec
 
 class Scalatest_featurespec_2_13Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def anyFeatureSpecRegistersTaggedAndIgnoredScenarios(): Unit = {
+    val suite: ShoppingCartFeatureSpec = new ShoppingCartFeatureSpec
+    val addItemTestName: String = findTestName(suite, "adds an item")
+    val removeItemTestName: String = findTestName(suite, "removes an item")
+    val ignoredTestName: String = findTestName(suite, "checks out without inventory")
+
+    assert(suite.testNames.size == 3)
+    assert(suite.tags(addItemTestName).contains(ShoppingCartFeatureSpec.Fast.name))
+    assert(suite.tags(ignoredTestName).contains(ShoppingCartFeatureSpec.Slow.name))
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("add", "remove"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(addItemTestName, removeItemTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
   }
+
+  @Test
+  def asyncFeatureSpecCompletesSuccessfulFutureScenarios(): Unit = {
+    val suite: AsyncCalculationFeatureSpec = new AsyncCalculationFeatureSpec
+    val additionTestName: String = findTestName(suite, "adds numbers asynchronously")
+    val multiplicationTestName: String = findTestName(suite, "multiplies numbers asynchronously")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executed.toSet == Set("addition", "multiplication"))
+    assert(succeededEvents(result.events).map(_.testName).toSet == Set(additionTestName, multiplicationTestName))
+    assert(ignoredEvents(result.events).isEmpty)
+  }
+
+  @Test
+  def fixtureAnyFeatureSpecProvidesFixturesAndReportsIgnoredScenarios(): Unit = {
+    val suite: TextFixtureFeatureSpec = new TextFixtureFeatureSpec
+    val upperCaseTestName: String = findTestName(suite, "upper-cases fixture text")
+    val ignoredTestName: String = findTestName(suite, "keeps ignored fixture scenarios registered")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(upperCaseTestName))
+    assert(suite.observedFixtures.asScala.toVector == Vector("feature-spec"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(upperCaseTestName))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector(ignoredTestName))
+  }
+
+  @Test
+  def fixtureAsyncFeatureSpecProvidesFixturesToFutureScenarios(): Unit = {
+    val suite: AsyncTextFixtureFeatureSpec = new AsyncTextFixtureFeatureSpec
+    val scenarioTestName: String = findTestName(suite, "decorates fixture text asynchronously")
+
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.fixtureNames.asScala.toVector == Vector(scenarioTestName))
+    assert(suite.observedFixtures.asScala.toVector == Vector("async-feature-spec"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(scenarioTestName))
+  }
+
+  final class ShoppingCartFeatureSpec extends AnyFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Shopping cart") {
+      Scenario("adds an item", ShoppingCartFeatureSpec.Fast) {
+        executed = executed :+ "add"
+        assert(Vector("book", "pen").contains("book"))
+      }
+
+      Scenario("removes an item") {
+        executed = executed :+ "remove"
+        assert(Vector("book", "pen").filterNot(_ == "pen") == Vector("book"))
+      }
+
+      ignore("checks out without inventory", ShoppingCartFeatureSpec.Slow) {
+        executed = executed :+ "ignored"
+        fail("ignored AnyFeatureSpec scenario was executed")
+      }
+    }
+  }
+
+  object ShoppingCartFeatureSpec {
+    val Fast: Tag = Tag("org.scalatest.featurespec.fast")
+    val Slow: Tag = Tag("org.scalatest.featurespec.slow")
+  }
+
+  final class AsyncCalculationFeatureSpec extends AsyncFeatureSpec {
+    var executed: Vector[String] = Vector.empty
+
+    Feature("Asynchronous calculations") {
+      Scenario("adds numbers asynchronously") {
+        Future.successful {
+          executed = executed :+ "addition"
+          assert(2 + 3 == 5)
+        }
+      }
+
+      Scenario("multiplies numbers asynchronously") {
+        Future.successful {
+          executed = executed :+ "multiplication"
+          assert(4 * 6 == 24)
+        }
+      }
+    }
+  }
+
+  final class TextFixtureFeatureSpec extends FixtureAnyFeatureSpec {
+    type FixtureParam = String
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val observedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override protected def withFixture(test: OneArgTest): Outcome = {
+      fixtureNames.add(test.name)
+      withFixture(test.toNoArgTest("feature-spec"))
+    }
+
+    Feature("Synchronous fixture scenarios") {
+      Scenario("upper-cases fixture text") { text: String =>
+        observedFixtures.add(text)
+        assert(text.toUpperCase == "FEATURE-SPEC")
+      }
+
+      ignore("keeps ignored fixture scenarios registered") { text: String =>
+        observedFixtures.add(text)
+        fail("ignored FixtureAnyFeatureSpec scenario was executed")
+      }
+    }
+  }
+
+  final class AsyncTextFixtureFeatureSpec extends FixtureAsyncFeatureSpec {
+    type FixtureParam = String
+
+    val fixtureNames: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+    val observedFixtures: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+    override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+      fixtureNames.add(test.name)
+      withFixture(test.toNoArgAsyncTest("async-feature-spec"))
+    }
+
+    Feature("Asynchronous fixture scenarios") {
+      Scenario("decorates fixture text asynchronously") { text: String =>
+        Future.successful {
+          observedFixtures.add(text)
+          assert(s"[$text]" == "[async-feature-spec]")
+        }
+      }
+    }
+  }
+
+  private def findTestName(suite: Suite, fragment: String): String = {
+    suite.testNames.find(_.contains(fragment)).getOrElse {
+      throw new AssertionError(s"Could not find test name containing '$fragment'")
+    }
+  }
+
+  private def runSuite(suite: Suite): RunResult = {
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val status = suite.run(None, Args(reporter = reporter))
+    status.whenCompleted { result: Try[Boolean] =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+  }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private final class RecordingReporter extends Reporter {
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit = {
+      recordedEvents.add(event)
+      ()
+    }
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+  }
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
 }

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.featurespec.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.featurespec.**"
+      "includeClasses" : "org.scalatest.featurespec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_featurespec_2_13.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5070

This PR introduces tests and metadata for org.scalatest:scalatest-featurespec_2.13:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 131195
- Cached input tokens: 991744
- Output tokens: 19116
- Metadata entries: 1
- Iterations: 4
- Library coverage percentage: 55.6
- Generated lines of code: 237
- Tested library lines of code: 134

### Metadata Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `dc138258bc784406309805ff4dc6d8955674f7cc`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1454/4166 (34.90%)
- Line: 134/241 (55.60%)
- Method: 189/605 (31.24%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
