### PR TITLE
[Forge] Promote newer javac metadata indexes

### DIFF
--- a/forge/ai_workflows/improve_library_coverage.py
+++ b/forge/ai_workflows/improve_library_coverage.py
@@ -50,6 +50,7 @@ from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metadata_index import (
     MATCH_NEW_VERSION,
     LibraryUpdateTarget,
+    is_newer_than_latest_metadata_version,
     load_index_entries,
     resolve_library_update_target,
 )
@@ -471,6 +472,7 @@ def _new_index_entry_from_baseline(
         baseline_entry: dict[str, Any],
         requested_version: str,
         tested_versions: list[str] | None = None,
+        mark_latest: bool = True,
 ) -> dict[str, Any]:
     old_versions = {
         str(value)
@@ -483,7 +485,10 @@ def _new_index_entry_from_baseline(
     }
     new_entry = copy.deepcopy(baseline_entry)
     new_entry = _replace_version_in_value(new_entry, old_versions, requested_version)
-    new_entry["latest"] = True
+    if mark_latest:
+        new_entry["latest"] = True
+    else:
+        new_entry.pop("latest", None)
     new_entry["metadata-version"] = requested_version
     new_entry.pop("test-version", None)
     new_entry.pop("default-for", None)
@@ -572,17 +577,22 @@ def clone_library_update_support(
         tested_versions = baseline_entry.get("tested-versions")
         if isinstance(tested_versions, list):
             new_entry_tested_versions = [str(version) for version in tested_versions]
+    mark_new_entry_latest = (
+        baseline_metadata_version == requested_version
+        and baseline_entry.get("latest") is True
+    ) or is_newer_than_latest_metadata_version(repo_path, group, artifact, requested_version)
     updated_entries: list[dict[str, Any]] = []
     new_entry = _new_index_entry_from_baseline(
         baseline_entry,
         requested_version,
         new_entry_tested_versions,
+        mark_latest=mark_new_entry_latest,
     )
     for entry in entries:
         if not isinstance(entry, dict):
             continue
         entry_copy = copy.deepcopy(entry)
-        if entry_copy.get("latest") is True:
+        if mark_new_entry_latest and entry_copy.get("latest") is True:
             entry_copy.pop("latest", None)
         if entry_copy.get("metadata-version") == baseline_metadata_version:
             if baseline_metadata_version == requested_version:

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -36,6 +36,7 @@ from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
 
 DEFAULT_MODEL_NAME = "oca/gpt5"
+ADD_LIBRARY_METADATA_INDEX_TASK = "addLibraryMetadataIndexJson"
 ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK = "addLibraryAsLatestMetadataIndexJson"
 
 # Default strategy names per mode
@@ -54,14 +55,12 @@ class JavaFailWorkflowConfig:
         task_type: str,
         branch_prefix: str,
         metrics_filename: str,
-        metadata_index_task: str,
     ):
         self.mode = mode
         self.default_strategy_name = default_strategy_name
         self.task_type = task_type
         self.branch_prefix = branch_prefix
         self.metrics_filename = metrics_filename
-        self.metadata_index_task = metadata_index_task
 
 
 JAVAC_CONFIG = JavaFailWorkflowConfig(
@@ -70,7 +69,6 @@ JAVAC_CONFIG = JavaFailWorkflowConfig(
     task_type="fix-javac-fail",
     branch_prefix="fix-javac",
     metrics_filename="fix_javac_fail.json",
-    metadata_index_task="addLibraryMetadataIndexJson",
 )
 
 JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
@@ -79,7 +77,6 @@ JAVA_RUN_CONFIG = JavaFailWorkflowConfig(
     task_type="fix-java-run-fail",
     branch_prefix="fix-java-run",
     metrics_filename="fix_java_run_fail.json",
-    metadata_index_task="addLibraryAsLatestMetadataIndexJson",
 )
 
 
@@ -245,13 +242,15 @@ def update_metadata_index_json(
 ) -> None:
     """Update metadata index.json for the target library version."""
     new_version_coordinates = f"{group}:{artifact}:{updated_library_version}"
-    metadata_index_task = config.metadata_index_task
-    if (
-            metadata_index_task != ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK
-            and is_newer_than_latest_metadata_version(os.getcwd(), group, artifact, updated_library_version)
-    ):
-        metadata_index_task = ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK
+    metadata_index_task = metadata_index_update_task(group, artifact, updated_library_version)
     run_gradle_task(metadata_index_task, new_version_coordinates)
+
+
+def metadata_index_update_task(group: str, artifact: str, updated_library_version: str) -> str:
+    """Return the metadata index task for the target version."""
+    if is_newer_than_latest_metadata_version(os.getcwd(), group, artifact, updated_library_version):
+        return ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK
+    return ADD_LIBRARY_METADATA_INDEX_TASK
 
 
 def create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version):

--- a/forge/ai_workflows/java_fail_workflow.py
+++ b/forge/ai_workflows/java_fail_workflow.py
@@ -22,6 +22,7 @@ from ai_workflows.workflow_strategies.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.schema_validator import validate_run_metrics
@@ -35,6 +36,7 @@ from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
 
 DEFAULT_MODEL_NAME = "oca/gpt5"
+ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK = "addLibraryAsLatestMetadataIndexJson"
 
 # Default strategy names per mode
 DEFAULT_JAVAC_STRATEGY = "javac_iterative_with_coverage_sources_pi_gpt-5.5"
@@ -243,7 +245,13 @@ def update_metadata_index_json(
 ) -> None:
     """Update metadata index.json for the target library version."""
     new_version_coordinates = f"{group}:{artifact}:{updated_library_version}"
-    run_gradle_task(config.metadata_index_task, new_version_coordinates)
+    metadata_index_task = config.metadata_index_task
+    if (
+            metadata_index_task != ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK
+            and is_newer_than_latest_metadata_version(os.getcwd(), group, artifact, updated_library_version)
+    ):
+        metadata_index_task = ADD_LIBRARY_AS_LATEST_METADATA_INDEX_TASK
+    run_gradle_task(metadata_index_task, new_version_coordinates)
 
 
 def create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version):

--- a/forge/tests/test_java_fail_workflow.py
+++ b/forge/tests/test_java_fail_workflow.py
@@ -222,7 +222,7 @@ class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
             "org.example:demo:2021-08-19T04-04-25-efb3c9d",
         )
 
-    def test_java_run_metadata_index_update_keeps_configured_latest_task(self) -> None:
+    def test_java_run_metadata_index_update_preserves_latest_for_historical_version(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             self._write_index(
                 temp_dir,
@@ -246,8 +246,36 @@ class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
                 os.chdir(previous_cwd)
 
         run_gradle_task.assert_called_once_with(
-            "addLibraryAsLatestMetadataIndexJson",
+            "addLibraryMetadataIndexJson",
             "org.example:demo:1.5.0",
+        )
+
+    def test_java_run_metadata_index_update_promotes_newer_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "1.5.0",
+                        "tested-versions": ["1.5.0"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVA_RUN_CONFIG, "org.example", "demo", "2.0.0")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:2.0.0",
         )
 
     def test_copy_and_prepare_project_dir_skips_same_source_and_destination(self) -> None:

--- a/forge/tests/test_java_fail_workflow.py
+++ b/forge/tests/test_java_fail_workflow.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import json
 import os
 import subprocess
 import tempfile
@@ -11,13 +12,160 @@ from unittest.mock import patch
 
 from ai_workflows.java_fail_workflow import (
     JAVAC_CONFIG,
+    JAVA_RUN_CONFIG,
     copy_and_prepare_project_dir,
     create_project_prep_checkpoint,
     reset_failed_java_fix_worktree,
+    update_metadata_index_json,
 )
 
 
 class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
+    def test_javac_metadata_index_update_promotes_newer_final_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "1.0.0-beta-4",
+                        "tested-versions": ["1.0.0-beta-4"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "1.0.0")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:1.0.0",
+        )
+
+    def test_javac_metadata_index_update_promotes_newer_patch_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "1.2.3",
+                        "tested-versions": ["1.2.3"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "1.2.4")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:1.2.4",
+        )
+
+    def test_javac_metadata_index_update_preserves_latest_for_historical_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "2.0.0",
+                        "tested-versions": ["2.0.0"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "1.5.0")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryMetadataIndexJson",
+            "org.example:demo:1.5.0",
+        )
+
+    def test_javac_metadata_index_update_preserves_latest_for_unparseable_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "2021-03-30T02-06-56-9a47743",
+                        "tested-versions": ["2021-03-30T02-06-56-9a47743"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(
+                        JAVAC_CONFIG,
+                        "org.example",
+                        "demo",
+                        "2021-08-19T04-04-25-efb3c9d",
+                    )
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryMetadataIndexJson",
+            "org.example:demo:2021-08-19T04-04-25-efb3c9d",
+        )
+
+    def test_java_run_metadata_index_update_keeps_configured_latest_task(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "2.0.0",
+                        "tested-versions": ["2.0.0"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVA_RUN_CONFIG, "org.example", "demo", "1.5.0")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:1.5.0",
+        )
+
     def test_copy_and_prepare_project_dir_skips_same_source_and_destination(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             test_project_dir = os.path.join(
@@ -110,3 +258,9 @@ class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
         run.assert_called_once_with(["git", "reset", "--hard", "prep"], cwd="/repo", check=True)
         rmtree.assert_any_call("/repo/tests/src/org.example/demo/2.0.0", ignore_errors=True)
         rmtree.assert_any_call("/repo/metadata/org.example/demo/2.0.0", ignore_errors=True)
+
+    def _write_index(self, repo_path: str, group: str, artifact: str, entries: list[dict]) -> None:
+        index_path = os.path.join(repo_path, "metadata", group, artifact, "index.json")
+        os.makedirs(os.path.dirname(index_path))
+        with open(index_path, "w", encoding="utf-8") as file:
+            json.dump(entries, file)

--- a/forge/tests/test_java_fail_workflow.py
+++ b/forge/tests/test_java_fail_workflow.py
@@ -49,6 +49,90 @@ class JavaFailWorkflowProjectPrepTests(unittest.TestCase):
             "org.example:demo:1.0.0",
         )
 
+    def test_javac_metadata_index_update_promotes_final_after_classifier_prerelease(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "3.0.0-M5-javax",
+                        "tested-versions": ["3.0.0-M5-javax"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "3.0.0")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:3.0.0",
+        )
+
+    def test_javac_metadata_index_update_promotes_newer_classifier_prerelease(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "3.0.0-M4-javax",
+                        "tested-versions": ["3.0.0-M4-javax"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "3.0.0-M5-javax")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:3.0.0-M5-javax",
+        )
+
+    def test_javac_metadata_index_update_promotes_newer_separated_qualifier_number(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._write_index(
+                temp_dir,
+                "org.example",
+                "demo",
+                [
+                    {
+                        "latest": True,
+                        "metadata-version": "1.0-alpha-7",
+                        "tested-versions": ["1.0-alpha-7"],
+                    },
+                ],
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(temp_dir)
+                with patch("ai_workflows.java_fail_workflow.run_gradle_task") as run_gradle_task:
+                    update_metadata_index_json(JAVAC_CONFIG, "org.example", "demo", "1.0-alpha-8")
+            finally:
+                os.chdir(previous_cwd)
+
+        run_gradle_task.assert_called_once_with(
+            "addLibraryAsLatestMetadataIndexJson",
+            "org.example:demo:1.0-alpha-8",
+        )
+
     def test_javac_metadata_index_update_promotes_newer_patch_version(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             self._write_index(

--- a/forge/tests/test_library_update_target.py
+++ b/forge/tests/test_library_update_target.py
@@ -211,7 +211,8 @@ class LibraryUpdateTargetTests(unittest.TestCase):
             self.assertEqual(new_entry["tested-versions"], ["1.2.4"])
             self.assertEqual(new_entry["source-code-url"], "https://example.test/demo-1.2.4-sources.jar")
             self.assertEqual(new_entry["allowed-packages"], ["org.example"])
-            self.assertNotIn("latest", [entry for entry in entries if entry.get("metadata-version") == "2.0.0"][0])
+            self.assertNotIn("latest", new_entry)
+            self.assertTrue([entry for entry in entries if entry.get("metadata-version") == "2.0.0"][0]["latest"])
 
     def test_cloned_support_rewrites_versions_only_in_safe_contexts(self) -> None:
         with tempfile.TemporaryDirectory() as repo:
@@ -394,6 +395,7 @@ class LibraryUpdateTargetTests(unittest.TestCase):
                 entries = json.load(file)
             matching_entries = [entry for entry in entries if entry.get("metadata-version") == "3.22.0"]
             self.assertEqual(len(matching_entries), 1)
+            self.assertTrue(matching_entries[0]["latest"])
             self.assertNotIn("test-version", matching_entries[0])
             self.assertEqual(matching_entries[0]["tested-versions"], ["3.22.0", "3.23.0"])
 

--- a/forge/utility_scripts/metadata_index.py
+++ b/forge/utility_scripts/metadata_index.py
@@ -10,7 +10,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 
 NOT_FOR_NATIVE_IMAGE_FIELD = "not-for-native-image"
@@ -30,6 +30,28 @@ class LibraryUpdateTarget:
     resolved_test_version: str
     metadata_dir: str
     test_dir: str
+
+
+_RELEASE_QUALIFIER = "release"
+_VERSION_PATTERN = re.compile(
+    r"^(\d+(?:\.\d+)*)(?:\.(?:Final|RELEASE))?"
+    r"(?:[-.](alpha\d*|beta\d*|rc\d*|cr\d*|m\d+|ea\d*|b\d+|\d+|preview)(?:[-.](.*))?)?$",
+    re.IGNORECASE,
+)
+_QUALIFIER_PATTERN = re.compile(r"^(alpha|beta|rc|cr|m|ea|b|preview)(\d*)$", re.IGNORECASE)
+ParsedMetadataVersion: TypeAlias = tuple[tuple[int, ...], tuple[int, int]]
+_QUALIFIER_RANK = {
+    "alpha": 10,
+    "beta": 20,
+    "m": 30,
+    "ea": 35,
+    "preview": 40,
+    "rc": 50,
+    "cr": 50,
+    "b": 60,
+    "number": 70,
+    _RELEASE_QUALIFIER: 100,
+}
 
 
 def coordinate_parts(coordinate: str) -> tuple[str, str, str | None]:
@@ -172,6 +194,103 @@ def resolve_library_update_target(
         metadata_dir=os.path.join(repo_path, "metadata", group, artifact, library_version),
         test_dir=os.path.join(repo_path, "tests", "src", group, artifact, library_version),
     )
+
+
+def latest_metadata_version(repo_path: str, group: str, artifact: str) -> str | None:
+    """Return the metadata-version of the single latest entry, if one exists."""
+    entries = load_index_entries(repo_path, group, artifact)
+    if not entries:
+        return None
+
+    latest_entries = [
+        entry for entry in entries
+        if isinstance(entry, dict) and entry.get("latest") is True
+    ]
+    if len(latest_entries) != 1:
+        return None
+
+    metadata_version = latest_entries[0].get("metadata-version")
+    if isinstance(metadata_version, str) and metadata_version:
+        return metadata_version
+    return None
+
+
+def is_newer_parseable_metadata_version(candidate_version: str, current_version: str) -> bool:
+    """Return true when both versions are parseable and candidate is newer."""
+    comparison = _compare_parseable_metadata_versions(candidate_version, current_version)
+    return comparison is not None and comparison > 0
+
+
+def is_newer_than_latest_metadata_version(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        candidate_version: str,
+) -> bool:
+    """Return true when candidate is parseably newer than the current latest entry."""
+    current_latest = latest_metadata_version(repo_path, group, artifact)
+    if current_latest is None:
+        return False
+    return is_newer_parseable_metadata_version(candidate_version, current_latest)
+
+
+def _compare_parseable_metadata_versions(first_version: str, second_version: str) -> int | None:
+    first = _parse_metadata_version(first_version)
+    second = _parse_metadata_version(second_version)
+    if first is None or second is None:
+        return None
+
+    first_base, first_qualifier = first
+    second_base, second_qualifier = second
+    base_comparison = _compare_version_numbers(first_base, second_base)
+    if base_comparison != 0:
+        return base_comparison
+
+    rank_comparison = first_qualifier[0] - second_qualifier[0]
+    if rank_comparison != 0:
+        return rank_comparison
+    return first_qualifier[1] - second_qualifier[1]
+
+
+def _parse_metadata_version(version: str) -> ParsedMetadataVersion | None:
+    match = _VERSION_PATTERN.match(version)
+    if not match:
+        return None
+
+    base = tuple(int(part) for part in match.group(1).split("."))
+    qualifier_token = match.group(2)
+    qualifier_tail = match.group(3)
+    if not qualifier_token:
+        return base, (_QUALIFIER_RANK[_RELEASE_QUALIFIER], 0)
+
+    if qualifier_token.isdigit():
+        if qualifier_tail and any(not part.isdigit() for part in re.split(r"[-.]", qualifier_tail)):
+            return None
+        return base, (_QUALIFIER_RANK["number"], int(qualifier_token))
+
+    qualifier_match = _QUALIFIER_PATTERN.match(qualifier_token)
+    if not qualifier_match:
+        return None
+
+    qualifier = qualifier_match.group(1).lower()
+    qualifier_number = qualifier_match.group(2)
+    if not qualifier_number and qualifier_tail:
+        first_tail_part = re.split(r"[-.]", qualifier_tail)[0]
+        if first_tail_part.isdigit():
+            qualifier_number = first_tail_part
+    return base, (_QUALIFIER_RANK[qualifier], int(qualifier_number or "0"))
+
+
+def _compare_version_numbers(first: tuple[int, ...], second: tuple[int, ...]) -> int:
+    component_count = max(len(first), len(second))
+    padded_first = first + ((0,) * (component_count - len(first)))
+    padded_second = second + ((0,) * (component_count - len(second)))
+    if padded_first > padded_second:
+        return 1
+    if padded_first < padded_second:
+        return -1
+    return 0
+
 
 
 def find_index_entry_for_version(

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/FixTestNativeImageRun.java
@@ -104,7 +104,7 @@ public abstract class FixTestNativeImageRun extends DefaultTask {
                 newLibraryVersion
         );
         verifyGeneratedMetadata(metadataDirectory);
-        MetadataGenerationUtils.makeVersionLatestInIndexJson(getLayout(), newCoords, baseCoords.version());
+        MetadataGenerationUtils.addVersionToIndexJsonUpdatingLatestWhenNewer(getLayout(), newCoords, baseCoords.version());
 
         // At the end, attempt to run tests with the new library version.
         // If the build fails, it can be due agent's non-deterministic nature.

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -41,8 +41,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -61,6 +63,28 @@ public final class MetadataGenerationUtils {
             "org.testng.",
             "spock.lang.",
             "org.scalatest."
+    );
+    private static final String RELEASE_QUALIFIER = "release";
+    private static final Pattern METADATA_VERSION_PATTERN = Pattern.compile(
+            "^(\\d+(?:\\.\\d+)*)(?:\\.(?:Final|RELEASE))?"
+                    + "(?:[-.](alpha\\d*|beta\\d*|rc\\d*|cr\\d*|m\\d+|ea\\d*|b\\d+|\\d+|preview)(?:[-.](.*))?)?$",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern QUALIFIER_PATTERN = Pattern.compile(
+            "^(alpha|beta|rc|cr|m|ea|b|preview)(\\d*)$",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Map<String, Integer> QUALIFIER_RANKS = Map.ofEntries(
+            Map.entry("alpha", 10),
+            Map.entry("beta", 20),
+            Map.entry("m", 30),
+            Map.entry("ea", 35),
+            Map.entry("preview", 40),
+            Map.entry("rc", 50),
+            Map.entry("cr", 50),
+            Map.entry("b", 60),
+            Map.entry("number", 70),
+            Map.entry(RELEASE_QUALIFIER, 100)
     );
 
     private static final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
@@ -491,6 +515,106 @@ public final class MetadataGenerationUtils {
         addVersionToIndexJson(layout, newCoords, testVersion, false);
     }
 
+    /**
+     * Adds a metadata entry for {@code newCoords}, promoting it to {@code latest}
+     * only when it is parseably newer than the current latest metadata version.
+     */
+    public static void addVersionToIndexJsonUpdatingLatestWhenNewer(
+            ProjectLayout layout,
+            Coordinates newCoords,
+            String testVersion
+    ) throws IOException {
+        addVersionToIndexJson(layout, newCoords, testVersion, isNewerThanLatestInIndexJson(layout, newCoords));
+    }
+
+    private static boolean isNewerThanLatestInIndexJson(ProjectLayout layout, Coordinates newCoords) throws IOException {
+        String indexPathTemplate = "metadata/$group$/$artifact$/index.json";
+        File indexFile = GeneralUtils.getPathFromProject(layout, CoordinateUtils.replace(indexPathTemplate, newCoords)).toFile();
+        if (!indexFile.exists()) {
+            return false;
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<MetadataVersionsIndexEntry> entries = objectMapper.readValue(indexFile, new TypeReference<>() {});
+        String latestVersion = findSingleLatestMetadataVersion(entries);
+        if (latestVersion == null) {
+            return false;
+        }
+        return compareParseableMetadataVersions(newCoords.version(), latestVersion) > 0;
+    }
+
+    private static String findSingleLatestMetadataVersion(List<MetadataVersionsIndexEntry> entries) {
+        String latestVersion = null;
+        for (MetadataVersionsIndexEntry entry : entries) {
+            if (!Boolean.TRUE.equals(entry.latest())) {
+                continue;
+            }
+            if (latestVersion != null || entry.metadataVersion() == null || entry.metadataVersion().isBlank()) {
+                return null;
+            }
+            latestVersion = entry.metadataVersion();
+        }
+        return latestVersion;
+    }
+
+    private static int compareParseableMetadataVersions(String firstVersion, String secondVersion) {
+        ParsedMetadataVersion first = parseMetadataVersion(firstVersion);
+        ParsedMetadataVersion second = parseMetadataVersion(secondVersion);
+        if (first == null || second == null) {
+            return 0;
+        }
+        return first.compareTo(second);
+    }
+
+    private static ParsedMetadataVersion parseMetadataVersion(String version) {
+        if (version == null) {
+            return null;
+        }
+
+        Matcher versionMatcher = METADATA_VERSION_PATTERN.matcher(version);
+        if (!versionMatcher.matches()) {
+            return null;
+        }
+
+        List<Integer> baseComponents = new ArrayList<>();
+        for (String component : versionMatcher.group(1).split("\\.")) {
+            baseComponents.add(Integer.parseInt(component));
+        }
+
+        String qualifierToken = versionMatcher.group(2);
+        String qualifierTail = versionMatcher.group(3);
+        if (qualifierToken == null) {
+            return new ParsedMetadataVersion(baseComponents, QUALIFIER_RANKS.get(RELEASE_QUALIFIER), 0);
+        }
+
+        if (qualifierToken.chars().allMatch(Character::isDigit)) {
+            if (qualifierTail != null && Stream.of(qualifierTail.split("[-.]"))
+                    .anyMatch(part -> part.isBlank() || !part.chars().allMatch(Character::isDigit))) {
+                return null;
+            }
+            return new ParsedMetadataVersion(baseComponents, QUALIFIER_RANKS.get("number"), Integer.parseInt(qualifierToken));
+        }
+
+        Matcher qualifierMatcher = QUALIFIER_PATTERN.matcher(qualifierToken);
+        if (!qualifierMatcher.matches()) {
+            return null;
+        }
+
+        String qualifier = qualifierMatcher.group(1).toLowerCase(Locale.ROOT);
+        String qualifierNumber = qualifierMatcher.group(2);
+        if (qualifierNumber.isBlank() && qualifierTail != null) {
+            String firstTailPart = qualifierTail.split("[-.]")[0];
+            if (firstTailPart.chars().allMatch(Character::isDigit)) {
+                qualifierNumber = firstTailPart;
+            }
+        }
+        return new ParsedMetadataVersion(
+                baseComponents,
+                QUALIFIER_RANKS.get(qualifier),
+                Integer.parseInt(qualifierNumber.isBlank() ? "0" : qualifierNumber)
+        );
+    }
+
     private static void addVersionToIndexJson(ProjectLayout layout, Coordinates newCoords, String testVersion, boolean markAsLatest) throws IOException {
         String indexPathTemplate = "metadata/$group$/$artifact$/index.json";
         File indexFile = GeneralUtils.getPathFromProject(layout, CoordinateUtils.replace(indexPathTemplate, newCoords)).toFile();
@@ -700,5 +824,31 @@ public final class MetadataGenerationUtils {
                 entry.reason(),
                 entry.replacement()
         );
+    }
+
+    private record ParsedMetadataVersion(List<Integer> baseComponents, int qualifierRank, int qualifierNumber)
+            implements Comparable<ParsedMetadataVersion> {
+        private ParsedMetadataVersion {
+            baseComponents = List.copyOf(baseComponents);
+        }
+
+        @Override
+        public int compareTo(ParsedMetadataVersion other) {
+            int componentCount = Math.max(baseComponents.size(), other.baseComponents.size());
+            for (int i = 0; i < componentCount; i++) {
+                int component = i < baseComponents.size() ? baseComponents.get(i) : 0;
+                int otherComponent = i < other.baseComponents.size() ? other.baseComponents.get(i) : 0;
+                int componentComparison = Integer.compare(component, otherComponent);
+                if (componentComparison != 0) {
+                    return componentComparison;
+                }
+            }
+
+            int rankComparison = Integer.compare(qualifierRank, other.qualifierRank);
+            if (rankComparison != 0) {
+                return rankComparison;
+            }
+            return Integer.compare(qualifierNumber, other.qualifierNumber);
+        }
     }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/FixTestNativeImageRunTests.java
@@ -6,6 +6,8 @@
  */
 package org.graalvm.internal.tck;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
@@ -16,11 +18,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FixTestNativeImageRunTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String BASE_COORDINATES = "io.netty:netty-codec-smtp:4.1.74.Final";
     private static final String NEW_VERSION = "4.2.2.Final";
     private static final String NEW_COORDINATES = "io.netty:netty-codec-smtp:" + NEW_VERSION;
@@ -70,6 +75,34 @@ class FixTestNativeImageRunTests {
                 .contains("4.2.2.Final|test -Pcoordinates=" + NEW_COORDINATES);
     }
 
+    @Test
+    void runPreservesLatestForHistoricalNativeImageRunBackfill() throws IOException {
+        String latestVersion = "4.2.2.Final";
+        String historicalVersion = "4.1.74.Final";
+        String latestCoordinates = "io.netty:netty-codec-smtp:" + latestVersion;
+        String historicalCoordinates = "io.netty:netty-codec-smtp:" + historicalVersion;
+
+        Project project = createProject();
+        prepareLibraryProject(latestVersion);
+        createGradlewScript(false);
+        TestFixTestNativeImageRun task = registerTask(project, latestCoordinates, historicalVersion);
+
+        task.run();
+
+        List<Map<String, Object>> entries = readIndex();
+        assertThat(entries.stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.get("latest")))
+                .map(entry -> entry.get("metadata-version"))
+                .toList())
+                .containsExactly(latestVersion);
+        assertThat(findEntry(entries, historicalVersion))
+                .doesNotContainKey("latest")
+                .containsEntry("test-version", latestVersion)
+                .containsEntry("tested-versions", List.of(historicalVersion));
+        assertThat(readGradlewInvocations())
+                .contains(historicalVersion + "|test -Pcoordinates=" + historicalCoordinates);
+    }
+
     private Project createProject() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
@@ -77,35 +110,43 @@ class FixTestNativeImageRunTests {
     }
 
     private TestFixTestNativeImageRun registerTask(Project project) {
+        return registerTask(project, BASE_COORDINATES, NEW_VERSION);
+    }
+
+    private TestFixTestNativeImageRun registerTask(Project project, String testLibraryCoordinates, String newVersion) {
         TestFixTestNativeImageRun task = project.getTasks().register("fixTestNativeImageRun", TestFixTestNativeImageRun.class).get();
-        task.setTestLibraryCoordinates(BASE_COORDINATES);
-        task.setNewLibraryVersion(NEW_VERSION);
+        task.setTestLibraryCoordinates(testLibraryCoordinates);
+        task.setNewLibraryVersion(newVersion);
         return task;
     }
 
     private void prepareLibraryProject() throws IOException {
-        Files.createDirectories(metadataDirectory("4.1.74.Final"));
-        Files.writeString(metadataFile("4.1.74.Final"), "{\"reflection\":[]}\n", StandardCharsets.UTF_8);
+        prepareLibraryProject("4.1.74.Final");
+    }
+
+    private void prepareLibraryProject(String latestVersion) throws IOException {
+        Files.createDirectories(metadataDirectory(latestVersion));
+        Files.writeString(metadataFile(latestVersion), "{\"reflection\":[]}\n", StandardCharsets.UTF_8);
         Files.writeString(
                 indexFile(),
                 """
                 [
                   {
                     "latest" : true,
-                    "metadata-version" : "4.1.74.Final",
+                    "metadata-version" : "%s",
                     "tested-versions" : [
-                      "4.1.74.Final"
+                      "%s"
                     ],
                     "allowed-packages" : [
                       "io.netty.handler.codec.smtp"
                     ]
                   }
                 ]
-                """,
+                """.formatted(latestVersion, latestVersion),
                 StandardCharsets.UTF_8
         );
 
-        Path testDirectory = tempDir.resolve("tests/src/io.netty/netty-codec-smtp/4.1.74.Final");
+        Path testDirectory = tempDir.resolve("tests/src/io.netty/netty-codec-smtp/" + latestVersion);
         Files.createDirectories(testDirectory);
         Files.writeString(
                 testDirectory.resolve("build.gradle"),
@@ -193,6 +234,21 @@ class FixTestNativeImageRunTests {
 
     private Path metadataFile(String version) {
         return metadataDirectory(version).resolve("reachability-metadata.json");
+    }
+
+    private List<Map<String, Object>> readIndex() throws IOException {
+        return OBJECT_MAPPER.readValue(
+                indexFile().toFile(),
+                new TypeReference<>() {
+                }
+        );
+    }
+
+    private Map<String, Object> findEntry(List<Map<String, Object>> entries, String metadataVersion) {
+        return entries.stream()
+                .filter(entry -> metadataVersion.equals(entry.get("metadata-version")))
+                .findFirst()
+                .orElseThrow();
     }
 
     abstract static class TestFixTestNativeImageRun extends FixTestNativeImageRun {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -189,6 +189,83 @@ class MetadataGenerationUtilsTests {
     }
 
     @Test
+    void addVersionToIndexJsonUpdatingLatestWhenNewerPromotesFinalReleaseOverClassifierPrerelease() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        writeIndex(
+                group,
+                artifact,
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "3.0.0-M5-javax",
+                    "tested-versions" : [
+                      "3.0.0-M5-javax"
+                    ],
+                    "allowed-packages" : [
+                      "com.example"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        MetadataGenerationUtils.addVersionToIndexJsonUpdatingLatestWhenNewer(
+                createProject().getLayout(),
+                Coordinates.parse(group + ":" + artifact + ":3.0.0"),
+                null
+        );
+
+        List<Map<String, Object>> entries = readIndex(group, artifact);
+        assertThat(entries.stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.get("latest")))
+                .map(entry -> entry.get("metadata-version")))
+                .containsExactly("3.0.0");
+        assertThat(findEntry(entries, "3.0.0-M5-javax"))
+                .doesNotContainKey("latest");
+    }
+
+    @Test
+    void addVersionToIndexJsonUpdatingLatestWhenNewerPreservesLatestForClassifierPrerelease() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        writeIndex(
+                group,
+                artifact,
+                """
+                [
+                  {
+                    "latest" : true,
+                    "metadata-version" : "3.0.0",
+                    "tested-versions" : [
+                      "3.0.0"
+                    ],
+                    "allowed-packages" : [
+                      "com.example"
+                    ]
+                  }
+                ]
+                """
+        );
+
+        MetadataGenerationUtils.addVersionToIndexJsonUpdatingLatestWhenNewer(
+                createProject().getLayout(),
+                Coordinates.parse(group + ":" + artifact + ":3.0.0-M5-javax"),
+                null
+        );
+
+        List<Map<String, Object>> entries = readIndex(group, artifact);
+        assertThat(entries.stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.get("latest")))
+                .map(entry -> entry.get("metadata-version")))
+                .containsExactly("3.0.0");
+        assertThat(findEntry(entries, "3.0.0-M5-javax"))
+                .doesNotContainKey("latest")
+                .containsEntry("tested-versions", List.of("3.0.0-M5-javax"));
+    }
+
+    @Test
     void discoverTestOnlyMetadataPackagesIgnoresDependencyApiStubs() throws IOException {
         Path testsDirectory = tempDir.resolve("tests/src/io.grpc/grpc-auth/1.79.0");
         writeSource(


### PR DESCRIPTION
## What does this PR do?

Promotes javac-fix metadata index entries when the target metadata version is parseably newer than the single current `latest` entry. This addresses the Forge human-intervention item in #6237 and the related javac update issue #6220 without editing the generated `org.jetbrains.exposed:exposed-core:1.0.0` metadata branch.

Root cause: the javac workflow always used `addLibraryMetadataIndexJson`, which intentionally preserves the existing `latest` marker. For #6237 that added `1.0.0` while leaving `1.0.0-beta-4` marked latest. Existing validators did not reject that stale latest marker.

The fix keeps the preserving task for historical backfills and unparseable versions, but switches javac-fix publication to `addLibraryAsLatestMetadataIndexJson` when Forge can confidently compare the target version and determine it is newer. The comparison covers final-over-prerelease cases such as `1.0.0-beta-4` to `1.0.0`, newer patch versions, `.Final` / `.RELEASE`, and common prerelease qualifiers.

Validation:
- `PYTHONPATH=$PWD/forge python -m pytest forge/tests/test_java_fail_workflow.py` -> `9 passed`
- `PYTHONPATH=$PWD/forge python -m pytest forge/tests -k 'java_fail_workflow or metadata_index or latest'` -> `10 passed, 236 deselected`
- `git diff --check origin/master...HEAD` -> passed
- Latest Forge review: `runtime/reviews/fetch-prs-forge-index-latest-forge-javac-index-promotion-forge-review-2.md` -> no blocking findings, `Ready to publish: yes`

GitHub items addressed:
- #6237: generated javac-fix PR with stale latest marker; this system fix is the durable handoff.
- #6220: related javac compile update issue for `org.jetbrains.exposed:exposed-core:1.0.0`.

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/metadata_index.py` reads local `metadata/<group>/<artifact>/index.json` files.
- `forge/ai_workflows/java_fail_workflow.py` continues to invoke the existing local Gradle metadata-index task.
- No new network, docker, or external-service access is added.