### PR TITLE
[GenAI] Test fix for io.circe:circe-numbers_3:0.15.0-M1 using gpt-5.5

### DIFF
--- a/metadata/io.circe/circe-numbers_3/0.15.0-M1/reachability-metadata.json
+++ b/metadata/io.circe/circe-numbers_3/0.15.0-M1/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.circe.numbers.SigAndExp"
+      },
+      "type": "java.math.BigInteger[]"
+    }
+  ]
+}

--- a/metadata/io.circe/circe-numbers_3/index.json
+++ b/metadata/io.circe/circe-numbers_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.15.0-M1",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "0.15.0-M1"
+    ],
+    "allowed-packages" : [
+      "io.circe.numbers"
+    ]
+  },
+  {
     "metadata-version" : "0.14.10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-numbers_3/$version$/circe-numbers_3-$version$-sources.jar",
     "repository-url" : "https://github.com/circe/circe",

--- a/metadata/io.circe/circe-numbers_3/index.json
+++ b/metadata/io.circe/circe-numbers_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.15.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-numbers_3/$version$/circe-numbers_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/circe/circe",
+    "test-code-url" : "https://github.com/circe/circe/tree/v$version$/modules/numbers/shared/src/test/scala/io/circe/numbers",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/circe/circe-numbers_3/$version$/circe-numbers_3-$version$-javadoc.jar",
+    "description" : "Circe Numbers provides numeric value support for Circe's JSON model, centered on the BiggerDecimal representation used for JSON numbers. It supplies Scala 3 JVM classes for preserving numeric precision and converting between decimal and integral forms in Circe.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/stats/io.circe/circe-numbers_3/0.15.0-M1/execution-metrics.json
+++ b/stats/io.circe/circe-numbers_3/0.15.0-M1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T06:41:05.317293Z",
+    "library": "io.circe:circe-numbers_3:0.15.0-M1",
+    "starting_commit": "ef5dc36e56ef241586868a5fd7a77b324fa43cca",
+    "ending_commit": "79ae31c63cd297097f900bc54a99c3b18a620530",
+    "previous_library": "io.circe:circe-numbers_3:0.14.10",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.15.0-M1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 871,
+          "missed": 157,
+          "ratio": 0.847276,
+          "total": 1028
+        },
+        "line": {
+          "covered": 170,
+          "missed": 14,
+          "ratio": 0.923913,
+          "total": 184
+        },
+        "method": {
+          "covered": 47,
+          "missed": 22,
+          "ratio": 0.681159,
+          "total": 69
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.14.10",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 818,
+          "missed": 131,
+          "ratio": 0.86196,
+          "total": 949
+        },
+        "line": {
+          "covered": 158,
+          "missed": 17,
+          "ratio": 0.902857,
+          "total": 175
+        },
+        "method": {
+          "covered": 47,
+          "missed": 22,
+          "ratio": 0.681159,
+          "total": 69
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 28976,
+      "cached_input_tokens_used": 44544,
+      "output_tokens_used": 1808,
+      "iterations": 1,
+      "cost_usd": 0.0765,
+      "tested_library_loc": 170,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 92.39,
+      "previous_library_coverage_percent": 90.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.circe/circe-numbers_3/0.15.0-M1/src/test/scala/io_circe/circe_numbers_3/Circe_numbers_3Test.scala",
+      "metadata_file": "metadata/io.circe/circe-numbers_3/0.15.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.circe/circe-numbers_3/0.15.0-M1/stats.json
+++ b/stats/io.circe/circe-numbers_3/0.15.0-M1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.15.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 871,
+        "missed" : 157,
+        "ratio" : 0.847276,
+        "total" : 1028
+      },
+      "line" : {
+        "covered" : 170,
+        "missed" : 14,
+        "ratio" : 0.923913,
+        "total" : 184
+      },
+      "method" : {
+        "covered" : 47,
+        "missed" : 22,
+        "ratio" : 0.681159,
+        "total" : 69
+      }
+    }
+  } ]
+}

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/.gitignore
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.circe:circe-numbers_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/gradle.properties
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.circe:circe-numbers_3:0.15.0-M1
+library.version = 0.15.0-M1
+metadata.dir = io.circe/circe-numbers_3/0.15.0-M1/

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/settings.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.circe.circe-numbers_3_tests'

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/src/test/scala/io_circe/circe_numbers_3/Circe_numbers_3Test.scala
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/src/test/scala/io_circe/circe_numbers_3/Circe_numbers_3Test.scala
@@ -38,16 +38,29 @@ class Circe_numbers_3Test {
   }
 
   @Test
-  def normalizesLeadingZerosInParsedNumbers(): Unit = {
-    val cases: List[(String, String, Option[Long], Boolean)] = List(
-      ("000123", "123", Some(123L), false),
-      ("-000123", "-123", Some(-123L), false),
-      ("000123.4500", "12345e-2", None, false),
-      ("0000", "0", Some(0L), false),
-      ("-0000", "-0", Some(0L), true)
+  def rejectsLeadingZerosButAcceptsSingleZeroForms(): Unit = {
+    val invalidLeadingZeroInputs: List[String] = List(
+      "000123",
+      "-000123",
+      "000123.4500",
+      "0000",
+      "-0000"
     )
 
-    cases.foreach {
+    invalidLeadingZeroInputs.foreach { (input: String) =>
+      assertThat(BiggerDecimal.parseBiggerDecimal(input)).isEqualTo(None)
+      assertThat(BiggerDecimal.parseBiggerDecimalUnsafe(input)).isNull()
+    }
+
+    val validSingleZeroCases: List[(String, String, Option[Long], Boolean)] = List(
+      ("0", "0", Some(0L), false),
+      ("-0", "-0", Some(0L), true),
+      ("0.000", "0", Some(0L), false),
+      ("-0.000", "-0", Some(0L), true),
+      ("0.1234500", "12345e-5", None, false)
+    )
+
+    validSingleZeroCases.foreach {
       case (input: String, expectedText: String, expectedLong: Option[Long], expectedNegativeZero: Boolean) =>
         val number: BiggerDecimal = parse(input)
 

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/src/test/scala/io_circe/circe_numbers_3/Circe_numbers_3Test.scala
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/src/test/scala/io_circe/circe_numbers_3/Circe_numbers_3Test.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_circe.circe_numbers_3
+
+import io.circe.numbers.BiggerDecimal
+import java.math.{BigDecimal as JBigDecimal, BigInteger as JBigInteger}
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.{assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
+
+class Circe_numbers_3Test {
+  @Test
+  def parsesCanonicalIntegerDecimalAndExponentForms(): Unit = {
+    val cases: List[(String, String, Option[Long], Boolean)] = List(
+      ("0", "0", Some(0L), true),
+      ("42", "42", Some(42L), true),
+      ("-17", "-17", Some(-17L), true),
+      ("1000.00", "1e3", Some(1000L), true),
+      ("-12.3400e+2", "-1234", Some(-1234L), true),
+      ("1.234e-2", "1234e-5", None, false),
+      ("12E3", "12e3", Some(12000L), true),
+      ("0.0012300", "123e-5", None, false)
+    )
+
+    cases.foreach {
+      case (input: String, expectedText: String, expectedLong: Option[Long], expectedWhole: Boolean) =>
+        val number: BiggerDecimal = parse(input)
+
+        assertThat(number.toString).isEqualTo(expectedText)
+        assertThat(number.isWhole).isEqualTo(expectedWhole)
+        assertThat(number.toLong).isEqualTo(expectedLong)
+        assertThat(number.isNegativeZero).isFalse()
+    }
+  }
+
+  @Test
+  def normalizesLeadingZerosInParsedNumbers(): Unit = {
+    val cases: List[(String, String, Option[Long], Boolean)] = List(
+      ("000123", "123", Some(123L), false),
+      ("-000123", "-123", Some(-123L), false),
+      ("000123.4500", "12345e-2", None, false),
+      ("0000", "0", Some(0L), false),
+      ("-0000", "-0", Some(0L), true)
+    )
+
+    cases.foreach {
+      case (input: String, expectedText: String, expectedLong: Option[Long], expectedNegativeZero: Boolean) =>
+        val number: BiggerDecimal = parse(input)
+
+        assertThat(number.toString).isEqualTo(expectedText)
+        assertThat(number.toLong).isEqualTo(expectedLong)
+        assertThat(number.isNegativeZero).isEqualTo(expectedNegativeZero)
+        assertThat(number).isEqualTo(parse(expectedText))
+    }
+  }
+
+  @Test
+  def rejectsMalformedNumberStrings(): Unit = {
+    val invalidInputs: List[String] = List(
+      "",
+      "-",
+      "+1",
+      "abc",
+      "1.",
+      "1e",
+      "1e+",
+      "1e-",
+      "1.2.3",
+      "1e2e3",
+      "--1",
+      "1a"
+    )
+
+    invalidInputs.foreach { (input: String) =>
+      assertThat(BiggerDecimal.parseBiggerDecimal(input)).isEqualTo(None)
+      assertThat(BiggerDecimal.parseBiggerDecimalUnsafe(input)).isNull()
+    }
+  }
+
+  @Test
+  def preservesTheSignOfNegativeZeroAcrossConstructorsAndParsing(): Unit = {
+    val negativeZeroValues: List[BiggerDecimal] = List(
+      BiggerDecimal.NegativeZero,
+      parse("-0"),
+      parse("-0.000"),
+      BiggerDecimal.fromDoubleUnsafe(-0.0d),
+      BiggerDecimal.fromFloat(-0.0f)
+    )
+    val unsignedZero: BiggerDecimal = BiggerDecimal.fromLong(0L)
+
+    negativeZeroValues.foreach { (number: BiggerDecimal) =>
+      assertThat(number).isEqualTo(BiggerDecimal.NegativeZero)
+      assertThat(number).isNotEqualTo(unsignedZero)
+      assertThat(number.isWhole).isTrue()
+      assertThat(number.isNegativeZero).isTrue()
+      assertThat(number.signum).isZero()
+      assertThat(number.toBigDecimal).isEqualTo(Some(JBigDecimal.ZERO))
+      assertThat(number.toBigInteger).isEqualTo(Some(JBigInteger.ZERO))
+      assertThat(number.toLong).isEqualTo(Some(0L))
+      assertThat(number.toString).isEqualTo("-0")
+      assertThat(java.lang.Double.doubleToRawLongBits(number.toDouble))
+        .isEqualTo(java.lang.Double.doubleToRawLongBits(-0.0d))
+      assertThat(java.lang.Float.floatToRawIntBits(number.toFloat))
+        .isEqualTo(java.lang.Float.floatToRawIntBits(-0.0f))
+    }
+
+    assertThat(unsignedZero.isNegativeZero).isFalse()
+    assertThat(unsignedZero.toString).isEqualTo("0")
+    assertThat(java.lang.Double.doubleToRawLongBits(unsignedZero.toDouble))
+      .isEqualTo(java.lang.Double.doubleToRawLongBits(0.0d))
+  }
+
+  @Test
+  def convertsFromJavaNumbersAndNormalizesTrailingZeros(): Unit = {
+    val fromBigInteger: BiggerDecimal =
+      BiggerDecimal.fromBigInteger(new JBigInteger("100000000000000000000"))
+    val fromBigDecimal: BiggerDecimal = BiggerDecimal.fromBigDecimal(new JBigDecimal("123.4500"))
+    val fromLong: BiggerDecimal = BiggerDecimal.fromLong(Long.MinValue)
+    val fromDouble: BiggerDecimal = BiggerDecimal.fromDoubleUnsafe(1.25d)
+    val fromFloat: BiggerDecimal = BiggerDecimal.fromFloat(12.5f)
+
+    assertThat(fromBigInteger.toString).isEqualTo("1e20")
+    assertThat(fromBigInteger.isWhole).isTrue()
+    assertThat(fromBigInteger.toBigInteger).isEqualTo(Some(new JBigInteger("100000000000000000000")))
+
+    assertThat(fromBigDecimal.toString).isEqualTo("12345e-2")
+    assertThat(fromBigDecimal.isWhole).isFalse()
+    assertThat(fromBigDecimal.toBigDecimal).isEqualTo(Some(new JBigDecimal("123.45")))
+    assertThat(fromBigDecimal.toBigInteger).isEqualTo(None)
+
+    assertThat(fromLong.toLong).isEqualTo(Some(Long.MinValue))
+    assertThat(fromLong.toString).isEqualTo(Long.MinValue.toString)
+
+    assertThat(fromDouble.toString).isEqualTo("125e-2")
+    assertThat(fromDouble.toDouble).isEqualTo(1.25d)
+
+    assertThat(fromFloat.toString).isEqualTo("125e-1")
+    assertThat(fromFloat.toFloat).isEqualTo(12.5f)
+  }
+
+  @Test
+  def comparesEquivalentNonZeroValuesAcrossParsingAndConstructors(): Unit = {
+    val reference: BiggerDecimal = parse("1000")
+    val equivalentValues: List[BiggerDecimal] = List(
+      parse("1e3"),
+      parse("1000.000"),
+      parse("10e2"),
+      BiggerDecimal.fromBigInteger(new JBigInteger("1000")),
+      BiggerDecimal.fromBigDecimal(new JBigDecimal("1000.000")),
+      BiggerDecimal.fromLong(1000L),
+      BiggerDecimal.fromDoubleUnsafe(1000.0d),
+      BiggerDecimal.fromFloat(1000.0f)
+    )
+
+    equivalentValues.foreach { (number: BiggerDecimal) =>
+      assertThat(number).isEqualTo(reference)
+      assertThat(number.hashCode()).isEqualTo(reference.hashCode())
+    }
+
+    assertThat(parse("1000.1")).isNotEqualTo(reference)
+    assertThat(BiggerDecimal.fromLong(1001L)).isNotEqualTo(reference)
+  }
+
+  @Test
+  def detectsIntegralLongBoundaries(): Unit = {
+    val validIntegrals: List[String] = List(
+      "0",
+      "1",
+      "-1",
+      "9223372036854775807",
+      "-9223372036854775808"
+    )
+    val invalidIntegrals: List[String] = List(
+      "9223372036854775808",
+      "10000000000000000000",
+      "-9223372036854775809",
+      "-10000000000000000000"
+    )
+
+    validIntegrals.foreach { (value: String) =>
+      assertThat(BiggerDecimal.integralIsValidLong(value)).isTrue()
+      assertThat(parse(value).toLong.isDefined).isTrue()
+    }
+
+    invalidIntegrals.foreach { (value: String) =>
+      assertThat(BiggerDecimal.integralIsValidLong(value)).isFalse()
+      assertThat(parse(value).toLong).isEqualTo(None)
+    }
+  }
+
+  @Test
+  def limitsBigIntegerConversionByWholeNumberAndMaximumDigits(): Unit = {
+    val whole: BiggerDecimal = parse("12345e2")
+    val fractional: BiggerDecimal = parse("123.45")
+    val hugeWhole: BiggerDecimal = parse("1e262145")
+
+    assertThat(whole.isWhole).isTrue()
+    assertThat(whole.toBigIntegerWithMaxDigits(JBigInteger.valueOf(6L))).isEqualTo(None)
+    assertThat(whole.toBigIntegerWithMaxDigits(JBigInteger.valueOf(7L)))
+      .isEqualTo(Some(new JBigInteger("1234500")))
+    assertThat(whole.toBigInteger).isEqualTo(Some(new JBigInteger("1234500")))
+
+    assertThat(fractional.isWhole).isFalse()
+    assertThat(fractional.toBigInteger).isEqualTo(None)
+    assertThat(fractional.toBigIntegerWithMaxDigits(JBigInteger.valueOf(100L))).isEqualTo(None)
+
+    assertThat(hugeWhole.isWhole).isTrue()
+    assertThat(hugeWhole.toBigInteger).isEqualTo(None)
+    assertThat(hugeWhole.toBigIntegerWithMaxDigits(JBigInteger.valueOf(10L))).isEqualTo(None)
+  }
+
+  @Test
+  def handlesValuesWhoseScaleCannotBeRepresentedByJavaBigDecimal(): Unit = {
+    val hugePositiveExponent: BiggerDecimal = parse("1e2147483649")
+    val hugeNegativeExponent: BiggerDecimal = parse("1e-2147483648")
+    val hugeNegativeNumber: BiggerDecimal = parse("-1e2147483649")
+
+    assertThat(hugePositiveExponent.toString).isEqualTo("1e2147483649")
+    assertThat(hugePositiveExponent.toBigDecimal).isEqualTo(None)
+    assertThat(hugePositiveExponent.toBigInteger).isEqualTo(None)
+    assertThat(hugePositiveExponent.toDouble).isEqualTo(Double.PositiveInfinity)
+    assertThat(hugePositiveExponent.toFloat).isEqualTo(Float.PositiveInfinity)
+
+    assertThat(hugeNegativeExponent.toString).isEqualTo("1e-2147483648")
+    assertThat(hugeNegativeExponent.toBigDecimal).isEqualTo(None)
+    assertThat(hugeNegativeExponent.toBigInteger).isEqualTo(None)
+    assertThat(hugeNegativeExponent.toDouble).isEqualTo(0.0d)
+    assertThat(hugeNegativeExponent.toFloat).isEqualTo(0.0f)
+
+    assertThat(hugeNegativeNumber.signum).isEqualTo(-1)
+    assertThat(hugeNegativeNumber.toDouble).isEqualTo(Double.NegativeInfinity)
+    assertThat(hugeNegativeNumber.toFloat).isEqualTo(Float.NegativeInfinity)
+  }
+
+  @Test
+  def throwsForNonFiniteFloatingPointInputs(): Unit = {
+    assertThrows(classOf[NumberFormatException], () => BiggerDecimal.fromDoubleUnsafe(Double.NaN))
+    assertThrows(
+      classOf[NumberFormatException],
+      () => BiggerDecimal.fromDoubleUnsafe(Double.PositiveInfinity)
+    )
+    assertThrows(classOf[NumberFormatException], () => BiggerDecimal.fromFloat(Float.NaN))
+    assertThrows(classOf[NumberFormatException], () => BiggerDecimal.fromFloat(Float.NegativeInfinity))
+  }
+
+  private def parse(input: String): BiggerDecimal = {
+    val parsed: Option[BiggerDecimal] = BiggerDecimal.parseBiggerDecimal(input)
+
+    assertTrue(parsed.isDefined, input)
+    parsed.get
+  }
+}

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/user-code-filter.json
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.circe.numbers.**"
+    },
+    {
+      "includeClasses" : "io_circe.circe_numbers_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6257

This PR provides test fixes and new metadata for io.circe:circe-numbers_3:0.15.0-M1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 28976
- Cached input tokens: 44544
- Output tokens: 1808
- Metadata entries: 1
- Iterations: 1
- Library coverage percentage: 92.39
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 90.29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `0c0af32cbe414f75a3c1a5e85358f47ab4e6989d`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.circe:circe-numbers_3:0.14.10: 0/0 covered calls (100.00%)
- io.circe:circe-numbers_3:0.15.0-M1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.circe:circe-numbers_3:0.14.10: 818/949 (86.20%)
- io.circe:circe-numbers_3:0.15.0-M1: 871/1028 (84.73%)

**Line:**
- io.circe:circe-numbers_3:0.14.10: 158/175 (90.29%)
- io.circe:circe-numbers_3:0.15.0-M1: 170/184 (92.39%)

**Method:**
- io.circe:circe-numbers_3:0.14.10: 47/69 (68.12%)
- io.circe:circe-numbers_3:0.15.0-M1: 47/69 (68.12%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
