### PR TITLE
[GenAI] Mark com.github.ghostdogpr:caliban-macros_3 as not for Native Image

### DIFF
--- a/metadata/com.github.ghostdogpr/caliban-macros_3/index.json
+++ b/metadata/com.github.ghostdogpr/caliban-macros_3/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published caliban-macros_3 2.10.0 JAR and sources JAR contain only META-INF/MANIFEST.MF and no JVM class files or sources.",
+    "replacement": "com.github.ghostdogpr:caliban_3:2.10.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #4987

This PR records `com.github.ghostdogpr:caliban-macros_3` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published caliban-macros_3 2.10.0 JAR and sources JAR contain only META-INF/MANIFEST.MF and no JVM class files or sources.

Replacement guidance:
- com.github.ghostdogpr:caliban_3:2.10.0

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
