### PR TITLE
[GenAI] Test fix for org.jetbrains.exposed:exposed-core:1.1.1 using gpt-5.5

### DIFF
--- a/metadata/org.jetbrains.exposed/exposed-core/1.1.1/reachability-metadata.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/1.1.1/reachability-metadata.json
@@ -1,0 +1,34 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.exposed.v1.core.Table"
+      },
+      "type": "org.jetbrains.exposed.v1.core.IntegerColumnType",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.exposed.v1.core.Table"
+      },
+      "type": "org.jetbrains.exposed.v1.core.ColumnType",
+      "methods": [
+        {
+          "name": "getNullable",
+          "parameterTypes": []
+        },
+        {
+          "name": "setNullable",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jetbrains.exposed/exposed-core/index.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/index.json
@@ -19,6 +19,19 @@
     ]
   },
   {
+    "metadata-version" : "1.1.1",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.0"
+    },
+    "tested-versions" : [
+      "1.1.1"
+    ],
+    "allowed-packages" : [
+      "org.jetbrains.exposed.v1"
+    ]
+  },
+  {
     "metadata-version" : "1.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/exposed/exposed-core/$version$/exposed-core-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/Exposed",

--- a/metadata/org.jetbrains.exposed/exposed-core/index.json
+++ b/metadata/org.jetbrains.exposed/exposed-core/index.json
@@ -20,6 +20,11 @@
   },
   {
     "metadata-version" : "1.1.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/exposed/exposed-core/$version$/exposed-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/JetBrains/Exposed",
+    "test-code-url" : "https://github.com/JetBrains/Exposed/tree/$version$/exposed-tests/src/test",
+    "documentation-url" : "https://github.com/JetBrains/Exposed/blob/$version$/docs/api/exposed-core/index.html",
+    "description" : "Exposed Core is the base module of JetBrains Exposed, a Kotlin SQL/ORM framework for building type-safe database code. It provides the SQL DSL primitives, schema and table model, expressions, statements, and dialect abstractions used by Exposed's JDBC, R2DBC, and DAO modules.",
     "language" : {
       "name" : "kotlin",
       "version" : "2.0"

--- a/stats/org.jetbrains.exposed/exposed-core/1.1.1/execution-metrics.json
+++ b/stats/org.jetbrains.exposed/exposed-core/1.1.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T10:15:11.275617Z",
+    "library": "org.jetbrains.exposed:exposed-core:1.1.1",
+    "starting_commit": "1c03499c4ff053f708f7d841157a7834d12d22f8",
+    "ending_commit": "1bcfcc76bbcef6543aa0ea39607e5393a7383e36",
+    "previous_library": "org.jetbrains.exposed:exposed-core:1.0.0-beta-4",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.1.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4336,
+          "missed": 54430,
+          "ratio": 0.073784,
+          "total": 58766
+        },
+        "line": {
+          "covered": 699,
+          "missed": 7305,
+          "ratio": 0.087331,
+          "total": 8004
+        },
+        "method": {
+          "covered": 322,
+          "missed": 3099,
+          "ratio": 0.094125,
+          "total": 3421
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.0.0-beta-4",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4466,
+          "missed": 50240,
+          "ratio": 0.081636,
+          "total": 54706
+        },
+        "line": {
+          "covered": 710,
+          "missed": 6615,
+          "ratio": 0.096928,
+          "total": 7325
+        },
+        "method": {
+          "covered": 339,
+          "missed": 2727,
+          "ratio": 0.110568,
+          "total": 3066
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 47361,
+      "cached_input_tokens_used": 231936,
+      "output_tokens_used": 2965,
+      "iterations": 1,
+      "cost_usd": 0.205,
+      "tested_library_loc": 699,
+      "metadata_entries": 5,
+      "previous_library_metadata_entries": 5,
+      "code_coverage_percent": 8.73,
+      "previous_library_coverage_percent": 9.69
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jetbrains.exposed/exposed-core/1.1.1/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt",
+      "metadata_file": "metadata/org.jetbrains.exposed/exposed-core/1.1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jetbrains.exposed/exposed-core/1.1.1/stats.json
+++ b/stats/org.jetbrains.exposed/exposed-core/1.1.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.1.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 4336,
+        "missed" : 54430,
+        "ratio" : 0.073784,
+        "total" : 58766
+      },
+      "line" : {
+        "covered" : 699,
+        "missed" : 7305,
+        "ratio" : 0.087331,
+        "total" : 8004
+      },
+      "method" : {
+        "covered" : 322,
+        "missed" : 3099,
+        "ratio" : 0.094125,
+        "total" : 3421
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/.gitignore
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/gradle.properties
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jetbrains.exposed:exposed-core:1.1.1
+library.version = 1.1.1
+metadata.dir = org.jetbrains.exposed/exposed-core/1.1.1/

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/settings.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jetbrains.exposed.exposed-core_tests'

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -16,17 +16,26 @@ import org.jetbrains.exposed.v1.core.Index
 import org.jetbrains.exposed.v1.core.Join
 import org.jetbrains.exposed.v1.core.QueryBuilder
 import org.jetbrains.exposed.v1.core.Schema
-import org.jetbrains.exposed.v1.core.SqlExpressionBuilder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.Version
 import org.jetbrains.exposed.v1.core.WindowFrameBound
 import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.append
+import org.jetbrains.exposed.v1.core.case
+import org.jetbrains.exposed.v1.core.coalesce
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.intLiteral
 import org.jetbrains.exposed.v1.core.intParam
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.rem
+import org.jetbrains.exposed.v1.core.rowNumber
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.core.stringParam
+import org.jetbrains.exposed.v1.core.times
 import org.jetbrains.exposed.v1.exceptions.DuplicateColumnException
 import org.junit.jupiter.api.Test
 
@@ -143,39 +152,31 @@ public class ExposedCoreTest {
 
     @Test
     fun expressionDslBuildsComparisonListsAliasesCasesAndWindows(): Unit {
-        val comparison = with(SqlExpressionBuilder) {
-            (intLiteral(1) less intLiteral(3)) and (stringLiteral("kotlin") like "kot%")
-        }
+        val comparison = (intLiteral(1) less intLiteral(3)) and (stringLiteral("kotlin") like "kot%")
         assertThat(comparison.toString()).isEqualTo("(1 < 3) AND ('kotlin' LIKE 'kot%')")
 
-        val inList = with(SqlExpressionBuilder) { intLiteral(2) inList listOf(3, 1, 2) }
+        val inList = intLiteral(2) inList listOf(3, 1, 2)
         assertThat(inList.toString()).isEqualTo("2 IN (3, 1, 2)")
 
-        val arithmetic = with(SqlExpressionBuilder) { ((intLiteral(5) + 4) * intLiteral(2)) % 3 }
+        val arithmetic = ((intLiteral(5) + 4) * intLiteral(2)) % 3
         assertThat(arithmetic.toString()).isEqualTo("(((5 + 4) * 2) % 3)")
 
-        val caseExpression = with(SqlExpressionBuilder) {
-            case()
-                .When(intLiteral(1) eq 1, stringLiteral("one"))
-                .Else(stringLiteral("other"))
-        }
+        val caseExpression = case()
+            .When(intLiteral(1) eq 1, stringLiteral("one"))
+            .Else(stringLiteral("other"))
         assertThat(caseExpression.toString()).isEqualTo("CASE WHEN 1 = 1 THEN 'one' ELSE 'other' END")
 
-        val coalesced = with(SqlExpressionBuilder) {
-            coalesce(stringLiteral("primary"), stringLiteral("fallback"), stringLiteral("last"))
-        }
+        val coalesced = coalesce(stringLiteral("primary"), stringLiteral("fallback"), stringLiteral("last"))
         assertThat(coalesced.toString()).isEqualTo("COALESCE('primary', 'fallback', 'last')")
 
         val aliased = intLiteral(10).alias("ten")
         assertThat(aliased.toString()).isEqualTo("10 ten")
         assertThat(aliased.aliasOnlyExpression().toString()).isEqualTo("ten")
 
-        val window = with(SqlExpressionBuilder) {
-            rowNumber()
-                .over()
-                .partitionBy(stringLiteral("partition"))
-                .rows(WindowFrameBound.unboundedPreceding())
-        }
+        val window = rowNumber()
+            .over()
+            .partitionBy(stringLiteral("partition"))
+            .rows(WindowFrameBound.unboundedPreceding())
         assertThat(window.toString()).isEqualTo("ROW_NUMBER() OVER(PARTITION BY 'partition' ROWS UNBOUNDED PRECEDING)")
     }
 

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/src/test/kotlin/org_jetbrains_exposed/exposed_core/Exposed_coreTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_exposed.exposed_core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.exposed.v1.core.Alias
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.DatabaseConfig
+import org.jetbrains.exposed.v1.core.ExperimentalKeywordApi
+import org.jetbrains.exposed.v1.core.Index
+import org.jetbrains.exposed.v1.core.Join
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Schema
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Version
+import org.jetbrains.exposed.v1.core.WindowFrameBound
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.append
+import org.jetbrains.exposed.v1.core.intLiteral
+import org.jetbrains.exposed.v1.core.intParam
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.stringParam
+import org.jetbrains.exposed.v1.exceptions.DuplicateColumnException
+import org.junit.jupiter.api.Test
+
+public class ExposedCoreTest {
+    @Test
+    fun tableMetadataTracksColumnsKeysReferencesAndAliases(): Unit {
+        assertThat(Users.tableName).isEqualTo("app.users")
+        assertThat(Users.schemaName).isEqualTo("app")
+        assertThat(Users.columns.map { it.name })
+            .containsExactly("id", "email", "display_name", "status", "score", "active", "generated_token")
+        val primaryKeyColumns: List<Column<*>> = requireNotNull(Users.primaryKey).columns.toList()
+        assertThat(primaryKeyColumns).containsExactly(Users.id)
+        assertThat(Users.autoIncColumn).isEqualTo(Users.id)
+
+        val emailIndex: Index = Users.indices.single()
+        assertThat(emailIndex.customName).isEqualTo("ux_users_email")
+        assertThat(emailIndex.unique).isTrue()
+        assertThat(emailIndex.columns).containsExactly(Users.email)
+
+        assertThat(Memberships.user.referee).isEqualTo(Users.id)
+        assertThat(Memberships.group.referee).isEqualTo(Groups.id)
+        assertThat(Memberships.foreignKeys).hasSize(2)
+
+        val userAlias: Alias<Users> = Users.alias("u")
+        val aliasedEmail: Column<String> = userAlias[Users.email]
+        assertThat(userAlias.tableName).isEqualTo("u")
+        assertThat(userAlias.tableNameWithAlias).isEqualTo("app.users u")
+        assertThat(aliasedEmail.name).isEqualTo(Users.email.name)
+        assertThat(aliasedEmail.table).isEqualTo(userAlias)
+        assertThat(userAlias.originalColumn(aliasedEmail)).isEqualTo(Users.email)
+    }
+
+    @Test
+    fun joinsInferForeignKeysAndExposeCombinedFieldSets(): Unit {
+        val userMembershipJoin: Join = Users.innerJoin(Memberships)
+
+        assertThat(userMembershipJoin.columns).containsExactlyElementsOf(Users.columns + Memberships.columns)
+        assertThat(userMembershipJoin.fields).containsExactlyElementsOf(Users.fields + Memberships.fields)
+        assertThat(userMembershipJoin.alreadyInJoin(Memberships)).isTrue()
+        assertThat(userMembershipJoin.alreadyInJoin(Groups)).isFalse()
+
+        val userMembershipGroupJoin: Join = userMembershipJoin.innerJoin(Groups)
+
+        assertThat(userMembershipGroupJoin.columns)
+            .containsExactlyElementsOf(Users.columns + Memberships.columns + Groups.columns)
+        assertThat(userMembershipGroupJoin.fields)
+            .containsExactlyElementsOf(Users.fields + Memberships.fields + Groups.fields)
+        assertThat(userMembershipGroupJoin.alreadyInJoin(Memberships)).isTrue()
+        assertThat(userMembershipGroupJoin.alreadyInJoin(Groups)).isTrue()
+    }
+
+    @Test
+    fun duplicateColumnNamesAreRejected(): Unit {
+        val table: Table = Table("duplicate_columns")
+        table.integer("id")
+
+        assertThatThrownBy { table.varchar("id", 16) }
+            .isInstanceOf(DuplicateColumnException::class.java)
+            .hasMessageContaining("id")
+            .hasMessageContaining("duplicate_columns")
+    }
+
+    @Test
+    fun columnDefaultsNullabilityAndGeneratedFlagsAreTracked(): Unit {
+        assertThat(Users.email.defaultValueFun == null).isTrue()
+        assertThat(Users.email.defaultValueInDb() == null).isTrue()
+        assertThat(Users.email.columnType.nullable).isFalse()
+
+        assertThat(Users.displayName.columnType.nullable).isTrue()
+        assertThat(Users.status.defaultValueFun?.invoke()).isEqualTo("active")
+        assertThat(Users.status.defaultValueInDb().toString()).isEqualTo("'active'")
+        assertThat(Users.score.defaultValueFun?.invoke()).isEqualTo(7)
+        assertThat(Users.score.defaultValueInDb() == null).isTrue()
+        assertThat(Users.active.defaultValueFun?.invoke()).isTrue()
+        assertThat(Users.active.defaultValueInDb()).isNotNull()
+
+        Users.generatedToken.defaultValueFun?.invoke().let { value: String? ->
+            assertThat(value).isEqualTo("generated")
+        }
+        assertThat(Users.generatedToken.isDatabaseGenerated()).isTrue()
+    }
+
+    @Test
+    fun columnTypesValidateAndFormatValues(): Unit {
+        assertThat(Users.id.columnType.valueFromDB("42")).isEqualTo(42)
+        assertThat(Users.email.columnType.valueFromDB(byteArrayOf(65, 66, 67))).isEqualTo("ABC")
+        assertThat(Users.email.columnType.valueToString("O'Reilly\nGuide")).isEqualTo("'O''Reilly\\nGuide'")
+        assertThat(Users.displayName.columnType.valueToString(null)).isEqualTo("NULL")
+
+        Users.email.columnType.validateValueBeforeUpdate("short@example.org")
+        assertThatThrownBy { Users.email.columnType.validateValueBeforeUpdate("x".repeat(129)) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("exceeds length")
+
+        assertThatThrownBy { Users.email.columnType.valueToString(null) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("NULL in non-nullable column")
+    }
+
+    @Test
+    fun queryBuilderFormatsInlineSqlAndPreparedArguments(): Unit {
+        val inlineBuilder: QueryBuilder = QueryBuilder(prepared = false)
+        inlineBuilder.append(intLiteral(42), ", ", stringLiteral("O'Reilly"))
+
+        assertThat(inlineBuilder.toString()).isEqualTo("42, 'O''Reilly'")
+        assertThat(inlineBuilder.args).isEmpty()
+
+        val preparedBuilder: QueryBuilder = QueryBuilder(prepared = true)
+        preparedBuilder.append(intParam(7), ", ", stringParam("alpha"))
+
+        assertThat(preparedBuilder.toString()).isEqualTo("?, ?")
+        assertThat(preparedBuilder.args.map { it.second }).containsExactly(7, "alpha")
+    }
+
+    @Test
+    fun expressionDslBuildsComparisonListsAliasesCasesAndWindows(): Unit {
+        val comparison = with(SqlExpressionBuilder) {
+            (intLiteral(1) less intLiteral(3)) and (stringLiteral("kotlin") like "kot%")
+        }
+        assertThat(comparison.toString()).isEqualTo("(1 < 3) AND ('kotlin' LIKE 'kot%')")
+
+        val inList = with(SqlExpressionBuilder) { intLiteral(2) inList listOf(3, 1, 2) }
+        assertThat(inList.toString()).isEqualTo("2 IN (3, 1, 2)")
+
+        val arithmetic = with(SqlExpressionBuilder) { ((intLiteral(5) + 4) * intLiteral(2)) % 3 }
+        assertThat(arithmetic.toString()).isEqualTo("(((5 + 4) * 2) % 3)")
+
+        val caseExpression = with(SqlExpressionBuilder) {
+            case()
+                .When(intLiteral(1) eq 1, stringLiteral("one"))
+                .Else(stringLiteral("other"))
+        }
+        assertThat(caseExpression.toString()).isEqualTo("CASE WHEN 1 = 1 THEN 'one' ELSE 'other' END")
+
+        val coalesced = with(SqlExpressionBuilder) {
+            coalesce(stringLiteral("primary"), stringLiteral("fallback"), stringLiteral("last"))
+        }
+        assertThat(coalesced.toString()).isEqualTo("COALESCE('primary', 'fallback', 'last')")
+
+        val aliased = intLiteral(10).alias("ten")
+        assertThat(aliased.toString()).isEqualTo("10 ten")
+        assertThat(aliased.aliasOnlyExpression().toString()).isEqualTo("ten")
+
+        val window = with(SqlExpressionBuilder) {
+            rowNumber()
+                .over()
+                .partitionBy(stringLiteral("partition"))
+                .rows(WindowFrameBound.unboundedPreceding())
+        }
+        assertThat(window.toString()).isEqualTo("ROW_NUMBER() OVER(PARTITION BY 'partition' ROWS UNBOUNDED PRECEDING)")
+    }
+
+    @Test
+    fun versionParsingComparesSemanticComponents(): Unit {
+        val version: Version = Version.from("1.2.0-beta-4")
+
+        assertThat(version.toString()).isEqualTo("1.2.0")
+        assertThat(version.covers("1.1.9")).isTrue()
+        assertThat(version.covers("1.2.0")).isTrue()
+        assertThat(version.covers("1.2.1")).isFalse()
+        assertThat(Version.from("2").covers(1, 9, 9)).isTrue()
+    }
+
+    @Test
+    @OptIn(ExperimentalKeywordApi::class)
+    fun databaseConfigBuilderAppliesDefaultsCustomizationsAndValidation(): Unit {
+        val defaultConfig: DatabaseConfig = DatabaseConfig()
+
+        assertThat(defaultConfig.useNestedTransactions).isFalse()
+        assertThat(defaultConfig.defaultFetchSize).isNull()
+        assertThat(defaultConfig.defaultIsolationLevel).isEqualTo(-1)
+        assertThat(defaultConfig.defaultMaxAttempts).isEqualTo(3)
+        assertThat(defaultConfig.defaultMinRetryDelay).isZero()
+        assertThat(defaultConfig.defaultMaxRetryDelay).isZero()
+        assertThat(defaultConfig.defaultReadOnly).isFalse()
+        assertThat(defaultConfig.warnLongQueriesDuration).isNull()
+        assertThat(defaultConfig.maxEntitiesToStoreInCachePerEntity).isEqualTo(Int.MAX_VALUE)
+        assertThat(defaultConfig.keepLoadedReferencesOutOfTransaction).isFalse()
+        assertThat(defaultConfig.explicitDialect).isNull()
+        assertThat(defaultConfig.defaultSchema).isNull()
+        assertThat(defaultConfig.logTooMuchResultSetsThreshold).isZero()
+        assertThat(defaultConfig.preserveKeywordCasing).isTrue()
+
+        val schema = Schema("analytics")
+        val customConfig: DatabaseConfig = DatabaseConfig {
+            useNestedTransactions = true
+            defaultFetchSize = 64
+            defaultIsolationLevel = 8
+            defaultMaxAttempts = 2
+            defaultMinRetryDelay = 10L
+            defaultMaxRetryDelay = 20L
+            defaultReadOnly = true
+            warnLongQueriesDuration = 250L
+            maxEntitiesToStoreInCachePerEntity = 5
+            keepLoadedReferencesOutOfTransaction = true
+            defaultSchema = schema
+            logTooMuchResultSetsThreshold = 3
+            preserveKeywordCasing = false
+        }
+
+        assertThat(customConfig.useNestedTransactions).isTrue()
+        assertThat(customConfig.defaultFetchSize).isEqualTo(64)
+        assertThat(customConfig.defaultIsolationLevel).isEqualTo(8)
+        assertThat(customConfig.defaultMaxAttempts).isEqualTo(2)
+        assertThat(customConfig.defaultMinRetryDelay).isEqualTo(10L)
+        assertThat(customConfig.defaultMaxRetryDelay).isEqualTo(20L)
+        assertThat(customConfig.defaultReadOnly).isTrue()
+        assertThat(customConfig.warnLongQueriesDuration).isEqualTo(250L)
+        assertThat(customConfig.maxEntitiesToStoreInCachePerEntity).isEqualTo(5)
+        assertThat(customConfig.keepLoadedReferencesOutOfTransaction).isTrue()
+        assertThat(customConfig.defaultSchema).isEqualTo(schema)
+        assertThat(customConfig.logTooMuchResultSetsThreshold).isEqualTo(3)
+        assertThat(customConfig.preserveKeywordCasing).isFalse()
+
+        assertThatThrownBy { DatabaseConfig { defaultMaxAttempts = 0 } }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("defaultMaxAttempts")
+    }
+}
+
+private object Users : Table("app.users") {
+    val id = integer("id").autoIncrement()
+    val email = varchar("email", 128).uniqueIndex("ux_users_email")
+    val displayName = varchar("display_name", 64).nullable()
+    val status = varchar("status", 32).default("active")
+    val score = integer("score").clientDefault { 7 }
+    val active = bool("active").default(true)
+    val generatedToken = varchar("generated_token", 32).clientDefault { "generated" }.databaseGenerated()
+
+    override val primaryKey = PrimaryKey(id, name = "pk_users")
+}
+
+private object Groups : Table("groups") {
+    val id = integer("id")
+    val name = varchar("name", 80)
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+private object Memberships : Table("memberships") {
+    val user = reference("user_id", Users.id)
+    val group = reference("group_id", Groups.id)
+    val role = varchar("role", 32).default("member")
+
+    override val primaryKey = PrimaryKey(user, group, name = "pk_memberships")
+}

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/user-code-filter.json
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.jetbrains.exposed.v1.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_exposed.exposed_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6317

This PR provides test fixes and new metadata for org.jetbrains.exposed:exposed-core:1.1.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 47361
- Cached input tokens: 231936
- Output tokens: 2965
- Metadata entries: 5
- Iterations: 1
- Library coverage percentage: 8.73
- Previous library version metadata entries: 5
- Previous library version coverage percentage: 9.69

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `160aed90b40aa9bf0ba96b851cfe0d77487212f0`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jetbrains.exposed:exposed-core:1.0.0-beta-4: 0/0 covered calls (100.00%)
- org.jetbrains.exposed:exposed-core:1.1.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jetbrains.exposed:exposed-core:1.0.0-beta-4: 4466/54706 (8.16%)
- org.jetbrains.exposed:exposed-core:1.1.1: 4336/58766 (7.38%)

**Line:**
- org.jetbrains.exposed:exposed-core:1.0.0-beta-4: 710/7325 (9.69%)
- org.jetbrains.exposed:exposed-core:1.1.1: 699/8004 (8.73%)

**Method:**
- org.jetbrains.exposed:exposed-core:1.0.0-beta-4: 339/3066 (11.06%)
- org.jetbrains.exposed:exposed-core:1.1.1: 322/3421 (9.41%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
