### PR TITLE
[GenAI] Test fix for jakarta.ws.rs:jakarta.ws.rs-api:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/reachability-metadata.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.client.FactoryFinder"
+      },
+      "glob": "META-INF/services/jakarta.ws.rs.client.ClientBuilder"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.client.ClientBuilder"
+      },
+      "glob": "jakarta/ws/rs/client/ClientBuilder.class"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.ext.FactoryFinder"
+      },
+      "glob": "META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.ext.RuntimeDelegate"
+      },
+      "glob": "jakarta/ws/rs/ext/RuntimeDelegate.class"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.sse.FactoryFinder"
+      },
+      "glob": "META-INF/services/jakarta.ws.rs.sse.SseEventSource$Builder"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.ws.rs.sse.SseEventSource$Builder"
+      },
+      "glob": "jakarta/ws/rs/sse/SseEventSource$Builder.class"
+    }
+  ]
+}

--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
@@ -25,7 +25,7 @@
       "3.0.0"
     ],
     "allowed-packages" : [
-      "javax.ws.rs"
+      "jakarta.ws.rs"
     ]
   }
 ]

--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "javax.ws.rs"
     ]
+  },
+  {
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "javax.ws.rs"
+    ]
   }
 ]

--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/$version$/jakarta.ws.rs-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/rest",
+    "test-code-url" : "https://github.com/jakartaee/rest/tree/$version$/jaxrs-api/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/$version$/jakarta.ws.rs-api-$version$-javadoc.jar",
+    "description" : "Jakarta RESTful Web Services API defines the standard annotations, interfaces, and runtime contracts for building RESTful services and clients in Jakarta EE. This artifact provides only the API types for resources, request and response handling, media negotiation, filters, interceptors, and extension points while implementations are supplied by Jakarta REST runtimes.",
     "tested-versions" : [
       "3.0.0"
     ],

--- a/stats/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/execution-metrics.json
+++ b/stats/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T07:12:06.549484Z",
+    "library": "jakarta.ws.rs:jakarta.ws.rs-api:3.0.0",
+    "starting_commit": "b74a40fd7be563fe149ea1a53e22b3f74a985582",
+    "ending_commit": "4cc71b7af4e595d9f0067a45a9b129327747006e",
+    "previous_library": "jakarta.ws.rs:jakarta.ws.rs-api:2.1.6",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 16,
+            "totalCalls": 16
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 715,
+          "missed": 5618,
+          "ratio": 0.112901,
+          "total": 6333
+        },
+        "line": {
+          "covered": 185,
+          "missed": 1228,
+          "ratio": 0.130927,
+          "total": 1413
+        },
+        "method": {
+          "covered": 31,
+          "missed": 410,
+          "ratio": 0.070295,
+          "total": 441
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.1.6",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 16,
+            "totalCalls": 16
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 22,
+        "totalCalls": 22
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 718,
+          "missed": 5677,
+          "ratio": 0.112275,
+          "total": 6395
+        },
+        "line": {
+          "covered": 186,
+          "missed": 1236,
+          "ratio": 0.130802,
+          "total": 1422
+        },
+        "method": {
+          "covered": 31,
+          "missed": 414,
+          "ratio": 0.069663,
+          "total": 445
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 55906,
+      "cached_input_tokens_used": 565760,
+      "output_tokens_used": 2587,
+      "iterations": 1,
+      "cost_usd": 0.3605,
+      "tested_library_loc": 185,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 6,
+      "code_coverage_percent": 13.09,
+      "previous_library_coverage_percent": 13.08
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java",
+      "metadata_file": "metadata/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/stats.json
+++ b/stats/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 16,
+          "totalCalls" : 16
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 22,
+      "totalCalls" : 22
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 715,
+        "missed" : 5618,
+        "ratio" : 0.112901,
+        "total" : 6333
+      },
+      "line" : {
+        "covered" : 185,
+        "missed" : 1228,
+        "ratio" : 0.130927,
+        "total" : 1413
+      },
+      "method" : {
+        "covered" : 31,
+        "missed" : 410,
+        "ratio" : 0.070295,
+        "total" : 441
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/.gitignore
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/build.gradle
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.ws.rs:jakarta.ws.rs-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/gradle.properties
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.ws.rs:jakarta.ws.rs-api:3.0.0
+library.version = 3.0.0
+metadata.dir = jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/settings.gradle
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.ws.rs.jakarta.ws.rs-api_tests'

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import javax.ws.rs.client.ClientBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ClientBuilderTest {
+    private static final String CLIENT_BUILDER_PROPERTY = ClientBuilder.JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY;
+    private static final String INVALID_CLIENT_BUILDER_CLASS = InvalidClientBuilderProvider.class.getName();
+
+    @Test
+    public void newBuilderReportsProviderLoadedAsWrongType() {
+        String previousProvider = System.getProperty(CLIENT_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, INVALID_CLIENT_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(ClientBuilderTest.class.getClassLoader());
+
+            assertThatThrownBy(ClientBuilder::newBuilder)
+                    .isInstanceOf(LinkageError.class)
+                    .hasMessageContaining("ClassCastException: attempting to cast")
+                    .hasMessageContaining("javax/ws/rs/client/ClientBuilder.class");
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(CLIENT_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, previousProvider);
+        }
+    }
+
+    public static final class InvalidClientBuilderProvider {
+        public InvalidClientBuilderProvider() {
+        }
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,7 +27,7 @@ public class ClientBuilderTest {
             assertThatThrownBy(ClientBuilder::newBuilder)
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/client/ClientBuilder.class");
+                    .hasMessageContaining("jakarta/ws/rs/client/ClientBuilder.class");
         } finally {
             restoreProviderProperty(previousProvider);
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.Variant.VariantListBuilder;
+import javax.ws.rs.ext.RuntimeDelegate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExtFactoryFinderTest extends RuntimeDelegate {
+    private static final String RUNTIME_DELEGATE_PROPERTY = RuntimeDelegate.JAXRS_RUNTIME_DELEGATE_PROPERTY;
+    private static final String TEST_RUNTIME_DELEGATE_CLASS = ExtFactoryFinderTest.class.getName();
+
+    @Test
+    public void getInstanceInstantiatesProviderWithCurrentClassLoaderWhenContextClassLoaderIsNull() {
+        String previousProvider = System.getProperty(RUNTIME_DELEGATE_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            RuntimeDelegate.setInstance(null);
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, TEST_RUNTIME_DELEGATE_CLASS);
+            Thread.currentThread().setContextClassLoader(null);
+
+            RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+
+            assertThat(delegate).isInstanceOf(ExtFactoryFinderTest.class);
+        } finally {
+            RuntimeDelegate.setInstance(null);
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void getInstanceInstantiatesProviderWithContextClassLoader() {
+        String previousProvider = System.getProperty(RUNTIME_DELEGATE_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            RuntimeDelegate.setInstance(null);
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, TEST_RUNTIME_DELEGATE_CLASS);
+            Thread.currentThread().setContextClassLoader(ExtFactoryFinderTest.class.getClassLoader());
+
+            RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+
+            assertThat(delegate).isInstanceOf(ExtFactoryFinderTest.class);
+        } finally {
+            RuntimeDelegate.setInstance(null);
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void getInstanceRetriesWithCurrentClassLoaderWhenContextClassLoaderCannotLoadProvider() {
+        String previousProvider = System.getProperty(RUNTIME_DELEGATE_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            RuntimeDelegate.setInstance(null);
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, TEST_RUNTIME_DELEGATE_CLASS);
+            Thread.currentThread().setContextClassLoader(new RejectingClassLoader());
+
+            RuntimeDelegate delegate = RuntimeDelegate.getInstance();
+
+            assertThat(delegate).isInstanceOf(ExtFactoryFinderTest.class);
+        } finally {
+            RuntimeDelegate.setInstance(null);
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(RUNTIME_DELEGATE_PROPERTY);
+        } else {
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, previousProvider);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    @Override
+    public UriBuilder createUriBuilder() {
+        return null;
+    }
+
+    @Override
+    public ResponseBuilder createResponseBuilder() {
+        return null;
+    }
+
+    @Override
+    public VariantListBuilder createVariantListBuilder() {
+        return null;
+    }
+
+    @Override
+    public <T> T createEndpoint(Application application, Class<T> endpointType) {
+        return null;
+    }
+
+    @Override
+    public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) {
+        return null;
+    }
+
+    @Override
+    public Link.Builder createLinkBuilder() {
+        return null;
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
@@ -6,12 +6,12 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.Variant.VariantListBuilder;
-import javax.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.Variant.VariantListBuilder;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import java.security.KeyStore;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FactoryFinderTest extends ClientBuilder {
+    private static final String CLIENT_BUILDER_PROPERTY = ClientBuilder.JAXRS_DEFAULT_CLIENT_BUILDER_PROPERTY;
+    private static final String TEST_CLIENT_BUILDER_CLASS = FactoryFinderTest.class.getName();
+
+    @Test
+    public void newBuilderInstantiatesProviderWithCurrentClassLoaderWhenContextClassLoaderIsNull() {
+        String previousProvider = System.getProperty(CLIENT_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, TEST_CLIENT_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(null);
+
+            ClientBuilder builder = ClientBuilder.newBuilder();
+
+            assertThat(builder).isInstanceOf(FactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void newBuilderInstantiatesProviderWithContextClassLoader() {
+        String previousProvider = System.getProperty(CLIENT_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, TEST_CLIENT_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(FactoryFinderTest.class.getClassLoader());
+
+            ClientBuilder builder = ClientBuilder.newBuilder();
+
+            assertThat(builder).isInstanceOf(FactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void newBuilderRetriesWithCurrentClassLoaderWhenContextClassLoaderCannotLoadProvider() {
+        String previousProvider = System.getProperty(CLIENT_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, TEST_CLIENT_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(new RejectingClassLoader());
+
+            ClientBuilder builder = ClientBuilder.newBuilder();
+
+            assertThat(builder).isInstanceOf(FactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(CLIENT_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(CLIENT_BUILDER_PROPERTY, previousProvider);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return null;
+    }
+
+    @Override
+    public ClientBuilder property(String name, Object value) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, int priority) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, Class<?>... contracts) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Object component) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, int priority) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, Class<?>... contracts) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder withConfig(Configuration config) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder sslContext(SSLContext sslContext) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder keyStore(KeyStore keyStore, char[] password) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder trustStore(KeyStore trustStore) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder hostnameVerifier(HostnameVerifier verifier) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder executorService(ExecutorService executorService) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+        return this;
+    }
+
+    @Override
+    public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+        return this;
+    }
+
+    @Override
+    public Client build() {
+        return null;
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
@@ -13,9 +13,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Configuration;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Configuration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import java.util.List;
+
+import javax.ws.rs.core.GenericType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericTypeTest {
+    @Test
+    public void resolvesGenericArrayRawType() {
+        GenericType<List<String>[]> genericType = new GenericType<List<String>[]>() {
+        };
+
+        assertThat(genericType.getRawType()).isEqualTo(List[].class);
+        assertThat(genericType.getType().getTypeName()).contains("java.util.List<java.lang.String>[]");
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
@@ -8,7 +8,7 @@ package jakarta_ws_rs.jakarta_ws_rs_api;
 
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import javax.ws.rs.ext.RuntimeDelegate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RuntimeDelegateTest {
+    private static final String RUNTIME_DELEGATE_PROPERTY = RuntimeDelegate.JAXRS_RUNTIME_DELEGATE_PROPERTY;
+    private static final String INVALID_RUNTIME_DELEGATE_CLASS = InvalidRuntimeDelegateProvider.class.getName();
+
+    @Test
+    public void getInstanceReportsProviderLoadedAsWrongType() {
+        String previousProvider = System.getProperty(RUNTIME_DELEGATE_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            RuntimeDelegate.setInstance(null);
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, INVALID_RUNTIME_DELEGATE_CLASS);
+            Thread.currentThread().setContextClassLoader(RuntimeDelegateTest.class.getClassLoader());
+
+            assertThatThrownBy(RuntimeDelegate::getInstance)
+                    .isInstanceOf(LinkageError.class)
+                    .hasMessageContaining("ClassCastException: attempting to cast")
+                    .hasMessageContaining("javax/ws/rs/ext/RuntimeDelegate.class");
+        } finally {
+            RuntimeDelegate.setInstance(null);
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(RUNTIME_DELEGATE_PROPERTY);
+        } else {
+            System.setProperty(RUNTIME_DELEGATE_PROPERTY, previousProvider);
+        }
+    }
+
+    public static final class InvalidRuntimeDelegateProvider {
+        public InvalidRuntimeDelegateProvider() {
+        }
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +28,7 @@ public class RuntimeDelegateTest {
             assertThatThrownBy(RuntimeDelegate::getInstance)
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/ext/RuntimeDelegate.class");
+                    .hasMessageContaining("jakarta/ws/rs/ext/RuntimeDelegate.class");
         } finally {
             RuntimeDelegate.setInstance(null);
             restoreProviderProperty(previousProvider);

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import javax.ws.rs.sse.SseEventSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SseEventSourceInnerBuilderTest {
+    private static final String SSE_BUILDER_PROPERTY =
+            SseEventSource.Builder.JAXRS_DEFAULT_SSE_BUILDER_PROPERTY;
+    private static final String INVALID_SSE_BUILDER_CLASS = InvalidSseEventSourceBuilderProvider.class.getName();
+
+    @Test
+    public void targetReportsProviderLoadedAsWrongType() {
+        String previousProvider = System.getProperty(SSE_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(SSE_BUILDER_PROPERTY, INVALID_SSE_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(SseEventSourceInnerBuilderTest.class.getClassLoader());
+
+            assertThatThrownBy(() -> SseEventSource.target(null))
+                    .isInstanceOf(LinkageError.class)
+                    .hasMessageContaining("ClassCastException: attempting to cast")
+                    .hasMessageContaining("javax/ws/rs/sse/SseEventSource$Builder.class");
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(SSE_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(SSE_BUILDER_PROPERTY, previousProvider);
+        }
+    }
+
+    public static final class InvalidSseEventSourceBuilderProvider {
+        public InvalidSseEventSourceBuilderProvider() {
+        }
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.sse.SseEventSource;
+import jakarta.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +28,7 @@ public class SseEventSourceInnerBuilderTest {
             assertThatThrownBy(() -> SseEventSource.target(null))
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/sse/SseEventSource$Builder.class");
+                    .hasMessageContaining("jakarta/ws/rs/sse/SseEventSource$Builder.class");
         } finally {
             restoreProviderProperty(previousProvider);
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_ws_rs.jakarta_ws_rs_api;
+
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.sse.SseEventSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SseFactoryFinderTest extends SseEventSource.Builder {
+    private static final String SSE_BUILDER_PROPERTY =
+            SseEventSource.Builder.JAXRS_DEFAULT_SSE_BUILDER_PROPERTY;
+    private static final String TEST_SSE_BUILDER_CLASS = SseFactoryFinderTest.class.getName();
+
+    @Test
+    public void targetInstantiatesProviderWithCurrentClassLoaderWhenContextClassLoaderIsNull() {
+        String previousProvider = System.getProperty(SSE_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(SSE_BUILDER_PROPERTY, TEST_SSE_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(null);
+
+            SseEventSource.Builder builder = SseEventSource.target(null);
+
+            assertThat(builder).isInstanceOf(SseFactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void targetInstantiatesProviderWithContextClassLoader() {
+        String previousProvider = System.getProperty(SSE_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(SSE_BUILDER_PROPERTY, TEST_SSE_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(SseFactoryFinderTest.class.getClassLoader());
+
+            SseEventSource.Builder builder = SseEventSource.target(null);
+
+            assertThat(builder).isInstanceOf(SseFactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    @Test
+    public void targetRetriesWithCurrentClassLoaderWhenContextClassLoaderCannotLoadProvider() {
+        String previousProvider = System.getProperty(SSE_BUILDER_PROPERTY);
+        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            System.setProperty(SSE_BUILDER_PROPERTY, TEST_SSE_BUILDER_CLASS);
+            Thread.currentThread().setContextClassLoader(new RejectingClassLoader());
+
+            SseEventSource.Builder builder = SseEventSource.target(null);
+
+            assertThat(builder).isInstanceOf(SseFactoryFinderTest.class);
+        } finally {
+            restoreProviderProperty(previousProvider);
+            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private static void restoreProviderProperty(String previousProvider) {
+        if (previousProvider == null) {
+            System.clearProperty(SSE_BUILDER_PROPERTY);
+        } else {
+            System.setProperty(SSE_BUILDER_PROPERTY, previousProvider);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+        private RejectingClassLoader() {
+            super(null);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    @Override
+    protected SseEventSource.Builder target(WebTarget endpoint) {
+        return this;
+    }
+
+    @Override
+    public SseEventSource.Builder reconnectingEvery(long delay, TimeUnit unit) {
+        return this;
+    }
+
+    @Override
+    public SseEventSource build() {
+        return null;
+    }
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
@@ -7,8 +7,8 @@
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.ws.rs.**"
+    },
+    {
+      "includeClasses" : "jakarta_ws_rs.jakarta_ws_rs_api.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
+++ b/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.ws.rs.**"
+      "includeClasses" : "jakarta.ws.rs.**"
     },
     {
       "includeClasses" : "jakarta_ws_rs.jakarta_ws_rs_api.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #6259

This PR provides test fixes and new metadata for jakarta.ws.rs:jakarta.ws.rs-api:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 55906
- Cached input tokens: 565760
- Output tokens: 2587
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 13.09
- Previous library version metadata entries: 6
- Previous library version coverage percentage: 13.08

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 22/22 covered calls (100.00%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 22/22 covered calls (100.00%)

**Reflection:**
- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 16/16 covered calls (100.00%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 16/16 covered calls (100.00%)

**Resources:**
- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 6/6 covered calls (100.00%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 718/6395 (11.23%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 715/6333 (11.29%)

**Line:**
- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 186/1422 (13.08%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 185/1413 (13.09%)

**Method:**
- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6: 31/445 (6.97%)
- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0: 31/441 (7.03%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
index 0f07925569..9d6feb892e 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ClientBuilderTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,7 +27,7 @@ public class ClientBuilderTest {
             assertThatThrownBy(ClientBuilder::newBuilder)
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/client/ClientBuilder.class");
+                    .hasMessageContaining("jakarta/ws/rs/client/ClientBuilder.class");
         } finally {
             restoreProviderProperty(previousProvider);
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
index 42df91747a..ce65ce0807 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/ExtFactoryFinderTest.java
@@ -6,12 +6,12 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.Variant.VariantListBuilder;
-import javax.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.Variant.VariantListBuilder;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
index affabea53e..897463635c 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/FactoryFinderTest.java
@@ -13,9 +13,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Configuration;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Configuration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
index 3300253b37..363a3fe579 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/GenericTypeTest.java
@@ -8,7 +8,7 @@ package jakarta_ws_rs.jakarta_ws_rs_api;
 
 import java.util.List;
 
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 
 import org.junit.jupiter.api.Test;
 
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
index 1d0f61ece1..94a13f3e46 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/RuntimeDelegateTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.ext.RuntimeDelegate;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +28,7 @@ public class RuntimeDelegateTest {
             assertThatThrownBy(RuntimeDelegate::getInstance)
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/ext/RuntimeDelegate.class");
+                    .hasMessageContaining("jakarta/ws/rs/ext/RuntimeDelegate.class");
         } finally {
             RuntimeDelegate.setInstance(null);
             restoreProviderProperty(previousProvider);
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
index 4ad30aa06b..efd6e63ba6 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseEventSourceInnerBuilderTest.java
@@ -6,7 +6,7 @@
  */
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
-import javax.ws.rs.sse.SseEventSource;
+import jakarta.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +28,7 @@ public class SseEventSourceInnerBuilderTest {
             assertThatThrownBy(() -> SseEventSource.target(null))
                     .isInstanceOf(LinkageError.class)
                     .hasMessageContaining("ClassCastException: attempting to cast")
-                    .hasMessageContaining("javax/ws/rs/sse/SseEventSource$Builder.class");
+                    .hasMessageContaining("jakarta/ws/rs/sse/SseEventSource$Builder.class");
         } finally {
             restoreProviderProperty(previousProvider);
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
index 122952ff1e..17cf81cb40 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/src/test/java/jakarta_ws_rs/jakarta_ws_rs_api/SseFactoryFinderTest.java
@@ -7,8 +7,8 @@
 package jakarta_ws_rs.jakarta_ws_rs_api;
 
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
diff --git 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/user-code-filter.json 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
index d37a5ee07f..0eb60e4675 100644
--- 1/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6/user-code-filter.json
+++ 2/tests/src/jakarta.ws.rs/jakarta.ws.rs-api/3.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.ws.rs.**"
+      "includeClasses" : "jakarta.ws.rs.**"
     },
     {
       "includeClasses" : "jakarta_ws_rs.jakarta_ws_rs_api.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
