### PR TITLE
[GenAI] Test fix for co.fs2:fs2-core_3:3.0-130-1713a29 using gpt-5.5

### DIFF
--- a/metadata/co.fs2/fs2-core_3/3.0-130-1713a29/reachability-metadata.json
+++ b/metadata/co.fs2/fs2-core_3/3.0-130-1713a29/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "fs2.internal.ScopedResource$"
+      },
+      "type": "fs2.internal.ScopedResource$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "scodec.bits.ByteVector$"
+      },
+      "type": "scodec.bits.ByteVector",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "fs2.Chunk"
+      },
+      "type": "fs2.Chunk$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "fs2.compression.Compression$$anon$1"
+      },
+      "type": "fs2.compression.Compression$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/co.fs2/fs2-core_3/index.json
+++ b/metadata/co.fs2/fs2-core_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.0-130-1713a29",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/co/fs2/fs2-core_3/$version$/fs2-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/typelevel/fs2",
+    "test-code-url" : "https://github.com/typelevel/fs2/tree/1713a29/core/shared/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/co/fs2/fs2-core_3/$version$/fs2-core_3-$version$-javadoc.jar",
+    "description" : "FS2 Core is the core module of Functional Streams for Scala, providing purely functional, effectful, and polymorphic stream processing abstractions. It defines composable streams and pulls with resource-safe execution, transformation, concurrency, and integration with Cats Effect typeclasses.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/metadata/co.fs2/fs2-core_3/index.json
+++ b/metadata/co.fs2/fs2-core_3/index.json
@@ -1,6 +1,20 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.0-130-1713a29",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.0-130-1713a29"
+    ],
+    "allowed-packages" : [
+      "fs2",
+      "scodec.bits"
+    ]
+  },
+  {
     "metadata-version" : "2.5.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/co/fs2/fs2-core_3/$version$/fs2-core_3-$version$-sources.jar",
     "repository-url" : "https://github.com/typelevel/fs2",

--- a/stats/co.fs2/fs2-core_3/3.0-130-1713a29/execution-metrics.json
+++ b/stats/co.fs2/fs2-core_3/3.0-130-1713a29/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T08:22:00.594056Z",
+    "library": "co.fs2:fs2-core_3:3.0-130-1713a29",
+    "starting_commit": "a2d500d73ac613177d4980d175c833e456cfafc4",
+    "ending_commit": "15b0499e3b6df77d98d215cbbadb50f7dc42a2c9",
+    "previous_library": "co.fs2:fs2-core_3:2.5.6",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0-130-1713a29",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11079,
+          "missed": 25516,
+          "ratio": 0.302746,
+          "total": 36595
+        },
+        "line": {
+          "covered": 1565,
+          "missed": 1726,
+          "ratio": 0.475539,
+          "total": 3291
+        },
+        "method": {
+          "covered": 954,
+          "missed": 2674,
+          "ratio": 0.262955,
+          "total": 3628
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.5.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11482,
+          "missed": 35982,
+          "ratio": 0.24191,
+          "total": 47464
+        },
+        "line": {
+          "covered": 1636,
+          "missed": 2361,
+          "ratio": 0.409307,
+          "total": 3997
+        },
+        "method": {
+          "covered": 1028,
+          "missed": 3886,
+          "ratio": 0.209198,
+          "total": 4914
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 47695,
+      "cached_input_tokens_used": 909824,
+      "output_tokens_used": 5874,
+      "iterations": 1,
+      "cost_usd": 0.6311,
+      "tested_library_loc": 1565,
+      "metadata_entries": 8,
+      "previous_library_metadata_entries": 4,
+      "code_coverage_percent": 47.55,
+      "previous_library_coverage_percent": 40.93
+    },
+    "artifacts": {
+      "test_file": "tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/src/test/scala/co_fs2/fs2_core_3/Fs2_core_3Test.scala",
+      "metadata_file": "metadata/co.fs2/fs2-core_3/3.0-130-1713a29/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/co.fs2/fs2-core_3/3.0-130-1713a29/stats.json
+++ b/stats/co.fs2/fs2-core_3/3.0-130-1713a29/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.0-130-1713a29",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11079,
+        "missed" : 25516,
+        "ratio" : 0.302746,
+        "total" : 36595
+      },
+      "line" : {
+        "covered" : 1565,
+        "missed" : 1726,
+        "ratio" : 0.475539,
+        "total" : 3291
+      },
+      "method" : {
+        "covered" : 954,
+        "missed" : 2674,
+        "ratio" : 0.262955,
+        "total" : 3628
+      }
+    }
+  } ]
+}

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/.gitignore
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "co.fs2:fs2-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/gradle.properties
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = co.fs2:fs2-core_3:3.0-130-1713a29
+library.version = 3.0-130-1713a29
+metadata.dir = co.fs2/fs2-core_3/3.0-130-1713a29/

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/settings.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'co.fs2.fs2-core_3_tests'

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/src/test/scala/co_fs2/fs2_core_3/Fs2_core_3Test.scala
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/src/test/scala/co_fs2/fs2_core_3/Fs2_core_3Test.scala
@@ -1,0 +1,335 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package co_fs2.fs2_core_3
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
+import cats.effect.concurrent.Deferred
+import fs2.Chunk
+import fs2.Pull
+import fs2.Stream
+import fs2.compression
+import fs2.concurrent.Queue
+import fs2.concurrent.Signal
+import fs2.hash
+import fs2.text
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
+
+class Fs2_core_3Test {
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def streamTransformationsCompileToExpectedCollections(): Unit = {
+    val transformed: Vector[String] = Stream
+      .range(0, 20)
+      .filter(_ % 3 != 0)
+      .map(_ + 1)
+      .drop(2)
+      .take(5)
+      .zipWithIndex
+      .map { case (value, index) => s"$index:$value" }
+      .intersperse("|")
+      .covary[IO]
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    val sum: Int = Stream
+      .emits(List(1, 2, 3, 4, 5))
+      .scan(0)(_ + _)
+      .covary[IO]
+      .compile
+      .lastOrError
+      .unsafeRunSync()
+
+    val chunked: Vector[List[Int]] = Stream
+      .emits(List(1, 2, 3, 4, 5))
+      .chunkN(2)
+      .map(_.toList)
+      .covary[IO]
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    assertEquals(Vector("0:5", "|", "1:6", "|", "2:8", "|", "3:9", "|", "4:11"), transformed)
+    assertEquals(15, sum)
+    assertEquals(Vector(List(1, 2), List(3, 4), List(5)), chunked)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def pullUnconsumesAndReemitsBoundedChunks(): Unit = {
+    def grouped(source: Stream[IO, Int]): Pull[IO, String, Unit] =
+      source.pull.unconsLimit(3).flatMap {
+        case Some((chunk, tail)) =>
+          Pull.output1(chunk.toList.mkString("[", ",", "]")) >> grouped(tail)
+        case None =>
+          Pull.done
+      }
+
+    val groups: Vector[String] = grouped(Stream.chunk(Chunk.array(Array(1, 2, 3, 4, 5, 6, 7))).covary[IO])
+      .stream
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    assertEquals(Vector("[1,2,3]", "[4,5,6]", "[7]"), groups)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def bracketFinalizerRunsWhenStreamFails(): Unit = {
+    val events = new CopyOnWriteArrayList[String]()
+    val boom = new IllegalStateException("boom")
+
+    val result: Either[Throwable, Vector[Int]] = Stream
+      .bracket(IO {
+        events.add("acquire")
+        "token"
+      })(resource => IO {
+        events.add(s"release:$resource")
+        ()
+      })
+      .flatMap(resource => Stream.emit(resource.length) ++ Stream.raiseError[IO](boom))
+      .compile
+      .toVector
+      .attempt
+      .unsafeRunSync()
+
+    result match {
+      case Left(error) => assertSame(boom, error)
+      case Right(value) => fail(s"Expected stream failure, got $value")
+    }
+    assertEquals(List("acquire", "release:token"), events.asScala.toList)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def chunksSupportPrimitiveStorageSlicingAndStatefulMapping(): Unit = {
+    val chunk: Chunk[Int] = Chunk.array(Array(1, 2, 3, 4, 5), 1, 3)
+    val positiveTens: List[Int] = chunk
+      .flatMap(value => Chunk(value, -value))
+      .filter(_ > 0)
+      .map(_ * 10)
+      .toList
+    val (finalState, accumulated): (Int, Chunk[String]) = chunk.mapAccumulate(0) { (sum, value) =>
+      val nextSum = sum + value
+      (nextSum, s"$value->$nextSum")
+    }
+    val copied = Array.fill(5)(0)
+
+    chunk.copyToArray(copied, 1)
+    val bytes: Array[Byte] = Chunk
+      .byteBuffer(ByteBuffer.wrap(Array[Byte](10, 20, 30, 40)))
+      .drop(1)
+      .take(2)
+      .toBytes
+      .toArray
+
+    assertEquals(List(20, 30, 40), positiveTens)
+    assertEquals(9, finalState)
+    assertEquals(List("2->2", "3->5", "4->9"), accumulated.toList)
+    assertArrayEquals(Array(0, 2, 3, 4, 0), copied)
+    assertArrayEquals(Array[Byte](20, 30), bytes)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def textPipesHandleUtf8LineSplittingAndBase64(): Unit = {
+    val textBytes: Array[Byte] = Array[Byte](0xef.toByte, 0xbb.toByte, 0xbf.toByte) ++
+      "hé\nworld\r\nlast".getBytes(StandardCharsets.UTF_8)
+
+    val decodedLines: Vector[String] = byteStream(textBytes, 2)
+      .through(text.utf8Decode)
+      .through(text.lines)
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    val plainText: String = "native-image friendly fs2"
+    val plainBytes: Array[Byte] = plainText.getBytes(StandardCharsets.UTF_8)
+    val encoded: String = byteStream(plainBytes, 5)
+      .through(text.base64.encode)
+      .compile
+      .string
+      .unsafeRunSync()
+    val decodedBytes: Vector[Byte] = Stream
+      .emits(Vector(encoded.take(4), " \n", encoded.drop(4)))
+      .covary[IO]
+      .through(text.base64.decode)
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    assertEquals(Vector("hé", "world", "last"), decodedLines)
+    assertEquals(Base64.getEncoder.encodeToString(plainBytes), encoded)
+    assertArrayEquals(plainBytes, decodedBytes.toArray)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def hashAndCompressionPipesRoundTripChunkedBytes(): Unit = {
+    val payload: Array[Byte] = ("FS2 compression and hashing " * 16).getBytes(StandardCharsets.UTF_8)
+
+    val sha256: Vector[Byte] = byteStream(payload, 11)
+      .through(hash.sha256)
+      .compile
+      .toVector
+      .unsafeRunSync()
+    val expectedDigest: Array[Byte] = MessageDigest.getInstance("SHA-256").digest(payload)
+
+    val deflatedRoundTrip: Vector[Byte] = byteStream(payload, 7)
+      .through(compression.deflate[IO](compression.DeflateParams.BEST_SPEED))
+      .through(compression.inflate[IO]())
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    val modificationTime: Instant = Instant.parse("2020-01-02T03:04:05Z")
+    val gzipRoundTrip: Vector[Byte] = byteStream(payload, 9)
+      .through(
+        compression.gzip[IO](
+          fileName = Some("payload.txt"),
+          modificationTime = Some(modificationTime),
+          comment = Some("metadata")
+        )
+      )
+      .through(compression.gunzip[IO]())
+      .flatMap { result =>
+        Stream.eval(IO {
+          assertEquals(Some("payload.txt"), result.fileName)
+          assertEquals(Some(modificationTime), result.modificationTime)
+          assertEquals(Some("metadata"), result.comment)
+        }).drain ++ result.content
+      }
+      .compile
+      .toVector
+      .unsafeRunSync()
+
+    assertArrayEquals(expectedDigest, sha256.toArray)
+    assertArrayEquals(payload, deflatedRoundTrip.toArray)
+    assertArrayEquals(payload, gzipRoundTrip.toArray)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def mapAsyncRunsEffectsConcurrentlyWhilePreservingInputOrder(): Unit = {
+    val ordered: Vector[Int] = (for {
+      firstReady <- Deferred[IO, Unit]
+      secondReady <- Deferred[IO, Unit]
+      thirdReady <- Deferred[IO, Unit]
+      firstGate <- Deferred[IO, Unit]
+      secondGate <- Deferred[IO, Unit]
+      thirdGate <- Deferred[IO, Unit]
+      readyByValue: Map[Int, Deferred[IO, Unit]] = Map(1 -> firstReady, 2 -> secondReady, 3 -> thirdReady)
+      gateByValue: Map[Int, Deferred[IO, Unit]] = Map(1 -> firstGate, 2 -> secondGate, 3 -> thirdGate)
+      fiber <- Stream
+        .emits(List(1, 2, 3))
+        .covary[IO]
+        .mapAsync(3) { value =>
+          for {
+            _ <- readyByValue(value).complete(())
+            _ <- gateByValue(value).get
+          } yield value
+        }
+        .compile
+        .toVector
+        .start
+      _ <- firstReady.get
+      _ <- secondReady.get
+      _ <- thirdReady.get
+      _ <- thirdGate.complete(())
+      _ <- secondGate.complete(())
+      _ <- firstGate.complete(())
+      values <- fiber.join
+    } yield values).unsafeRunSync()
+
+    assertEquals(Vector(1, 2, 3), ordered)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def queuesExposeBoundedOffersChunksAndTermination(): Unit = {
+    val queueResult: (Boolean, Boolean, Boolean, List[Int], Option[Int], Int, Int) = (for {
+      queue <- Queue.bounded[IO, Int](2)
+      firstOffer <- queue.offer1(1)
+      secondOffer <- queue.offer1(2)
+      thirdOffer <- queue.offer1(3)
+      chunk <- queue.dequeueChunk1(5)
+      empty <- queue.tryDequeue1
+      _ <- queue.enqueue1(4)
+      dequeued <- queue.dequeue1
+      mapped = queue.imap[String](_.toString)(_.toInt)
+      _ <- mapped.enqueue1("5")
+      mappedDequeued <- queue.dequeue1
+    } yield (
+      firstOffer,
+      secondOffer,
+      thirdOffer,
+      chunk.toList,
+      empty,
+      dequeued,
+      mappedDequeued
+    )).unsafeRunSync()
+
+    val terminated: Vector[String] = (for {
+      queue <- Queue.noneTerminated[IO, String]
+      _ <- queue.enqueue1(Some("alpha"))
+      _ <- queue.enqueue1(Some("beta"))
+      _ <- queue.enqueue1(None)
+      values <- queue.dequeue.compile.toVector
+    } yield values).unsafeRunSync()
+
+    assertTrue(queueResult._1)
+    assertTrue(queueResult._2)
+    assertFalse(queueResult._3)
+    assertEquals(List(1, 2), queueResult._4)
+    assertEquals(None, queueResult._5)
+    assertEquals(4, queueResult._6)
+    assertEquals(5, queueResult._7)
+    assertEquals(Vector("alpha", "beta"), terminated)
+  }
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  def signalConstantCanBeMappedAndSampledContinuously(): Unit = {
+    val signal: Signal[IO, Int] = Signal.constant[IO, Int](21).map(_ * 2)
+    val current: Int = signal.get.unsafeRunSync()
+    val samples: Vector[Int] = signal.continuous.take(3).compile.toVector.unsafeRunSync()
+
+    assertEquals(42, current)
+    assertEquals(Vector(42, 42, 42), samples)
+  }
+
+  private def byteStream(bytes: Array[Byte], chunkSize: Int): Stream[IO, Byte] = {
+    val chunks: Vector[Chunk[Byte]] = bytes
+      .grouped(chunkSize)
+      .map(chunk => Chunk.bytes(chunk))
+      .toVector
+    Stream.emits(chunks).covary[IO].flatMap(chunk => Stream.chunk(chunk).covary[IO])
+  }
+}

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/src/test/scala/co_fs2/fs2_core_3/Fs2_core_3Test.scala
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/src/test/scala/co_fs2/fs2_core_3/Fs2_core_3Test.scala
@@ -6,15 +6,17 @@
  */
 package co_fs2.fs2_core_3
 
-import cats.effect.ContextShift
+import cats.effect.Deferred
 import cats.effect.IO
-import cats.effect.Timer
-import cats.effect.concurrent.Deferred
+import cats.effect.Outcome
+import cats.effect.std.Queue
+import cats.effect.unsafe.implicits.global
 import fs2.Chunk
 import fs2.Pull
 import fs2.Stream
-import fs2.compression
-import fs2.concurrent.Queue
+import fs2.compression.Compression
+import fs2.compression.DeflateParams
+import fs2.compression.InflateParams
 import fs2.concurrent.Signal
 import fs2.hash
 import fs2.text
@@ -34,13 +36,9 @@ import java.time.Instant
 import java.util.Base64
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
 
 class Fs2_core_3Test {
-  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-  private implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   def streamTransformationsCompileToExpectedCollections(): Unit = {
@@ -147,7 +145,6 @@ class Fs2_core_3Test {
       .byteBuffer(ByteBuffer.wrap(Array[Byte](10, 20, 30, 40)))
       .drop(1)
       .take(2)
-      .toBytes
       .toArray
 
     assertEquals(List(20, 30, 40), positiveTens)
@@ -203,8 +200,8 @@ class Fs2_core_3Test {
     val expectedDigest: Array[Byte] = MessageDigest.getInstance("SHA-256").digest(payload)
 
     val deflatedRoundTrip: Vector[Byte] = byteStream(payload, 7)
-      .through(compression.deflate[IO](compression.DeflateParams.BEST_SPEED))
-      .through(compression.inflate[IO]())
+      .through(Compression[IO].deflate(DeflateParams.BEST_SPEED))
+      .through(Compression[IO].inflate(InflateParams.DEFAULT))
       .compile
       .toVector
       .unsafeRunSync()
@@ -212,13 +209,13 @@ class Fs2_core_3Test {
     val modificationTime: Instant = Instant.parse("2020-01-02T03:04:05Z")
     val gzipRoundTrip: Vector[Byte] = byteStream(payload, 9)
       .through(
-        compression.gzip[IO](
+        Compression[IO].gzip(
           fileName = Some("payload.txt"),
           modificationTime = Some(modificationTime),
           comment = Some("metadata")
         )
       )
-      .through(compression.gunzip[IO]())
+      .through(Compression[IO].gunzip())
       .flatMap { result =>
         Stream.eval(IO {
           assertEquals(Some("payload.txt"), result.fileName)
@@ -265,7 +262,11 @@ class Fs2_core_3Test {
       _ <- thirdGate.complete(())
       _ <- secondGate.complete(())
       _ <- firstGate.complete(())
-      values <- fiber.join
+      values <- fiber.join.flatMap {
+        case Outcome.Succeeded(values) => values
+        case Outcome.Errored(error) => IO.raiseError(error)
+        case Outcome.Canceled() => IO.raiseError(new IllegalStateException("mapAsync stream was canceled"))
+      }
     } yield values).unsafeRunSync()
 
     assertEquals(Vector(1, 2, 3), ordered)
@@ -274,34 +275,30 @@ class Fs2_core_3Test {
   @Test
   @Timeout(value = 60, unit = TimeUnit.SECONDS)
   def queuesExposeBoundedOffersChunksAndTermination(): Unit = {
-    val queueResult: (Boolean, Boolean, Boolean, List[Int], Option[Int], Int, Int) = (for {
+    val queueResult: (Boolean, Boolean, Boolean, List[Int], Option[Int], Int) = (for {
       queue <- Queue.bounded[IO, Int](2)
-      firstOffer <- queue.offer1(1)
-      secondOffer <- queue.offer1(2)
-      thirdOffer <- queue.offer1(3)
-      chunk <- queue.dequeueChunk1(5)
-      empty <- queue.tryDequeue1
-      _ <- queue.enqueue1(4)
-      dequeued <- queue.dequeue1
-      mapped = queue.imap[String](_.toString)(_.toInt)
-      _ <- mapped.enqueue1("5")
-      mappedDequeued <- queue.dequeue1
+      firstOffer <- queue.tryOffer(1)
+      secondOffer <- queue.tryOffer(2)
+      thirdOffer <- queue.tryOffer(3)
+      chunk <- Stream.fromQueueUnterminated(queue, 5).take(2).compile.toList
+      empty <- queue.tryTake
+      _ <- queue.offer(4)
+      dequeued <- queue.take
     } yield (
       firstOffer,
       secondOffer,
       thirdOffer,
-      chunk.toList,
+      chunk,
       empty,
-      dequeued,
-      mappedDequeued
+      dequeued
     )).unsafeRunSync()
 
     val terminated: Vector[String] = (for {
-      queue <- Queue.noneTerminated[IO, String]
-      _ <- queue.enqueue1(Some("alpha"))
-      _ <- queue.enqueue1(Some("beta"))
-      _ <- queue.enqueue1(None)
-      values <- queue.dequeue.compile.toVector
+      queue <- Queue.unbounded[IO, Option[String]]
+      _ <- queue.offer(Some("alpha"))
+      _ <- queue.offer(Some("beta"))
+      _ <- queue.offer(None)
+      values <- Stream.fromQueueNoneTerminated(queue, 5).compile.toVector
     } yield values).unsafeRunSync()
 
     assertTrue(queueResult._1)
@@ -310,7 +307,6 @@ class Fs2_core_3Test {
     assertEquals(List(1, 2), queueResult._4)
     assertEquals(None, queueResult._5)
     assertEquals(4, queueResult._6)
-    assertEquals(5, queueResult._7)
     assertEquals(Vector("alpha", "beta"), terminated)
   }
 
@@ -328,7 +324,7 @@ class Fs2_core_3Test {
   private def byteStream(bytes: Array[Byte], chunkSize: Int): Stream[IO, Byte] = {
     val chunks: Vector[Chunk[Byte]] = bytes
       .grouped(chunkSize)
-      .map(chunk => Chunk.bytes(chunk))
+      .map(chunk => Chunk.array(chunk))
       .toVector
     Stream.emits(chunks).covary[IO].flatMap(chunk => Stream.chunk(chunk).covary[IO])
   }

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/user-code-filter.json
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "fs2.**"
+    },
+    {
+      "includeClasses" : "co_fs2.fs2_core_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6205

This PR provides test fixes and new metadata for co.fs2:fs2-core_3:3.0-130-1713a29, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 47695
- Cached input tokens: 909824
- Output tokens: 5874
- Metadata entries: 8
- Iterations: 1
- Library coverage percentage: 47.55
- Previous library version metadata entries: 4
- Previous library version coverage percentage: 40.93

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1db2ab4602ded690dee9935840b74c9edd9e2dca`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- co.fs2:fs2-core_3:2.5.6: 0/0 covered calls (100.00%)
- co.fs2:fs2-core_3:3.0-130-1713a29: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- co.fs2:fs2-core_3:2.5.6: 11482/47464 (24.19%)
- co.fs2:fs2-core_3:3.0-130-1713a29: 11079/36595 (30.27%)

**Line:**
- co.fs2:fs2-core_3:2.5.6: 1636/3997 (40.93%)
- co.fs2:fs2-core_3:3.0-130-1713a29: 1565/3291 (47.55%)

**Method:**
- co.fs2:fs2-core_3:2.5.6: 1028/4914 (20.92%)
- co.fs2:fs2-core_3:3.0-130-1713a29: 954/3628 (26.30%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
