### PR TITLE
[GenAI] Test fix for jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/reachability-metadata.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "jakarta.enterprise.util.SecurityActions"
+      },
+      "type": "java.lang.reflect.Method[]"
+    }
+  ]
+}

--- a/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
@@ -18,6 +18,11 @@
   },
   {
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/cdi",
+    "test-code-url" : "https://github.com/jakartaee/cdi/tree/$version$/api/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-javadoc.jar",
+    "description" : "Jakarta CDI API defines the annotations and interfaces for Contexts and Dependency Injection, a Jakarta EE programming model for type-safe dependency injection, contextual lifecycles, interceptors, decorators, and events. This artifact provides API classes for CDI applications and implementations and does not include a CDI runtime implementation.",
     "tested-versions" : [
       "3.0.0"
     ],

--- a/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
@@ -15,5 +15,15 @@
       "javax.decorator",
       "javax.enterprise"
     ]
+  },
+  {
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "javax.decorator",
+      "javax.enterprise"
+    ]
   }
 ]

--- a/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
@@ -1,34 +1,35 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "2.0.1",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/jakartaee/cdi",
-    "test-code-url" : "https://github.com/jakartaee/cdi/tree/$version$/api/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-javadoc.jar",
-    "description" : "Jakarta CDI API defines the annotations and interfaces for Contexts and Dependency Injection, the Java/Jakarta EE programming model for type-safe dependency injection, contextual lifecycles, interceptors, decorators, and events. This artifact provides the API classes used by CDI applications and implementations; it does not include a CDI runtime implementation.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "2.0.1",
+    "source-code-url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
+    "repository-url": "https://github.com/jakartaee/cdi",
+    "test-code-url": "https://github.com/jakartaee/cdi/tree/$version$/api/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-javadoc.jar",
+    "description": "Jakarta CDI API defines the annotations and interfaces for Contexts and Dependency Injection, the Java/Jakarta EE programming model for type-safe dependency injection, contextual lifecycles, interceptors, decorators, and events. This artifact provides the API classes used by CDI applications and implementations; it does not include a CDI runtime implementation.",
+    "tested-versions": [
       "2.0.1",
       "2.0.2"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "javax.decorator",
       "javax.enterprise"
     ]
   },
   {
-    "metadata-version" : "3.0.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/jakartaee/cdi",
-    "test-code-url" : "https://github.com/jakartaee/cdi/tree/$version$/api/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-javadoc.jar",
-    "description" : "Jakarta CDI API defines the annotations and interfaces for Contexts and Dependency Injection, a Jakarta EE programming model for type-safe dependency injection, contextual lifecycles, interceptors, decorators, and events. This artifact provides API classes for CDI applications and implementations and does not include a CDI runtime implementation.",
-    "tested-versions" : [
+    "metadata-version": "3.0.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
+    "repository-url": "https://github.com/jakartaee/cdi",
+    "test-code-url": "https://github.com/jakartaee/cdi/tree/$version$/api/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-javadoc.jar",
+    "description": "Jakarta CDI API defines the annotations and interfaces for Contexts and Dependency Injection, a Jakarta EE programming model for type-safe dependency injection, contextual lifecycles, interceptors, decorators, and events. This artifact provides API classes for CDI applications and implementations and does not include a CDI runtime implementation.",
+    "tested-versions": [
       "3.0.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "javax.decorator",
-      "javax.enterprise"
+      "javax.enterprise",
+      "jakarta.enterprise.util"
     ]
   }
 ]

--- a/stats/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/execution-metrics.json
+++ b/stats/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T08:50:19.151969Z",
+    "library": "jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0",
+    "starting_commit": "5985102b9211a95cd7b4e543adf00e5084b167e9",
+    "ending_commit": "a2b0f7a1b271e5fe73edfe225a3f9a64d028d3fe",
+    "previous_library": "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 3,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 224,
+          "missed": 2013,
+          "ratio": 0.100134,
+          "total": 2237
+        },
+        "line": {
+          "covered": 58,
+          "missed": 494,
+          "ratio": 0.105072,
+          "total": 552
+        },
+        "method": {
+          "covered": 12,
+          "missed": 190,
+          "ratio": 0.059406,
+          "total": 202
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.0.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.666667,
+            "coveredCalls": 2,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 0.666667,
+        "coveredCalls": 2,
+        "totalCalls": 3
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 206,
+          "missed": 2021,
+          "ratio": 0.092501,
+          "total": 2227
+        },
+        "line": {
+          "covered": 53,
+          "missed": 493,
+          "ratio": 0.09707,
+          "total": 546
+        },
+        "method": {
+          "covered": 10,
+          "missed": 192,
+          "ratio": 0.049505,
+          "total": 202
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 50678,
+      "cached_input_tokens_used": 567296,
+      "output_tokens_used": 8739,
+      "iterations": 2,
+      "cost_usd": 0.5458,
+      "tested_library_loc": 58,
+      "metadata_entries": 1,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 10.51,
+      "previous_library_coverage_percent": 9.71
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java",
+      "metadata_file": "metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/stats.json
+++ b/stats/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 3,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 3,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 224,
+        "missed" : 2013,
+        "ratio" : 0.100134,
+        "total" : 2237
+      },
+      "line" : {
+        "covered" : 58,
+        "missed" : 494,
+        "ratio" : 0.105072,
+        "total" : 552
+      },
+      "method" : {
+        "covered" : 12,
+        "missed" : 190,
+        "ratio" : 0.059406,
+        "total" : 202
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/.gitignore
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.enterprise:jakarta.enterprise.cdi-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
+
+tasks.named("test") {
+    if ((JavaVersion.current().majorVersion as int) < 24) {
+        File allPermissionsPolicy = layout.projectDirectory.file("src/test/resources/all-permissions.policy").asFile
+        jvmArgs += [
+                "-Djava.security.manager=default",
+                "-Djava.security.policy==${allPermissionsPolicy.toURI()}"
+        ]
+    }
+}

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
@@ -26,12 +26,14 @@ graalvmNative {
     }
 }
 
-tasks.named("test") {
-    if ((JavaVersion.current().majorVersion as int) < 24) {
-        File allPermissionsPolicy = layout.projectDirectory.file("src/test/resources/all-permissions.policy").asFile
-        jvmArgs += [
-                "-Djava.security.manager=default",
-                "-Djava.security.policy==${allPermissionsPolicy.toURI()}"
-        ]
+tasks.named("test", Test) {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
     }
+
+    File allPermissionsPolicy = layout.projectDirectory.file("src/test/resources/all-permissions.policy").asFile
+    jvmArgs += [
+            "-Djava.security.manager=allow",
+            "-Djava.security.policy==${allPermissionsPolicy.toURI()}"
+    ]
 }

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/gradle.properties
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0
+library.version = 3.0.0
+metadata.dir = jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/settings.gradle
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.enterprise.jakarta.enterprise.cdi-api_tests'

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_enterprise.jakarta_enterprise_cdi_api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.security.Permission;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityActionsTest {
+    @Test
+    @SuppressWarnings("removal")
+    void annotationLiteralDiscoversDeclaredMembersWithoutSecurityManager() {
+        final SecurityManager previousSecurityManager = System.getSecurityManager();
+        final boolean securityManagerCleared = clearSecurityManagerIfPresent();
+
+        try {
+            final NamedQualifier qualifier = new NamedQualifierLiteral("without-security-manager");
+
+            assertThat(qualifier.annotationType()).isEqualTo(NamedQualifier.class);
+            assertThat(qualifier.toString()).contains("value=\"without-security-manager\"");
+        } finally {
+            if (securityManagerCleared) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void annotationLiteralDiscoversDeclaredMembersWithSecurityManager() {
+        final SecurityManager previousSecurityManager = System.getSecurityManager();
+        final PermissiveSecurityManager securityManager = new PermissiveSecurityManager();
+        final boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+
+        try {
+            final NamedQualifier qualifier = new NamedQualifierLiteral("with-security-manager");
+
+            assertThat(qualifier.annotationType()).isEqualTo(NamedQualifier.class);
+            assertThat(qualifier.toString()).contains("value=\"with-security-manager\"");
+            if (securityManagerInstalled) {
+                assertThat(System.getSecurityManager()).isSameAs(securityManager);
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean clearSecurityManagerIfPresent() {
+        if (System.getSecurityManager() == null) {
+            return false;
+        }
+        try {
+            System.setSecurityManager(null);
+            return System.getSecurityManager() == null;
+        } catch (final UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(final SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (final UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface NamedQualifier {
+        String value();
+    }
+
+    private static final class NamedQualifierLiteral extends AnnotationLiteral<NamedQualifier>
+            implements NamedQualifier {
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        private NamedQualifierLiteral(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static final class PermissiveSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(final Permission permission) {
+        }
+    }
+}

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.security.Permission;
 
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/resources/all-permissions.policy
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/resources/all-permissions.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.decorator.**"
+    },
+    {
+      "includeClasses" : "javax.enterprise.**"
+    },
+    {
+      "includeClasses" : "jakarta_enterprise.jakarta_enterprise_cdi_api.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
+++ b/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
@@ -4,10 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.decorator.**"
+      "includeClasses" : "jakarta.decorator.**"
     },
     {
-      "includeClasses" : "javax.enterprise.**"
+      "includeClasses" : "jakarta.enterprise.**"
     },
     {
       "includeClasses" : "jakarta_enterprise.jakarta_enterprise_cdi_api.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #6215

This PR provides test fixes and new metadata for jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 50678
- Cached input tokens: 567296
- Output tokens: 8739
- Metadata entries: 1
- Iterations: 2
- Library coverage percentage: 10.51
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 9.71

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `151c4bdba50a0c6432c37fd74a9976e6173e4d5a`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1: 2/3 covered calls (66.67%)
- jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0: 3/3 covered calls (100.00%)

**Reflection:**
- jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1: 2/3 covered calls (66.67%)
- jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0: 3/3 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1: 206/2227 (9.25%)
- jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0: 224/2237 (10.01%)

**Line:**
- jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1: 53/546 (9.71%)
- jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0: 58/552 (10.51%)

**Method:**
- jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.1: 10/202 (4.95%)
- jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0: 12/202 (5.94%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/build.gradle 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
index fa4b3eba01..21e56f9785 100644
--- 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/build.gradle
+++ 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/build.gradle
@@ -26,12 +26,14 @@ graalvmNative {
     }
 }
 
-tasks.named("test") {
-    if ((JavaVersion.current().majorVersion as int) < 24) {
-        File allPermissionsPolicy = layout.projectDirectory.file("src/test/resources/all-permissions.policy").asFile
-        jvmArgs += [
-                "-Djava.security.manager=default",
-                "-Djava.security.policy==${allPermissionsPolicy.toURI()}"
-        ]
+tasks.named("test", Test) {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
     }
+
+    File allPermissionsPolicy = layout.projectDirectory.file("src/test/resources/all-permissions.policy").asFile
+    jvmArgs += [
+            "-Djava.security.manager=allow",
+            "-Djava.security.policy==${allPermissionsPolicy.toURI()}"
+    ]
 }
diff --git 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
index e577e01ace..af292891f5 100644
--- 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
+++ 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/src/test/java/jakarta_enterprise/jakarta_enterprise_cdi_api/SecurityActionsTest.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.security.Permission;
 
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.junit.jupiter.api.Test;
 
diff --git 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/user-code-filter.json 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
index 115ae50122..2f8c41fbe5 100644
--- 1/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/2.0.1/user-code-filter.json
+++ 2/tests/src/jakarta.enterprise/jakarta.enterprise.cdi-api/3.0.0/user-code-filter.json
@@ -4,10 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.decorator.**"
+      "includeClasses" : "jakarta.decorator.**"
     },
     {
-      "includeClasses" : "javax.enterprise.**"
+      "includeClasses" : "jakarta.enterprise.**"
     },
     {
       "includeClasses" : "jakarta_enterprise.jakarta_enterprise_cdi_api.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
