### PR TITLE
[Forge] Fix test-only dependency stub classification

### DIFF
--- a/forge/prompt_templates/persistent/dynamic_access_rules.md
+++ b/forge/prompt_templates/persistent/dynamic_access_rules.md
@@ -6,6 +6,7 @@ Rules:
 - Do not broaden the patch into unrelated features.
 - Use upstream test sources only as behavioral examples.
 - Use documentation and source context only as API guidance.
+- Do not create source stubs, fake replacements, or shadow classes for library or dependency API types in their real packages. If a needed API is missing from the test classpath, add the correct test dependency or leave the call site unreached with an explanation.
 - Do not use reflection directly in the tests unless the public API requires it naturally.
 - Do not compile or run tests yourself. The workflow will do that externally.
 - Follow idiomatic `{test_language_display_name}` coding conventions.

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
@@ -88,7 +88,7 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
             throw new IllegalArgumentException("Cannot find tests directory for " + coordinate + ": " + testsDirectory);
         }
 
-        Set<String> testPackages = MetadataGenerationUtils.discoverTestPackages(testsDirectory);
+        Set<String> testPackages = MetadataGenerationUtils.discoverTestOnlyMetadataPackages(testsDirectory);
         Set<String> testResources = discoverTestResources(testsDirectory);
 
         ObjectNode libraryMetadata = requireObjectNode(objectMapper.readTree(metadataFile.toFile()), metadataFile);

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -45,6 +45,15 @@ public final class MetadataGenerationUtils {
 
     public static final String BUILD_FILE = "build.gradle";
     private static final String USER_CODE_FILTER_FILE = "user-code-filter.json";
+    private static final List<String> TEST_SOURCE_SETS = List.of("src/test/java", "src/test/kotlin", "src/test/groovy", "src/test/scala");
+    private static final List<String> TEST_SOURCE_EXTENSIONS = List.of(".java", ".kt", ".groovy", ".scala");
+    private static final List<String> TEST_SOURCE_MARKERS = List.of(
+            "@Test",
+            "org.junit.",
+            "org.testng.",
+            "spock.lang.",
+            "org.scalatest."
+    );
 
     private static final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -132,12 +141,10 @@ public final class MetadataGenerationUtils {
 
     /**
      * Walks the conventional test source roots and returns the package names they contain.
-     * Shared with SplitTestOnlyMetadataTask so the same set drives both filter generation
-     * and the test-only split.
      */
     public static Set<String> discoverTestPackages(Path testsDirectory) throws IOException {
         Set<String> packages = new LinkedHashSet<>();
-        for (String sourceSet : List.of("src/test/java", "src/test/kotlin", "src/test/groovy", "src/test/scala")) {
+        for (String sourceSet : TEST_SOURCE_SETS) {
             Path sourceRoot = testsDirectory.resolve(sourceSet);
             if (!Files.isDirectory(sourceRoot)) {
                 continue;
@@ -156,6 +163,46 @@ public final class MetadataGenerationUtils {
             }
         }
         return packages;
+    }
+
+    /**
+     * Returns packages that are clear test owners for metadata splitting.
+     * Dependency API stubs may live under src/test in their real packages, but
+     * they are not test-only merely because a generated test provided a stub.
+     */
+    public static Set<String> discoverTestOnlyMetadataPackages(Path testsDirectory) throws IOException {
+        Set<String> packages = new LinkedHashSet<>();
+        for (String sourceSet : TEST_SOURCE_SETS) {
+            Path sourceRoot = testsDirectory.resolve(sourceSet);
+            if (!Files.isDirectory(sourceRoot)) {
+                continue;
+            }
+            try (var pathStream = Files.walk(sourceRoot)) {
+                for (Path path : pathStream.filter(Files::isRegularFile).toList()) {
+                    if (!isTestOwnedSource(path)) {
+                        continue;
+                    }
+                    Path relativeParent = sourceRoot.relativize(path).getParent();
+                    if (relativeParent == null) {
+                        continue;
+                    }
+                    String packageName = relativeParent.toString().replace('/', '.').replace('\\', '.');
+                    if (!packageName.isBlank()) {
+                        packages.add(packageName);
+                    }
+                }
+            }
+        }
+        return packages;
+    }
+
+    private static boolean isTestOwnedSource(Path path) throws IOException {
+        String fileName = path.getFileName().toString();
+        if (TEST_SOURCE_EXTENSIONS.stream().noneMatch(fileName::endsWith)) {
+            return false;
+        }
+        String source = Files.readString(path, StandardCharsets.UTF_8);
+        return TEST_SOURCE_MARKERS.stream().anyMatch(source::contains);
     }
 
     /**

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SplitTestOnlyMetadataTaskTests {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void leavesDependencyPackageStubMetadataShippedAndMovesTestFixtureMetadata() throws IOException {
+        String coordinate = "io.grpc:grpc-auth:1.79.0";
+        writeSource(
+                "tests/src/io.grpc/grpc-auth/1.79.0/src/test/java/com/google/auth/oauth2/ServiceAccountCredentials.java",
+                """
+                package com.google.auth.oauth2;
+
+                public final class ServiceAccountCredentials {
+                    public String getClientId() {
+                        return "client";
+                    }
+                }
+                """
+        );
+        writeSource(
+                "tests/src/io.grpc/grpc-auth/1.79.0/src/test/java/io_grpc/grpc_auth/GrpcAuthTest.java",
+                """
+                package io_grpc.grpc_auth;
+
+                import org.junit.jupiter.api.Test;
+
+                public class GrpcAuthTest {
+                    @Test
+                    void exercisesAuth() {
+                    }
+
+                    static final class Fixture {
+                    }
+                }
+                """
+        );
+        writeJson(
+                "metadata/io.grpc/grpc-auth/1.79.0/reachability-metadata.json",
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "io.grpc.auth.GoogleAuthLibraryCallCredentials$JwtHelper"
+                      },
+                      "type": "com.google.auth.oauth2.ServiceAccountCredentials",
+                      "methods": [
+                        {
+                          "name": "getClientId",
+                          "parameterTypes": []
+                        }
+                      ]
+                    },
+                    {
+                      "condition": {
+                        "typeReached": "io_grpc.grpc_auth.GrpcAuthTest"
+                      },
+                      "type": "io_grpc.grpc_auth.GrpcAuthTest$Fixture"
+                    }
+                  ]
+                }
+                """
+        );
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        SplitTestOnlyMetadataTask task = project.getTasks()
+                .register("splitTestOnlyMetadata", SplitTestOnlyMetadataTask.class)
+                .get();
+        task.setCoordinatesOverride(List.of(coordinate));
+
+        task.run();
+
+        JsonNode shippedMetadata = readJson("metadata/io.grpc/grpc-auth/1.79.0/reachability-metadata.json");
+        JsonNode testOnlyMetadata = readJson(
+                "tests/src/io.grpc/grpc-auth/1.79.0/src/test/resources/META-INF/native-image/reachability-metadata.json"
+        );
+
+        assertThat(shippedMetadata.get("reflection"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("com.google.auth.oauth2.ServiceAccountCredentials");
+        assertThat(testOnlyMetadata.get("reflection"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("io_grpc.grpc_auth.GrpcAuthTest$Fixture");
+    }
+
+    private void writeSource(String relativePath, String content) throws IOException {
+        Path file = tempDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
+    }
+
+    private void writeJson(String relativePath, String content) throws IOException {
+        Path file = tempDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
+    }
+
+    private JsonNode readJson(String relativePath) throws IOException {
+        return OBJECT_MAPPER.readTree(tempDir.resolve(relativePath).toFile());
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -188,10 +188,48 @@ class MetadataGenerationUtilsTests {
                 .containsEntry("allowed-packages", List.of("graphql"));
     }
 
+    @Test
+    void discoverTestOnlyMetadataPackagesIgnoresDependencyApiStubs() throws IOException {
+        Path testsDirectory = tempDir.resolve("tests/src/io.grpc/grpc-auth/1.79.0");
+        writeSource(
+                testsDirectory.resolve("src/test/java/com/google/auth/oauth2/ServiceAccountCredentials.java"),
+                """
+                package com.google.auth.oauth2;
+
+                public final class ServiceAccountCredentials {
+                }
+                """
+        );
+        writeSource(
+                testsDirectory.resolve("src/test/java/io_grpc/grpc_auth/GrpcAuthTest.java"),
+                """
+                package io_grpc.grpc_auth;
+
+                import org.junit.jupiter.api.Test;
+
+                public class GrpcAuthTest {
+                    @Test
+                    void exercisesAuth() {
+                    }
+                }
+                """
+        );
+
+        assertThat(MetadataGenerationUtils.discoverTestPackages(testsDirectory))
+                .containsExactlyInAnyOrder("com.google.auth.oauth2", "io_grpc.grpc_auth");
+        assertThat(MetadataGenerationUtils.discoverTestOnlyMetadataPackages(testsDirectory))
+                .containsExactly("io_grpc.grpc_auth");
+    }
+
     private Project createProject() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
                 .build();
+    }
+
+    private void writeSource(Path file, String content) throws IOException {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
     }
 
     private void writeIndex(String group, String artifact, String content) throws IOException {


### PR DESCRIPTION
## Root cause

Forge generated test-source stubs for missing dependency APIs in the real dependency namespace, for example `tests/src/io.grpc/grpc-auth/1.79.0/src/test/java/com/google/auth/oauth2/`. `SplitTestOnlyMetadataTask` treated every package discovered under `src/test/java` as test-owned, so metadata whose `type` referenced `com.google.auth.oauth2` was moved from shipped metadata into test-only metadata.

That made #6177 hide real dependency integration metadata for #6159 behind the test-only split solely because generated stubs existed in a dependency package. The prompt also did not explicitly forbid creating source stubs, fake replacements, or shadow classes for library/dependency APIs in their real packages.

## Fix

- Adds `MetadataGenerationUtils.discoverTestOnlyMetadataPackages`, a conservative split classifier that only treats packages as test-owned when their source files contain clear test-framework markers.
- Keeps `discoverTestPackages` unchanged for broader test-source package discovery, including user-code filter generation.
- Updates `SplitTestOnlyMetadataTask` to use the test-only classifier instead of all discovered test-source packages.
- Adds a split-task regression test showing dependency-package stub metadata remains shipped while real test fixture metadata moves to test-only metadata.
- Adds utility coverage proving dependency API stubs are ignored by the split classifier but still discovered by the broader package scanner.
- Tightens Forge dynamic-access rules so generated tests do not create source stubs, fake replacements, or shadow classes for library/dependency API types in their real packages.

## GitHub items addressed

- Addresses the dependency-stub/test-only classification side of PR #6177.
- Links to the original new-library request #6159 because the misplaced `com.google.auth.oauth2` metadata came from the generated `io.grpc:grpc-auth:1.79.0` support path.
- This is a Forge/build-logic system fix only. It does not edit generated metadata, stats, tests, or the failed/generated branch for #6177.

## Validation

Passed on the clean publication branch rebased to current `origin/master`:

- `git diff origin/master --check` -> passed
- `./gradlew :tck-build-logic:test --rerun-tasks --tests '*SplitTestOnlyMetadataTask*' --tests '*MetadataGenerationUtilsTests*'` -> `BUILD SUCCESSFUL`
- `PYTHONPATH=forge python -m pytest forge -k 'test_only or dependency_stub or metadata_generation or generated_test' -q` -> `2 passed, 239 deselected, 1 warning`

Reviewer validation from `runtime/reviews/fetch-prs-forge-coverage-metadata-evidence-forge-test-only-dependency-stub-classification-forge-review-2.md` reported no blocking findings, no validation gaps, and `Ready to publish: yes`.

## Publication notes

Configured reviewers were `[]`, so this PR uses repository-default review routing. After this PR exists, #6177 can be updated with the second durable Forge handoff; the earlier dynamic-access evidence handoff is #6249.

## Code sections where the PR accesses files, network, docker or some external service

- `MetadataGenerationUtils.discoverTestOnlyMetadataPackages` walks and reads local test-source files under `tests/src/.../src/test/*`.
- `SplitTestOnlyMetadataTask` continues to read and write local reachability metadata and test-only metadata files.
- No new network, docker, or external-service access is added.
