### PR TITLE
[Forge] Route broken-behavior generated tests

### DIFF
--- a/forge/ai_workflows/add_new_library_support.py
+++ b/forge/ai_workflows/add_new_library_support.py
@@ -47,7 +47,12 @@ from utility_scripts.source_context import (
     resolve_test_source_layout,
 )
 from utility_scripts.stage_logger import log_stage
-from utility_scripts.test_quality_checks import cleanup_scaffold_placeholder_tests, format_placeholder_occurrence
+from utility_scripts.test_quality_checks import (
+    cleanup_scaffold_placeholder_tests,
+    collect_generated_test_validity_issues,
+    format_generated_test_validity_issue,
+    format_placeholder_occurrence,
+)
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import resolve_graalvm_java_home, validate_repo_paths
@@ -544,7 +549,7 @@ def main(argv=None):
         checkpoint_commit_hash=checkpoint_commit_hash,
     )
 
-    scaffold_placeholder_quality_gate_failed = False
+    generated_test_validity_gate_failed = False
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         placeholder_cleanup = cleanup_scaffold_placeholder_tests(
             test_source_layout.source_root,
@@ -563,6 +568,16 @@ def main(argv=None):
                     f"WARNING: Scaffold placeholder test remains in generated sources: "
                     f"{format_placeholder_occurrence(occurrence, reachability_repo_path)}",
                 )
+        generated_test_validity_issues = collect_generated_test_validity_issues(test_source_layout.source_root)
+        for issue in generated_test_validity_issues:
+            generated_test_validity_gate_failed = True
+            log_stage(
+                "generated-test-quality",
+                "WARNING: Suspicious generated test target requires human review: "
+                f"{format_generated_test_validity_issue(issue, reachability_repo_path)}",
+            )
+    if generated_test_validity_gate_failed:
+        workflow_status = RUN_STATUS_FAILURE
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         if is_benchmark_mode:

--- a/forge/git_scripts/make_pr_new_library_support.py
+++ b/forge/git_scripts/make_pr_new_library_support.py
@@ -43,6 +43,10 @@ from utility_scripts.local_ci_verification import (
     run_local_ci_verification,
 )
 from utility_scripts.repo_path_resolver import resolve_repo_roots
+from utility_scripts.test_quality_checks import (
+    collect_generated_test_validity_issues,
+    format_generated_test_validity_issue,
+)
 
 REPO = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH = 'master'
@@ -606,10 +610,18 @@ def update_large_library_state_after_publish(
     state.save(state_path)
 
 
-def validate_run_quality(coordinates: str, metrics_repo_path: str) -> None:
+def validate_run_quality(coordinates: str, metrics_repo_path: str, repo_path: str) -> None:
     """Raise ValueError if the run metrics are not good enough for a PR."""
     matched = read_pending_metrics(metrics_repo_path)
     quality_issues = collect_new_library_support_quality_issues(matched)
+    group, artifact, version = coordinates.split(":")
+    test_source_root = os.path.join(repo_path, "tests", "src", group, artifact, version, "src", "test")
+    generated_test_validity_issues = collect_generated_test_validity_issues(test_source_root)
+    quality_issues.extend(
+        "suspicious generated test target requires human review: "
+        f"{format_generated_test_validity_issue(issue, repo_path)}"
+        for issue in generated_test_validity_issues
+    )
     if quality_issues:
         details = "; ".join(quality_issues)
         raise ValueError(f"Refusing to create PR for {coordinates}: {details}")
@@ -628,7 +640,7 @@ def main(argv=None):
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     ensure_gh_authenticated()
-    validate_run_quality(coordinates, metrics_repo_path)
+    validate_run_quality(coordinates, metrics_repo_path, repo_path)
 
     branch = push_current_branch_to_origin(
         coordinates=coordinates,

--- a/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
+++ b/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
@@ -26,3 +26,5 @@ Rules:
 - Focus on the active class only.
 - Create or update tests only under the resolved target test source root listed above. Do not edit cloned baseline test directories or other versioned test directories.
 - Reporter issue context identifies what is missing; infer the requested metadata from that context and ensure any added or modified reachability metadata uses appropriate conditions, preferably `typeReached`.
+- Cover supported behavior through the library's normal public API. Do not satisfy coverage by asserting a known broken, regressed, or version-specific failure path for the current artifact.
+- If the remaining call site is reachable only through behavior that is known to be broken in this library version, choose another supported path or leave the call site uncovered.

--- a/forge/prompt_templates/persistent/dynamic_access_rules.md
+++ b/forge/prompt_templates/persistent/dynamic_access_rules.md
@@ -7,12 +7,14 @@ Rules:
 - Use upstream test sources only as behavioral examples.
 - Use documentation and source context only as API guidance.
 - Do not create source stubs, fake replacements, or shadow classes for library or dependency API types in their real packages. If a needed API is missing from the test classpath, add the correct test dependency or leave the call site unreached with an explanation.
+- Target supported library behavior. Do not make an uncovered dynamic-access call "covered" by asserting a known bug, regression, broken path, or version-specific failure in the target artifact.
 - Do not use reflection directly in the tests unless the public API requires it naturally.
 - Do not compile or run tests yourself. The workflow will do that externally.
 - Follow idiomatic `{test_language_display_name}` coding conventions.
 - All top-level test classes must be public.
 - Keep tests outside the library's packages. Do not place a test in the same package as the library just to access package-private or internal code.
 - Keep tests version-agnostic. Do not hardcode the artifact version in normal test inputs or assertions.
+- Exception assertions are acceptable only for documented, supported negative-path APIs. Do not write tests whose method name, comments, or assertions describe a known broken behavior path such as "fails before", "regression", "broken", or "version-specific" failure.
 - Every individual test must complete in under 60 seconds. Use bounded waits and close all clients, servers, executors, and other background resources.
 - Tests should execute under Native Image by default.
 - Never generate, write, or modify reachability metadata or Native Image config entries. Do not create or edit `reachability-metadata.json`, `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, `predefined-classes-config.json`, or any other file under `src/test/resources/META-INF/native-image`; Forge handles metadata generation and merging externally.

--- a/forge/tests/test_make_pr_new_library_support.py
+++ b/forge/tests/test_make_pr_new_library_support.py
@@ -13,6 +13,7 @@ from git_scripts.make_pr_new_library_support import (
     DynamicAccessMetadataEvidence,
     build_pull_request_body,
     load_dynamic_access_metadata_evidence,
+    validate_run_quality,
 )
 
 
@@ -218,6 +219,53 @@ class MakePrNewLibrarySupportTests(unittest.TestCase):
             )
 
         self.assertNotIn("### Metadata/dynamic-access evidence", body)
+
+    def test_validate_run_quality_rejects_suspicious_generated_test_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path, tempfile.TemporaryDirectory() as metrics_repo_path:
+            metrics_path = os.path.join(metrics_repo_path, ".pending_metrics.json")
+            with open(metrics_path, "w", encoding="utf-8") as file:
+                json.dump(
+                    {
+                        "status": "success",
+                        "metrics": {
+                            "code_coverage_percent": 5.0,
+                        },
+                    },
+                    file,
+                )
+            test_file = os.path.join(
+                repo_path,
+                "tests",
+                "src",
+                "plexus",
+                "plexus-utils",
+                "1.0.2",
+                "src",
+                "test",
+                "java",
+                "plexus",
+                "plexus_utils",
+                "ReflectorTest.java",
+            )
+            os.makedirs(os.path.dirname(test_file), exist_ok=True)
+            with open(test_file, "w", encoding="utf-8") as file:
+                file.write(
+                    """
+import org.junit.jupiter.api.Test;
+
+class ReflectorTest {
+    @Test
+    void objectPropertyFindsAccessorButFailsBeforeInvokingIt() {
+        // Version 1.0.2 fails before invoking the accessor.
+        assertThatThrownBy(() -> reflector.getObjectProperty(fixture, "value"))
+                .isInstanceOf(ReflectorException.class);
+    }
+}
+""".lstrip()
+                )
+
+            with self.assertRaisesRegex(ValueError, "suspicious generated test target"):
+                validate_run_quality("plexus:plexus-utils:1.0.2", metrics_repo_path, repo_path)
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -11,6 +11,8 @@ import unittest
 from utility_scripts.test_quality_checks import (
     SCAFFOLD_PLACEHOLDER_TEXT,
     cleanup_scaffold_placeholder_tests,
+    collect_generated_test_validity_issues,
+    format_generated_test_validity_issue,
     format_placeholder_occurrence,
 )
 
@@ -192,6 +194,58 @@ class ExampleTest {
             self.assertEqual(result.removed_files, [])
             self.assertTrue(os.path.exists(placeholder_file))
             self.assertEqual(len(result.remaining_placeholders), 1)
+
+    def test_reports_version_specific_broken_behavior_exception_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_file = os.path.join(tmp_dir, "ReflectorTest.java")
+            self._write_file(
+                test_file,
+                """
+package plexus.plexus_utils;
+
+import org.junit.jupiter.api.Test;
+
+class ReflectorTest {
+    @Test
+    void objectPropertyFindsAccessorButFailsBeforeInvokingIt() {
+        // Version 1.0.2 finds getValue, then looks on Class.class, and fails before Method.invoke.
+        assertThatThrownBy(() -> reflector.getObjectProperty(fixture, "value"))
+                .isInstanceOf(ReflectorException.class)
+                .hasCauseInstanceOf(NoSuchFieldException.class);
+    }
+}
+""",
+            )
+
+            issues = collect_generated_test_validity_issues(tmp_dir)
+
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0].file_path, test_file)
+            self.assertIn("version-specific broken behavior", issues[0].reason)
+            self.assertIn("FailsBefore", format_generated_test_validity_issue(issues[0], tmp_dir))
+
+    def test_allows_ordinary_negative_path_exception_assertions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._write_file(
+                os.path.join(tmp_dir, "ParserTest.java"),
+                """
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+class ParserTest {
+    @Test
+    void invalidInputThrowsUsefulException() {
+        assertThatThrownBy(() -> parser.parse("not-json"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+""",
+            )
+
+            issues = collect_generated_test_validity_issues(tmp_dir)
+
+            self.assertEqual(issues, [])
 
     @staticmethod
     def _write_file(file_path: str, content: str) -> None:

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -14,6 +14,10 @@ from utility_scripts.metadata_index import find_index_entry_for_version
 from utility_scripts.style_checks import run_style_fix_and_checks
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
+from utility_scripts.test_quality_checks import (
+    collect_generated_test_validity_issues,
+    format_generated_test_validity_issue,
+)
 
 
 def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -213,6 +217,16 @@ def run_library_finalization(
         return False
     log_stage("style-checks", f"Running style checks for {library}")
     if not run_style_fix_and_checks(repo_path, library, model_name=model_name):
+        return False
+    test_source_root = os.path.join(repo_path, "tests", "src", group, artifact, library_version, "src", "test")
+    generated_test_validity_issues = collect_generated_test_validity_issues(test_source_root)
+    if generated_test_validity_issues:
+        for issue in generated_test_validity_issues:
+            log_stage(
+                "generated-test-quality",
+                "WARNING: Suspicious generated test target requires human review: "
+                f"{format_generated_test_validity_issue(issue, repo_path)}",
+            )
         return False
     log_stage("generate-library-stats", f"Running generateLibraryStats for {library}")
     if not _run_gradle_command(repo_path, ["./gradlew", "generateLibraryStats", f"-Pcoordinates={library}"]):

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -29,6 +29,40 @@ SCAFFOLD_PLACEHOLDER_TEST_PATTERNS = (
     ),
 )
 TEST_ANNOTATION_PATTERN = re.compile(r"(?m)^\s*@Test\b")
+TEST_BLOCK_ANNOTATION_PATTERN = re.compile(
+    r"(?m)^\s*@(?:Test|ParameterizedTest|RepeatedTest|TestFactory|TestTemplate)\b"
+)
+EXCEPTION_ASSERTION_PATTERN = re.compile(
+    r"\b(?:assertThrows|assertThatThrownBy|assertThatExceptionOfType|assertFailsWith|expectThrows)\b"
+    r"|\.hasCauseInstanceOf\s*\([^)]*(?:Exception|Error)\.class"
+    r"|\.is(?:Exactly)?InstanceOf\s*\([^)]*(?:Exception|Error)\.class"
+    r"|\bcatch\s*\([^)]*(?:Exception|Error)\b",
+    re.IGNORECASE,
+)
+BROKEN_BEHAVIOR_CONTEXT_PATTERN = re.compile(
+    r"\b(?:"
+    r"known(?:\s+|[_-])?(?:broken|failure|regression|bug|defect)"
+    r"|broken(?:\s+|[_-])?(?:behavior|path|implementation)"
+    r"|version[- _]?specific"
+    r"|library[- _]?version[- _]?specific"
+    r"|regression"
+    r"|buggy"
+    r"|defect"
+    r"|failure(?:\s+|[_-])?path"
+    r"|fails?(?:\s+|[_-])?before"
+    r"|known(?:\s+|[_-])?to(?:\s+|[_-])?fail"
+    r"|this\s+version\s+(?:fails|throws|raises)"
+    r")\b",
+    re.IGNORECASE,
+)
+VERSIONED_FAILURE_CONTEXT_PATTERN = re.compile(
+    r"\bversion\s+[`\"]?\d+(?:\.\d+){1,4}[^`\n\"]*"
+    r"(?:fail|throw|exception|regression|broken)"
+    r"|(?:fail|throw|exception|regression|broken)[^`\n\"]*"
+    r"\bversion\s+[`\"]?\d+(?:\.\d+){1,4}",
+    re.IGNORECASE,
+)
+NATIVE_IMAGE_UNSUPPORTED_PATTERN = re.compile(r"\bNativeImageSupport\.isUnsupportedFeatureError\s*\(")
 
 
 @dataclass(frozen=True)
@@ -41,6 +75,14 @@ class PlaceholderOccurrence:
 class ScaffoldPlaceholderCleanupResult:
     removed_files: list[str]
     remaining_placeholders: list[PlaceholderOccurrence]
+
+
+@dataclass(frozen=True)
+class GeneratedTestValidityIssue:
+    file_path: str
+    line_number: int
+    reason: str
+    evidence: str
 
 
 def cleanup_scaffold_placeholder_tests(
@@ -82,6 +124,31 @@ def format_placeholder_occurrence(occurrence: PlaceholderOccurrence, repo_path: 
     if repo_path:
         display_path = os.path.relpath(occurrence.file_path, repo_path)
     return f"{display_path}:{occurrence.line_number}"
+
+
+def collect_generated_test_validity_issues(test_source_root: str) -> list[GeneratedTestValidityIssue]:
+    """Find generated tests that look like they codify a known broken library path."""
+    if not os.path.isdir(test_source_root):
+        return []
+
+    issues: list[GeneratedTestValidityIssue] = []
+    for root_dir, _, file_names in os.walk(test_source_root):
+        for file_name in file_names:
+            if not file_name.endswith(TEST_SOURCE_EXTENSIONS):
+                continue
+            file_path = os.path.join(root_dir, file_name)
+            issues.extend(_collect_file_generated_test_validity_issues(file_path))
+    return issues
+
+
+def format_generated_test_validity_issue(
+        issue: GeneratedTestValidityIssue,
+        repo_path: str | None = None,
+) -> str:
+    display_path = issue.file_path
+    if repo_path:
+        display_path = os.path.relpath(issue.file_path, repo_path)
+    return f"{display_path}:{issue.line_number}: {issue.reason}: {issue.evidence}"
 
 
 def _find_scaffold_test_files(test_source_root: str, repo_path: str, scaffold_commit_hash: str) -> list[str]:
@@ -144,3 +211,93 @@ def _contains_only_scaffold_junit_placeholder_test(file_path: str) -> bool:
         any(pattern.search(source) for pattern in SCAFFOLD_PLACEHOLDER_TEST_PATTERNS)
         and len(TEST_ANNOTATION_PATTERN.findall(source)) == 1
     )
+
+
+def _collect_file_generated_test_validity_issues(file_path: str) -> list[GeneratedTestValidityIssue]:
+    try:
+        with open(file_path, "r", encoding="utf-8") as source_file:
+            lines = source_file.readlines()
+    except OSError:
+        return []
+
+    issues: list[GeneratedTestValidityIssue] = []
+    for start_index, end_index in _iter_test_block_ranges(lines):
+        block_lines = lines[start_index:end_index]
+        block_text = "".join(block_lines)
+        if not _looks_like_broken_behavior_exception_target(block_text):
+            continue
+        evidence_index, evidence = _find_broken_behavior_evidence(block_lines)
+        issues.append(
+            GeneratedTestValidityIssue(
+                file_path=file_path,
+                line_number=start_index + evidence_index + 1,
+                reason="test appears to assert a known version-specific broken behavior path",
+                evidence=evidence,
+            )
+        )
+    return issues
+
+
+def _iter_test_block_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    annotation_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if TEST_BLOCK_ANNOTATION_PATTERN.search(line)
+    ]
+    ranges: list[tuple[int, int]] = []
+    for position, annotation_index in enumerate(annotation_indexes):
+        start_index = _include_leading_comment_context(lines, annotation_index)
+        end_index = annotation_indexes[position + 1] if position + 1 < len(annotation_indexes) else len(lines)
+        ranges.append((start_index, end_index))
+    return ranges
+
+
+def _include_leading_comment_context(lines: list[str], annotation_index: int) -> int:
+    start_index = annotation_index
+    lower_bound = max(0, annotation_index - 12)
+    while start_index > lower_bound:
+        previous = lines[start_index - 1].strip()
+        if not previous or previous.startswith(("//", "/*", "*")) or previous.endswith("*/"):
+            start_index -= 1
+            continue
+        break
+    return start_index
+
+
+def _looks_like_broken_behavior_exception_target(block_text: str) -> bool:
+    if NATIVE_IMAGE_UNSUPPORTED_PATTERN.search(block_text):
+        return False
+    if EXCEPTION_ASSERTION_PATTERN.search(block_text) is None:
+        return False
+    context_text = _with_camel_case_word_boundaries(block_text)
+    return (
+        BROKEN_BEHAVIOR_CONTEXT_PATTERN.search(context_text) is not None
+        or VERSIONED_FAILURE_CONTEXT_PATTERN.search(context_text) is not None
+    )
+
+
+def _find_broken_behavior_evidence(block_lines: list[str]) -> tuple[int, str]:
+    for index, line in enumerate(block_lines):
+        stripped = line.strip()
+        context_line = _with_camel_case_word_boundaries(stripped)
+        if (
+                BROKEN_BEHAVIOR_CONTEXT_PATTERN.search(context_line)
+                or VERSIONED_FAILURE_CONTEXT_PATTERN.search(context_line)
+        ):
+            return index, _trim_evidence(stripped)
+    for index, line in enumerate(block_lines):
+        stripped = line.strip()
+        if EXCEPTION_ASSERTION_PATTERN.search(stripped):
+            return index, _trim_evidence(stripped)
+    return 0, "(test block)"
+
+
+def _trim_evidence(value: str) -> str:
+    value = value.strip()
+    if len(value) <= 160:
+        return value
+    return value[:157].rstrip() + "..."
+
+
+def _with_camel_case_word_boundaries(value: str) -> str:
+    return re.sub(r"(?<=[a-z])(?=[A-Z])", " ", value)


### PR DESCRIPTION
## Summary

This publishes the Forge system fix for the human-intervention item in #6197.

Root cause: Forge generated and published a dynamic-access coverage test for `plexus:plexus-utils:1.0.2` that asserted the known broken `Reflector#getObjectProperty` failure path. The generated test passed by locking in a version-specific regression rather than exercising supported library behavior, so the workflow reported success and allowed publication.

Fix:
- update dynamic-access prompt rules to target supported public API behavior and avoid known broken/version-specific failure paths
- add a generated-test validity scanner for exception assertions coupled with high-signal broken/regression/version-specific context
- fail the add-new-library workflow/finalization path and PR publication gate when suspicious generated tests are found
- add regression coverage for the plexus `Reflector#getObjectProperty` pattern while allowing ordinary supported negative-path exception tests

GitHub items addressed:
- #6197 remains the original generated-library PR that exposed the defect; this PR is the durable Forge handoff for that human-intervention item.

## Validation

- `PYTHONPATH=forge python -m pytest forge/tests/test_test_quality_checks.py forge/tests/test_make_pr_new_library_support.py` -> 13 passed
- `PYTHONPATH=forge python -m pytest forge -k "test_quality or dynamic_access or generated_test or review"` -> 36 passed, 208 deselected
- `python -m py_compile forge/utility_scripts/test_quality_checks.py forge/utility_scripts/library_finalization.py forge/ai_workflows/add_new_library_support.py forge/git_scripts/make_pr_new_library_support.py` -> passed
- `git diff --check origin/master...HEAD` -> passed

Reviewers requested: none configured; repository defaults apply.