### PR TITLE
[GenAI] Test fix for com.beust:jcommander:1.75 using gpt-5.5

### DIFF
--- a/metadata/com.beust/jcommander/1.75/reachability-metadata.json
+++ b/metadata/com.beust/jcommander/1.75/reachability-metadata.json
@@ -1,0 +1,239 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": "com.beust.jcommander.converters.StringConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com.beust.jcommander.validators.NoValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com.beust.jcommander.validators.NoValueValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.internal.JDK6Console"
+      },
+      "type": "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "com_beust.jcommander.ParameterizedTest$CommandOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.WrappedParameter"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.WrappedParameter"
+      },
+      "type": "java.util.Map",
+      "methods": [
+        {
+          "name": "put",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.DynamicParameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameters"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameters"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.ResourceBundle"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.SubParameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.Stable"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.DefaultUsageFormatter"
+      },
+      "bundle": "com_beust.jcommander.parameter_descriptions"
+    }
+  ]
+}

--- a/metadata/com.beust/jcommander/1.75/reachability-metadata.json
+++ b/metadata/com.beust/jcommander/1.75/reachability-metadata.json
@@ -1,116 +1,86 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": "com.beust.jcommander.converters.StringConverter",
-      "methods": [
+      "type" : "com.beust.jcommander.converters.StringConverter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com.beust.jcommander.validators.NoValidator",
-      "methods": [
+      "type" : "com.beust.jcommander.validators.NoValidator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com.beust.jcommander.validators.NoValueValidator",
-      "methods": [
+      "type" : "com.beust.jcommander.validators.NoValueValidator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.internal.JDK6Console"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.WrappedParameter"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": "com_beust.jcommander.ParameterizedTest$CommandOptions"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.util.Map"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.WrappedParameter"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.WrappedParameter"
       },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
-      },
-      "type": "java.util.Map"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.WrappedParameter"
-      },
-      "type": "java.util.Map",
-      "methods": [
+      "type" : "java.util.Map",
+      "methods" : [
         {
-          "name": "put",
-          "parameterTypes": [
+          "name" : "put",
+          "parameterTypes" : [
             "java.lang.Object",
             "java.lang.Object"
           ]
@@ -118,122 +88,122 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.DynamicParameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameters"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameters"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.ResourceBundle"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.SubParameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Inherited"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jdk.internal.vm.annotation.Stable"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.DefaultUsageFormatter"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.DefaultUsageFormatter"
       },
-      "bundle": "com_beust.jcommander.parameter_descriptions"
+      "bundle" : "com_beust.jcommander.parameter_descriptions"
     }
   ]
 }

--- a/metadata/com.beust/jcommander/index.json
+++ b/metadata/com.beust/jcommander/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "com.beust.jcommander"
     ]
+  },
+  {
+    "metadata-version" : "1.75",
+    "tested-versions" : [
+      "1.75"
+    ],
+    "allowed-packages" : [
+      "com.beust.jcommander"
+    ]
   }
 ]

--- a/metadata/com.beust/jcommander/index.json
+++ b/metadata/com.beust/jcommander/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.75",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-sources.jar",
+    "repository-url" : "https://github.com/cbeust/jcommander",
+    "test-code-url" : "https://github.com/cbeust/jcommander/tree/$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-javadoc.jar",
+    "description" : "JCommander is an annotation-based command-line parsing framework for Java applications. It maps command-line arguments onto Java objects, supports typed converters and validators, and helps generate usage output for command-line tools.",
     "tested-versions" : [
       "1.75"
     ],

--- a/stats/com.beust/jcommander/1.75/execution-metrics.json
+++ b/stats/com.beust/jcommander/1.75/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T09:22:17.704217Z",
+    "library": "com.beust:jcommander:1.75",
+    "starting_commit": "8c2c9fe38c816b64e5394d6f62a08e38662631af",
+    "ending_commit": "9bb12559205713fc2ff4b28443b870f267c30774",
+    "previous_library": "com.beust:jcommander:1.72",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.75",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 28,
+            "totalCalls": 28
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3325,
+          "missed": 3295,
+          "ratio": 0.502266,
+          "total": 6620
+        },
+        "line": {
+          "covered": 755,
+          "missed": 737,
+          "ratio": 0.506032,
+          "total": 1492
+        },
+        "method": {
+          "covered": 161,
+          "missed": 159,
+          "ratio": 0.503125,
+          "total": 320
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.72",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 27,
+            "totalCalls": 27
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 31,
+        "totalCalls": 31
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2859,
+          "missed": 3633,
+          "ratio": 0.440388,
+          "total": 6492
+        },
+        "line": {
+          "covered": 643,
+          "missed": 715,
+          "ratio": 0.47349,
+          "total": 1358
+        },
+        "method": {
+          "covered": 134,
+          "missed": 156,
+          "ratio": 0.462069,
+          "total": 290
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 93944,
+      "cached_input_tokens_used": 605696,
+      "output_tokens_used": 8324,
+      "iterations": 4,
+      "cost_usd": 0.5525,
+      "tested_library_loc": 755,
+      "metadata_entries": 26,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 29,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 50.6,
+      "previous_library_coverage_percent": 47.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java",
+      "metadata_file": "metadata/com.beust/jcommander/1.75/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.beust/jcommander/1.75/stats.json
+++ b/stats/com.beust/jcommander/1.75/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.75",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 28,
+          "totalCalls" : 28
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3325,
+        "missed" : 3295,
+        "ratio" : 0.502266,
+        "total" : 6620
+      },
+      "line" : {
+        "covered" : 755,
+        "missed" : 737,
+        "ratio" : 0.506032,
+        "total" : 1492
+      },
+      "method" : {
+        "covered" : 161,
+        "missed" : 159,
+        "ratio" : 0.503125,
+        "total" : 320
+      }
+    }
+  } ]
+}

--- a/tests/src/com.beust/jcommander/1.75/.gitignore
+++ b/tests/src/com.beust/jcommander/1.75/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.beust/jcommander/1.75/build.gradle
+++ b/tests/src/com.beust/jcommander/1.75/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.beust:jcommander:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/gradle.properties
+++ b/tests/src/com.beust/jcommander/1.75/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.beust:jcommander:1.75
+library.version = 1.75
+metadata.dir = com.beust/jcommander/1.75/

--- a/tests/src/com.beust/jcommander/1.75/settings.gradle
+++ b/tests/src/com.beust/jcommander/1.75/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.beust.jcommander_tests'

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.internal.JDK6Console;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDK6ConsoleTest {
+    @Test
+    void delegatesToConsoleWriterAndReadsWithEcho() throws Exception {
+        RecordingConsole console = new RecordingConsole("typed value", "secret".toCharArray());
+        JDK6Console jdk6Console = new JDK6Console(console);
+
+        jdk6Console.print("prompt: ");
+        char[] password = jdk6Console.readPassword(true);
+        jdk6Console.println("done");
+
+        assertThat(password).containsExactly('t', 'y', 'p', 'e', 'd', ' ', 'v', 'a', 'l', 'u', 'e');
+        assertThat(console.output()).isEqualTo("prompt: done" + System.lineSeparator());
+        assertThat(console.readLineCalls).isEqualTo(1);
+        assertThat(console.readPasswordCalls).isZero();
+    }
+
+    @Test
+    void delegatesToConsoleReadPasswordWhenEchoIsDisabled() throws Exception {
+        RecordingConsole console = new RecordingConsole("ignored", "secret".toCharArray());
+        JDK6Console jdk6Console = new JDK6Console(console);
+
+        char[] password = jdk6Console.readPassword(false);
+
+        assertThat(password).containsExactly('s', 'e', 'c', 'r', 'e', 't');
+        assertThat(console.readLineCalls).isZero();
+        assertThat(console.readPasswordCalls).isEqualTo(1);
+    }
+
+    public static class RecordingConsole {
+        private final String line;
+        private final char[] password;
+        private final StringWriter output = new StringWriter();
+        private final PrintWriter writer = new PrintWriter(output);
+        private int readLineCalls;
+        private int readPasswordCalls;
+
+        RecordingConsole(String line, char[] password) {
+            this.line = line;
+            this.password = password;
+        }
+
+        public PrintWriter writer() {
+            return writer;
+        }
+
+        public String readLine() {
+            readLineCalls++;
+            return line;
+        }
+
+        public char[] readPassword() {
+            readPasswordCalls++;
+            return password;
+        }
+
+        String output() {
+            writer.flush();
+            return output.toString();
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -6,7 +6,9 @@
  */
 package com_beust.jcommander;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JcommanderTest {
     @Test
     void createsConsoleThroughJdkConsoleLookup() {
-        assertThat(JCommander.getConsole()).isNotNull();
+        assertThat(new JCommander().getConsole()).isNotNull();
     }
 
     @Test
@@ -23,12 +25,51 @@ public class JcommanderTest {
         JCommander commander = new JCommander(new RootCommand());
         commander.addCommand(new LocalizedCommand());
 
-        String description = commander.getCommandDescription("localized");
+        StringBuilder usage = new StringBuilder();
+        commander.getUsageFormatter().usage(usage);
 
-        assertThat(description).isEqualTo("localized command description");
+        assertThat(usage.toString()).contains("localized command description");
+    }
+
+    @Test
+    void parsesParameterWithStringConverterConstructor() {
+        ConvertedOptions options = new ConvertedOptions();
+
+        JCommander.newBuilder()
+                .addObject(options)
+                .build()
+                .parse("--converted", "alpha");
+
+        assertThat(options.converted.value).isEqualTo("--converted=alpha");
     }
 
     public static class RootCommand {
+    }
+
+    public static class ConvertedOptions {
+        @Parameter(names = "--converted", converter = OptionNameConverter.class)
+        private ConvertedValue converted;
+    }
+
+    public static class ConvertedValue {
+        private final String value;
+
+        public ConvertedValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class OptionNameConverter implements IStringConverter<ConvertedValue> {
+        private final String optionName;
+
+        public OptionNameConverter(String optionName) {
+            this.optionName = optionName;
+        }
+
+        @Override
+        public ConvertedValue convert(String value) {
+            return new ConvertedValue(optionName + "=" + value);
+        }
     }
 
     @Parameters(

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JcommanderTest {
+    @Test
+    void createsConsoleThroughJdkConsoleLookup() {
+        assertThat(JCommander.getConsole()).isNotNull();
+    }
+
+    @Test
+    void resolvesCommandDescriptionFromParametersResourceBundle() {
+        JCommander commander = new JCommander(new RootCommand());
+        commander.addCommand(new LocalizedCommand());
+
+        String description = commander.getCommandDescription("localized");
+
+        assertThat(description).isEqualTo("localized command description");
+    }
+
+    public static class RootCommand {
+    }
+
+    @Parameters(
+            commandNames = "localized",
+            commandDescription = "fallback command description",
+            commandDescriptionKey = "command.description",
+            resourceBundle = "com_beust.jcommander.parameter_descriptions")
+    public static class LocalizedCommand {
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterDescriptionTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterDescriptionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.IParameterValidator2;
+import com.beust.jcommander.IValueValidator;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.SubParameter;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterDescriptionTest {
+    @Test
+    void parsesOrderedSubParametersIntoValueObject() {
+        CoordinateCommand command = new CoordinateCommand();
+
+        new JCommander(command, "--coordinate", "10", "20");
+
+        assertThat(command.coordinate).isNotNull();
+        assertThat(command.coordinate.x).isEqualTo("10");
+        assertThat(command.coordinate.y).isEqualTo("20");
+    }
+
+    @Test
+    void invokesParameterAndValueValidatorsDeclaredOnParameter() {
+        RecordingParameterValidator.invocations.set(0);
+        RecordingParameterValidator.contextInvocations.set(0);
+        RecordingValueValidator.invocations.set(0);
+        ValidatedCommand command = new ValidatedCommand();
+
+        new JCommander(command, "--name", "jcommander");
+
+        assertThat(command.name).isEqualTo("jcommander");
+        assertThat(RecordingParameterValidator.invocations.get()).isEqualTo(1);
+        assertThat(RecordingParameterValidator.contextInvocations.get()).isEqualTo(1);
+        assertThat(RecordingValueValidator.invocations.get()).isEqualTo(2);
+    }
+
+    @Test
+    void readsParameterDescriptionsFromParametersResourceBundle() {
+        ParametersBundleCommand command = new ParametersBundleCommand();
+        JCommander commander = new JCommander(command);
+
+        ParameterDescription description = parameterDescription(commander, "--from-parameters");
+
+        assertThat(description.getDescription()).isEqualTo("description loaded from @Parameters");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void readsParameterDescriptionsFromDeprecatedResourceBundleAnnotation() {
+        DeprecatedBundleCommand command = new DeprecatedBundleCommand();
+        JCommander commander = new JCommander(command);
+
+        ParameterDescription description = parameterDescription(
+                commander,
+                "--from-deprecated-bundle");
+
+        assertThat(description.getDescription())
+                .isEqualTo("description loaded from @ResourceBundle");
+    }
+
+    private static ParameterDescription parameterDescription(JCommander commander, String name) {
+        return commander.getParameters().stream()
+                .filter(description -> description.getNames().contains(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing parameter description for " + name));
+    }
+
+    public static class CoordinateCommand {
+        @Parameter(names = "--coordinate", arity = 2)
+        private Coordinate coordinate;
+    }
+
+    public static class Coordinate {
+        @SubParameter(order = 0)
+        public String x;
+
+        @SubParameter(order = 1)
+        public String y;
+    }
+
+    public static class ValidatedCommand {
+        @Parameter(
+                names = "--name",
+                validateWith = RecordingParameterValidator.class,
+                validateValueWith = RecordingValueValidator.class)
+        private String name;
+    }
+
+    public static class RecordingParameterValidator implements IParameterValidator2 {
+        private static final AtomicInteger invocations = new AtomicInteger();
+        private static final AtomicInteger contextInvocations = new AtomicInteger();
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            invocations.incrementAndGet();
+        }
+
+        @Override
+        public void validate(String name, String value, ParameterDescription parameterDescription)
+                throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            assertThat(parameterDescription.getNames()).contains("--name");
+            contextInvocations.incrementAndGet();
+        }
+    }
+
+    public static class RecordingValueValidator implements IValueValidator<String> {
+        private static final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            invocations.incrementAndGet();
+        }
+    }
+
+    @Parameters(resourceBundle = "com_beust.jcommander.parameter_descriptions")
+    public static class ParametersBundleCommand {
+        @Parameter(names = "--from-parameters", descriptionKey = "parameters.description")
+        private String value;
+    }
+
+    @com.beust.jcommander.ResourceBundle("com_beust.jcommander.parameter_descriptions")
+    public static class DeprecatedBundleCommand {
+        @Parameter(names = "--from-deprecated-bundle", descriptionKey = "deprecated.description")
+        private String value;
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -44,6 +44,16 @@ public class ParameterizedTest {
         assertThat(parameterized.get(options)).isEqualTo("secret-token");
     }
 
+    @Test
+    void booleanMethodBackedParameterUsesIsGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setEnabled");
+
+        parameterized.set(options, true);
+
+        assertThat(parameterized.get(options)).isEqualTo(true);
+    }
+
     private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
         return parameters.stream()
                 .filter(parameterized -> name.equals(parameterized.getName()))
@@ -59,6 +69,8 @@ public class ParameterizedTest {
 
         private String token;
 
+        private boolean enabled;
+
         @Parameter(names = "--level")
         public void setLevel(int level) {
             this.level = level;
@@ -71,6 +83,15 @@ public class ParameterizedTest {
         @Parameter(names = "--token")
         public void setToken(String token) {
             this.token = token;
+        }
+
+        @Parameter(names = "--enabled")
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
     }
 }

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameterized;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterizedTest {
+    @Test
+    void fieldBackedParameterCanBeReadAndWritten() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "fieldValue");
+
+        parameterized.set(options, "configured");
+
+        assertThat(parameterized.get(options)).isEqualTo("configured");
+    }
+
+    @Test
+    void methodBackedParameterCanUseSetterAndMatchingGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setLevel");
+
+        parameterized.set(options, 42);
+
+        assertThat(parameterized.get(options)).isEqualTo(42);
+    }
+
+    @Test
+    void methodBackedParameterFallsBackToMatchingFieldWhenGetterIsMissing() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setToken");
+
+        parameterized.set(options, "secret-token");
+
+        assertThat(parameterized.get(options)).isEqualTo("secret-token");
+    }
+
+    private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
+        return parameters.stream()
+                .filter(parameterized -> name.equals(parameterized.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing parameterized member: " + name));
+    }
+
+    public static class CommandOptions {
+        @Parameter(names = "--field")
+        private String fieldValue;
+
+        private int level;
+
+        private String token;
+
+        @Parameter(names = "--level")
+        public void setLevel(int level) {
+            this.level = level;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+
+        @Parameter(names = "--token")
+        public void setToken(String token) {
+            this.token = token;
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/WrappedParameterTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/WrappedParameterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.JCommander;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WrappedParameterTest {
+    @Test
+    void parsesDynamicParametersIntoMap() {
+        DynamicParametersCommand command = new DynamicParametersCommand();
+
+        new JCommander(command, "-D", "host=localhost", "-Dport=8080");
+
+        assertThat(command.definitions)
+                .containsEntry("host", "localhost")
+                .containsEntry("port", "8080");
+    }
+
+    public static class DynamicParametersCommand {
+        @DynamicParameter(names = "-D")
+        private Map<String, String> definitions = new LinkedHashMap<>();
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/defaultprovider/PropertyFileDefaultProviderTest.java
+++ b/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/defaultprovider/PropertyFileDefaultProviderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander.defaultprovider;
+
+import com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFileDefaultProviderTest {
+    @Test
+    void loadsDefaultValuesFromClasspathPropertyFile() {
+        PropertyFileDefaultProvider provider = new PropertyFileDefaultProvider();
+
+        assertThat(provider.getDefaultValueFor("--host")).isEqualTo("localhost");
+        assertThat(provider.getDefaultValueFor("-port")).isEqualTo("8080");
+    }
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.beust/jcommander/1.75/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.internal.JDK6Console"
+      },
+      "type" : "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
+      },
+      "type" : "com_beust.jcommander.ParameterizedTest$CommandOptions"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider"
+      },
+      "glob" : "jcommander.properties"
+    }
+  ]
+}

--- a/tests/src/com.beust/jcommander/1.75/src/test/resources/com_beust/jcommander/parameter_descriptions.properties
+++ b/tests/src/com.beust/jcommander/1.75/src/test/resources/com_beust/jcommander/parameter_descriptions.properties
@@ -1,0 +1,3 @@
+parameters.description=description loaded from @Parameters
+deprecated.description=description loaded from @ResourceBundle
+command.description=localized command description

--- a/tests/src/com.beust/jcommander/1.75/src/test/resources/jcommander.properties
+++ b/tests/src/com.beust/jcommander/1.75/src/test/resources/jcommander.properties
@@ -1,0 +1,2 @@
+host=localhost
+port=8080

--- a/tests/src/com.beust/jcommander/1.75/user-code-filter.json
+++ b/tests/src/com.beust/jcommander/1.75/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.beust.jcommander.**"
+    },
+    {
+      "includeClasses" : "com_beust.jcommander.**"
+    },
+    {
+      "includeClasses" : "com_beust.jcommander.defaultprovider.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6206

This PR provides test fixes and new metadata for com.beust:jcommander:1.75, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 93944
- Cached input tokens: 605696
- Output tokens: 8324
- Metadata entries: 26
- Test-only metadata entries: 6
- Iterations: 4
- Library coverage percentage: 50.6
- Previous library version metadata entries: 29
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 47.35

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `151c4bdba50a0c6432c37fd74a9976e6173e4d5a`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.beust:jcommander:1.72: 31/31 covered calls (100.00%)
- com.beust:jcommander:1.75: 32/32 covered calls (100.00%)

**Reflection:**
- com.beust:jcommander:1.72: 27/27 covered calls (100.00%)
- com.beust:jcommander:1.75: 28/28 covered calls (100.00%)

**Resources:**
- com.beust:jcommander:1.72: 4/4 covered calls (100.00%)
- com.beust:jcommander:1.75: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.beust:jcommander:1.72: 2859/6492 (44.04%)
- com.beust:jcommander:1.75: 3325/6620 (50.23%)

**Line:**
- com.beust:jcommander:1.72: 643/1358 (47.35%)
- com.beust:jcommander:1.75: 755/1492 (50.60%)

**Method:**
- com.beust:jcommander:1.72: 134/290 (46.21%)
- com.beust:jcommander:1.75: 161/320 (50.31%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/JcommanderTest.java 2/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
index ef7d9e6122..1dc509af11 100644
--- 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ 2/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -6,7 +6,9 @@
  */
 package com_beust.jcommander;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JcommanderTest {
     @Test
     void createsConsoleThroughJdkConsoleLookup() {
-        assertThat(JCommander.getConsole()).isNotNull();
+        assertThat(new JCommander().getConsole()).isNotNull();
     }
 
     @Test
@@ -23,14 +25,53 @@ public class JcommanderTest {
         JCommander commander = new JCommander(new RootCommand());
         commander.addCommand(new LocalizedCommand());
 
-        String description = commander.getCommandDescription("localized");
+        StringBuilder usage = new StringBuilder();
+        commander.getUsageFormatter().usage(usage);
 
-        assertThat(description).isEqualTo("localized command description");
+        assertThat(usage.toString()).contains("localized command description");
+    }
+
+    @Test
+    void parsesParameterWithStringConverterConstructor() {
+        ConvertedOptions options = new ConvertedOptions();
+
+        JCommander.newBuilder()
+                .addObject(options)
+                .build()
+                .parse("--converted", "alpha");
+
+        assertThat(options.converted.value).isEqualTo("--converted=alpha");
     }
 
     public static class RootCommand {
     }
 
+    public static class ConvertedOptions {
+        @Parameter(names = "--converted", converter = OptionNameConverter.class)
+        private ConvertedValue converted;
+    }
+
+    public static class ConvertedValue {
+        private final String value;
+
+        public ConvertedValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class OptionNameConverter implements IStringConverter<ConvertedValue> {
+        private final String optionName;
+
+        public OptionNameConverter(String optionName) {
+            this.optionName = optionName;
+        }
+
+        @Override
+        public ConvertedValue convert(String value) {
+            return new ConvertedValue(optionName + "=" + value);
+        }
+    }
+
     @Parameters(
             commandNames = "localized",
             commandDescription = "fallback command description",
diff --git 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/ParameterizedTest.java 2/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
index 3d34bc1b6a..afe3371f38 100644
--- 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ 2/tests/src/com.beust/jcommander/1.75/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -44,6 +44,16 @@ public class ParameterizedTest {
         assertThat(parameterized.get(options)).isEqualTo("secret-token");
     }
 
+    @Test
+    void booleanMethodBackedParameterUsesIsGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setEnabled");
+
+        parameterized.set(options, true);
+
+        assertThat(parameterized.get(options)).isEqualTo(true);
+    }
+
     private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
         return parameters.stream()
                 .filter(parameterized -> name.equals(parameterized.getName()))
@@ -59,6 +69,8 @@ public class ParameterizedTest {
 
         private String token;
 
+        private boolean enabled;
+
         @Parameter(names = "--level")
         public void setLevel(int level) {
             this.level = level;
@@ -72,5 +84,14 @@ public class ParameterizedTest {
         public void setToken(String token) {
             this.token = token;
         }
+
+        @Parameter(names = "--enabled")
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
