### PR TITLE
[GenAI] Test fix for org.apache.maven.surefire:surefire-api:3.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
@@ -1,0 +1,194 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.shared.utils.io.DirectoryScanner"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setSkipAfterFailureCount",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setSystemExitTimeout",
+          "parameterTypes": [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name": "setTestArtifactInfo",
+          "parameterTypes": [
+            "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.cli.CommandLineOption"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.provider.ProviderParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.report.ReporterConfiguration"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.report.ReporterFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods": [
+        {
+          "name": "getName",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.suite.RunResult",
+      "methods": [
+        {
+          "name": "getCompletedCount",
+          "parameterTypes": []
+        },
+        {
+          "name": "getErrors",
+          "parameterTypes": []
+        },
+        {
+          "name": "getFailures",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSkipped",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.suite.RunResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.RunOrderParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestListResolver"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      },
+      "type": "org.apache.maven.surefire.api.testset.TestRequest"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      },
+      "type": "org.apache.maven.surefire.api.util.DefaultScanResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      },
+      "type": "org.apache.maven.surefire.api.util.TestsToRun"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest$NoArgValue"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type": "org_apache_maven_surefire.surefire_api.SurefireReflectorTest$RecordingProvider"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json
@@ -1,194 +1,182 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultScanResult"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.shared.utils.io.DirectoryScanner"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.shared.utils.io.DirectoryScanner"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.booter.BaseProviderFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "boolean"
           ]
         },
         {
-          "name": "setSkipAfterFailureCount",
-          "parameterTypes": [
+          "name" : "setSkipAfterFailureCount",
+          "parameterTypes" : [
             "int"
           ]
         },
         {
-          "name": "setSystemExitTimeout",
-          "parameterTypes": [
+          "name" : "setSystemExitTimeout",
+          "parameterTypes" : [
             "java.lang.Integer"
           ]
         },
         {
-          "name": "setTestArtifactInfo",
-          "parameterTypes": [
+          "name" : "setTestArtifactInfo",
+          "parameterTypes" : [
             "org.apache.maven.surefire.api.testset.TestArtifactInfo"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.booter.BaseProviderFactory"
+      "type" : "org.apache.maven.surefire.api.booter.BaseProviderFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.cli.CommandLineOption"
+      "type" : "org.apache.maven.surefire.api.cli.CommandLineOption"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.filter.SpecificTestClassFilter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String[]"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.provider.ProviderParameters"
+      "type" : "org.apache.maven.surefire.api.provider.ProviderParameters"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.report.ReporterConfiguration"
+      "type" : "org.apache.maven.surefire.api.report.ReporterConfiguration"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.report.ReporterFactory"
+      "type" : "org.apache.maven.surefire.api.report.ReporterFactory"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.report.SimpleReportEntry",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.report.SimpleReportEntry",
+      "methods" : [
         {
-          "name": "getName",
-          "parameterTypes": []
+          "name" : "getName",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.suite.RunResult",
-      "methods": [
+      "type" : "org.apache.maven.surefire.api.suite.RunResult",
+      "methods" : [
         {
-          "name": "getCompletedCount",
-          "parameterTypes": []
+          "name" : "getCompletedCount",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getErrors",
-          "parameterTypes": []
+          "name" : "getErrors",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getFailures",
-          "parameterTypes": []
+          "name" : "getFailures",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getSkipped",
-          "parameterTypes": []
+          "name" : "getSkipped",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.suite.RunResult"
+      "type" : "org.apache.maven.surefire.api.suite.RunResult"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
+      "type" : "org.apache.maven.surefire.api.testset.DirectoryScannerParameters"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.RunOrderParameters"
+      "type" : "org.apache.maven.surefire.api.testset.RunOrderParameters"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestArtifactInfo"
+      "type" : "org.apache.maven.surefire.api.testset.TestArtifactInfo"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestListResolver"
+      "type" : "org.apache.maven.surefire.api.testset.TestListResolver"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.booter.SurefireReflector"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector"
       },
-      "type": "org.apache.maven.surefire.api.testset.TestRequest"
+      "type" : "org.apache.maven.surefire.api.testset.TestRequest"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultScanResult"
       },
-      "type": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "type" : "org.apache.maven.surefire.api.util.DefaultScanResult"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.DefaultScanResult"
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.DefaultScanResult"
       },
-      "type": "org.apache.maven.surefire.api.util.TestsToRun"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
-      },
-      "type": "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest$NoArgValue"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.surefire.api.util.ReflectionUtils"
-      },
-      "type": "org_apache_maven_surefire.surefire_api.SurefireReflectorTest$RecordingProvider"
+      "type" : "org.apache.maven.surefire.api.util.TestsToRun"
     }
   ]
 }

--- a/metadata/org.apache.maven.surefire/surefire-api/index.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/index.json
@@ -14,5 +14,15 @@
       "org.apache.maven.plugin.surefire.runorder",
       "org.apache.maven.surefire"
     ]
+  },
+  {
+    "metadata-version" : "3.0.0",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.plugin.surefire.runorder",
+      "org.apache.maven.surefire"
+    ]
   }
 ]

--- a/metadata/org.apache.maven.surefire/surefire-api/index.json
+++ b/metadata/org.apache.maven.surefire/surefire-api/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/$version$/surefire-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-surefire",
+    "test-code-url" : "https://github.com/apache/maven-surefire/tree/surefire-$version$/surefire-api/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/$version$/surefire-api-$version$-javadoc.jar",
+    "description" : "Apache Maven Surefire API provides the shared provider, reporting, booter, scanning, and test-set interfaces used by Maven Surefire and Failsafe components. It supports executing and reporting tests in Maven-based JVM builds by exposing common contracts that Surefire plugins, booters, and test framework providers use.",
     "tested-versions" : [
       "3.0.0"
     ],

--- a/stats/org.apache.maven.surefire/surefire-api/3.0.0/execution-metrics.json
+++ b/stats/org.apache.maven.surefire/surefire-api/3.0.0/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T11:34:10.670069Z",
+    "library": "org.apache.maven.surefire:surefire-api:3.0.0",
+    "starting_commit": "a1341883bdb2d8d92af2a7b5fe333e5fc033e319",
+    "ending_commit": "fc353169b3351f73632ec071397e87429290dce1",
+    "previous_library": "org.apache.maven.surefire:surefire-api:2.22.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 14,
+            "totalCalls": 14
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 14,
+        "totalCalls": 14
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 898,
+          "missed": 9990,
+          "ratio": 0.082476,
+          "total": 10888
+        },
+        "line": {
+          "covered": 218,
+          "missed": 2178,
+          "ratio": 0.090985,
+          "total": 2396
+        },
+        "method": {
+          "covered": 75,
+          "missed": 690,
+          "ratio": 0.098039,
+          "total": 765
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.22.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 60,
+            "totalCalls": 60
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 60,
+        "totalCalls": 60
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2372,
+          "missed": 13019,
+          "ratio": 0.154116,
+          "total": 15391
+        },
+        "line": {
+          "covered": 472,
+          "missed": 2797,
+          "ratio": 0.144387,
+          "total": 3269
+        },
+        "method": {
+          "covered": 104,
+          "missed": 662,
+          "ratio": 0.13577,
+          "total": 766
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 144137,
+      "cached_input_tokens_used": 3234304,
+      "output_tokens_used": 19866,
+      "iterations": 3,
+      "cost_usd": 2.2132,
+      "tested_library_loc": 218,
+      "metadata_entries": 30,
+      "test_only_metadata_entries": 3,
+      "previous_library_metadata_entries": 53,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 9.1,
+      "previous_library_coverage_percent": 14.44
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java",
+      "metadata_file": "metadata/org.apache.maven.surefire/surefire-api/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.surefire/surefire-api/3.0.0/stats.json
+++ b/stats/org.apache.maven.surefire/surefire-api/3.0.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 14,
+          "totalCalls" : 14
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 14,
+      "totalCalls" : 14
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 898,
+        "missed" : 9990,
+        "ratio" : 0.082476,
+        "total" : 10888
+      },
+      "line" : {
+        "covered" : 218,
+        "missed" : 2178,
+        "ratio" : 0.090985,
+        "total" : 2396
+      },
+      "method" : {
+        "covered" : 75,
+        "missed" : 690,
+        "ratio" : 0.098039,
+        "total" : 765
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/.gitignore
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-booter:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-shared-utils:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/gradle.properties
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.surefire:surefire-api:3.0.0
+library.version = 3.0.0
+metadata.dir = org.apache.maven.surefire/surefire-api/3.0.0/

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/settings.gradle
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.surefire.surefire-api_tests'

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.maven.surefire.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.util.TestsToRun;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class DefaultDirectoryScannerTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    public void locatesScannedTestClassesThroughTheSuppliedClassLoader() throws IOException {
+        final Path classFile = temporaryDirectory.resolve(
+                DefaultDirectoryScannerTest.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, new byte[0]);
+
+        final DefaultDirectoryScanner scanner = new DefaultDirectoryScanner(
+                temporaryDirectory.toFile(),
+                Collections.singletonList("**/*Test.class"),
+                Collections.singletonList("**/*Ignored.class"),
+                Collections.singletonList("**/DefaultDirectoryScannerTest.java"));
+
+        final TestsToRun tests = scanner.locateTestClasses(
+                DefaultDirectoryScannerTest.class.getClassLoader(),
+                testClass -> testClass == DefaultDirectoryScannerTest.class);
+
+        assertThat(tests.getLocatedClasses()).containsExactly(DefaultDirectoryScannerTest.class);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -13,8 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.apache.maven.surefire.util.DefaultDirectoryScanner;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.maven.surefire.util.DefaultScanResult;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultScanResult;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 
 public class DefaultScanResultTest {

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.surefire.util.DefaultScanResult;
+import org.apache.maven.surefire.util.TestsToRun;
+import org.junit.jupiter.api.Test;
+
+public class DefaultScanResultTest {
+
+    @Test
+    public void appliesFilterAfterLoadingEachScannedClassByName() {
+        final ClassLoader classLoader = DefaultScanResultTest.class.getClassLoader();
+        final DefaultScanResult scanResult = new DefaultScanResult(Arrays.asList(
+                DefaultScanResult.class.getName(),
+                TestsToRun.class.getName()));
+
+        final TestsToRun acceptedClasses = scanResult.applyFilter(
+                testClass -> testClass == DefaultScanResult.class,
+                classLoader);
+        final List<Class<?>> rejectedClasses = scanResult.getClassesSkippedByValidation(
+                testClass -> testClass == DefaultScanResult.class,
+                classLoader);
+
+        assertThat(acceptedClasses.getLocatedClasses()).containsExactly(DefaultScanResult.class);
+        assertThat(rejectedClasses).containsExactly(TestsToRun.class);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Java7SupportTest {
+
+    @Test
+    public void symbolicLinkLifecycleUsesJava7SupportOperations(@TempDir final Path tempDirectory) throws IOException {
+        final Path target = tempDirectory.resolve("target.txt");
+        final Path link = tempDirectory.resolve("link.txt");
+        Files.write(target, "surefire".getBytes(StandardCharsets.UTF_8));
+
+        final Thread currentThread = Thread.currentThread();
+        final ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(Java7SupportTest.class.getClassLoader());
+        try {
+            assertThat(Java7Support.isAtLeastJava7()).isTrue();
+            assertThat(Java7Support.exists(link.toFile())).isFalse();
+
+            final File createdLink = Java7Support.createSymbolicLink(link.toFile(), target.toFile());
+
+            assertThat(createdLink).isEqualTo(link.toFile());
+            assertThat(Java7Support.exists(createdLink)).isTrue();
+            assertThat(Java7Support.isSymLink(createdLink)).isTrue();
+            assertThat(Java7Support.readSymbolicLink(createdLink)).isEqualTo(target.toFile());
+            assertThat(new String(Files.readAllBytes(link), StandardCharsets.UTF_8)).isEqualTo("surefire");
+
+            Java7Support.delete(createdLink);
+
+            assertThat(Java7Support.exists(createdLink)).isFalse();
+            assertThat(Files.exists(target)).isTrue();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.maven.surefire.SpecificTestClassFilter;
+import org.apache.maven.surefire.report.SimpleReportEntry;
+import org.apache.maven.surefire.testset.TestArtifactInfo;
+import org.apache.maven.surefire.util.ReflectionUtils;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionUtilsTest {
+
+    @Test
+    public void loadsClassesByNameThroughTheSuppliedClassLoader() {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+
+        assertThat(ReflectionUtils.tryLoadClass(classLoader, SimpleReportEntry.class.getName()))
+                .isEqualTo(SimpleReportEntry.class);
+        assertThat(ReflectionUtils.loadClass(classLoader, TestArtifactInfo.class.getName()))
+                .isEqualTo(TestArtifactInfo.class);
+    }
+
+    @Test
+    public void instantiatesClassesWithSupportedConstructorShapes() {
+        final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+
+        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
+                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
+                classLoader,
+                SpecificTestClassFilter.class.getName(),
+                String[].class,
+                new String[] {ReflectionUtilsTest.class.getName()});
+        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
+                classLoader,
+                TestArtifactInfo.class.getName(),
+                String.class,
+                "provider-version",
+                String.class,
+                "tests");
+        final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
+                TestArtifactInfo.class.getName(),
+                new Class[] {String.class, String.class},
+                new Object[] {"provider-version", "main"},
+                classLoader);
+
+        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
+        assertThat(twoArgArtifact)
+                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
+                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
+                    assertThat(artifact.getClassifier()).isEqualTo("tests");
+                });
+        assertThat(newInstanceArtifact)
+                .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
+                    assertThat(artifact.getVersion()).isEqualTo("provider-version");
+                    assertThat(artifact.getClassifier()).isEqualTo("main");
+                });
+    }
+
+    @Test
+    public void findsAndInvokesPublicMethods() throws InvocationTargetException {
+        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+
+        final Method getName = ReflectionUtils.getMethod(entry, "getName");
+        final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
+
+        assertThat(getSourceName).isNotNull();
+        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
+        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -8,52 +8,57 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.maven.surefire.SpecificTestClassFilter;
-import org.apache.maven.surefire.report.SimpleReportEntry;
-import org.apache.maven.surefire.testset.TestArtifactInfo;
-import org.apache.maven.surefire.util.ReflectionUtils;
+import org.apache.maven.surefire.api.filter.SpecificTestClassFilter;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
+import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilsTest {
 
     @Test
-    public void loadsClassesByNameThroughTheSuppliedClassLoader() {
+    public void loadsClassesByNameThroughTheSuppliedClassLoader() throws ReflectiveOperationException {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+        final NoArgValue source = new NoArgValue();
 
         assertThat(ReflectionUtils.tryLoadClass(classLoader, SimpleReportEntry.class.getName()))
                 .isEqualTo(SimpleReportEntry.class);
         assertThat(ReflectionUtils.loadClass(classLoader, TestArtifactInfo.class.getName()))
                 .isEqualTo(TestArtifactInfo.class);
+        assertThat(ReflectionUtils.reloadClass(classLoader, source)).isEqualTo(NoArgValue.class);
     }
 
     @Test
     public void instantiatesClassesWithSupportedConstructorShapes() {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
 
-        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
-                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final NoArgValue noArgValue = ReflectionUtils.instantiate(
+                classLoader, NoArgValue.class.getName(), NoArgValue.class);
         final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
                 classLoader,
                 SpecificTestClassFilter.class.getName(),
                 String[].class,
                 new String[] {ReflectionUtilsTest.class.getName()});
-        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
-                classLoader,
-                TestArtifactInfo.class.getName(),
+        final Constructor<TestArtifactInfo> testArtifactInfoConstructor = ReflectionUtils.tryGetConstructor(
+                TestArtifactInfo.class,
                 String.class,
+                String.class);
+        final TestArtifactInfo twoArgArtifact = ReflectionUtils.newInstance(
+                testArtifactInfoConstructor,
                 "provider-version",
-                String.class,
                 "tests");
         final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
                 TestArtifactInfo.class.getName(),
-                new Class[] {String.class, String.class},
+                new Class<?>[] {String.class, String.class},
                 new Object[] {"provider-version", "main"},
                 classLoader);
 
-        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(noArgValue.value()).isEqualTo("created");
         assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
         assertThat(twoArgArtifact)
                 .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
@@ -69,14 +74,29 @@ public class ReflectionUtilsTest {
 
     @Test
     public void findsAndInvokesPublicMethods() throws InvocationTargetException {
-        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                1L,
+                "reflection-source",
+                "reflection-source-text",
+                "reflection-name",
+                "reflection-name-text");
 
         final Method getName = ReflectionUtils.getMethod(entry, "getName");
         final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
 
+        final String name = ReflectionUtils.invokeMethodWithArray(entry, getName);
+        final String sourceName = ReflectionUtils.invokeMethodWithArray2(entry, getSourceName);
+
         assertThat(getSourceName).isNotNull();
-        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
-        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(name).isEqualTo("reflection-name");
+        assertThat(sourceName).isEqualTo("reflection-source");
         assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
+    }
+
+    public static final class NoArgValue {
+        public String value() {
+            return "created";
+        }
     }
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+import org.apache.maven.surefire.booter.SurefireReflector;
+import org.junit.jupiter.api.Test;
+
+public class SurefireReflectorInnerClassLoaderProxyTest {
+
+    @Test
+    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
+        final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
+        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
+        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
+
+        final String greeting = proxy.greet("Maven Surefire");
+
+        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
+    }
+
+    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
+            throws Exception {
+        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
+                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
+        constructor.setAccessible(true);
+        return (InvocationHandler) constructor.newInstance(reflector, delegate);
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static final class GreetingDelegate implements GreetingService {
+        @Override
+        public String greet(final String name) {
+            return "Hello, " + name;
+        }
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -8,47 +8,27 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
-
+import org.apache.maven.surefire.api.suite.RunResult;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorInnerClassLoaderProxyTest {
 
     @Test
-    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
+    public void convertsRunResultLoadedThroughProviderApiTypes() {
         final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
-        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
-        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
-                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
+        final RunResult runResult = new RunResult(7, 1, 2, 3);
 
-        final String greeting = proxy.greet("Maven Surefire");
+        final Object converted = reflector.convertIfRunResult(runResult);
+        final Object unchanged = reflector.convertIfRunResult("not-a-run-result");
 
-        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
-    }
-
-    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
-            throws Exception {
-        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
-                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
-                .findFirst()
-                .orElseThrow(IllegalStateException::new);
-        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
-        constructor.setAccessible(true);
-        return (InvocationHandler) constructor.newInstance(reflector, delegate);
-    }
-
-    public interface GreetingService {
-        String greet(String name);
-    }
-
-    public static final class GreetingDelegate implements GreetingService {
-        @Override
-        public String greet(final String name) {
-            return "Hello, " + name;
-        }
+        assertThat(converted)
+                .isInstanceOfSatisfying(RunResult.class, convertedRunResult -> {
+                    assertThat(convertedRunResult.getCompletedCount()).isEqualTo(7);
+                    assertThat(convertedRunResult.getErrors()).isEqualTo(1);
+                    assertThat(convertedRunResult.getFailures()).isEqualTo(2);
+                    assertThat(convertedRunResult.getSkipped()).isEqualTo(3);
+                });
+        assertThat(unchanged).isEqualTo("not-a-run-result");
     }
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_surefire.surefire_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.booter.SurefireReflector;
+import org.junit.jupiter.api.Test;
+
+public class SurefireReflectorTest {
+
+    @Test
+    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+        final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
+        final SurefireReflector reflector = new SurefireReflector(classLoader);
+        final ConsoleLogger logger = new NullConsoleLogger();
+
+        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+
+        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
+        assertThat(decoratedLogger).isNotSameAs(logger);
+    }
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -8,22 +8,47 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
-import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
+import org.apache.maven.surefire.api.provider.ProviderParameters;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorTest {
 
     @Test
-    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+    public void constructorLoadsProviderApiTypesAndConfiguresProviderFactory() {
         final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
         final SurefireReflector reflector = new SurefireReflector(classLoader);
-        final ConsoleLogger logger = new NullConsoleLogger();
+        final TestArtifactInfo testArtifactInfo = new TestArtifactInfo("provider-version", "tests");
 
-        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+        final BaseProviderFactory providerFactory = (BaseProviderFactory) reflector.createBooterConfiguration(
+                classLoader,
+                true);
+        reflector.setTestArtifactInfoAware(providerFactory, testArtifactInfo);
+        reflector.setSkipAfterFailureCount(providerFactory, 3);
+        reflector.setSystemExitTimeout(providerFactory, 30);
+        final Object provider = reflector.instantiateProvider(RecordingProvider.class.getName(), providerFactory);
 
-        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
-        assertThat(decoratedLogger).isNotSameAs(logger);
+        assertThat(providerFactory.isInsideFork()).isTrue();
+        assertThat(providerFactory.getTestArtifactInfo().getVersion()).isEqualTo("provider-version");
+        assertThat(providerFactory.getTestArtifactInfo().getClassifier()).isEqualTo("tests");
+        assertThat(providerFactory.getSkipAfterFailureCount()).isEqualTo(3);
+        assertThat(providerFactory.getSystemExitTimeout()).isEqualTo(30);
+        assertThat(provider)
+                .isInstanceOfSatisfying(RecordingProvider.class, recordingProvider ->
+                        assertThat(recordingProvider.providerParameters()).isSameAs(providerFactory));
+    }
+
+    public static final class RecordingProvider {
+        private final ProviderParameters providerParameters;
+
+        public RecordingProvider(final ProviderParameters providerParameters) {
+            this.providerParameters = providerParameters;
+        }
+
+        public ProviderParameters providerParameters() {
+            return providerParameters;
+        }
     }
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector$ClassLoaderProxy"
+      },
+      "type" : "org_apache_maven_surefire.surefire_api.SurefireReflectorInnerClassLoaderProxyTest$GreetingDelegate"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -5,6 +5,18 @@
         "typeReached" : "org.apache.maven.surefire.booter.SurefireReflector$ClassLoaderProxy"
       },
       "type" : "org_apache_maven_surefire.surefire_api.SurefireReflectorInnerClassLoaderProxyTest$GreetingDelegate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type" : "org_apache_maven_surefire.surefire_api.ReflectionUtilsTest$NoArgValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.surefire.api.util.ReflectionUtils"
+      },
+      "type" : "org_apache_maven_surefire.surefire_api.SurefireReflectorTest$RecordingProvider"
     }
   ]
 }

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.plugin.surefire.runorder.**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.surefire.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_surefire.surefire_api.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
+++ b/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -4,10 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugin.surefire.runorder.**"
-    },
-    {
-      "includeClasses" : "org.apache.maven.surefire.**"
+      "includeClasses" : "org.apache.maven.surefire.api.**"
     },
     {
       "includeClasses" : "org_apache_maven_surefire.surefire_api.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #6311

This PR provides test fixes and new metadata for org.apache.maven.surefire:surefire-api:3.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 144137
- Cached input tokens: 3234304
- Output tokens: 19866
- Metadata entries: 30
- Test-only metadata entries: 3
- Iterations: 3
- Library coverage percentage: 9.1
- Previous library version metadata entries: 53
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 14.44

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `5227d4b6e46d7940b1da8c92398f9fe898fe71a4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.surefire:surefire-api:2.22.2: 60/60 covered calls (100.00%)
- org.apache.maven.surefire:surefire-api:3.0.0: 14/14 covered calls (100.00%)

**Reflection:**
- org.apache.maven.surefire:surefire-api:2.22.2: 60/60 covered calls (100.00%)
- org.apache.maven.surefire:surefire-api:3.0.0: 14/14 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.surefire:surefire-api:2.22.2: 2372/15391 (15.41%)
- org.apache.maven.surefire:surefire-api:3.0.0: 898/10888 (8.25%)

**Line:**
- org.apache.maven.surefire:surefire-api:2.22.2: 472/3269 (14.44%)
- org.apache.maven.surefire:surefire-api:3.0.0: 218/2396 (9.10%)

**Method:**
- org.apache.maven.surefire:surefire-api:2.22.2: 104/766 (13.58%)
- org.apache.maven.surefire:surefire-api:3.0.0: 75/765 (9.80%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/build.gradle 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
index 631fa8c973..f205df50e4 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/build.gradle
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.apache.maven.surefire:surefire-api:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-booter:$libraryVersion"
+    testImplementation "org.apache.maven.surefire:surefire-shared-utils:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
index d9e17b0bb3..b3875c090a 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultDirectoryScannerTest.java
@@ -13,8 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.apache.maven.surefire.util.DefaultDirectoryScanner;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultDirectoryScanner;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
index c7ab12f531..c127e93c19 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/DefaultScanResultTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.maven.surefire.util.DefaultScanResult;
-import org.apache.maven.surefire.util.TestsToRun;
+import org.apache.maven.surefire.api.util.DefaultScanResult;
+import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.jupiter.api.Test;
 
 public class DefaultScanResultTest {
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
index b5909e492c..ee35829f17 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/Java7SupportTest.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.maven.surefire.shade.org.apache.maven.shared.utils.io.Java7Support;
+import org.apache.maven.surefire.shared.utils.io.Java7Support;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
index 71f0ae8e35..b2a6eb2c44 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/ReflectionUtilsTest.java
@@ -8,52 +8,57 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.maven.surefire.SpecificTestClassFilter;
-import org.apache.maven.surefire.report.SimpleReportEntry;
-import org.apache.maven.surefire.testset.TestArtifactInfo;
-import org.apache.maven.surefire.util.ReflectionUtils;
+import org.apache.maven.surefire.api.filter.SpecificTestClassFilter;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
+import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilsTest {
 
     @Test
-    public void loadsClassesByNameThroughTheSuppliedClassLoader() {
+    public void loadsClassesByNameThroughTheSuppliedClassLoader() throws ReflectiveOperationException {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
+        final NoArgValue source = new NoArgValue();
 
         assertThat(ReflectionUtils.tryLoadClass(classLoader, SimpleReportEntry.class.getName()))
                 .isEqualTo(SimpleReportEntry.class);
         assertThat(ReflectionUtils.loadClass(classLoader, TestArtifactInfo.class.getName()))
                 .isEqualTo(TestArtifactInfo.class);
+        assertThat(ReflectionUtils.reloadClass(classLoader, source)).isEqualTo(NoArgValue.class);
     }
 
     @Test
     public void instantiatesClassesWithSupportedConstructorShapes() {
         final ClassLoader classLoader = ReflectionUtilsTest.class.getClassLoader();
 
-        final SimpleReportEntry noArgEntry = ReflectionUtils.instantiate(
-                classLoader, SimpleReportEntry.class.getName(), SimpleReportEntry.class);
+        final NoArgValue noArgValue = ReflectionUtils.instantiate(
+                classLoader, NoArgValue.class.getName(), NoArgValue.class);
         final Object oneArgFilter = ReflectionUtils.instantiateOneArg(
                 classLoader,
                 SpecificTestClassFilter.class.getName(),
                 String[].class,
                 new String[] {ReflectionUtilsTest.class.getName()});
-        final Object twoArgArtifact = ReflectionUtils.instantiateTwoArgs(
-                classLoader,
-                TestArtifactInfo.class.getName(),
+        final Constructor<TestArtifactInfo> testArtifactInfoConstructor = ReflectionUtils.tryGetConstructor(
+                TestArtifactInfo.class,
                 String.class,
+                String.class);
+        final TestArtifactInfo twoArgArtifact = ReflectionUtils.newInstance(
+                testArtifactInfoConstructor,
                 "provider-version",
-                String.class,
                 "tests");
         final Object newInstanceArtifact = ReflectionUtils.instantiateObject(
                 TestArtifactInfo.class.getName(),
-                new Class[] {String.class, String.class},
+                new Class<?>[] {String.class, String.class},
                 new Object[] {"provider-version", "main"},
                 classLoader);
 
-        assertThat(noArgEntry.getName()).isEqualTo("null");
+        assertThat(noArgValue.value()).isEqualTo("created");
         assertThat(oneArgFilter).isInstanceOf(SpecificTestClassFilter.class);
         assertThat(twoArgArtifact)
                 .isInstanceOfSatisfying(TestArtifactInfo.class, artifact -> {
@@ -69,14 +74,29 @@ public class ReflectionUtilsTest {
 
     @Test
     public void findsAndInvokesPublicMethods() throws InvocationTargetException {
-        final SimpleReportEntry entry = new SimpleReportEntry("reflection-source", "reflection-name");
+        final SimpleReportEntry entry = new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                1L,
+                "reflection-source",
+                "reflection-source-text",
+                "reflection-name",
+                "reflection-name-text");
 
         final Method getName = ReflectionUtils.getMethod(entry, "getName");
         final Method getSourceName = ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "getSourceName");
 
+        final String name = ReflectionUtils.invokeMethodWithArray(entry, getName);
+        final String sourceName = ReflectionUtils.invokeMethodWithArray2(entry, getSourceName);
+
         assertThat(getSourceName).isNotNull();
-        assertThat(ReflectionUtils.invokeMethodWithArray(entry, getName)).isEqualTo("reflection-name");
-        assertThat(ReflectionUtils.invokeMethodWithArray2(entry, getSourceName)).isEqualTo("reflection-source");
+        assertThat(name).isEqualTo("reflection-name");
+        assertThat(sourceName).isEqualTo("reflection-source");
         assertThat(ReflectionUtils.tryGetMethod(SimpleReportEntry.class, "missingMethod")).isNull();
     }
+
+    public static final class NoArgValue {
+        public String value() {
+            return "created";
+        }
+    }
 }
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
index c3da611e4d..c2089ac8d7 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorInnerClassLoaderProxyTest.java
@@ -8,47 +8,27 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
-
+import org.apache.maven.surefire.api.suite.RunResult;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorInnerClassLoaderProxyTest {
 
     @Test
-    public void invocationHandlerDispatchesCallsToDelegateByPublicMethodSignature() throws Exception {
+    public void convertsRunResultLoadedThroughProviderApiTypes() {
         final SurefireReflector reflector = new SurefireReflector(getClass().getClassLoader());
-        final InvocationHandler handler = newClassLoaderProxy(reflector, new GreetingDelegate());
-        final GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
-                getClass().getClassLoader(), new Class[] {GreetingService.class}, handler);
-
-        final String greeting = proxy.greet("Maven Surefire");
-
-        assertThat(greeting).isEqualTo("Hello, Maven Surefire");
-    }
-
-    private static InvocationHandler newClassLoaderProxy(final SurefireReflector reflector, final Object delegate)
-            throws Exception {
-        final Class<?> proxyClass = Arrays.stream(SurefireReflector.class.getDeclaredClasses())
-                .filter(candidate -> "ClassLoaderProxy".equals(candidate.getSimpleName()))
-                .findFirst()
-                .orElseThrow(IllegalStateException::new);
-        final Constructor<?> constructor = proxyClass.getDeclaredConstructor(SurefireReflector.class, Object.class);
-        constructor.setAccessible(true);
-        return (InvocationHandler) constructor.newInstance(reflector, delegate);
-    }
-
-    public interface GreetingService {
-        String greet(String name);
-    }
-
-    public static final class GreetingDelegate implements GreetingService {
-        @Override
-        public String greet(final String name) {
-            return "Hello, " + name;
-        }
+        final RunResult runResult = new RunResult(7, 1, 2, 3);
+
+        final Object converted = reflector.convertIfRunResult(runResult);
+        final Object unchanged = reflector.convertIfRunResult("not-a-run-result");
+
+        assertThat(converted)
+                .isInstanceOfSatisfying(RunResult.class, convertedRunResult -> {
+                    assertThat(convertedRunResult.getCompletedCount()).isEqualTo(7);
+                    assertThat(convertedRunResult.getErrors()).isEqualTo(1);
+                    assertThat(convertedRunResult.getFailures()).isEqualTo(2);
+                    assertThat(convertedRunResult.getSkipped()).isEqualTo(3);
+                });
+        assertThat(unchanged).isEqualTo("not-a-run-result");
     }
 }
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
index 6986899d6a..75950f927f 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/src/test/java/org_apache_maven_surefire/surefire_api/SurefireReflectorTest.java
@@ -8,22 +8,47 @@ package org_apache_maven_surefire.surefire_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
-import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
+import org.apache.maven.surefire.api.provider.ProviderParameters;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
 import org.apache.maven.surefire.booter.SurefireReflector;
 import org.junit.jupiter.api.Test;
 
 public class SurefireReflectorTest {
 
     @Test
-    public void constructorLoadsProviderApiTypesAndConsoleLoggerDecorator() {
+    public void constructorLoadsProviderApiTypesAndConfiguresProviderFactory() {
         final ClassLoader classLoader = SurefireReflectorTest.class.getClassLoader();
         final SurefireReflector reflector = new SurefireReflector(classLoader);
-        final ConsoleLogger logger = new NullConsoleLogger();
+        final TestArtifactInfo testArtifactInfo = new TestArtifactInfo("provider-version", "tests");
 
-        final Object decoratedLogger = reflector.createConsoleLogger(logger);
+        final BaseProviderFactory providerFactory = (BaseProviderFactory) reflector.createBooterConfiguration(
+                classLoader,
+                true);
+        reflector.setTestArtifactInfoAware(providerFactory, testArtifactInfo);
+        reflector.setSkipAfterFailureCount(providerFactory, 3);
+        reflector.setSystemExitTimeout(providerFactory, 30);
+        final Object provider = reflector.instantiateProvider(RecordingProvider.class.getName(), providerFactory);
 
-        assertThat(decoratedLogger).isInstanceOf(ConsoleLogger.class);
-        assertThat(decoratedLogger).isNotSameAs(logger);
+        assertThat(providerFactory.isInsideFork()).isTrue();
+        assertThat(providerFactory.getTestArtifactInfo().getVersion()).isEqualTo("provider-version");
+        assertThat(providerFactory.getTestArtifactInfo().getClassifier()).isEqualTo("tests");
+        assertThat(providerFactory.getSkipAfterFailureCount()).isEqualTo(3);
+        assertThat(providerFactory.getSystemExitTimeout()).isEqualTo(30);
+        assertThat(provider)
+                .isInstanceOfSatisfying(RecordingProvider.class, recordingProvider ->
+                        assertThat(recordingProvider.providerParameters()).isSameAs(providerFactory));
+    }
+
+    public static final class RecordingProvider {
+        private final ProviderParameters providerParameters;
+
+        public RecordingProvider(final ProviderParameters providerParameters) {
+            this.providerParameters = providerParameters;
+        }
+
+        public ProviderParameters providerParameters() {
+            return providerParameters;
+        }
     }
 }
diff --git 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/user-code-filter.json 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
index 0d8a97b90a..9f3439f800 100644
--- 1/tests/src/org.apache.maven.surefire/surefire-api/2.22.2/user-code-filter.json
+++ 2/tests/src/org.apache.maven.surefire/surefire-api/3.0.0/user-code-filter.json
@@ -4,10 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "org.apache.maven.plugin.surefire.runorder.**"
-    },
-    {
-      "includeClasses" : "org.apache.maven.surefire.**"
+      "includeClasses" : "org.apache.maven.surefire.api.**"
     },
     {
       "includeClasses" : "org_apache_maven_surefire.surefire_api.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
