### PR TITLE
[GenAI] Test fix for org.apache.arrow:arrow-memory-core:13.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.arrow/arrow-memory-core/13.0.0/reachability-metadata.json
+++ b/metadata/org.apache.arrow/arrow-memory-core/13.0.0/reachability-metadata.json
@@ -1,0 +1,64 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.arrow.memory.DefaultAllocationManagerOption"
+      },
+      "type": "org.apache.arrow.memory.DefaultAllocationManagerFactory",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.arrow.memory.DefaultAllocationManagerOption"
+      },
+      "type": "org.apache.arrow.memory.NettyAllocationManager",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.arrow.memory.util.MemoryUtil$2"
+      },
+      "type": "org.apache.arrow.memory.util.MemoryUtil$2",
+      "fields": [
+        {
+          "name": "val$direct"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.arrow.memory.util.MemoryUtil"
+      },
+      "type": "java.nio.DirectByteBuffer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "int"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "long"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/apache/arrow/memory/DefaultAllocationManagerFactory.class"
+    }
+  ]
+}

--- a/metadata/org.apache.arrow/arrow-memory-core/index.json
+++ b/metadata/org.apache.arrow/arrow-memory-core/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "13.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-memory-core/$version$/arrow-memory-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/arrow",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-memory-core/$version$/arrow-memory-core-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-memory-core/$version$/arrow-memory-core-$version$-javadoc.jar",
+    "description" : "Apache Arrow Memory Core provides the core Java off-heap memory management APIs used by Arrow libraries and applications, including allocators, buffers, reference management, and allocation accounting. It is the foundation Arrow Java modules use to allocate and track Arrow buffers consistently across memory implementations.",
     "tested-versions" : [
       "13.0.0"
     ],

--- a/metadata/org.apache.arrow/arrow-memory-core/index.json
+++ b/metadata/org.apache.arrow/arrow-memory-core/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "13.0.0",
+    "tested-versions" : [
+      "13.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.arrow"
+    ]
+  },
+  {
     "metadata-version" : "7.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/arrow/arrow-memory-core/$version$/arrow-memory-core-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/arrow",

--- a/stats/org.apache.arrow/arrow-memory-core/13.0.0/execution-metrics.json
+++ b/stats/org.apache.arrow/arrow-memory-core/13.0.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T04:04:53.746809Z",
+    "library": "org.apache.arrow:arrow-memory-core:13.0.0",
+    "starting_commit": "4efb2d26f20936378303ee813abf9b78fc40494f",
+    "ending_commit": "879e5a0ac5cffdec2e6c14828147c4170962fbed",
+    "previous_library": "org.apache.arrow:arrow-memory-core:7.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "13.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 9,
+        "totalCalls": 9
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 728,
+          "missed": 9329,
+          "ratio": 0.072387,
+          "total": 10057
+        },
+        "line": {
+          "covered": 206,
+          "missed": 1985,
+          "ratio": 0.094021,
+          "total": 2191
+        },
+        "method": {
+          "covered": 49,
+          "missed": 429,
+          "ratio": 0.10251,
+          "total": 478
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "7.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.857143,
+            "coveredCalls": 6,
+            "totalCalls": 7
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.875,
+        "coveredCalls": 7,
+        "totalCalls": 8
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 969,
+          "missed": 8909,
+          "ratio": 0.098097,
+          "total": 9878
+        },
+        "line": {
+          "covered": 261,
+          "missed": 1879,
+          "ratio": 0.121963,
+          "total": 2140
+        },
+        "method": {
+          "covered": 59,
+          "missed": 409,
+          "ratio": 0.126068,
+          "total": 468
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 19328,
+      "cached_input_tokens_used": 138752,
+      "output_tokens_used": 2587,
+      "iterations": 1,
+      "cost_usd": 0.147,
+      "tested_library_loc": 206,
+      "metadata_entries": 10,
+      "previous_library_metadata_entries": 10,
+      "code_coverage_percent": 9.4,
+      "previous_library_coverage_percent": 12.2
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilTest.java",
+      "metadata_file": "metadata/org.apache.arrow/arrow-memory-core/13.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.arrow/arrow-memory-core/13.0.0/stats.json
+++ b/stats/org.apache.arrow/arrow-memory-core/13.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "13.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 8,
+          "totalCalls" : 8
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 9,
+      "totalCalls" : 9
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 728,
+        "missed" : 9329,
+        "ratio" : 0.072387,
+        "total" : 10057
+      },
+      "line" : {
+        "covered" : 206,
+        "missed" : 1985,
+        "ratio" : 0.094021,
+        "total" : 2191
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 429,
+        "ratio" : 0.10251,
+        "total" : 478
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/.gitignore
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/build.gradle
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/build.gradle
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.arrow:arrow-memory-core:$libraryVersion"
+    testImplementation "org.apache.arrow:arrow-memory-netty:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.withType(Test).configureEach {
+    jvmArgs += [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED",
+        "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED"
+    ]
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+    binaries {
+        all {
+            buildArgs.addAll([
+                '--add-opens=java.base/java.lang=ALL-UNNAMED',
+                '--add-opens=java.base/java.nio=ALL-UNNAMED',
+                '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED',
+                '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED'
+            ])
+        }
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/gradle.properties
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.arrow:arrow-memory-core:13.0.0
+library.version = 13.0.0
+metadata.dir = org.apache.arrow/arrow-memory-core/13.0.0/

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/settings.gradle
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.arrow.arrow-memory-core_tests'

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/CheckAllocatorTest.java
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/CheckAllocatorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_arrow.arrow_memory_core;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.DefaultAllocationManagerOption;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CheckAllocatorTest {
+    @Test
+    void rootAllocatorScansClasspathWhenAllocationManagerTypeIsUnknown() {
+        String propertyName = DefaultAllocationManagerOption.ALLOCATION_MANAGER_TYPE_PROPERTY_NAME;
+        String previousType = System.getProperty(propertyName);
+        System.setProperty(propertyName, DefaultAllocationManagerOption.AllocationManagerType.Unknown.name());
+        try {
+            try (BufferAllocator allocator = new RootAllocator(128)) {
+                assertThat(allocator.getRoot()).isSameAs(allocator);
+                assertThat(allocator.getLimit()).isEqualTo(128L);
+            }
+        } finally {
+            restoreProperty(propertyName, previousType);
+        }
+    }
+
+    private static void restoreProperty(String propertyName, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, previousValue);
+        }
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/DefaultAllocationManagerOptionTest.java
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/DefaultAllocationManagerOptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_arrow.arrow_memory_core;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultAllocationManagerOptionTest {
+    private static final String ALLOCATION_MANAGER_TYPE_PROPERTY_NAME = "arrow.allocation.manager.type";
+
+    @Test
+    void rootAllocatorLoadsConfiguredNettyAllocationManagerFactory() {
+        String previousType = System.getProperty(ALLOCATION_MANAGER_TYPE_PROPERTY_NAME);
+        System.setProperty(ALLOCATION_MANAGER_TYPE_PROPERTY_NAME, "Netty");
+        try {
+            try (BufferAllocator allocator = new RootAllocator(64)) {
+                assertThat(allocator.getRoot()).isSameAs(allocator);
+                assertThat(allocator.getLimit()).isEqualTo(64L);
+            }
+        } finally {
+            restoreProperty(previousType);
+        }
+    }
+
+    private static void restoreProperty(String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(ALLOCATION_MANAGER_TYPE_PROPERTY_NAME);
+        } else {
+            System.setProperty(ALLOCATION_MANAGER_TYPE_PROPERTY_NAME, previousValue);
+        }
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_arrow.arrow_memory_core;
+
+import org.apache.arrow.memory.util.MemoryUtil;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryUtilAnonymous2Test {
+    private static final String DIRECT_BUFFER_LOOKUP_ACTION_CLASS_NAME =
+            "org.apache.arrow.memory.util.MemoryUtil$2";
+    private static final String DIRECT_BUFFER_FIELD_NAME = "val$direct";
+
+    @Test
+    void runLooksUpDeclaredConstructorOnConfiguredBufferClass() throws Throwable {
+        Class<?> privilegedActionClass = Class.forName(DIRECT_BUFFER_LOOKUP_ACTION_CLASS_NAME);
+        MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(
+                privilegedActionClass,
+                MethodHandles.lookup()
+        );
+        MethodHandle actionConstructor = lookup.findConstructor(
+                privilegedActionClass,
+                MethodType.methodType(void.class, ByteBuffer.class)
+        );
+        @SuppressWarnings("unchecked")
+        PrivilegedAction<Object> privilegedAction =
+                (PrivilegedAction<Object>) actionConstructor.invoke((ByteBuffer) null);
+        ConstructorLookupTarget lookupTarget = new ConstructorLookupTarget(0L, 0);
+        replaceDirectBufferField(privilegedActionClass, privilegedAction, lookupTarget);
+
+        Object result = AccessController.doPrivileged(privilegedAction);
+
+        assertThat(result).isInstanceOf(Constructor.class);
+        Constructor<?> constructor = (Constructor<?>) result;
+        assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructorLookupTarget.class);
+        assertThat(constructor.getParameterTypes()).containsExactly(long.class, int.class);
+    }
+
+    private static void replaceDirectBufferField(
+            Class<?> privilegedActionClass,
+            PrivilegedAction<Object> privilegedAction,
+            Object directBufferReplacement
+    ) throws NoSuchFieldException {
+        Field field = privilegedActionClass.getDeclaredField(DIRECT_BUFFER_FIELD_NAME);
+        long fieldOffset = MemoryUtil.UNSAFE.objectFieldOffset(field);
+        MemoryUtil.UNSAFE.putObject(privilegedAction, fieldOffset, directBufferReplacement);
+    }
+
+    public static final class ConstructorLookupTarget {
+        private final long address;
+        private final int capacity;
+
+        private ConstructorLookupTarget(long address, int capacity) {
+            this.address = address;
+            this.capacity = capacity;
+        }
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
@@ -15,7 +15,6 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,12 +41,13 @@ public class MemoryUtilAnonymous2Test {
         ConstructorLookupTarget lookupTarget = new ConstructorLookupTarget(0L, 0);
         replaceDirectBufferField(privilegedActionClass, privilegedAction, lookupTarget);
 
-        Object result = AccessController.doPrivileged(privilegedAction);
+        Object result = privilegedAction.run();
 
         assertThat(result).isInstanceOf(Constructor.class);
         Constructor<?> constructor = (Constructor<?>) result;
         assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructorLookupTarget.class);
-        assertThat(constructor.getParameterTypes()).containsExactly(long.class, int.class);
+        assertThat(constructor.getParameterTypes())
+                .containsExactly(long.class, expectedCapacityParameterType());
     }
 
     private static void replaceDirectBufferField(
@@ -60,11 +60,22 @@ public class MemoryUtilAnonymous2Test {
         MemoryUtil.UNSAFE.putObject(privilegedAction, fieldOffset, directBufferReplacement);
     }
 
+    private static Class<?> expectedCapacityParameterType() {
+        int majorVersion = Integer.parseInt(
+                System.getProperty("java.specification.version").split("\\D+")[0]
+        );
+        return majorVersion >= 21 ? long.class : int.class;
+    }
+
     public static final class ConstructorLookupTarget {
         private final long address;
-        private final int capacity;
+        private final long capacity;
 
         private ConstructorLookupTarget(long address, int capacity) {
+            this(address, (long) capacity);
+        }
+
+        private ConstructorLookupTarget(long address, long capacity) {
             this.address = address;
             this.capacity = capacity;
         }

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilTest.java
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_arrow.arrow_memory_core;
+
+import org.apache.arrow.memory.util.MemoryUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MemoryUtilTest {
+    private static final String DIRECT_BUFFER_CONSTRUCTOR_FIELD_NAME = "DIRECT_BUFFER_CONSTRUCTOR";
+
+    @Test
+    void directBufferCreatesByteBufferViewForMemoryAddressWhenConstructorIsAvailable() throws Exception {
+        Constructor<?> compatibleConstructor = findCompatibleDirectBufferConstructor();
+        Object previousConstructor = replaceDirectBufferConstructor(compatibleConstructor);
+        int capacity = 8;
+        long address = MemoryUtil.UNSAFE.allocateMemory(capacity);
+        try {
+            MemoryUtil.UNSAFE.setMemory(address, capacity, (byte) 0);
+
+            ByteBuffer buffer = MemoryUtil.directBuffer(address, capacity);
+
+            assertThat(buffer.isDirect()).isTrue();
+            assertThat(buffer.capacity()).isEqualTo(capacity);
+            assertThat(MemoryUtil.getByteBufferAddress(buffer)).isEqualTo(address);
+
+            buffer.put(0, (byte) 42);
+            assertThat(MemoryUtil.UNSAFE.getByte(address)).isEqualTo((byte) 42);
+        } finally {
+            MemoryUtil.UNSAFE.freeMemory(address);
+            replaceDirectBufferConstructor(previousConstructor);
+        }
+    }
+
+    @Test
+    void directBufferRejectsNegativeCapacityBeforeInvokingConstructor() throws Exception {
+        Constructor<?> compatibleConstructor = findCompatibleDirectBufferConstructor();
+        Object previousConstructor = replaceDirectBufferConstructor(compatibleConstructor);
+        try {
+            assertThatThrownBy(() -> MemoryUtil.directBuffer(1L, -1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Capacity is negative");
+        } finally {
+            replaceDirectBufferConstructor(previousConstructor);
+        }
+    }
+
+    private static Constructor<?> findCompatibleDirectBufferConstructor() throws Exception {
+        Class<? extends ByteBuffer> directBufferClass = ByteBuffer.allocateDirect(0).getClass();
+        try {
+            Constructor<?> constructor = directBufferClass.getDeclaredConstructor(long.class, int.class);
+            constructor.setAccessible(true);
+            return constructor;
+        } catch (NoSuchMethodException e) {
+            Constructor<?> constructor = directBufferClass.getDeclaredConstructor(long.class, long.class);
+            constructor.setAccessible(true);
+            return constructor;
+        }
+    }
+
+    private static Object replaceDirectBufferConstructor(Object constructor) throws Exception {
+        Field field = MemoryUtil.class.getDeclaredField(DIRECT_BUFFER_CONSTRUCTOR_FIELD_NAME);
+        Object staticFieldBase = MemoryUtil.UNSAFE.staticFieldBase(field);
+        long staticFieldOffset = MemoryUtil.UNSAFE.staticFieldOffset(field);
+        Object previousValue = MemoryUtil.UNSAFE.getObject(staticFieldBase, staticFieldOffset);
+        MemoryUtil.UNSAFE.putObjectVolatile(staticFieldBase, staticFieldOffset, constructor);
+        return previousValue;
+    }
+}

--- a/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/user-code-filter.json
+++ b/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.arrow.**"
+    },
+    {
+      "includeClasses" : "org_apache_arrow.arrow_memory_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6262

This PR provides test fixes and new metadata for org.apache.arrow:arrow-memory-core:13.0.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 19328
- Cached input tokens: 138752
- Output tokens: 2587
- Metadata entries: 10
- Iterations: 1
- Library coverage percentage: 9.4
- Previous library version metadata entries: 10
- Previous library version coverage percentage: 12.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cc4805cd805fa12cb550827cc38864ec8fd54395`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.arrow:arrow-memory-core:7.0.0: 7/8 covered calls (87.50%)
- org.apache.arrow:arrow-memory-core:13.0.0: 9/9 covered calls (100.00%)

**Reflection:**
- org.apache.arrow:arrow-memory-core:7.0.0: 6/7 covered calls (85.71%)
- org.apache.arrow:arrow-memory-core:13.0.0: 8/8 covered calls (100.00%)

**Resources:**
- org.apache.arrow:arrow-memory-core:7.0.0: 1/1 covered calls (100.00%)
- org.apache.arrow:arrow-memory-core:13.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.arrow:arrow-memory-core:7.0.0: 969/9878 (9.81%)
- org.apache.arrow:arrow-memory-core:13.0.0: 728/10057 (7.24%)

**Line:**
- org.apache.arrow:arrow-memory-core:7.0.0: 261/2140 (12.20%)
- org.apache.arrow:arrow-memory-core:13.0.0: 206/2191 (9.40%)

**Method:**
- org.apache.arrow:arrow-memory-core:7.0.0: 59/468 (12.61%)
- org.apache.arrow:arrow-memory-core:13.0.0: 49/478 (10.25%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.arrow/arrow-memory-core/7.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java 2/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
index 9bd7a8c150..1c102e6824 100644
--- 1/tests/src/org.apache.arrow/arrow-memory-core/7.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
+++ 2/tests/src/org.apache.arrow/arrow-memory-core/13.0.0/src/test/java/org_apache_arrow/arrow_memory_core/MemoryUtilAnonymous2Test.java
@@ -15,7 +15,6 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,12 +41,13 @@ public class MemoryUtilAnonymous2Test {
         ConstructorLookupTarget lookupTarget = new ConstructorLookupTarget(0L, 0);
         replaceDirectBufferField(privilegedActionClass, privilegedAction, lookupTarget);
 
-        Object result = AccessController.doPrivileged(privilegedAction);
+        Object result = privilegedAction.run();
 
         assertThat(result).isInstanceOf(Constructor.class);
         Constructor<?> constructor = (Constructor<?>) result;
         assertThat(constructor.getDeclaringClass()).isEqualTo(ConstructorLookupTarget.class);
-        assertThat(constructor.getParameterTypes()).containsExactly(long.class, int.class);
+        assertThat(constructor.getParameterTypes())
+                .containsExactly(long.class, expectedCapacityParameterType());
     }
 
     private static void replaceDirectBufferField(
@@ -60,11 +60,22 @@ public class MemoryUtilAnonymous2Test {
         MemoryUtil.UNSAFE.putObject(privilegedAction, fieldOffset, directBufferReplacement);
     }
 
+    private static Class<?> expectedCapacityParameterType() {
+        int majorVersion = Integer.parseInt(
+                System.getProperty("java.specification.version").split("\\D+")[0]
+        );
+        return majorVersion >= 21 ? long.class : int.class;
+    }
+
     public static final class ConstructorLookupTarget {
         private final long address;
-        private final int capacity;
+        private final long capacity;
 
         private ConstructorLookupTarget(long address, int capacity) {
+            this(address, (long) capacity);
+        }
+
+        private ConstructorLookupTarget(long address, long capacity) {
             this.address = address;
             this.capacity = capacity;
         }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
