### PR TITLE
[GenAI] Test fix for com.squareup.okhttp3:okhttp:3.7.0 using gpt-5.5

### DIFF
--- a/metadata/com.squareup.okhttp3/okhttp/3.7.0/reachability-metadata.json
+++ b/metadata/com.squareup.okhttp3/okhttp/3.7.0/reachability-metadata.json
@@ -1,0 +1,82 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform$JettyNegoProvider"
+      },
+      "type" : "java.lang.Object",
+      "methods" : [
+        {
+          "name" : "toString",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.Util"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.connection.RouteException"
+      },
+      "type" : "java.lang.Throwable",
+      "methods" : [
+        {
+          "name" : "addSuppressed",
+          "parameterTypes" : [
+            "java.lang.Throwable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.Jdk9Platform"
+      },
+      "type" : "javax.net.ssl.SSLParameters",
+      "methods" : [
+        {
+          "name" : "setApplicationProtocols",
+          "parameterTypes" : [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.Jdk9Platform"
+      },
+      "type" : "javax.net.ssl.SSLSocket",
+      "methods" : [
+        {
+          "name" : "getApplicationProtocol",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform"
+      },
+      "type" : "org.apache.harmony.xnet.provider.jsse.SSLParametersImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.Platform"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.publicsuffix.PublicSuffixDatabase"
+      },
+      "glob" : "publicsuffixes.gz"
+    }
+  ]
+}

--- a/metadata/com.squareup.okhttp3/okhttp/index.json
+++ b/metadata/com.squareup.okhttp3/okhttp/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "okhttp3"
     ]
+  },
+  {
+    "metadata-version" : "3.7.0",
+    "tested-versions" : [
+      "3.7.0"
+    ],
+    "allowed-packages" : [
+      "okhttp3"
+    ]
   }
 ]

--- a/metadata/com.squareup.okhttp3/okhttp/index.json
+++ b/metadata/com.squareup.okhttp3/okhttp/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "3.7.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/$version$/okhttp-$version$-sources.jar",
+    "repository-url" : "https://github.com/square/okhttp",
+    "test-code-url" : "https://github.com/square/okhttp/tree/parent-$version$/okhttp-tests/src/test/java",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/$version$/okhttp-$version$-javadoc.jar",
+    "description" : "OkHttp is an HTTP and HTTP/2 client for Android and Java applications. It provides a fluent client API for issuing network requests, managing connections, caching responses, and integrating with related testing utilities.",
     "tested-versions" : [
       "3.7.0"
     ],

--- a/stats/com.squareup.okhttp3/okhttp/3.7.0/execution-metrics.json
+++ b/stats/com.squareup.okhttp3/okhttp/3.7.0/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T07:40:48.756527Z",
+    "library": "com.squareup.okhttp3:okhttp:3.7.0",
+    "starting_commit": "106ca46a84f1e880f44ca2412c00d6087b9b260f",
+    "ending_commit": "c484ecd7bd0cf3f2b11281fb7f6e7d017bc7961d",
+    "previous_library": "com.squareup.okhttp3:okhttp:3.6.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.7.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 24,
+            "totalCalls": 24
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1750,
+          "missed": 39107,
+          "ratio": 0.042832,
+          "total": 40857
+        },
+        "line": {
+          "covered": 384,
+          "missed": 7780,
+          "ratio": 0.047036,
+          "total": 8164
+        },
+        "method": {
+          "covered": 74,
+          "missed": 1366,
+          "ratio": 0.051389,
+          "total": 1440
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.6.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1263,
+          "missed": 38710,
+          "ratio": 0.031596,
+          "total": 39973
+        },
+        "line": {
+          "covered": 257,
+          "missed": 7641,
+          "ratio": 0.03254,
+          "total": 7898
+        },
+        "method": {
+          "covered": 65,
+          "missed": 1335,
+          "ratio": 0.046429,
+          "total": 1400
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 44044,
+      "cached_input_tokens_used": 330240,
+      "output_tokens_used": 3341,
+      "iterations": 2,
+      "cost_usd": 0.2653,
+      "tested_library_loc": 384,
+      "metadata_entries": 12,
+      "test_only_metadata_entries": 123,
+      "previous_library_metadata_entries": 11,
+      "previous_library_test_only_metadata_entries": 123,
+      "code_coverage_percent": 4.7,
+      "previous_library_coverage_percent": 3.25
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/util/Log.java",
+      "metadata_file": "metadata/com.squareup.okhttp3/okhttp/3.7.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.squareup.okhttp3/okhttp/3.7.0/stats.json
+++ b/stats/com.squareup.okhttp3/okhttp/3.7.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "3.7.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 24,
+          "totalCalls" : 24
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 25,
+      "totalCalls" : 25
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1750,
+        "missed" : 39107,
+        "ratio" : 0.042832,
+        "total" : 40857
+      },
+      "line" : {
+        "covered" : 384,
+        "missed" : 7780,
+        "ratio" : 0.047036,
+        "total" : 8164
+      },
+      "method" : {
+        "covered" : 74,
+        "missed" : 1366,
+        "ratio" : 0.051389,
+        "total" : 1440
+      }
+    }
+  } ]
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/.gitignore
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.squareup.okhttp3:okhttp:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    binaries {
+        test {
+            // okhttp3.internal.Util eagerly resolves UTF-32 charsets during static init.
+            buildArgs.add("-H:+AddAllCharsets")
+        }
+    }
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/gradle.properties
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.squareup.okhttp3:okhttp:3.7.0
+library.version = 3.7.0
+metadata.dir = com.squareup.okhttp3/okhttp/3.7.0/

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/settings.gradle
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.squareup.okhttp3.okhttp_tests'

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/net/Network.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/net/Network.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package android.net;
+
+public final class Network {
+    private Network() {
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/net/http/X509TrustManagerExtensions.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/net/http/X509TrustManagerExtensions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package android.net.http;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import javax.net.ssl.X509TrustManager;
+
+public final class X509TrustManagerExtensions {
+    private static String lastHostname;
+    private final X509TrustManager trustManager;
+
+    public X509TrustManagerExtensions(X509TrustManager trustManager) {
+        this.trustManager = trustManager;
+    }
+
+    public List<Certificate> checkServerTrusted(X509Certificate[] chain, String authType,
+            String hostname) {
+        lastHostname = hostname;
+        return Arrays.asList(chain);
+    }
+
+    public X509TrustManager trustManager() {
+        return trustManager;
+    }
+
+    public static String lastHostname() {
+        return lastHostname;
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/util/Log.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/android/util/Log.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package android.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public final class Log {
+    public static final int DEBUG = 3;
+    public static final int WARN = 5;
+
+    private Log() {
+    }
+
+    public static int println(int priority, String tag, String message) {
+        return message.length();
+    }
+
+    public static String getStackTraceString(Throwable throwable) {
+        StringWriter writer = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com/android/org/conscrypt/SSLParametersImpl.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com/android/org/conscrypt/SSLParametersImpl.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.android.org.conscrypt;
+
+public final class SSLParametersImpl {
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/AndroidPlatformInnerAndroidCertificateChainCleanerTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/AndroidPlatformInnerAndroidCertificateChainCleanerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.net.http.X509TrustManagerExtensions;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.internal.platform.Platform;
+import okhttp3.internal.tls.CertificateChainCleaner;
+import org.junit.jupiter.api.Test;
+
+public class AndroidPlatformInnerAndroidCertificateChainCleanerTest {
+    @Test
+    void androidCertificateChainCleanerInvokesTrustManagerExtensions() throws Exception {
+        CertificateChainCleaner cleaner = Platform.get()
+                .buildCertificateChainCleaner(new EmptyTrustManager());
+
+        List<Certificate> cleanedChain = cleaner.clean(Collections.emptyList(), "example.com");
+
+        assertThat(cleanedChain).isEmpty();
+        assertThat(X509TrustManagerExtensions.lastHostname()).isEqualTo("example.com");
+    }
+
+    private static final class EmptyTrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/AndroidPlatformInnerCloseGuardTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/AndroidPlatformInnerCloseGuardTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dalvik.system.CloseGuard;
+import okhttp3.internal.platform.Platform;
+import org.junit.jupiter.api.Test;
+
+public class AndroidPlatformInnerCloseGuardTest {
+    @Test
+    void androidPlatformOpensAndWarnsCloseGuard() {
+        Platform platform = Platform.get();
+
+        Object stackTrace = platform.getStackTraceForCloseable("response.body().close()");
+        platform.logCloseableLeak("leaked response", stackTrace);
+
+        assertThat(stackTrace).isInstanceOf(CloseGuard.class);
+        CloseGuard closeGuard = (CloseGuard) stackTrace;
+        assertThat(closeGuard.closer()).isEqualTo("response.body().close()");
+        assertThat(closeGuard.warned()).isTrue();
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/Jdk9PlatformTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/Jdk9PlatformTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import okhttp3.Protocol;
+import okhttp3.internal.platform.Platform;
+import org.junit.jupiter.api.Test;
+
+public class Jdk9PlatformTest {
+    @Test
+    void configuresApplicationProtocolsOnJdkSslSocket() throws Exception {
+        Platform platform = newJdk9Platform();
+        assertThat(platform).isNotNull();
+
+        try (SSLSocket socket = (SSLSocket) SSLContext.getDefault()
+                .getSocketFactory()
+                .createSocket()) {
+            platform.configureTlsExtensions(socket, "example.com",
+                    Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+
+            assertThat(platform.getSelectedProtocol(socket)).isNull();
+        }
+    }
+
+    private static Platform newJdk9Platform() throws Exception {
+        Class<?> platformClass = Class.forName("okhttp3.internal.platform.Jdk9Platform");
+        Method buildIfSupported = platformClass.getDeclaredMethod("buildIfSupported");
+        buildIfSupported.setAccessible(true);
+        return (Platform) buildIfSupported.invoke(null);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/JdkWithJettyBootPlatformInnerJettyNegoProviderTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/JdkWithJettyBootPlatformInnerJettyNegoProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import javax.net.ssl.SSLSocket;
+import okhttp3.Protocol;
+import okhttp3.internal.platform.Platform;
+import org.eclipse.jetty.alpn.ALPN;
+import org.junit.jupiter.api.Test;
+
+public class JdkWithJettyBootPlatformInnerJettyNegoProviderTest {
+    @Test
+    void jettyNegoProviderDelegatesObjectMethodsToInvocationHandler() throws Exception {
+        Platform platform = newJettyBootPlatform();
+        RecordingSslSocket socket = new RecordingSslSocket();
+
+        platform.configureTlsExtensions(socket, "example.com",
+                Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+        ALPN.Provider provider = ALPN.get(socket);
+        String selectedProtocol = ((ALPN.ClientProvider) provider)
+                .selectProtocol(Arrays.asList("spdy/3.1", "h2"));
+        String description = provider.toString();
+
+        assertThat(selectedProtocol).isEqualTo("h2");
+        assertThat(description).contains("JettyNegoProvider");
+    }
+
+    private static Platform newJettyBootPlatform() throws Exception {
+        Class<?> platformClass = Class.forName(
+                "okhttp3.internal.platform.JdkWithJettyBootPlatform");
+        Constructor<?> constructor = platformClass.getDeclaredConstructor(Method.class,
+                Method.class, Method.class, Class.class, Class.class);
+        constructor.setAccessible(true);
+        return (Platform) constructor.newInstance(
+                ALPN.class.getMethod("put", SSLSocket.class, ALPN.Provider.class),
+                ALPN.class.getMethod("get", SSLSocket.class),
+                ALPN.class.getMethod("remove", SSLSocket.class),
+                ALPN.ClientProvider.class,
+                ALPN.ServerProvider.class);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/JdkWithJettyBootPlatformTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/JdkWithJettyBootPlatformTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import okhttp3.Protocol;
+import okhttp3.internal.platform.Platform;
+import org.eclipse.jetty.alpn.ALPN;
+import org.junit.jupiter.api.Test;
+
+public class JdkWithJettyBootPlatformTest {
+    @Test
+    void jettyBootPlatformConfiguresReadsAndRemovesAlpnProvider() throws Exception {
+        Platform platform = newJettyBootPlatform();
+        RecordingSslSocket socket = new RecordingSslSocket();
+
+        platform.configureTlsExtensions(socket, "example.com",
+                Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+        ALPN.Provider provider = ALPN.get(socket);
+        ((ALPN.ClientProvider) provider).protocolSelected("h2");
+        String selectedProtocol = platform.getSelectedProtocol(socket);
+        platform.afterHandshake(socket);
+
+        assertThat(provider).isNotNull();
+        assertThat(selectedProtocol).isEqualTo("h2");
+        assertThat(ALPN.get(socket)).isNull();
+    }
+
+    @Test
+    void jettyBootPlatformBuildIfSupportedDiscoversAlpnProvider() throws Exception {
+        Platform platform = newJettyBootPlatform();
+
+        assertThat(platform).isNotNull();
+    }
+
+    private static Platform newJettyBootPlatform() throws Exception {
+        Class<?> platformClass = Class.forName(
+                "okhttp3.internal.platform.JdkWithJettyBootPlatform");
+        Method buildIfSupported = platformClass.getDeclaredMethod("buildIfSupported");
+        buildIfSupported.setAccessible(true);
+        return (Platform) buildIfSupported.invoke(null);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/OptionalMethodTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/OptionalMethodTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import okhttp3.Protocol;
+import okhttp3.internal.platform.Platform;
+import org.junit.jupiter.api.Test;
+
+public class OptionalMethodTest {
+    @Test
+    void androidPlatformInvokesOptionalTlsSocketMethods() {
+        RecordingSslSocket socket = new RecordingSslSocket();
+        Platform platform = Platform.get();
+
+        platform.configureTlsExtensions(socket, "example.com",
+                Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+        String selectedProtocol = platform.getSelectedProtocol(socket);
+
+        assertThat(socket.useSessionTickets()).isTrue();
+        assertThat(socket.hostname()).isEqualTo("example.com");
+        assertThat(new String(socket.alpnProtocols(), StandardCharsets.UTF_8))
+                .contains("h2", "http/1.1");
+        assertThat(selectedProtocol).isEqualTo("h2");
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PlatformTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PlatformTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.internal.platform.Platform;
+import org.junit.jupiter.api.Test;
+
+public class PlatformTest {
+    @Test
+    void trustManagerReadsPrivateContextFieldFromSocketFactory() {
+        X509TrustManager trustManager = new Platform()
+                .trustManager(new NullContextSslSocketFactory());
+
+        assertThat(trustManager).isNull();
+    }
+
+    private static final class NullContextSslSocketFactory extends SSLSocketFactory {
+        @SuppressWarnings("unused")
+        private final Object context = null;
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return new String[0];
+        }
+
+        @Override
+        public Socket createSocket(Socket socket, String host, int port, boolean autoClose)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+                int localPort) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PublicSuffixDatabaseTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PublicSuffixDatabaseTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.internal.publicsuffix.PublicSuffixDatabase;
+import org.junit.jupiter.api.Test;
+
+public class PublicSuffixDatabaseTest {
+    @Test
+    void effectiveTldPlusOneLoadsBundledPublicSuffixResource() {
+        PublicSuffixDatabase database = PublicSuffixDatabase.get();
+
+        assertThat(database.getEffectiveTldPlusOne("www.google.com")).isEqualTo("google.com");
+        assertThat(database.getEffectiveTldPlusOne("adwords.google.co.uk")).isEqualTo("google.co.uk");
+        assertThat(database.getEffectiveTldPlusOne("com")).isNull();
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/RecordingSslSocket.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/RecordingSslSocket.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+public final class RecordingSslSocket extends SSLSocket {
+    private boolean useSessionTickets;
+    private String hostname;
+    private byte[] alpnProtocols;
+    private byte[] selectedAlpnProtocol = "h2".getBytes(StandardCharsets.UTF_8);
+
+    public boolean useSessionTickets() {
+        return useSessionTickets;
+    }
+
+    public String hostname() {
+        return hostname;
+    }
+
+    public byte[] alpnProtocols() {
+        return alpnProtocols;
+    }
+
+    public void setUseSessionTickets(boolean useSessionTickets) {
+        this.useSessionTickets = useSessionTickets;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public void setAlpnProtocols(byte[] alpnProtocols) {
+        this.alpnProtocols = alpnProtocols;
+    }
+
+    public byte[] getAlpnSelectedProtocol() {
+        return selectedAlpnProtocol;
+    }
+
+    public void setSelectedAlpnProtocol(String selectedAlpnProtocol) {
+        this.selectedAlpnProtocol = selectedAlpnProtocol.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getEnabledCipherSuites() {
+        return new String[0];
+    }
+
+    @Override
+    public void setEnabledCipherSuites(String[] suites) {
+    }
+
+    @Override
+    public String[] getSupportedProtocols() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getEnabledProtocols() {
+        return new String[0];
+    }
+
+    @Override
+    public void setEnabledProtocols(String[] protocols) {
+    }
+
+    @Override
+    public SSLSession getSession() {
+        return null;
+    }
+
+    @Override
+    public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+    }
+
+    @Override
+    public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+    }
+
+    @Override
+    public void startHandshake() throws IOException {
+    }
+
+    @Override
+    public void setUseClientMode(boolean mode) {
+    }
+
+    @Override
+    public boolean getUseClientMode() {
+        return true;
+    }
+
+    @Override
+    public void setNeedClientAuth(boolean need) {
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return false;
+    }
+
+    @Override
+    public void setWantClientAuth(boolean want) {
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return false;
+    }
+
+    @Override
+    public void setEnableSessionCreation(boolean flag) {
+    }
+
+    @Override
+    public boolean getEnableSessionCreation() {
+        return true;
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/RouteExceptionTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/RouteExceptionTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import okhttp3.internal.connection.RouteException;
+import org.junit.jupiter.api.Test;
+
+public class RouteExceptionTest {
+    @Test
+    void addConnectExceptionSuppressesPreviousFailure() {
+        IOException first = new IOException("first route failed");
+        IOException second = new IOException("second route failed");
+        RouteException routeException = new RouteException(first);
+
+        routeException.addConnectException(second);
+
+        assertThat(routeException.getLastConnectException()).isSameAs(second);
+        assertThat(second.getSuppressed()).containsExactly(first);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/TrustRootIndexTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/TrustRootIndexTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.internal.tls.TrustRootIndex;
+import org.junit.jupiter.api.Test;
+
+public class TrustRootIndexTest {
+    @Test
+    void androidStyleTrustManagerMethodIsDiscoveredAndInvoked() {
+        AndroidStyleTrustManager trustManager = new AndroidStyleTrustManager();
+        TrustRootIndex trustRootIndex = TrustRootIndex.get(trustManager);
+
+        assertThat(trustRootIndex.findByIssuerAndSignature(null)).isNull();
+        assertThat(trustManager.invocationCount).isEqualTo(1);
+    }
+
+    public static final class AndroidStyleTrustManager implements X509TrustManager {
+        private int invocationCount;
+
+        @SuppressWarnings("unused")
+        private TrustAnchor findTrustAnchorByIssuerAndSignature(X509Certificate certificate) {
+            invocationCount++;
+            return null;
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.internal.Util;
+import org.junit.jupiter.api.Test;
+
+public class UtilTest {
+    @Test
+    void intersectReturnsTypedArrayOfCommonElements() {
+        String[] result = Util.intersect(String.class,
+                new String[] {"h2", "http/1.1", "spdy/3.1"},
+                new String[] {"http/1.1", "h2"});
+
+        assertThat(result).containsExactly("h2", "http/1.1");
+        assertThat(result.getClass().getComponentType()).isEqualTo(String.class);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public class UtilTest {
     @Test
     void intersectReturnsTypedArrayOfCommonElements() {
-        String[] result = Util.intersect(String.class,
+        String[] result = Util.intersect(Util.NATURAL_ORDER,
                 new String[] {"h2", "http/1.1", "spdy/3.1"},
                 new String[] {"http/1.1", "h2"});
 

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/dalvik/system/CloseGuard.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/dalvik/system/CloseGuard.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dalvik.system;
+
+public final class CloseGuard {
+    private String closer;
+    private boolean warned;
+
+    private CloseGuard() {
+    }
+
+    public static CloseGuard get() {
+        return new CloseGuard();
+    }
+
+    public void open(String closer) {
+        this.closer = closer;
+    }
+
+    public void warnIfOpen() {
+        this.warned = closer != null;
+    }
+
+    public String closer() {
+        return closer;
+    }
+
+    public boolean warned() {
+        return warned;
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/org/eclipse/jetty/alpn/ALPN.java
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/org/eclipse/jetty/alpn/ALPN.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.eclipse.jetty.alpn;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLSocket;
+
+public final class ALPN {
+    private static final Map<SSLSocket, Provider> PROVIDERS = new ConcurrentHashMap<>();
+
+    private ALPN() {
+    }
+
+    public static void put(SSLSocket socket, Provider provider) {
+        PROVIDERS.put(socket, provider);
+    }
+
+    public static Provider get(SSLSocket socket) {
+        return PROVIDERS.get(socket);
+    }
+
+    public static void remove(SSLSocket socket) {
+        PROVIDERS.remove(socket);
+    }
+
+    public interface Provider {
+    }
+
+    public interface ClientProvider extends Provider {
+        boolean supports();
+
+        void unsupported();
+
+        List<String> protocols();
+
+        String selectProtocol(List<String> protocols);
+
+        void protocolSelected(String protocol);
+    }
+
+    public interface ServerProvider extends Provider {
+        String select(List<String> protocols);
+
+        void selected(String protocol);
+    }
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,801 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform"
+      },
+      "type" : "android.net.Network"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform"
+      },
+      "type" : "android.net.http.X509TrustManagerExtensions",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "javax.net.ssl.X509TrustManager"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform$AndroidCertificateChainCleaner"
+      },
+      "type" : "android.net.http.X509TrustManagerExtensions",
+      "methods" : [
+        {
+          "name" : "checkServerTrusted",
+          "parameterTypes" : [
+            "java.security.cert.X509Certificate[]",
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform"
+      },
+      "type" : "com.android.org.conscrypt.SSLParametersImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.DHParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.Platform"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.PlatformTest$NullContextSslSocketFactory",
+      "fields" : [
+        {
+          "name" : "context"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.OptionalMethodTest"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.RecordingSslSocket",
+      "methods" : [
+        {
+          "name" : "getAlpnSelectedProtocol",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAlpnProtocols",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        },
+        {
+          "name" : "setHostname",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setUseSessionTickets",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.RecordingSslSocket",
+      "methods" : [
+        {
+          "name" : "getAlpnSelectedProtocol",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAlpnProtocols",
+          "parameterTypes" : [
+            "byte[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.OptionalMethod"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.RecordingSslSocket",
+      "methods" : [
+        {
+          "name" : "setHostname",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setUseSessionTickets",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.tls.TrustRootIndex"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.TrustRootIndexTest$AndroidStyleTrustManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.tls.TrustRootIndex$AndroidTrustRootIndex"
+      },
+      "type" : "com_squareup_okhttp3.okhttp.TrustRootIndexTest$AndroidStyleTrustManager",
+      "methods" : [
+        {
+          "name" : "findTrustAnchorByIssuerAndSignature",
+          "parameterTypes" : [
+            "java.security.cert.X509Certificate"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.AndroidPlatform$CloseGuard"
+      },
+      "type" : "dalvik.system.CloseGuard",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "open",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "warnIfOpen",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "java.security.KeyStoreSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "okhttp3.internal.platform.Jdk9Platform",
+      "methods" : [
+        {
+          "name" : "buildIfSupported",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.JdkWithJettyBootPlatformInnerJettyNegoProviderTest"
+      },
+      "type" : "okhttp3.internal.platform.JdkWithJettyBootPlatform",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.reflect.Method",
+            "java.lang.reflect.Method",
+            "java.lang.reflect.Method",
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.JdkWithJettyBootPlatformTest"
+      },
+      "type" : "okhttp3.internal.platform.JdkWithJettyBootPlatform",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.reflect.Method",
+            "java.lang.reflect.Method",
+            "java.lang.reflect.Method",
+            "java.lang.Class",
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name" : "buildIfSupported",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.JdkWithJettyBootPlatformInnerJettyNegoProviderTest"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.JdkWithJettyBootPlatformTest"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN",
+      "methods" : [
+        {
+          "name" : "get",
+          "parameterTypes" : [
+            "javax.net.ssl.SSLSocket"
+          ]
+        },
+        {
+          "name" : "put",
+          "parameterTypes" : [
+            "javax.net.ssl.SSLSocket",
+            "org.eclipse.jetty.alpn.ALPN$Provider"
+          ]
+        },
+        {
+          "name" : "remove",
+          "parameterTypes" : [
+            "javax.net.ssl.SSLSocket"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN$ClientProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN$Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform"
+      },
+      "type" : "org.eclipse.jetty.alpn.ALPN$ServerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.DSA$SHA224withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.DSA$SHA256withDSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA224",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.SHA5$SHA384",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.SHA5$SHA512",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.rsa.PSSParameters",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.rsa.RSAPSSSignature",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA224withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.ssl.SSLSocketImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "okhttp3.internal.platform.JdkWithJettyBootPlatform"
+      },
+      "type" : {
+        "proxy" : [
+          "org.eclipse.jetty.alpn.ALPN$ClientProvider",
+          "org.eclipse.jetty.alpn.ALPN$ServerProvider"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.AndroidPlatformInnerAndroidCertificateChainCleanerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.AndroidPlatformInnerAndroidCertificateChainCleanerTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_squareup_okhttp3.okhttp.Jdk9PlatformTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
@@ -1,0 +1,31 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "okhttp3.**"
+    },
+    {
+      "includeClasses" : "com_squareup_okhttp3.okhttp.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.**"
+    },
+    {
+      "includeClasses" : "android.net.http.**"
+    },
+    {
+      "includeClasses" : "android.net.**"
+    },
+    {
+      "includeClasses" : "android.util.**"
+    },
+    {
+      "includeClasses" : "dalvik.system.**"
+    },
+    {
+      "includeClasses" : "com.android.org.conscrypt.**"
+    }
+  ]
+}

--- a/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
+++ b/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
@@ -7,10 +7,7 @@
       "includeClasses" : "okhttp3.**"
     },
     {
-      "includeClasses" : "com_squareup_okhttp3.okhttp.**"
-    },
-    {
-      "includeClasses" : "org.eclipse.jetty.alpn.**"
+      "includeClasses" : "android.util.**"
     },
     {
       "includeClasses" : "android.net.http.**"
@@ -19,13 +16,16 @@
       "includeClasses" : "android.net.**"
     },
     {
-      "includeClasses" : "android.util.**"
-    },
-    {
       "includeClasses" : "dalvik.system.**"
     },
     {
       "includeClasses" : "com.android.org.conscrypt.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.**"
+    },
+    {
+      "includeClasses" : "com_squareup_okhttp3.okhttp.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #6256

This PR provides test fixes and new metadata for com.squareup.okhttp3:okhttp:3.7.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 44044
- Cached input tokens: 330240
- Output tokens: 3341
- Metadata entries: 12
- Test-only metadata entries: 123
- Iterations: 2
- Library coverage percentage: 4.7
- Previous library version metadata entries: 11
- Previous library version test-only metadata entries: 123
- Previous library version coverage percentage: 3.25

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1db2ab4602ded690dee9935840b74c9edd9e2dca`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.squareup.okhttp3:okhttp:3.6.0: 25/25 covered calls (100.00%)
- com.squareup.okhttp3:okhttp:3.7.0: 25/25 covered calls (100.00%)

**Reflection:**
- com.squareup.okhttp3:okhttp:3.6.0: 25/25 covered calls (100.00%)
- com.squareup.okhttp3:okhttp:3.7.0: 24/24 covered calls (100.00%)

**Resources:**
- com.squareup.okhttp3:okhttp:3.6.0: N/A
- com.squareup.okhttp3:okhttp:3.7.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.squareup.okhttp3:okhttp:3.6.0: 1263/39973 (3.16%)
- com.squareup.okhttp3:okhttp:3.7.0: 1750/40857 (4.28%)

**Line:**
- com.squareup.okhttp3:okhttp:3.6.0: 257/7898 (3.25%)
- com.squareup.okhttp3:okhttp:3.7.0: 384/8164 (4.70%)

**Method:**
- com.squareup.okhttp3:okhttp:3.6.0: 65/1400 (4.64%)
- com.squareup.okhttp3:okhttp:3.7.0: 74/1440 (5.14%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PublicSuffixDatabaseTest.java 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PublicSuffixDatabaseTest.java
new file mode 100644
index 0000000000..2d2bfeb13d
--- /dev/null
+++ 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/PublicSuffixDatabaseTest.java
@@ -0,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_squareup_okhttp3.okhttp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.internal.publicsuffix.PublicSuffixDatabase;
+import org.junit.jupiter.api.Test;
+
+public class PublicSuffixDatabaseTest {
+    @Test
+    void effectiveTldPlusOneLoadsBundledPublicSuffixResource() {
+        PublicSuffixDatabase database = PublicSuffixDatabase.get();
+
+        assertThat(database.getEffectiveTldPlusOne("www.google.com")).isEqualTo("google.com");
+        assertThat(database.getEffectiveTldPlusOne("adwords.google.co.uk")).isEqualTo("google.co.uk");
+        assertThat(database.getEffectiveTldPlusOne("com")).isNull();
+    }
+}
diff --git 1/tests/src/com.squareup.okhttp3/okhttp/3.6.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
index 43cf13ec98..43543a798e 100644
--- 1/tests/src/com.squareup.okhttp3/okhttp/3.6.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
+++ 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/src/test/java/com_squareup_okhttp3/okhttp/UtilTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public class UtilTest {
     @Test
     void intersectReturnsTypedArrayOfCommonElements() {
-        String[] result = Util.intersect(String.class,
+        String[] result = Util.intersect(Util.NATURAL_ORDER,
                 new String[] {"h2", "http/1.1", "spdy/3.1"},
                 new String[] {"http/1.1", "h2"});
 
diff --git 1/tests/src/com.squareup.okhttp3/okhttp/3.6.0/user-code-filter.json 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
index 73bad89bd4..7b89dce942 100644
--- 1/tests/src/com.squareup.okhttp3/okhttp/3.6.0/user-code-filter.json
+++ 2/tests/src/com.squareup.okhttp3/okhttp/3.7.0/user-code-filter.json
@@ -7,10 +7,7 @@
       "includeClasses" : "okhttp3.**"
     },
     {
-      "includeClasses" : "com_squareup_okhttp3.okhttp.**"
-    },
-    {
-      "includeClasses" : "org.eclipse.jetty.alpn.**"
+      "includeClasses" : "android.util.**"
     },
     {
       "includeClasses" : "android.net.http.**"
@@ -18,14 +15,17 @@
     {
       "includeClasses" : "android.net.**"
     },
-    {
-      "includeClasses" : "android.util.**"
-    },
     {
       "includeClasses" : "dalvik.system.**"
     },
     {
       "includeClasses" : "com.android.org.conscrypt.**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.**"
+    },
+    {
+      "includeClasses" : "com_squareup_okhttp3.okhttp.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
