### PR TITLE
[Forge] Block generated native-image test skips

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -47,7 +47,12 @@ from utility_scripts.source_context import (
     resolve_test_source_layout,
 )
 from utility_scripts.stage_logger import log_stage
-from utility_scripts.test_quality_checks import cleanup_scaffold_placeholder_tests, format_placeholder_occurrence
+from utility_scripts.test_quality_checks import (
+    cleanup_scaffold_placeholder_tests,
+    find_native_image_skip_guards,
+    format_native_image_skip_occurrence,
+    format_placeholder_occurrence,
+)
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
@@ -563,6 +568,15 @@ def main(argv=None):
                     f"WARNING: Scaffold placeholder test remains in generated sources: "
                     f"{format_placeholder_occurrence(occurrence, reachability_repo_path)}",
                 )
+        native_image_skip_guards = find_native_image_skip_guards(test_source_layout.source_root)
+        if native_image_skip_guards:
+            for occurrence in native_image_skip_guards:
+                log_stage(
+                    "generated-test-quality",
+                    f"Native-image test skip detected: "
+                    f"{format_native_image_skip_occurrence(occurrence, reachability_repo_path)}",
+                )
+            workflow_status = RUN_STATUS_FAILURE
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         if is_benchmark_mode:

--- a/forge/ai_workflows/workflow_strategies/workflow_strategy.py
+++ b/forge/ai_workflows/workflow_strategies/workflow_strategy.py
@@ -25,6 +25,7 @@ from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_persistent_instructions, load_prompt_template
+from utility_scripts.test_quality_checks import find_native_image_skip_guards, format_native_image_skip_occurrence
 
 RUN_STATUS_SUCCESS = "success"
 RUN_STATUS_FAILURE = "failure"
@@ -409,11 +410,34 @@ class WorkflowStrategy(ABC):
             model_name=self.model_name,
         ):
             return RUN_STATUS_FAILURE, None
+        if not self._run_generated_test_quality_gate():
+            return RUN_STATUS_FAILURE, None
         log_stage("commit-iteration", f"Running commit iteration for {self.library}")
         if not self._commit_library_iteration():
             return RUN_STATUS_FAILURE, None
         checkpoint_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
         return test_retry_status, checkpoint_commit_hash
+
+    def _run_generated_test_quality_gate(self) -> bool:
+        """Reject generated tests that skip native-image assertions before committing."""
+        test_source_root = os.path.join(
+            self.reachability_repo_path,
+            "tests",
+            "src",
+            self.group,
+            self.artifact,
+            self.version,
+        )
+        native_image_skip_guards = find_native_image_skip_guards(test_source_root)
+        if not native_image_skip_guards:
+            return True
+        for occurrence in native_image_skip_guards:
+            log_stage(
+                "generated-test-quality",
+                f"Native-image test skip detected: "
+                f"{format_native_image_skip_occurrence(occurrence, self.reachability_repo_path)}",
+            )
+        return False
 
     def _run_split_test_only_metadata(self, library: str) -> bool:
         """Split test-only metadata before stats generation or committing."""

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -14,6 +14,7 @@ from utility_scripts.local_ci_verification import (
     CommandRecord,
     LOCAL_CI_VERIFICATION_KEY,
     LocalCIVerificationResult,
+    LocalCIVerificationError,
     classify_repo_fix_paths,
     fetch_pr_base_ref,
     format_local_ci_verification_pr_section,
@@ -22,6 +23,7 @@ from utility_scripts.local_ci_verification import (
     _github_repo_slug_from_url,
     _graalvm_home_for_java_version,
     _merge_test_matrix_entries,
+    _run_generated_test_quality_validation,
     _run_infrastructure_matrix_entries,
     _run_recorded_command,
     _run_recorded_command_without_new_docker_images,
@@ -251,6 +253,76 @@ class LocalCIVerificationTests(unittest.TestCase):
         self.assertEqual(captured_env["JAVA_HOME"], "/matrix/jdk")
         self.assertEqual(captured_env["GRADLE_OPTS"], "-Xmx2g -Dfile.encoding=UTF-8")
         self.assertNotIn("JAVA_OPTS", captured_env)
+
+    def test_generated_test_quality_validation_rejects_native_image_short_circuit(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            test_file = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "org.example",
+                "demo",
+                "1.0.0",
+                "src",
+                "test",
+                "java",
+                "org_example",
+                "demo",
+                "DemoTest.java",
+            )
+            os.makedirs(os.path.dirname(test_file), exist_ok=True)
+            with open(test_file, "w", encoding="utf-8") as file:
+                file.write(
+                    """
+package org_example.demo;
+
+import org.junit.jupiter.api.Test;
+
+class DemoTest {
+    @Test
+    void skipsNativeImage() {
+        if (NativeImageSupport.isNativeImageRuntime()) {
+            return;
+        }
+    }
+}
+""".lstrip()
+                )
+            result = LocalCIVerificationResult(status="running", base_commit="base")
+
+            failed = _run_generated_test_quality_validation(
+                repo_path,
+                ["tests/src/org.example/demo/1.0.0/src/test/java/org_example/demo/DemoTest.java"],
+                result,
+            )
+
+            self.assertIsNotNone(failed)
+            self.assertEqual(result.commands[0].gate, "generated-test-quality")
+            self.assertIn("DemoTest.java", result.commands[0].output_excerpt)
+
+    def test_generated_test_quality_failure_does_not_run_fixup(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            with open(os.path.join(repo_path, "README.md"), "w", encoding="utf-8") as file:
+                file.write("base\n")
+            base = _commit_all(repo_path, "base")
+            failed = CommandRecord(
+                gate="generated-test-quality",
+                command=["generated-test-quality", "tests/src/org.example/demo/1.0.0"],
+                returncode=1,
+                output_excerpt="DemoTest.java: native-image guard returns before exercising assertions",
+            )
+
+            with patch("utility_scripts.local_ci_verification._run_verification_once", return_value=failed), \
+                    patch("utility_scripts.local_ci_verification._run_fixup") as fixup:
+                with self.assertRaises(LocalCIVerificationError):
+                    run_local_ci_verification(
+                        repo_path=repo_path,
+                        coordinates="org.example:demo:1.0.0",
+                        base_commit=base,
+                    )
+
+            fixup.assert_not_called()
 
     def test_test_matrix_skips_docker_networking_for_non_docker_coordinate(self) -> None:
         result = LocalCIVerificationResult(status="running", base_commit="base")

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -11,6 +11,8 @@ import unittest
 from utility_scripts.test_quality_checks import (
     SCAFFOLD_PLACEHOLDER_TEXT,
     cleanup_scaffold_placeholder_tests,
+    find_native_image_skip_guards,
+    format_native_image_skip_occurrence,
     format_placeholder_occurrence,
 )
 
@@ -192,6 +194,160 @@ class ExampleTest {
             self.assertEqual(result.removed_files, [])
             self.assertTrue(os.path.exists(placeholder_file))
             self.assertEqual(len(result.remaining_placeholders), 1)
+
+    def test_reports_native_image_early_return(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "AgentTest.java")
+            self._write_file(
+                test_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class AgentTest {
+    @Test
+    void exercisesAgent() {
+        if (NativeImageSupport.isNativeImageRuntime()) {
+            return;
+        }
+        org.assertj.core.api.Assertions.assertThat("agent").isNotEmpty();
+    }
+}
+""",
+            )
+
+            occurrences = find_native_image_skip_guards(tmp_dir)
+
+            self.assertEqual(len(occurrences), 1)
+            self.assertIn("returns before exercising assertions", occurrences[0].reason)
+            self.assertIn("AgentTest.java", format_native_image_skip_occurrence(occurrences[0], tmp_dir))
+
+    def test_reports_lombok_like_native_image_empty_optional_short_circuit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "AgentTest.java")
+            self._write_file(
+                test_file,
+                """
+package org.example;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import org.graalvm.nativeimage.ImageInfo;
+import org.junit.jupiter.api.Test;
+
+class AgentTest {
+    @Test
+    void opensLombokJar() {
+        Optional<Path> lombokJar = locateLombokJar();
+        if (lombokJar.isEmpty()) {
+            return;
+        }
+        org.assertj.core.api.Assertions.assertThat(lombokJar.get()).exists();
+    }
+
+    static Optional<Path> locateLombokJar() {
+        if (ImageInfo.inImageRuntimeCode()) {
+            return Optional.empty();
+        }
+        return Optional.of(Path.of("lombok.jar"));
+    }
+}
+""",
+            )
+
+            occurrences = find_native_image_skip_guards(tmp_dir)
+
+            self.assertEqual(len(occurrences), 1)
+            self.assertIn("returns before exercising assertions", occurrences[0].reason)
+
+    def test_reports_native_image_assumption_and_abort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "ShadowClassLoaderTest.java")
+            self._write_file(
+                test_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+class ShadowClassLoaderTest {
+    @Test
+    void enumeratesResources() {
+        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+            Assumptions.assumeTrue(false, "resources unavailable in native image");
+        }
+        org.assertj.core.api.Assertions.assertThat("resource").isNotEmpty();
+    }
+
+    @Test
+    void abortsNativeImagePath() {
+        boolean nativeImage = NativeImageSupport.isNativeImageRuntime();
+        if (nativeImage) {
+            throw new org.opentest4j.TestAbortedException("skip native image");
+        }
+        org.assertj.core.api.Assertions.assertThat("resource").isNotEmpty();
+    }
+}
+""",
+            )
+
+            occurrences = find_native_image_skip_guards(tmp_dir)
+
+            self.assertEqual(len(occurrences), 2)
+            self.assertTrue(all("aborts or assumes away" in occurrence.reason for occurrence in occurrences))
+
+    def test_reports_disabled_in_native_image_annotation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "DisabledTest.java")
+            self._write_file(
+                test_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class DisabledTest {
+    @DisabledInNativeImage
+    @Test
+    void onlyRunsOnJvm() {
+        org.assertj.core.api.Assertions.assertThat("jvm").isNotEmpty();
+    }
+}
+""",
+            )
+
+            occurrences = find_native_image_skip_guards(tmp_dir)
+
+            self.assertEqual(len(occurrences), 1)
+            self.assertIn("@DisabledInNativeImage", occurrences[0].reason)
+
+    def test_allows_unsupported_feature_assertion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "UnsupportedFeatureTest.java")
+            self._write_file(
+                test_file,
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class UnsupportedFeatureTest {
+    @Test
+    void dynamicLoadingReportsUnsupportedFeature() {
+        Throwable failure = org.assertj.core.api.Assertions.catchThrowable(() -> {
+            throw new UnsupportedOperationException("dynamic loading unsupported");
+        });
+        org.assertj.core.api.Assertions.assertThat(
+            NativeImageSupport.isUnsupportedFeatureError(failure)
+        ).isTrue();
+    }
+}
+""",
+            )
+
+            self.assertEqual(find_native_image_skip_guards(tmp_dir), [])
 
     @staticmethod
     def _write_file(file_path: str, content: str) -> None:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -19,11 +19,17 @@ from pathlib import Path
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics, write_pending_metrics
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+from utility_scripts.test_quality_checks import (
+    TEST_SOURCE_EXTENSIONS,
+    find_native_image_skip_guards,
+    format_native_image_skip_occurrence,
+)
 
 LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
 HUMAN_INTERVENTION_LABEL = "human-intervention"
 MAX_OUTPUT_CHARS = 12000
 MAX_FIXUP_ATTEMPTS = 2
+NON_FIXABLE_GATES = {"generated-test-quality"}
 CODEX_MODEL_NAME = "oca/gpt-5.4"
 CODEX_TIMEOUT_SECONDS = 1800
 DEFAULT_BASE_BRANCH = "master"
@@ -125,7 +131,7 @@ def run_local_ci_verification(
 
         result.failure_gate = failed_command.gate
         result.failure_command = failed_command.command
-        if attempt >= max_fixup_attempts:
+        if failed_command.gate in NON_FIXABLE_GATES or attempt >= max_fixup_attempts:
             result.status = "failure"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
             _write_verification_metrics(metrics_repo_path, result)
@@ -236,6 +242,9 @@ def _run_verification_once(
         result: LocalCIVerificationResult,
 ) -> CommandRecord | None:
     changed_files = changed_files_for_ci(repo_path, base_commit)
+    failed = _run_generated_test_quality_validation(repo_path, changed_files, result)
+    if failed is not None:
+        return failed
 
     try:
         changed_metadata_matrix = _gradle_json_output(
@@ -309,6 +318,54 @@ def _run_verification_once(
             return failed
 
     return None
+
+
+def _run_generated_test_quality_validation(
+        repo_path: str,
+        changed_files: list[str],
+        result: LocalCIVerificationResult,
+) -> CommandRecord | None:
+    test_source_roots = _changed_test_source_roots(repo_path, changed_files)
+    if not test_source_roots:
+        return None
+
+    occurrences = [
+        occurrence
+        for source_root in test_source_roots
+        for occurrence in find_native_image_skip_guards(source_root)
+    ]
+    command = [
+        "generated-test-quality",
+        *[os.path.relpath(source_root, repo_path) for source_root in test_source_roots],
+    ]
+    output = "\n".join(format_native_image_skip_occurrence(occurrence, repo_path) for occurrence in occurrences)
+    if not occurrences:
+        result.commands.append(CommandRecord(
+            gate="generated-test-quality",
+            command=command,
+            returncode=0,
+            output_excerpt="No generated native-image skips detected.",
+        ))
+        return None
+
+    record = CommandRecord(
+        gate="generated-test-quality",
+        command=command,
+        returncode=1,
+        output_excerpt=output[:MAX_OUTPUT_CHARS],
+    )
+    result.commands.append(record)
+    return record
+
+
+def _changed_test_source_roots(repo_path: str, changed_files: list[str]) -> list[str]:
+    roots: set[str] = set()
+    for path in changed_files:
+        parts = path.split("/")
+        if len(parts) < 6 or parts[0:2] != ["tests", "src"] or not path.endswith(TEST_SOURCE_EXTENSIONS):
+            continue
+        roots.add(os.path.join(repo_path, *parts[:5]))
+    return sorted(roots)
 
 
 def _run_test_matrix_entries(

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -29,12 +29,46 @@ SCAFFOLD_PLACEHOLDER_TEST_PATTERNS = (
     ),
 )
 TEST_ANNOTATION_PATTERN = re.compile(r"(?m)^\s*@Test\b")
+NATIVE_IMAGE_DISABLED_ANNOTATION_PATTERN = re.compile(r"@\s*DisabledInNativeImage\b")
+NATIVE_IMAGE_RUNTIME_PATTERNS = (
+    re.compile(r"\b(?:NativeImageSupport\.)?isNativeImageRuntime\s*\("),
+    re.compile(r"\b(?:org\.graalvm\.nativeimage\.)?ImageInfo\.inImage(?:Runtime)?Code\s*\("),
+    re.compile(r"\borg\.graalvm\.nativeimage\.imagecode\b"),
+    re.compile(r"\bSystem\.getProperty\s*\(\s*\"org\.graalvm\.nativeimage\.imagecode\""),
+    re.compile(r"\bBoolean\.getBoolean\s*\(\s*\"org\.graalvm\.nativeimage\.imagecode\""),
+)
+BOOLEAN_NATIVE_ASSIGNMENT_PATTERN = re.compile(
+    r"\b(?:boolean|Boolean|var)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<expr>[^;]*);"
+)
+NATIVE_HELPER_METHOD_PATTERN = re.compile(
+    r"\b(?:boolean|Boolean)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*\{(?P<body>.*?)\}",
+    re.DOTALL,
+)
+NATIVE_HELPER_NAME_PATTERN = re.compile(r"\bnative(?:Image)?\b|\binNativeImage\b|\bisNative\b", re.IGNORECASE)
+IF_PATTERN = re.compile(r"\bif\s*\(")
+SKIP_RETURN_PATTERN = re.compile(
+    r"\breturn\s*(?:;|Optional\.empty\s*\(\s*\)\s*;|"
+    r"(?:Collections\.)?empty(?:List|Set|Map)\s*\(\s*\)\s*;|"
+    r"(?:List|Set|Map)\.of\s*\(\s*\)\s*;|null\s*;)"
+)
+ASSUMPTION_OR_ABORT_PATTERN = re.compile(
+    r"\b(?:Assumptions\.)?assume(?:True|False|That)\s*\(|"
+    r"\b(?:Assumptions\.)?abort\s*\(|"
+    r"\bTestAbortedException\b"
+)
 
 
 @dataclass(frozen=True)
 class PlaceholderOccurrence:
     file_path: str
     line_number: int
+
+
+@dataclass(frozen=True)
+class NativeImageSkipOccurrence:
+    file_path: str
+    line_number: int
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -84,6 +118,27 @@ def format_placeholder_occurrence(occurrence: PlaceholderOccurrence, repo_path: 
     return f"{display_path}:{occurrence.line_number}"
 
 
+def find_native_image_skip_guards(test_source_root: str) -> list[NativeImageSkipOccurrence]:
+    """Return generated tests that skip or abort assertions only under native image."""
+    if not os.path.isdir(test_source_root):
+        return []
+
+    occurrences: list[NativeImageSkipOccurrence] = []
+    for file_path in _iter_test_source_files(test_source_root):
+        occurrences.extend(_native_image_skip_occurrences(file_path))
+    return occurrences
+
+
+def format_native_image_skip_occurrence(
+        occurrence: NativeImageSkipOccurrence,
+        repo_path: str | None = None,
+) -> str:
+    display_path = occurrence.file_path
+    if repo_path:
+        display_path = os.path.relpath(occurrence.file_path, repo_path)
+    return f"{display_path}:{occurrence.line_number}: {occurrence.reason}"
+
+
 def _find_scaffold_test_files(test_source_root: str, repo_path: str, scaffold_commit_hash: str) -> list[str]:
     relative_source_root = os.path.relpath(test_source_root, repo_path)
     result = subprocess.run(
@@ -112,6 +167,15 @@ def _find_scaffold_test_files(test_source_root: str, repo_path: str, scaffold_co
         for relative_path in result.stdout.splitlines()
         if relative_path.endswith(TEST_SOURCE_EXTENSIONS)
     ]
+
+
+def _iter_test_source_files(test_source_root: str) -> list[str]:
+    test_source_files: list[str] = []
+    for root, _, files in os.walk(test_source_root):
+        for file_name in files:
+            if file_name.endswith(TEST_SOURCE_EXTENSIONS):
+                test_source_files.append(os.path.join(root, file_name))
+    return sorted(test_source_files)
 
 
 def _file_contains_placeholder(file_path: str) -> bool:
@@ -144,3 +208,199 @@ def _contains_only_scaffold_junit_placeholder_test(file_path: str) -> bool:
         any(pattern.search(source) for pattern in SCAFFOLD_PLACEHOLDER_TEST_PATTERNS)
         and len(TEST_ANNOTATION_PATTERN.findall(source)) == 1
     )
+
+
+def _native_image_skip_occurrences(file_path: str) -> list[NativeImageSkipOccurrence]:
+    try:
+        with open(file_path, "r", encoding="utf-8") as source_file:
+            lines = source_file.readlines()
+    except OSError:
+        return []
+
+    source = "".join(lines)
+    native_names = _native_image_indicator_names(source)
+    occurrences: list[NativeImageSkipOccurrence] = []
+    for line_number, line in enumerate(lines, start=1):
+        if NATIVE_IMAGE_DISABLED_ANNOTATION_PATTERN.search(line):
+            occurrences.append(NativeImageSkipOccurrence(
+                file_path,
+                line_number,
+                "@DisabledInNativeImage disables generated native-image coverage",
+            ))
+
+    for if_statement in _iter_if_statements(lines):
+        if not _contains_native_image_runtime_guard(if_statement.text, native_names):
+            continue
+        for action_line, reason in _native_image_skip_actions(lines, if_statement):
+            occurrences.append(NativeImageSkipOccurrence(file_path, action_line, reason))
+
+    return _deduplicate_native_image_skip_occurrences(occurrences)
+
+
+@dataclass(frozen=True)
+class _IfStatement:
+    line_number: int
+    text: str
+    end_index: int
+    body_start_index: int
+    body_end_index: int
+    has_block: bool
+
+
+def _native_image_indicator_names(source: str) -> set[str]:
+    native_names: set[str] = set()
+    for match in BOOLEAN_NATIVE_ASSIGNMENT_PATTERN.finditer(source):
+        if _contains_native_image_runtime_guard(match.group("expr"), native_names):
+            native_names.add(match.group("name"))
+
+    for match in NATIVE_HELPER_METHOD_PATTERN.finditer(source):
+        method_name = match.group("name")
+        if not NATIVE_HELPER_NAME_PATTERN.search(method_name):
+            continue
+        body = match.group("body")
+        if _contains_native_image_runtime_guard(body, native_names):
+            native_names.add(method_name)
+    return native_names
+
+
+def _contains_native_image_runtime_guard(text: str, native_names: set[str]) -> bool:
+    if "NativeImageSupport.isUnsupportedFeatureError" in text:
+        text = text.replace("NativeImageSupport.isUnsupportedFeatureError", "")
+    if any(pattern.search(text) for pattern in NATIVE_IMAGE_RUNTIME_PATTERNS):
+        return True
+    return any(re.search(rf"\b{re.escape(name)}\b\s*(?:\(\s*\))?", text) for name in native_names)
+
+
+def _iter_if_statements(lines: list[str]) -> list[_IfStatement]:
+    statements: list[_IfStatement] = []
+    index = 0
+    while index < len(lines):
+        if lines[index].strip().startswith("//") or IF_PATTERN.search(lines[index]) is None:
+            index += 1
+            continue
+        statement = _read_if_statement(lines, index)
+        if statement is None:
+            index += 1
+            continue
+        statements.append(statement)
+        index += 1
+    return statements
+
+
+def _read_if_statement(lines: list[str], start_index: int) -> _IfStatement | None:
+    text_parts: list[str] = []
+    paren_depth = 0
+    saw_if = False
+    end_index = start_index
+    for index in range(start_index, len(lines)):
+        line = lines[index]
+        if not saw_if:
+            if_match = IF_PATTERN.search(line)
+            if if_match is None:
+                return None
+            line_fragment = line[if_match.start():]
+            saw_if = True
+        else:
+            line_fragment = line
+        text_parts.append(line_fragment)
+        paren_depth += line_fragment.count("(") - line_fragment.count(")")
+        end_index = index
+        if saw_if and paren_depth <= 0:
+            break
+
+    text = "".join(text_parts)
+    brace_index = text.find("{")
+    if brace_index != -1:
+        body_end_index = _find_block_end(lines, end_index)
+        return _IfStatement(
+            start_index + 1,
+            text,
+            end_index,
+            end_index + 1,
+            body_end_index,
+            True,
+        )
+
+    trailing = text[text.rfind(")") + 1:]
+    if trailing.strip():
+        return _IfStatement(start_index + 1, text, end_index, end_index, end_index, False)
+
+    next_index = _next_significant_line_index(lines, end_index + 1)
+    if next_index is None:
+        return None
+    if lines[next_index].strip().startswith("{"):
+        body_end_index = _find_block_end(lines, next_index)
+        return _IfStatement(
+            start_index + 1,
+            text,
+            next_index,
+            next_index + 1,
+            body_end_index,
+            True,
+        )
+    return _IfStatement(start_index + 1, text, end_index, next_index, next_index, False)
+
+
+def _find_block_end(lines: list[str], start_index: int) -> int:
+    depth = 0
+    saw_open = False
+    for index in range(start_index, len(lines)):
+        for char in lines[index]:
+            if char == "{":
+                depth += 1
+                saw_open = True
+            elif char == "}":
+                depth -= 1
+                if saw_open and depth == 0:
+                    return index
+    return len(lines) - 1
+
+
+def _next_significant_line_index(lines: list[str], start_index: int) -> int | None:
+    for index in range(start_index, len(lines)):
+        stripped = lines[index].strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        return index
+    return None
+
+
+def _native_image_skip_actions(
+        lines: list[str],
+        if_statement: _IfStatement,
+) -> list[tuple[int, str]]:
+    actions: list[tuple[int, str]] = []
+    ranges = [(if_statement.line_number, if_statement.text)]
+    if if_statement.has_block:
+        ranges.extend(
+            (line_number, lines[line_number - 1])
+            for line_number in range(if_statement.body_start_index + 1, if_statement.body_end_index + 1)
+        )
+    else:
+        if if_statement.body_start_index == if_statement.end_index:
+            body_text = if_statement.text[if_statement.text.rfind(")") + 1:]
+            ranges = [(if_statement.line_number, body_text)]
+        else:
+            line_number = if_statement.body_start_index + 1
+            ranges = [(line_number, lines[if_statement.body_start_index])]
+
+    for line_number, text in ranges:
+        if SKIP_RETURN_PATTERN.search(text):
+            actions.append((line_number, "native-image guard returns before exercising assertions"))
+        if ASSUMPTION_OR_ABORT_PATTERN.search(text):
+            actions.append((line_number, "native-image guard aborts or assumes away generated test coverage"))
+    return actions
+
+
+def _deduplicate_native_image_skip_occurrences(
+        occurrences: list[NativeImageSkipOccurrence],
+) -> list[NativeImageSkipOccurrence]:
+    seen: set[tuple[str, int, str]] = set()
+    deduplicated: list[NativeImageSkipOccurrence] = []
+    for occurrence in occurrences:
+        key = (occurrence.file_path, occurrence.line_number, occurrence.reason)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(occurrence)
+    return deduplicated


### PR DESCRIPTION
## What does this PR do?

Addresses human-intervention item #6230.

Forge generated `org.projectlombok:lombok:1.18.20` support with a successful local CI result, but the generated native-image tests could return early instead of exercising or asserting the native path. The blocked cases were introduced by a post-generation update, so prompt guidance alone was insufficient.

This adds a generated-test quality gate that rejects native-image short-circuits after generation, before strategy commit finalization, and during local CI verification. The gate reports native-image guarded `return`, empty optional/collection/null returns, assumptions/aborts, and `@DisabledInNativeImage`, while preserving accepted assertions such as `NativeImageSupport.isUnsupportedFeatureError(...)`.

Validation:
- `PYTHONPATH=$PWD/forge python -m pytest forge/tests/test_test_quality_checks.py` -> `10 passed`
- `PYTHONPATH=$PWD/forge python -m pytest forge -k 'test_quality or generated_test or native_image or dynamic_access'` -> `40 passed, 208 deselected`
- `PYTHONPATH=$PWD/forge python -m pytest forge/tests/test_workflow_strategy.py forge/tests/test_local_ci_verification.py` -> `25 passed`
- `git diff --check origin/master...HEAD` -> passed

## Code sections where the PR accesses files, network, docker or some external service

- `forge/utility_scripts/test_quality_checks.py` scans generated test source files under `tests/src/...`.
- `forge/utility_scripts/local_ci_verification.py` inspects changed generated test source paths before running the normal local CI gates.
- No new network, docker, or external service access is added.
