### PR TITLE
[GenAI] Test fix for org.scalacheck:scalacheck_2.13:1.19.0 using gpt-5.5

### DIFF
--- a/metadata/org.scalacheck/scalacheck_2.13/1.19.0/reachability-metadata.json
+++ b/metadata/org.scalacheck/scalacheck_2.13/1.19.0/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.rng.Seed$"
+      },
+      "type": "java.lang.Object[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$2"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$3"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.Platform$"
+      },
+      "type": "org_scalacheck.scalacheck_2_13.PlatformClassProperties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.Platform$"
+      },
+      "type": "org_scalacheck.scalacheck_2_13.PlatformModuleProperties$"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.ScalaCheckRunner"
+      },
+      "type": "sbt.testing.Task[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$2"
+      },
+      "type": "sbt.testing.Task[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$3"
+      },
+      "type": "sbt.testing.Task[]"
+    }
+  ]
+}

--- a/metadata/org.scalacheck/scalacheck_2.13/1.19.0/reachability-metadata.json
+++ b/metadata/org.scalacheck/scalacheck_2.13/1.19.0/reachability-metadata.json
@@ -1,52 +1,40 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.scalacheck.rng.Seed$"
+      "condition" : {
+        "typeReached" : "org.scalacheck.rng.Seed$"
       },
-      "type": "java.lang.Object[][]"
+      "type" : "java.lang.Object[][]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$2"
+      "condition" : {
+        "typeReached" : "org.scalacheck.ScalaCheckRunner$$anon$2"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$3"
+      "condition" : {
+        "typeReached" : "org.scalacheck.ScalaCheckRunner$$anon$3"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalacheck.Platform$"
+      "condition" : {
+        "typeReached" : "org.scalacheck.ScalaCheckRunner"
       },
-      "type": "org_scalacheck.scalacheck_2_13.PlatformClassProperties"
+      "type" : "sbt.testing.Task[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalacheck.Platform$"
+      "condition" : {
+        "typeReached" : "org.scalacheck.ScalaCheckRunner$$anon$2"
       },
-      "type": "org_scalacheck.scalacheck_2_13.PlatformModuleProperties$"
+      "type" : "sbt.testing.Task[]"
     },
     {
-      "condition": {
-        "typeReached": "org.scalacheck.ScalaCheckRunner"
+      "condition" : {
+        "typeReached" : "org.scalacheck.ScalaCheckRunner$$anon$3"
       },
-      "type": "sbt.testing.Task[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$2"
-      },
-      "type": "sbt.testing.Task[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.scalacheck.ScalaCheckRunner$$anon$3"
-      },
-      "type": "sbt.testing.Task[]"
+      "type" : "sbt.testing.Task[]"
     }
   ]
 }

--- a/metadata/org.scalacheck/scalacheck_2.13/index.json
+++ b/metadata/org.scalacheck/scalacheck_2.13/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "1.19.0",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "1.19.0"
+    ],
+    "allowed-packages" : [
+      "org.scalacheck"
+    ]
+  },
+  {
     "metadata-version" : "1.18.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.13/$version$/scalacheck_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/typelevel/scalacheck",

--- a/metadata/org.scalacheck/scalacheck_2.13/index.json
+++ b/metadata/org.scalacheck/scalacheck_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "1.19.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.13/$version$/scalacheck_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/typelevel/scalacheck",
+    "test-code-url" : "https://github.com/typelevel/scalacheck/tree/v$version$/core/shared/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalacheck/scalacheck_2.13/$version$/scalacheck_2.13-$version$-javadoc.jar",
+    "description" : "ScalaCheck is a Scala property-based testing library for generating test data and checking properties over many randomized cases. It can be used standalone or with Scala test frameworks to exercise Scala and Java code and shrink failing examples.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/stats/org.scalacheck/scalacheck_2.13/1.19.0/execution-metrics.json
+++ b/stats/org.scalacheck/scalacheck_2.13/1.19.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T03:40:52.487063Z",
+    "library": "org.scalacheck:scalacheck_2.13:1.19.0",
+    "starting_commit": "6474a9252cdd4069c5f37efab2284ce15e62aaeb",
+    "ending_commit": "f796fc25963f9dd566ef41f0e29baa33418d274f",
+    "previous_library": "org.scalacheck:scalacheck_2.13:1.18.1",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.19.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3757,
+          "missed": 57916,
+          "ratio": 0.060918,
+          "total": 61673
+        },
+        "line": {
+          "covered": 414,
+          "missed": 2526,
+          "ratio": 0.140816,
+          "total": 2940
+        },
+        "method": {
+          "covered": 316,
+          "missed": 3806,
+          "ratio": 0.076662,
+          "total": 4122
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.18.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 6,
+        "totalCalls": 6
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3702,
+          "missed": 52085,
+          "ratio": 0.06636,
+          "total": 55787
+        },
+        "line": {
+          "covered": 410,
+          "missed": 2501,
+          "ratio": 0.140845,
+          "total": 2911
+        },
+        "method": {
+          "covered": 305,
+          "missed": 3493,
+          "ratio": 0.080305,
+          "total": 3798
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 47943,
+      "cached_input_tokens_used": 235520,
+      "output_tokens_used": 2770,
+      "iterations": 1,
+      "cost_usd": 0.2009,
+      "tested_library_loc": 414,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 5,
+      "previous_library_test_only_metadata_entries": 4,
+      "code_coverage_percent": 14.08,
+      "previous_library_coverage_percent": 14.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/scala/org_scalacheck/scalacheck_2_13/PlatformTest.scala",
+      "metadata_file": "metadata/org.scalacheck/scalacheck_2.13/1.19.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalacheck/scalacheck_2.13/1.19.0/stats.json
+++ b/stats/org.scalacheck/scalacheck_2.13/1.19.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "1.19.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 6,
+      "totalCalls" : 6
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3757,
+        "missed" : 57916,
+        "ratio" : 0.060918,
+        "total" : 61673
+      },
+      "line" : {
+        "covered" : 414,
+        "missed" : 2526,
+        "ratio" : 0.140816,
+        "total" : 2940
+      },
+      "method" : {
+        "covered" : 316,
+        "missed" : 3806,
+        "ratio" : 0.076662,
+        "total" : 4122
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/.gitignore
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/gradle.properties
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalacheck:scalacheck_2.13:1.19.0
+library.version = 1.19.0
+metadata.dir = org.scalacheck/scalacheck_2.13/1.19.0/

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/settings.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalacheck.scalacheck_2.13_tests'

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -22,6 +22,18 @@
           "name" : "MODULE$"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalacheck.Platform$"
+      },
+      "type" : "org_scalacheck.scalacheck_2_13.PlatformClassProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalacheck.Platform$"
+      },
+      "type" : "org_scalacheck.scalacheck_2_13.PlatformModuleProperties$"
     }
   ]
 }

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,27 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.scalacheck.Platform$"
+      },
+      "type" : "org_scalacheck.scalacheck_2_13.PlatformClassProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.scalacheck.Platform$"
+      },
+      "type" : "org_scalacheck.scalacheck_2_13.PlatformModuleProperties$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/scala/org_scalacheck/scalacheck_2_13/PlatformTest.scala
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/scala/org_scalacheck/scalacheck_2_13/PlatformTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalacheck.scalacheck_2_13
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.ScalaCheckFramework
+import sbt.testing.Event
+import sbt.testing.EventHandler
+import sbt.testing.Fingerprint
+import sbt.testing.Logger
+import sbt.testing.Selector
+import sbt.testing.Status
+import sbt.testing.SubclassFingerprint
+import sbt.testing.Task
+import sbt.testing.TaskDef
+
+import scala.collection.mutable.ListBuffer
+
+class PlatformTest {
+  @Test
+  def frameworkLoadsPropertiesModule(): Unit = {
+    val statuses: Seq[Status] = runDiscoveredProperties(
+      "org_scalacheck.scalacheck_2_13.PlatformModuleProperties",
+      isModule = true
+    )
+
+    assertEquals(Seq(Status.Success), statuses)
+  }
+
+  @Test
+  def frameworkInstantiatesPropertiesClass(): Unit = {
+    val statuses: Seq[Status] = runDiscoveredProperties(
+      "org_scalacheck.scalacheck_2_13.PlatformClassProperties",
+      isModule = false
+    )
+
+    assertEquals(Seq(Status.Success), statuses)
+  }
+
+  private def runDiscoveredProperties(fullyQualifiedName: String, isModule: Boolean): Seq[Status] = {
+    val framework: ScalaCheckFramework = new ScalaCheckFramework
+    val fingerprint: Fingerprint = propertiesFingerprint(framework, isModule)
+    val loader: ClassLoader = getClass.getClassLoader
+    val runner: sbt.testing.Runner = framework.runner(
+      Array("-minSuccessfulTests", "1"),
+      Array.empty[String],
+      loader
+    )
+    val taskDef: TaskDef = new TaskDef(fullyQualifiedName, fingerprint, true, Array.empty[Selector])
+    val rootTasks: Array[Task] = runner.tasks(Array(taskDef))
+    val statuses: ListBuffer[Status] = ListBuffer.empty[Status]
+    val handler: EventHandler = (event: Event) => statuses += event.status()
+
+    assertEquals(1, rootTasks.length)
+    val propertyTasks: Array[Task] = rootTasks.flatMap(_.execute(handler, Array(NoOpLogger)))
+    assertEquals(1, propertyTasks.length)
+    val remainingTasks: Array[Task] = propertyTasks.flatMap(_.execute(handler, Array(NoOpLogger)))
+
+    assertTrue(remainingTasks.isEmpty)
+    assertEquals("Passed: Total 1, Failed 0, Errors 0, Passed 1", runner.done())
+    statuses.toSeq
+  }
+
+  private def propertiesFingerprint(framework: ScalaCheckFramework, isModule: Boolean): Fingerprint =
+    framework.fingerprints().collectFirst {
+      case fingerprint: SubclassFingerprint
+          if fingerprint.isModule() == isModule && fingerprint.superclassName() == "org.scalacheck.Properties" =>
+        fingerprint
+    }.getOrElse(throw new AssertionError(s"No ScalaCheck Properties fingerprint found for module=$isModule"))
+}
+
+object NoOpLogger extends Logger {
+  override def ansiCodesSupported(): Boolean = false
+
+  override def error(msg: String): Unit = ()
+
+  override def warn(msg: String): Unit = ()
+
+  override def info(msg: String): Unit = ()
+
+  override def debug(msg: String): Unit = ()
+
+  override def trace(t: Throwable): Unit = ()
+}
+
+object PlatformModuleProperties extends Properties("platformModuleProperties") {
+  property("passes") = Prop.proved
+}
+
+class PlatformClassProperties extends Properties("platformClassProperties") {
+  property("passes") = Prop.proved
+}

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/scala/org_scalacheck/scalacheck_2_13/PlatformTest.scala
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/src/test/scala/org_scalacheck/scalacheck_2_13/PlatformTest.scala
@@ -16,9 +16,9 @@ import sbt.testing.Event
 import sbt.testing.EventHandler
 import sbt.testing.Fingerprint
 import sbt.testing.Logger
-import sbt.testing.Selector
 import sbt.testing.Status
 import sbt.testing.SubclassFingerprint
+import sbt.testing.SuiteSelector
 import sbt.testing.Task
 import sbt.testing.TaskDef
 
@@ -54,7 +54,7 @@ class PlatformTest {
       Array.empty[String],
       loader
     )
-    val taskDef: TaskDef = new TaskDef(fullyQualifiedName, fingerprint, true, Array.empty[Selector])
+    val taskDef: TaskDef = new TaskDef(fullyQualifiedName, fingerprint, true, Array(new SuiteSelector))
     val rootTasks: Array[Task] = runner.tasks(Array(taskDef))
     val statuses: ListBuffer[Status] = ListBuffer.empty[Status]
     val handler: EventHandler = (event: Event) => statuses += event.status()

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/user-code-filter.json
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.scalacheck.**"
+    },
+    {
+      "includeClasses" : "org_scalacheck.scalacheck_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6267

This PR provides test fixes and new metadata for org.scalacheck:scalacheck_2.13:1.19.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 47943
- Cached input tokens: 235520
- Output tokens: 2770
- Metadata entries: 6
- Test-only metadata entries: 6
- Iterations: 1
- Library coverage percentage: 14.08
- Previous library version metadata entries: 5
- Previous library version test-only metadata entries: 4
- Previous library version coverage percentage: 14.08

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cc4805cd805fa12cb550827cc38864ec8fd54395`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scalacheck:scalacheck_2.13:1.18.1: 6/6 covered calls (100.00%)
- org.scalacheck:scalacheck_2.13:1.19.0: 6/6 covered calls (100.00%)

**Reflection:**
- org.scalacheck:scalacheck_2.13:1.18.1: 6/6 covered calls (100.00%)
- org.scalacheck:scalacheck_2.13:1.19.0: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scalacheck:scalacheck_2.13:1.18.1: 3702/55787 (6.64%)
- org.scalacheck:scalacheck_2.13:1.19.0: 3757/61673 (6.09%)

**Line:**
- org.scalacheck:scalacheck_2.13:1.18.1: 410/2911 (14.08%)
- org.scalacheck:scalacheck_2.13:1.19.0: 414/2940 (14.08%)

**Method:**
- org.scalacheck:scalacheck_2.13:1.18.1: 305/3798 (8.03%)
- org.scalacheck:scalacheck_2.13:1.19.0: 316/4122 (7.67%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
