### PR TITLE
[Forge] Gate dynamic-access publication evidence

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -90,7 +90,7 @@ from utility_scripts.metadata_index import (
     resolve_metadata_version,
     resolve_test_dir,
 )
-from utility_scripts.metrics_writer import read_pending_metrics
+from utility_scripts.metrics_writer import DYNAMIC_ACCESS_MIN_COVERAGE_RATIO, read_pending_metrics
 from utility_scripts.repo_path_resolver import (
     git_env_limited_to_repo_root,
     get_forge_subdir_name,
@@ -195,7 +195,7 @@ SCRIPT_RUN_METRICS_DIR = "script_run_metrics"
 ADD_NEW_LIBRARY_METRICS_FILE = "add_new_library_support.json"
 FIX_JAVAC_METRICS_FILE = "fix_javac_fail.json"
 FIX_JAVA_RUN_METRICS_FILE = "fix_java_run_fail.json"
-LOW_DYNAMIC_ACCESS_COVERAGE_RATIO = 0.10
+LOW_DYNAMIC_ACCESS_COVERAGE_RATIO = DYNAMIC_ACCESS_MIN_COVERAGE_RATIO
 HUMAN_INTERVENTION_LABEL_COLOR = "B60205"
 HUMAN_INTERVENTION_LABEL_DESCRIPTION = (
     "Requires manual follow-up because automated processing needs human attention"

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from git_scripts.common_git import (
     ensure_gh_authenticated,
@@ -55,6 +55,7 @@ DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_MAX_ITEMS = 8
 class DynamicAccessMetadataEvidence:
     covered_call_sites: list[str]
     metadata_rules: list[str]
+    test_only_metadata_rules: list[str] = field(default_factory=list)
 
 
 def _extract_covered_dynamic_access_calls(library_stats: dict | None) -> int | None:
@@ -76,22 +77,30 @@ def format_dynamic_access_metadata_entry_note(
         metadata_entries: int,
         library_stats: dict | None,
         evidence: DynamicAccessMetadataEvidence | None = None,
+        test_only_metadata_entries: int = 0,
 ) -> str:
     """Explain large dynamic-access/metadata-entry count differences in generated PR bodies."""
     covered_calls = _extract_covered_dynamic_access_calls(library_stats)
     if covered_calls is None:
         return ""
-    if metadata_entries > 0 and covered_calls < metadata_entries * DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO:
+    total_metadata_entries = metadata_entries + test_only_metadata_entries
+    if total_metadata_entries > 0 and covered_calls < total_metadata_entries * DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO:
         return ""
-    if metadata_entries <= 0 and covered_calls <= 0:
+    if total_metadata_entries <= 0 and covered_calls <= 0:
         return ""
 
+    metadata_entries_line = f"- Metadata entries: {total_metadata_entries}"
+    if test_only_metadata_entries > 0:
+        metadata_entries_line = (
+            f"- Metadata entries: {total_metadata_entries} "
+            f"({metadata_entries} shipped, {test_only_metadata_entries} test-only)"
+        )
     lines = [
         "",
         "### Metadata/dynamic-access evidence",
         "",
         f"- Covered dynamic-access calls: {covered_calls}",
-        f"- Metadata entries: {metadata_entries}",
+        metadata_entries_line,
         "- These counts are different dimensions: covered dynamic-access calls count observed call sites, "
         "while metadata entries count generated reachability-config items. Depending on the access type, "
         "a single metadata rule can cover multiple observed call sites, or no shipped rule may be required "
@@ -103,11 +112,22 @@ def format_dynamic_access_metadata_entry_note(
     if evidence and evidence.metadata_rules:
         lines.append("- Generated metadata rules:")
         lines.extend(f"  - {metadata_rule}" for metadata_rule in evidence.metadata_rules)
-    lines.append(
-        "- Use the call-site and metadata-rule lists together to review whether the observed dynamic-access "
-        "paths are explained by the generated reachability metadata."
-    )
+    if evidence and evidence.test_only_metadata_rules:
+        lines.append("- Generated test-only metadata rules:")
+        lines.extend(f"  - {metadata_rule}" for metadata_rule in evidence.test_only_metadata_rules)
+    if has_reviewable_dynamic_access_metadata_evidence(evidence):
+        lines.append(
+            "- Use the call-site and metadata-rule lists together to review whether the observed dynamic-access "
+            "paths are explained by the generated reachability metadata."
+        )
     return "\n".join(lines) + "\n"
+
+
+def has_reviewable_dynamic_access_metadata_evidence(evidence: DynamicAccessMetadataEvidence | None) -> bool:
+    """Return True when mismatch evidence contains both call sites and generated rule summaries."""
+    if evidence is None:
+        return False
+    return bool(evidence.covered_call_sites and (evidence.metadata_rules or evidence.test_only_metadata_rules))
 
 
 def load_dynamic_access_metadata_evidence(repo_path: str, coordinates: str) -> DynamicAccessMetadataEvidence | None:
@@ -133,14 +153,30 @@ def load_dynamic_access_metadata_evidence(repo_path: str, coordinates: str) -> D
         version,
         "reachability-metadata.json",
     )
+    test_metadata_path = os.path.join(
+        repo_path,
+        "tests",
+        "src",
+        group,
+        artifact,
+        version,
+        "src",
+        "test",
+        "resources",
+        "META-INF",
+        "native-image",
+        "reachability-metadata.json",
+    )
 
     covered_call_sites = _load_covered_dynamic_access_call_sites(report_path)
     metadata_rules = _load_metadata_rule_summaries(metadata_path)
-    if not covered_call_sites and not metadata_rules:
+    test_only_metadata_rules = _load_metadata_rule_summaries(test_metadata_path)
+    if not covered_call_sites and not metadata_rules and not test_only_metadata_rules:
         return None
     return DynamicAccessMetadataEvidence(
         covered_call_sites=covered_call_sites,
         metadata_rules=metadata_rules,
+        test_only_metadata_rules=test_only_metadata_rules,
     )
 
 
@@ -315,7 +351,12 @@ Summary:
 - Generated lines of code: {generated_loc}
 - Tested library lines of code: {tested_library_loc}
 """
-    body += format_dynamic_access_metadata_entry_note(entries_found, library_stats, dynamic_access_evidence)
+    body += format_dynamic_access_metadata_entry_note(
+        entries_found,
+        library_stats,
+        dynamic_access_evidence,
+        test_only_metadata_entries=test_only_metadata_entries,
+    )
     body += "\n" + format_forge_revision_section() + "\n"
     if library_stats:
         body += "\n" + format_stats_section(library_stats) + "\n"
@@ -409,6 +450,15 @@ def create_pull_request(
 
     library_stats = load_library_stats(repo_path, coordinates)
     dynamic_access_evidence = load_dynamic_access_metadata_evidence(repo_path, coordinates)
+    quality_issues = collect_new_library_support_quality_issues(
+        matched,
+        has_reviewable_dynamic_access_metadata_evidence=has_reviewable_dynamic_access_metadata_evidence(
+            dynamic_access_evidence,
+        ),
+    )
+    if quality_issues:
+        details = "; ".join(quality_issues)
+        raise ValueError(f"Refusing to create PR for {coordinates}: {details}")
     body = build_pull_request_body(
         issue_no=issue_no,
         coordinates=coordinates,
@@ -606,10 +656,18 @@ def update_large_library_state_after_publish(
     state.save(state_path)
 
 
-def validate_run_quality(coordinates: str, metrics_repo_path: str) -> None:
+def validate_run_quality(coordinates: str, metrics_repo_path: str, repo_path: str | None = None) -> None:
     """Raise ValueError if the run metrics are not good enough for a PR."""
     matched = read_pending_metrics(metrics_repo_path)
-    quality_issues = collect_new_library_support_quality_issues(matched)
+    dynamic_access_evidence = None
+    if repo_path is not None:
+        dynamic_access_evidence = load_dynamic_access_metadata_evidence(repo_path, coordinates)
+    quality_issues = collect_new_library_support_quality_issues(
+        matched,
+        has_reviewable_dynamic_access_metadata_evidence=has_reviewable_dynamic_access_metadata_evidence(
+            dynamic_access_evidence,
+        ),
+    )
     if quality_issues:
         details = "; ".join(quality_issues)
         raise ValueError(f"Refusing to create PR for {coordinates}: {details}")
@@ -628,7 +686,7 @@ def main(argv=None):
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     ensure_gh_authenticated()
-    validate_run_quality(coordinates, metrics_repo_path)
+    validate_run_quality(coordinates, metrics_repo_path, repo_path)
 
     branch = push_current_branch_to_origin(
         coordinates=coordinates,

--- a/forge/tests/test_make_pr_new_library_support.py
+++ b/forge/tests/test_make_pr_new_library_support.py
@@ -13,7 +13,40 @@ from git_scripts.make_pr_new_library_support import (
     DynamicAccessMetadataEvidence,
     build_pull_request_body,
     load_dynamic_access_metadata_evidence,
+    validate_run_quality,
 )
+from utility_scripts.metrics_writer import write_pending_metrics
+
+
+def _dynamic_access_report_payload(coordinates: str = "org.osgi:org.osgi.framework:1.8.0") -> dict:
+    return {
+        "coordinate": coordinates,
+        "hasDynamicAccess": True,
+        "totals": {
+            "coveredCalls": 1,
+            "totalCalls": 1,
+        },
+        "classes": [
+            {
+                "className": "org.osgi.framework.FrameworkUtil$FilterImpl",
+                "sourceFile": "FrameworkUtil.java",
+                "coveredCalls": 1,
+                "totalCalls": 1,
+                "callSites": [
+                    {
+                        "metadataType": "reflection",
+                        "trackedApi": "java.lang.Class#getMethod(String,Class[])",
+                        "frame": (
+                            "org.osgi.framework.FrameworkUtil$FilterImpl."
+                            "valueOf(java.lang.Object,java.lang.String)"
+                        ),
+                        "line": 1144,
+                        "covered": True,
+                    },
+                ],
+            },
+        ],
+    }
 
 
 class MakePrNewLibrarySupportTests(unittest.TestCase):
@@ -80,6 +113,42 @@ class MakePrNewLibrarySupportTests(unittest.TestCase):
         self.assertIn("- Generated metadata rules:", body)
         self.assertIn("org.osgi.framework.Version.valueOf(java.lang.String)", body)
 
+    def test_build_pull_request_body_includes_test_only_metadata_rules_for_count_gap(self) -> None:
+        body = build_pull_request_body(
+            issue_no=3744,
+            coordinates="org.osgi:org.osgi.framework:1.8.0",
+            model_display_name="gpt-5.5",
+            agent_name="pi",
+            strategy_name="dynamic_access_main_sources_pi_gpt-5.5",
+            run_status="success",
+            metrics={
+                "metadata_entries": 0,
+                "test_only_metadata_entries": 1,
+            },
+            library_stats={
+                "dynamicAccess": {
+                    "coveredCalls": 2,
+                    "totalCalls": 2,
+                    "coverageRatio": 1.0,
+                    "breakdown": {},
+                },
+            },
+            dynamic_access_evidence=DynamicAccessMetadataEvidence(
+                covered_call_sites=[
+                    "[reflection] java.lang.Class#getDeclaredConstructor(Class[]) <- "
+                    "org.osgi.framework.FrameworkUtil$FilterImpl.create(java.lang.String) (line 42)",
+                ],
+                metadata_rules=[],
+                test_only_metadata_rules=[
+                    "make `org.osgi.framework.TestFixture` available for reflection",
+                ],
+            ),
+        )
+
+        self.assertIn("- Metadata entries: 1 (0 shipped, 1 test-only)", body)
+        self.assertIn("- Generated test-only metadata rules:", body)
+        self.assertIn("org.osgi.framework.TestFixture", body)
+
     def test_build_pull_request_body_explains_covered_calls_with_zero_metadata_entries(self) -> None:
         body = build_pull_request_body(
             issue_no=1,
@@ -121,34 +190,7 @@ class MakePrNewLibrarySupportTests(unittest.TestCase):
             os.makedirs(report_dir)
             with open(os.path.join(report_dir, "dynamic-access-coverage.json"), "w", encoding="utf-8") as file:
                 json.dump(
-                    {
-                        "coordinate": "org.osgi:org.osgi.framework:1.8.0",
-                        "hasDynamicAccess": True,
-                        "totals": {
-                            "coveredCalls": 1,
-                            "totalCalls": 1,
-                        },
-                        "classes": [
-                            {
-                                "className": "org.osgi.framework.FrameworkUtil$FilterImpl",
-                                "sourceFile": "FrameworkUtil.java",
-                                "coveredCalls": 1,
-                                "totalCalls": 1,
-                                "callSites": [
-                                    {
-                                        "metadataType": "reflection",
-                                        "trackedApi": "java.lang.Class#getMethod(String,Class[])",
-                                        "frame": (
-                                            "org.osgi.framework.FrameworkUtil$FilterImpl."
-                                            "valueOf(java.lang.Object,java.lang.String)"
-                                        ),
-                                        "line": 1144,
-                                        "covered": True,
-                                    },
-                                ],
-                            },
-                        ],
-                    },
+                    _dynamic_access_report_payload(),
                     file,
                 )
 
@@ -194,6 +236,143 @@ class MakePrNewLibrarySupportTests(unittest.TestCase):
         self.assertIn("FrameworkUtil$FilterImpl.valueOf", evidence.covered_call_sites[0])
         self.assertEqual(1, len(evidence.metadata_rules))
         self.assertIn("org.osgi.framework.Version.valueOf(java.lang.String)", evidence.metadata_rules[0])
+
+    def test_load_dynamic_access_metadata_evidence_reads_test_only_metadata_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            report_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.osgi",
+                "org.osgi.framework",
+                "1.8.0",
+                "build",
+                "reports",
+                "dynamic-access",
+            )
+            os.makedirs(report_dir)
+            with open(os.path.join(report_dir, "dynamic-access-coverage.json"), "w", encoding="utf-8") as file:
+                json.dump(_dynamic_access_report_payload(), file)
+
+            test_metadata_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.osgi",
+                "org.osgi.framework",
+                "1.8.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(test_metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "reflection": [
+                            {
+                                "type": "org.osgi.framework.TestFixture",
+                                "methods": [
+                                    {
+                                        "name": "create",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    file,
+                )
+
+            evidence = load_dynamic_access_metadata_evidence(
+                repo_path,
+                "org.osgi:org.osgi.framework:1.8.0",
+            )
+
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertEqual(1, len(evidence.covered_call_sites))
+        self.assertEqual(1, len(evidence.test_only_metadata_rules))
+        self.assertIn("org.osgi.framework.TestFixture.create()", evidence.test_only_metadata_rules[0])
+
+    def test_validate_run_quality_blocks_mismatch_without_reviewable_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as metrics_root:
+            write_pending_metrics(
+                metrics_root,
+                {
+                    "status": "success",
+                    "metrics": {
+                        "code_coverage_percent": 10.0,
+                        "metadata_entries": 1,
+                    },
+                    "stats": {
+                        "dynamicAccess": {
+                            "coveredCalls": 4,
+                            "totalCalls": 4,
+                            "coverageRatio": 1.0,
+                            "breakdown": {},
+                        },
+                    },
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "without reviewable call-site and metadata-rule evidence"):
+                validate_run_quality("org.osgi:org.osgi.framework:1.8.0", metrics_root)
+
+    def test_validate_run_quality_allows_mismatch_with_call_site_and_test_only_rule_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as metrics_root:
+            report_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.osgi",
+                "org.osgi.framework",
+                "1.8.0",
+                "build",
+                "reports",
+                "dynamic-access",
+            )
+            os.makedirs(report_dir)
+            with open(os.path.join(report_dir, "dynamic-access-coverage.json"), "w", encoding="utf-8") as file:
+                json.dump(_dynamic_access_report_payload(), file)
+            test_metadata_dir = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.osgi",
+                "org.osgi.framework",
+                "1.8.0",
+                "src",
+                "test",
+                "resources",
+                "META-INF",
+                "native-image",
+            )
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(test_metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
+                json.dump({"reflection": [{"type": "org.osgi.framework.TestFixture"}]}, file)
+            write_pending_metrics(
+                metrics_root,
+                {
+                    "status": "success",
+                    "metrics": {
+                        "code_coverage_percent": 10.0,
+                        "metadata_entries": 0,
+                        "test_only_metadata_entries": 1,
+                    },
+                    "stats": {
+                        "dynamicAccess": {
+                            "coveredCalls": 2,
+                            "totalCalls": 2,
+                            "coverageRatio": 1.0,
+                            "breakdown": {},
+                        },
+                    },
+                },
+            )
+
+            validate_run_quality("org.osgi:org.osgi.framework:1.8.0", metrics_root, repo_path)
 
     def test_build_pull_request_body_omits_count_gap_note_for_close_counts(self) -> None:
         with patch("git_scripts.make_pr_new_library_support.format_forge_revision_section", return_value="Forge"):

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -15,6 +15,7 @@ from ai_workflows.add_new_library_support import (
 from ai_workflows.java_fail_workflow import JAVAC_CONFIG, resolve_fix_metrics_json, write_fix_metrics
 from utility_scripts.library_stats import load_library_stats_entry, resolve_stats_file_path
 from utility_scripts.metrics_writer import (
+    collect_new_library_support_quality_issues,
     count_metadata_entries,
     count_test_only_metadata_entries,
     create_run_metrics_output_json,
@@ -67,6 +68,28 @@ class DummyAgent:
 
 
 class MetricsPathTests(unittest.TestCase):
+    def test_new_library_quality_rejects_zero_dynamic_access_coverage(self) -> None:
+        issues = collect_new_library_support_quality_issues(
+            {
+                "status": "success",
+                "code_coverage_percent": 8.43,
+                "metrics": {
+                    "metadata_entries": 0,
+                },
+                "stats": {
+                    "dynamicAccess": {
+                        "coveredCalls": 0,
+                        "totalCalls": 8,
+                        "coverageRatio": 0.0,
+                        "breakdown": {},
+                    },
+                },
+            }
+        )
+
+        self.assertTrue(issues)
+        self.assertIn("dynamic-access coverage is 0/8", "; ".join(issues))
+
     def test_count_metadata_entries_uses_metadata_version_for_tested_version(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo", "1.0.0")

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -27,6 +27,8 @@ from git_scripts.common_git import git_remote_exists
 DEFAULT_INPUT_RATE_PER_1M = 3.00
 DEFAULT_CACHED_INPUT_RATE_PER_1M = 3.00
 DEFAULT_OUTPUT_RATE_PER_1M = 12.00
+DYNAMIC_ACCESS_MIN_COVERAGE_RATIO = 0.20
+DYNAMIC_ACCESS_METADATA_ENTRY_GAP_RATIO = 1.75
 
 INPUT_TOKEN_RATE_PER_1M_BY_MODEL = {
     "oca/gpt-5.4": 2.50,
@@ -1017,16 +1019,82 @@ def commit_run_metrics_with_retry(
             shutil.rmtree(snapshot_root, ignore_errors=True)
 
 
-def collect_new_library_support_quality_issues(run_metrics: dict) -> list[str]:
+def _dynamic_access_stats_from_run_metrics(run_metrics: dict) -> dict | None:
+    stats = run_metrics.get("stats")
+    if not isinstance(stats, dict):
+        return None
+    dynamic_access = stats.get("dynamicAccess")
+    if not isinstance(dynamic_access, dict):
+        return None
+    return dynamic_access
+
+
+def _dynamic_access_call_counts(dynamic_access: dict) -> tuple[int, int, float] | None:
+    total_calls = int(dynamic_access.get("totalCalls", 0) or 0)
+    if total_calls <= 0:
+        return None
+    covered_calls = int(dynamic_access.get("coveredCalls", 0) or 0)
+    coverage_ratio = dynamic_access.get("coverageRatio")
+    if coverage_ratio is None:
+        coverage_ratio = covered_calls / total_calls
+    return covered_calls, total_calls, float(coverage_ratio)
+
+
+def _run_metrics_metadata_entry_count(metrics: dict, key: str) -> int:
+    return int(metrics.get(key, 0) or 0)
+
+
+def _has_dynamic_access_metadata_entry_gap(covered_calls: int, metadata_entries: int) -> bool:
+    if covered_calls <= 0:
+        return False
+    if metadata_entries <= 0:
+        return True
+    return covered_calls >= metadata_entries * DYNAMIC_ACCESS_METADATA_ENTRY_GAP_RATIO
+
+
+def collect_new_library_support_quality_issues(
+        run_metrics: dict,
+        has_reviewable_dynamic_access_metadata_evidence: bool = False,
+) -> list[str]:
     """Return validation failures for a new-library-support run that is not meaningful enough for a PR."""
     status = run_metrics.get("status")
     if status not in {"success", "success_with_intervention", "chunk_ready"}:
         return [f"workflow status is `{status or 'unknown'}`"]
 
     metrics = run_metrics.get("metrics") or {}
+    issues = []
 
-    code_coverage_percent = float(metrics.get("code_coverage_percent", 0.0) or 0.0)
+    raw_code_coverage_percent = metrics.get("code_coverage_percent", run_metrics.get("code_coverage_percent", 0.0))
+    code_coverage_percent = float(raw_code_coverage_percent or 0.0)
     if code_coverage_percent <= 0.0:
-        return ["library coverage percentage is zero"]
+        issues.append("library coverage percentage is zero")
 
-    return []
+    dynamic_access = _dynamic_access_stats_from_run_metrics(run_metrics)
+    dynamic_access_counts = None if dynamic_access is None else _dynamic_access_call_counts(dynamic_access)
+    if dynamic_access_counts is not None:
+        covered_calls, total_calls, coverage_ratio = dynamic_access_counts
+        if coverage_ratio <= DYNAMIC_ACCESS_MIN_COVERAGE_RATIO:
+            issues.append(
+                "dynamic-access coverage is "
+                f"{covered_calls}/{total_calls} ({coverage_ratio * 100.0:.2f}%), "
+                f"at or below the required {DYNAMIC_ACCESS_MIN_COVERAGE_RATIO * 100.0:.0f}%"
+            )
+
+        metadata_entries = _run_metrics_metadata_entry_count(metrics, "metadata_entries")
+        test_only_metadata_entries = _run_metrics_metadata_entry_count(metrics, "test_only_metadata_entries")
+        total_metadata_entries = metadata_entries + test_only_metadata_entries
+        if covered_calls > 0 and total_metadata_entries <= 0:
+            issues.append(
+                "covered dynamic-access calls were reported but no shipped or test-only metadata entries were generated"
+            )
+        elif (
+                _has_dynamic_access_metadata_entry_gap(covered_calls, total_metadata_entries)
+                and not has_reviewable_dynamic_access_metadata_evidence
+        ):
+            issues.append(
+                "covered dynamic-access calls "
+                f"({covered_calls}) are disproportionate to shipped plus test-only metadata entries "
+                f"({total_metadata_entries}) without reviewable call-site and metadata-rule evidence"
+            )
+
+    return issues


### PR DESCRIPTION
## Root cause

Forge published generated `library-new-request` PRs when the workflow status was successful and line coverage was positive, but it did not treat `run_metrics["stats"]["dynamicAccess"]` as a publication-quality gate. That let PR #6228 publish even though committed stats reported `0/8 (0.00%)` dynamic-access coverage and the generated metadata was `{}`.

Forge also emitted generic dynamic-access/metadata mismatch text without durable reviewer evidence. PRs #6233, #6210, #6198, and the dynamic-access evidence side of #6177 showed cases where reviewers needed concrete covered call-site evidence plus shipped/test-only metadata-rule summaries to decide whether a mismatch was expected.

## Fix

- Adds shared dynamic-access publication thresholds to the new-library quality gate.
- Rejects new-library publication when dynamic-access coverage is at or below 20%, when covered dynamic-access calls exist with no shipped or test-only metadata entries, or when covered calls are disproportionate to metadata entries without reviewable call-site/rule evidence.
- Loads dynamic-access coverage and both shipped and test-only metadata summaries before PR creation, so unexplained mismatches fail before `gh pr create`.
- Expands the PR-body evidence section to include covered call sites, shipped metadata rules, and test-only metadata rules when mismatch evidence is reviewable.
- Reuses the same threshold for Forge human-intervention routing.

## GitHub items addressed

- Addresses PR #6228 as the clean `0/8` dynamic-access publication-gate failure.
- Addresses PRs #6233, #6210, and #6198 by preventing unexplained dynamic-access/metadata mismatches from reaching review without concrete evidence.
- Addresses the dynamic-access evidence side of PR #6177. The remaining #6177 dependency-stub/test-only classification risk is intentionally left gated for the separate follow-up noted by review.
- This is a Forge system fix only. It does not edit generated metadata, stats, or tests on the failed/generated branches.

## Validation

Passed on the clean publication branch rebased to current `origin/master`:

- `PYTHONPATH=forge python -m pytest forge/tests/test_make_pr_new_library_support.py forge/tests/test_metrics_paths.py -k 'quality or metrics or make_pr_new_library_support or dynamic_access or human_intervention'` -> `18 passed, 1 warning`
- `PYTHONPATH=forge python -m pytest forge -k 'quality or metrics or make_pr_new_library_support or dynamic_access or human_intervention'` -> `53 passed, 193 deselected, 1 warning`
- `git diff origin/master --check` -> passed

Reviewer validation from `runtime/reviews/fetch-prs-forge-coverage-metadata-evidence-forge-dynamic-access-publication-evidence-gate-forge-review-2.md` reported no blocking findings, no validation gaps, and `Ready to publish: yes`. The recorded smoke check showed #6233/#6228/#6210/#6198 blocked by this gate and #6177 not blocked by this specific gate, matching the split follow-up.

## Publication notes

Configured reviewers were `[]`, so this PR uses repository-default review routing. After this PR exists, #6233, #6228, #6210, and #6198 will get handoff comments and have `human-intervention` replaced with `human-intervention-fixed`; #6177 keeps `human-intervention` for the separate classification follow-up.
