### PR TITLE
[GenAI] Test fix for ch.qos.logback:logback-core:1.5.30 using gpt-5.5

### DIFF
--- a/metadata/ch.qos.logback/logback-core/1.5.30/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-core/1.5.30/reachability-metadata.json
@@ -1,0 +1,141 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.Loader"
+      },
+      "type": "ch.qos.logback.core.ContextBase"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "ch.qos.logback.core.model.Model",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.joran.util.AggregationAssessor"
+      },
+      "type": "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type": "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type": "ch_qos_logback.logback_core.OptionHelperTest$NamedComponent"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type": "ch_qos_logback.logback_core.OptionHelperTest$NoArgComponent"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type": "ch_qos_logback.logback_core.StringToObjectConverterTest$ValueObject"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.EnvUtil"
+      },
+      "type": "example.missing.DoesNotExist"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "java.util.AbstractList"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.ConsoleAppender"
+      },
+      "type": "org.fusesource.jansi.AnsiConsole"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.CoreVersionUtil"
+      },
+      "glob": "ch/qos/logback/core/logback-core-version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "ch.qos.logback.core.util.Loader"
+      },
+      "glob": "ch_qos_logback/logback_core/LoaderTest.class"
+    }
+  ]
+}

--- a/metadata/ch.qos.logback/logback-core/1.5.30/reachability-metadata.json
+++ b/metadata/ch.qos.logback/logback-core/1.5.30/reachability-metadata.json
@@ -1,141 +1,105 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.Loader"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.Loader"
       },
-      "type": "ch.qos.logback.core.ContextBase"
+      "type" : "ch.qos.logback.core.ContextBase"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "ch.qos.logback.core.model.Model",
-      "serializable": true
+      "type" : "ch.qos.logback.core.model.Model",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.joran.util.AggregationAssessor"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.EnvUtil"
       },
-      "type": "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+      "type" : "example.missing.DoesNotExist"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.OptionHelper"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
       },
-      "type": "ch_qos_logback.logback_core.OptionHelperTest$NamedComponent"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.OptionHelper"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
       },
-      "type": "ch_qos_logback.logback_core.OptionHelperTest$NoArgComponent"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
       },
-      "type": "ch_qos_logback.logback_core.StringToObjectConverterTest$ValueObject"
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.EnvUtil"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.net.AutoFlushingObjectWriter"
       },
-      "type": "example.missing.DoesNotExist"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.StringToObjectConverter"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "java.lang.String",
-      "serializable": true
+      "type" : "java.util.AbstractCollection"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.net.AutoFlushingObjectWriter"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.util.AbstractList"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
       },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.joran.util.StringToObjectConverter"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.joran.util.beans.BeanDescriptionFactory"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
-      },
-      "type": "java.util.AbstractCollection"
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
-      },
-      "type": "java.util.AbstractList"
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.model.processor.SerializeModelModelHandler"
-      },
-      "type": "java.util.ArrayList",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.ConsoleAppender"
-      },
-      "type": "org.fusesource.jansi.AnsiConsole"
+      "type" : "java.util.ArrayList",
+      "serializable" : true
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.CoreVersionUtil"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.CoreVersionUtil"
       },
-      "glob": "ch/qos/logback/core/logback-core-version.properties"
+      "glob" : "ch/qos/logback/core/logback-core-version.properties"
     },
     {
-      "condition": {
-        "typeReached": "ch.qos.logback.core.util.Loader"
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.Loader"
       },
-      "glob": "ch_qos_logback/logback_core/LoaderTest.class"
+      "glob" : "ch_qos_logback/logback_core/LoaderTest.class"
     }
   ]
 }

--- a/metadata/ch.qos.logback/logback-core/index.json
+++ b/metadata/ch.qos.logback/logback-core/index.json
@@ -47,6 +47,11 @@
   },
   {
     "metadata-version" : "1.5.30",
+    "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-sources.jar",
+    "repository-url" : "https://github.com/qos-ch/logback",
+    "test-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-test-sources.jar",
+    "documentation-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-javadoc.jar",
+    "description" : "Logback Core is the foundational module of the Logback logging framework for Java. It provides appenders, encoders, layouts, rolling policies, filters, and support classes used by higher-level Logback modules.",
     "tested-versions" : [
       "1.5.30"
     ],

--- a/metadata/ch.qos.logback/logback-core/index.json
+++ b/metadata/ch.qos.logback/logback-core/index.json
@@ -44,5 +44,14 @@
     "allowed-packages" : [
       "ch.qos.logback.core"
     ]
+  },
+  {
+    "metadata-version" : "1.5.30",
+    "tested-versions" : [
+      "1.5.30"
+    ],
+    "allowed-packages" : [
+      "ch.qos.logback.core"
+    ]
   }
 ]

--- a/stats/ch.qos.logback/logback-core/1.5.30/execution-metrics.json
+++ b/stats/ch.qos.logback/logback-core/1.5.30/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T13:18:05.697151Z",
+    "library": "ch.qos.logback:logback-core:1.5.30",
+    "starting_commit": "4ff7d0cb5f810b38304574172bf1bb4b1c1a1874",
+    "ending_commit": "e8dc72f1da06d7ef373ca46fabf55bd7f00fa33a",
+    "previous_library": "ch.qos.logback:logback-core:1.5.26",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.5.30",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 31,
+            "totalCalls": 31
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 35,
+        "totalCalls": 35
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3471,
+          "missed": 34718,
+          "ratio": 0.09089,
+          "total": 38189
+        },
+        "line": {
+          "covered": 966,
+          "missed": 9638,
+          "ratio": 0.091098,
+          "total": 10604
+        },
+        "method": {
+          "covered": 256,
+          "missed": 2376,
+          "ratio": 0.097264,
+          "total": 2632
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.5.26",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 32,
+            "totalCalls": 32
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 37,
+        "totalCalls": 37
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3538,
+          "missed": 35204,
+          "ratio": 0.091322,
+          "total": 38742
+        },
+        "line": {
+          "covered": 999,
+          "missed": 9778,
+          "ratio": 0.092697,
+          "total": 10777
+        },
+        "method": {
+          "covered": 265,
+          "missed": 2413,
+          "ratio": 0.098954,
+          "total": 2678
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 68755,
+      "cached_input_tokens_used": 534528,
+      "output_tokens_used": 9057,
+      "iterations": 2,
+      "cost_usd": 0.539,
+      "tested_library_loc": 966,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 13,
+      "previous_library_metadata_entries": 23,
+      "previous_library_test_only_metadata_entries": 10,
+      "code_coverage_percent": 9.11,
+      "previous_library_coverage_percent": 9.27
+    },
+    "artifacts": {
+      "test_file": "tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/org/codehaus/janino/ScriptEvaluator.java",
+      "metadata_file": "metadata/ch.qos.logback/logback-core/1.5.30/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/ch.qos.logback/logback-core/1.5.30/stats.json
+++ b/stats/ch.qos.logback/logback-core/1.5.30/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.5.30",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 31,
+          "totalCalls" : 31
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 35,
+      "totalCalls" : 35
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3471,
+        "missed" : 34718,
+        "ratio" : 0.09089,
+        "total" : 38189
+      },
+      "line" : {
+        "covered" : 966,
+        "missed" : 9638,
+        "ratio" : 0.091098,
+        "total" : 10604
+      },
+      "method" : {
+        "covered" : 256,
+        "missed" : 2376,
+        "ratio" : 0.097264,
+        "total" : 2632
+      }
+    }
+  } ]
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/.gitignore
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/build.gradle
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "ch.qos.logback:logback-core:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/gradle.properties
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = ch.qos.logback:logback-core:1.5.30
+library.version = 1.5.30
+metadata.dir = ch.qos.logback/logback-core/1.5.30/

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/settings.gradle
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'ch.qos.logback.logback-core_tests'

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/AggregationAssessorTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/AggregationAssessorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.joran.spi.DefaultNestedComponentRegistry;
+import ch.qos.logback.core.joran.util.AggregationAssessor;
+import ch.qos.logback.core.joran.util.beans.BeanDescriptionCache;
+import ch.qos.logback.core.util.AggregationType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AggregationAssessorTest {
+
+    @Test
+    void infersDefaultComponentClassFromInstantiableConcreteSetterType() {
+        BeanDescriptionCache beanDescriptionCache = new BeanDescriptionCache(new ContextBase());
+        AggregationAssessor assessor = new AggregationAssessor(beanDescriptionCache, ConfigurableContainer.class);
+        DefaultNestedComponentRegistry registry = new DefaultNestedComponentRegistry();
+
+        AggregationType aggregationType = assessor.computeAggregationType("component");
+        Class<?> componentClass = assessor.getClassNameViaImplicitRules("component", aggregationType, registry);
+
+        assertThat(aggregationType).isEqualTo(AggregationType.AS_COMPLEX_PROPERTY);
+        assertThat(componentClass).isEqualTo(ConcreteComponent.class);
+    }
+
+    public static class ConfigurableContainer {
+        private ConcreteComponent component;
+
+        public void setComponent(ConcreteComponent component) {
+            this.component = component;
+        }
+
+        public ConcreteComponent getComponent() {
+            return component;
+        }
+    }
+
+    public static class ConcreteComponent {
+        public ConcreteComponent() {
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/AutoFlushingObjectWriterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/AutoFlushingObjectWriterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.net.AutoFlushingObjectWriter;
+import ch.qos.logback.core.net.ObjectWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoFlushingObjectWriterTest {
+
+    @Test
+    void writeSerializesObjectThroughObjectOutputStream() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(output)) {
+            int headerSize = output.size();
+            ObjectWriter writer = new AutoFlushingObjectWriter(objectOutputStream, 1);
+
+            writer.write("logback-payload");
+
+            byte[] serializedBytes = output.toByteArray();
+            assertThat(serializedBytes.length).isGreaterThan(headerSize);
+            assertThat(new String(serializedBytes, StandardCharsets.ISO_8859_1)).contains("logback-payload");
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/ConsoleAppenderTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/ConsoleAppenderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.encoder.EchoEncoder;
+import org.fusesource.jansi.AnsiConsole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsoleAppenderTest {
+    @BeforeEach
+    void resetAnsiConsole() {
+        AnsiConsole.reset();
+    }
+
+    @Test
+    void withJansiUsesAnsiConsoleOutMethodForSystemOut() {
+        ConsoleAppender<String> appender = newConsoleAppender("System.out");
+
+        appender.start();
+        appender.doAppend("jansi out branch");
+
+        assertThat(appender.isStarted()).isTrue();
+        assertThat(AnsiConsole.systemInstallCount()).isEqualTo(1);
+        assertThat(AnsiConsole.outCount()).isEqualTo(1);
+        assertThat(AnsiConsole.wrapSystemErrCount()).isZero();
+        assertThat(AnsiConsole.outContent()).contains("jansi out branch");
+    }
+
+    @Test
+    void withJansiFallsBackToWrapSystemErrWhenErrMethodIsUnavailable() {
+        ConsoleAppender<String> appender = newConsoleAppender("System.err");
+
+        appender.start();
+        appender.doAppend("jansi err wrapper branch");
+
+        assertThat(appender.isStarted()).isTrue();
+        assertThat(AnsiConsole.systemInstallCount()).isEqualTo(1);
+        assertThat(AnsiConsole.outCount()).isZero();
+        assertThat(AnsiConsole.wrapSystemErrCount()).isEqualTo(1);
+        assertThat(AnsiConsole.errContent()).contains("jansi err wrapper branch");
+    }
+
+    private static ConsoleAppender<String> newConsoleAppender(String target) {
+        ContextBase context = new ContextBase();
+        context.setName("console-appender-test-context");
+
+        EchoEncoder<String> encoder = new EchoEncoder<>();
+        encoder.setContext(context);
+        encoder.start();
+
+        ConsoleAppender<String> appender = new ConsoleAppender<>();
+        appender.setContext(context);
+        appender.setName("console-appender-test");
+        appender.setEncoder(encoder);
+        appender.setTarget(target);
+        appender.setWithJansi(true);
+        return appender;
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/CoreVersionUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/CoreVersionUtilTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.util.CoreVersionUtil;
+import org.junit.jupiter.api.Test;
+
+public class CoreVersionUtilTest {
+
+    @Test
+    void readsSelfDeclaredCoreVersionFromPackagedProperties() {
+        String coreVersion = CoreVersionUtil.getCoreVersionBySelfDeclaredProperties();
+
+        assertThat(coreVersion).isNotBlank();
+        assertThat(coreVersion).matches("\\d+\\.\\d+\\.\\d+.*");
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/EnvUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/EnvUtilTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.util.EnvUtil;
+import org.junit.jupiter.api.Test;
+
+public class EnvUtilTest {
+
+    @Test
+    void detectsJaninoScriptEvaluatorThroughLogbackClassLoader() {
+        boolean janinoAvailable = EnvUtil.isJaninoAvailable();
+
+        assertThat(janinoAvailable).isTrue();
+    }
+
+    @Test
+    void detectsAvailableAndUnavailableClassesThroughCallerClassLoader() {
+        assertThat(EnvUtil.isClassAvailable(EnvUtilTest.class, String.class.getName())).isTrue();
+        assertThat(EnvUtil.isClassAvailable(EnvUtilTest.class, "example.missing.DoesNotExist")).isFalse();
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/FileUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/FileUtilTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.util.FileUtil;
+import org.junit.jupiter.api.Test;
+
+public class FileUtilTest {
+
+    private static final String RESOURCE_NAME = "version-util-test-dependencies.properties";
+
+    @Test
+    void readsResourceFromProvidedClassLoader() {
+        FileUtil fileUtil = new FileUtil(new ContextBase());
+
+        String resourceContents = fileUtil.resourceAsString(FileUtilTest.class.getClassLoader(), RESOURCE_NAME);
+
+        assertThat(resourceContents).isNotNull();
+        assertThat(resourceContents.trim()).isEqualTo("version-util-dependency=4.5.6-test");
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/HardenedObjectInputStreamTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/HardenedObjectInputStreamTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.net.HardenedObjectInputStream;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class HardenedObjectInputStreamTest {
+
+    @Test
+    void readsWhitelistedSerializableObject() throws Exception {
+        SerializablePayload payload = new SerializablePayload("logback", 7);
+        byte[] serializedPayload = serialize(payload);
+
+        try (HardenedObjectInputStream inputStream = new HardenedObjectInputStream(
+                new ByteArrayInputStream(serializedPayload),
+                List.of(SerializablePayload.class.getName()))) {
+            Object deserializedObject = inputStream.readObject();
+
+            assertThat(deserializedObject).isEqualTo(payload);
+        }
+    }
+
+    @Test
+    void rejectsNonWhitelistedSerializableObject() throws Exception {
+        byte[] serializedPayload = serialize(new SerializablePayload("blocked", 1));
+
+        try (HardenedObjectInputStream inputStream = new HardenedObjectInputStream(
+                new ByteArrayInputStream(serializedPayload),
+                new String[0])) {
+            assertThatThrownBy(inputStream::readObject)
+                    .isInstanceOf(InvalidClassException.class)
+                    .hasMessageContaining("Unauthorized deserialization attempt")
+                    .hasMessageContaining(SerializablePayload.class.getName());
+        }
+    }
+
+    private static byte[] serialize(Serializable object) throws Exception {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(object);
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    private static final class SerializablePayload implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String text;
+        private final int value;
+
+        private SerializablePayload(String text, int value) {
+            this.text = text;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof SerializablePayload)) {
+                return false;
+            }
+            SerializablePayload that = (SerializablePayload) other;
+            return value == that.value && text.equals(that.text);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = text.hashCode();
+            result = 31 * result + value;
+            return result;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/LoaderTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/LoaderTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.util.Loader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.LinkedHashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.graalvm.internal.tck.NativeImageSupport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LoaderTest {
+
+    private static final String TEST_CLASS_RESOURCE = LoaderTest.class.getName().replace('.', '/') + ".class";
+    private static final String IGNORE_TCL_PROPERTY_NAME = "logback.ignoreTCL";
+    private static final String LOGBACK_PACKAGE = "ch.qos.logback.";
+    private static final String ISOLATED_CALLABLE_CLASS_NAME = LoaderTest.class.getName() + "$IsolatedLoaderCallable";
+
+    @BeforeAll
+    static void clearIgnoreThreadContextClassLoaderProperty() {
+        System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+    }
+
+    @Test
+    void loadsResourcesAndClassesFromProvidedClassLoaders() throws Exception {
+        ClassLoader classLoader = LoaderTest.class.getClassLoader();
+        Set<URL> resources = Loader.getResources(TEST_CLASS_RESOURCE, classLoader);
+        URL resource = Loader.getResource(TEST_CLASS_RESOURCE, classLoader);
+
+        assertThat(resources).isNotEmpty();
+        assertThat(resource).isNotNull();
+        assertThat(resources).contains(resource);
+        assertThat(Loader.loadClass(ContextBase.class.getName(), new ContextBase())).isEqualTo(ContextBase.class);
+    }
+
+    @Test
+    void loadsClassThroughThreadContextClassLoader() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        TrackingClassLoader trackingClassLoader = new TrackingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(ContextBase.class.getName())
+        );
+        thread.setContextClassLoader(trackingClassLoader);
+
+        try {
+            assertThat(Loader.loadClass(ContextBase.class.getName())).isEqualTo(ContextBase.class);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(trackingClassLoader.getDelegatedLoads()).contains(ContextBase.class.getName());
+    }
+
+    @Test
+    void fallsBackToClassForNameWhenThreadContextClassLoaderCannotLoadTheClass() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader previousClassLoader = thread.getContextClassLoader();
+        RejectingClassLoader rejectingClassLoader = new RejectingClassLoader(
+                LoaderTest.class.getClassLoader(),
+                Set.of(ContextBase.class.getName())
+        );
+        thread.setContextClassLoader(rejectingClassLoader);
+
+        try {
+            assertThat(Loader.loadClass(ContextBase.class.getName())).isEqualTo(ContextBase.class);
+        } finally {
+            thread.setContextClassLoader(previousClassLoader);
+        }
+
+        assertThat(rejectingClassLoader.getRejectedLoads()).contains(ContextBase.class.getName());
+    }
+
+    @Test
+    void canIgnoreThreadContextClassLoaderWhenConfiguredBeforeLoaderInitialization() throws Exception {
+        String previousValue = System.getProperty(IGNORE_TCL_PROPERTY_NAME);
+        System.setProperty(IGNORE_TCL_PROPERTY_NAME, Boolean.TRUE.toString());
+
+        try (ChildFirstClassLoader classLoader = new ChildFirstClassLoader(new URL[] {
+                codeSourceUrl(LoaderTest.class),
+                codeSourceUrl(ContextBase.class)
+        }, LoaderTest.class.getClassLoader())) {
+            Callable<?> action = ServiceLoader.load(Callable.class, classLoader).stream()
+                    .map(ServiceLoader.Provider::get)
+                    .filter(provider -> provider.getClass().getName().equals(ISOLATED_CALLABLE_CLASS_NAME))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Expected an isolated Loader callable provider"));
+
+            assertThat(action.call()).isEqualTo(String.class.getName());
+        } catch (Error error) {
+            if (!NativeImageSupport.isUnsupportedFeatureError(error)) {
+                throw error;
+            }
+        } finally {
+            restoreSystemProperty(previousValue);
+        }
+    }
+
+    private static URL codeSourceUrl(Class<?> type) {
+        CodeSource codeSource = type.getProtectionDomain().getCodeSource();
+
+        assertThat(codeSource).isNotNull();
+        return codeSource.getLocation();
+    }
+
+    private static void restoreSystemProperty(String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(IGNORE_TCL_PROPERTY_NAME);
+        } else {
+            System.setProperty(IGNORE_TCL_PROPERTY_NAME, previousValue);
+        }
+    }
+
+    public static final class IsolatedLoaderCallable implements Callable<String> {
+
+        @Override
+        public String call() throws ClassNotFoundException {
+            return Loader.loadClass(String.class.getName()).getName();
+        }
+    }
+
+    private static final class TrackingClassLoader extends ClassLoader {
+
+        private final Set<String> delegatedLoads = new LinkedHashSet<>();
+        private final Set<String> trackedClassNames;
+
+        private TrackingClassLoader(ClassLoader parent, Set<String> trackedClassNames) {
+            super(parent);
+            this.trackedClassNames = trackedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (trackedClassNames.contains(name)) {
+                delegatedLoads.add(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getDelegatedLoads() {
+            return delegatedLoads;
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+
+        private final Set<String> rejectedLoads = new LinkedHashSet<>();
+        private final Set<String> rejectedClassNames;
+
+        private RejectingClassLoader(ClassLoader parent, Set<String> rejectedClassNames) {
+            super(parent);
+            this.rejectedClassNames = rejectedClassNames;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (rejectedClassNames.contains(name)) {
+                rejectedLoads.add(name);
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+
+        private Set<String> getRejectedLoads() {
+            return rejectedLoads;
+        }
+    }
+
+    private static final class ChildFirstClassLoader extends URLClassLoader {
+
+        private ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    if (isChildFirst(name)) {
+                        try {
+                            loadedClass = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loadedClass = super.loadClass(name, false);
+                        }
+                    } else {
+                        loadedClass = super.loadClass(name, false);
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+
+        private boolean isChildFirst(String className) {
+            return className.startsWith(LOGBACK_PACKAGE) || className.equals(ISOLATED_CALLABLE_CLASS_NAME);
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/OptionHelperTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/OptionHelperTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.util.OptionHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionHelperTest {
+    @Test
+    void instantiateClassWithSuperclassRestrictionUsesPublicNoArgConstructor() throws Exception {
+        Object instance = OptionHelper.instantiateClassWithSuperclassRestriction(NoArgComponent.class, Component.class);
+
+        assertThat(instance).isInstanceOf(NoArgComponent.class);
+        assertThat(((NoArgComponent) instance).name()).isEqualTo("no-arg");
+    }
+
+    @Test
+    void instantiateByClassNameUsesClassLoaderAndPublicNoArgConstructor() throws Exception {
+        Object instance = OptionHelper.instantiateByClassNameAndParameter(
+                NoArgComponent.class.getName(),
+                Component.class,
+                OptionHelperTest.class.getClassLoader(),
+                null,
+                null);
+
+        assertThat(instance).isInstanceOf(NoArgComponent.class);
+        assertThat(((NoArgComponent) instance).name()).isEqualTo("no-arg");
+    }
+
+    @Test
+    void instantiateByClassNameUsesPublicParameterizedConstructor() throws Exception {
+        Object instance = OptionHelper.instantiateByClassNameAndParameter(
+                NamedComponent.class.getName(),
+                Component.class,
+                OptionHelperTest.class.getClassLoader(),
+                String.class,
+                "configured-name");
+
+        assertThat(instance).isInstanceOf(NamedComponent.class);
+        assertThat(((NamedComponent) instance).name()).isEqualTo("configured-name");
+    }
+
+    public interface Component {
+        String name();
+    }
+
+    public static class NoArgComponent implements Component {
+        public NoArgComponent() {
+        }
+
+        @Override
+        public String name() {
+            return "no-arg";
+        }
+    }
+
+    public static class NamedComponent implements Component {
+        private final String name;
+
+        public NamedComponent(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/PropertySetterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/PropertySetterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.joran.util.PropertySetter;
+import ch.qos.logback.core.joran.util.beans.BeanDescriptionCache;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertySetterTest {
+
+    @Test
+    void setsSimplePropertyAndAddsBasicCollectionValue() {
+        ConfigurableTarget target = new ConfigurableTarget();
+        PropertySetter propertySetter = new PropertySetter(new BeanDescriptionCache(new ContextBase()), target);
+
+        propertySetter.setProperty("name", "primary");
+        propertySetter.addBasicProperty("port", "1042");
+
+        assertThat(target.getName()).isEqualTo("primary");
+        assertThat(target.getPortTotal()).isEqualTo(1042);
+    }
+
+    public static class ConfigurableTarget {
+        private String name;
+        private int portTotal;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void addPort(int port) {
+            portTotal += port;
+        }
+
+        public int getPortTotal() {
+            return portTotal;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.net.server.AbstractServerSocketAppender;
+import ch.qos.logback.core.spi.PreSerializationTransformer;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ServerSocketFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemoteReceiverStreamClientTest {
+
+    private static final int TIMEOUT_MILLIS = 5_000;
+
+    @Test
+    void writesSerializedEventToConnectedReceiver() throws Exception {
+        ContextBase context = new ContextBase();
+        context.setName("remote-receiver-stream-client-test-context");
+        LoopbackServerSocketFactory serverSocketFactory = new LoopbackServerSocketFactory();
+        StringServerSocketAppender appender = new StringServerSocketAppender(serverSocketFactory);
+        appender.setContext(context);
+        appender.setName("remote-receiver-stream-client-test");
+        appender.setPort(0);
+
+        try {
+            appender.start();
+
+            assertThat(appender.isStarted()).isTrue();
+
+            try (Socket receiverSocket = new Socket()) {
+                receiverSocket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
+                        serverSocketFactory.awaitPort()), TIMEOUT_MILLIS);
+                receiverSocket.setSoTimeout(TIMEOUT_MILLIS);
+
+                try (ObjectInputStream inputStream = new ObjectInputStream(
+                        receiverSocket.getInputStream())) {
+                    appender.doAppend("remote-receiver-payload");
+
+                    assertThat(inputStream.readObject()).isEqualTo("remote-receiver-payload");
+                }
+            }
+        } finally {
+            appender.stop();
+            context.stop();
+        }
+    }
+
+    private static final class StringServerSocketAppender
+            extends AbstractServerSocketAppender<String> {
+
+        private final ServerSocketFactory serverSocketFactory;
+
+        private StringServerSocketAppender(ServerSocketFactory serverSocketFactory) {
+            this.serverSocketFactory = serverSocketFactory;
+        }
+
+        @Override
+        protected void postProcessEvent(String event) {
+        }
+
+        @Override
+        protected PreSerializationTransformer<String> getPST() {
+            return event -> event;
+        }
+
+        @Override
+        protected ServerSocketFactory getServerSocketFactory() {
+            return serverSocketFactory;
+        }
+    }
+
+    private static final class LoopbackServerSocketFactory extends ServerSocketFactory {
+
+        private final CountDownLatch socketCreated = new CountDownLatch(1);
+
+        private volatile int port;
+
+        @Override
+        public ServerSocket createServerSocket(int port) throws IOException {
+            return createLoopbackServerSocket(0, 50);
+        }
+
+        @Override
+        public ServerSocket createServerSocket(int port, int backlog) throws IOException {
+            return createLoopbackServerSocket(0, backlog);
+        }
+
+        @Override
+        public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress)
+                throws IOException {
+            return createLoopbackServerSocket(0, backlog);
+        }
+
+        private ServerSocket createLoopbackServerSocket(int port, int backlog)
+                throws IOException {
+            ServerSocket serverSocket = new ServerSocket(port, backlog,
+                    InetAddress.getLoopbackAddress());
+            this.port = serverSocket.getLocalPort();
+            socketCreated.countDown();
+            return serverSocket;
+        }
+
+        private int awaitPort() throws InterruptedException {
+            assertThat(socketCreated.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
+            return port;
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
@@ -6,23 +6,16 @@
  */
 package ch_qos_logback.logback_core;
 
-import ch.qos.logback.core.ContextBase;
-import ch.qos.logback.core.net.server.AbstractServerSocketAppender;
-import ch.qos.logback.core.spi.PreSerializationTransformer;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.net.AbstractSocketAppender;
+import ch.qos.logback.core.spi.PreSerializationTransformer;
 import java.io.ObjectInputStream;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.net.ServerSocketFactory;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class RemoteReceiverStreamClientTest {
 
@@ -31,21 +24,22 @@ public class RemoteReceiverStreamClientTest {
     @Test
     void writesSerializedEventToConnectedReceiver() throws Exception {
         ContextBase context = new ContextBase();
-        context.setName("remote-receiver-stream-client-test-context");
-        LoopbackServerSocketFactory serverSocketFactory = new LoopbackServerSocketFactory();
-        StringServerSocketAppender appender = new StringServerSocketAppender(serverSocketFactory);
-        appender.setContext(context);
-        appender.setName("remote-receiver-stream-client-test");
-        appender.setPort(0);
+        context.setName("socket-appender-test-context");
+        StringSocketAppender appender = new StringSocketAppender();
 
-        try {
+        try (ServerSocket serverSocket = new ServerSocket(0, 50,
+                InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            appender.setContext(context);
+            appender.setName("socket-appender-test");
+            appender.setRemoteHost(InetAddress.getLoopbackAddress().getHostAddress());
+            appender.setPort(serverSocket.getLocalPort());
+
             appender.start();
 
             assertThat(appender.isStarted()).isTrue();
 
-            try (Socket receiverSocket = new Socket()) {
-                receiverSocket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
-                        serverSocketFactory.awaitPort()), TIMEOUT_MILLIS);
+            try (Socket receiverSocket = serverSocket.accept()) {
                 receiverSocket.setSoTimeout(TIMEOUT_MILLIS);
 
                 try (ObjectInputStream inputStream = new ObjectInputStream(
@@ -61,14 +55,7 @@ public class RemoteReceiverStreamClientTest {
         }
     }
 
-    private static final class StringServerSocketAppender
-            extends AbstractServerSocketAppender<String> {
-
-        private final ServerSocketFactory serverSocketFactory;
-
-        private StringServerSocketAppender(ServerSocketFactory serverSocketFactory) {
-            this.serverSocketFactory = serverSocketFactory;
-        }
+    private static final class StringSocketAppender extends AbstractSocketAppender<String> {
 
         @Override
         protected void postProcessEvent(String event) {
@@ -77,48 +64,6 @@ public class RemoteReceiverStreamClientTest {
         @Override
         protected PreSerializationTransformer<String> getPST() {
             return event -> event;
-        }
-
-        @Override
-        protected ServerSocketFactory getServerSocketFactory() {
-            return serverSocketFactory;
-        }
-    }
-
-    private static final class LoopbackServerSocketFactory extends ServerSocketFactory {
-
-        private final CountDownLatch socketCreated = new CountDownLatch(1);
-
-        private volatile int port;
-
-        @Override
-        public ServerSocket createServerSocket(int port) throws IOException {
-            return createLoopbackServerSocket(0, 50);
-        }
-
-        @Override
-        public ServerSocket createServerSocket(int port, int backlog) throws IOException {
-            return createLoopbackServerSocket(0, backlog);
-        }
-
-        @Override
-        public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress)
-                throws IOException {
-            return createLoopbackServerSocket(0, backlog);
-        }
-
-        private ServerSocket createLoopbackServerSocket(int port, int backlog)
-                throws IOException {
-            ServerSocket serverSocket = new ServerSocket(port, backlog,
-                    InetAddress.getLoopbackAddress());
-            this.port = serverSocket.getLocalPort();
-            socketCreated.countDown();
-            return serverSocket;
-        }
-
-        private int awaitPort() throws InterruptedException {
-            assertThat(socketCreated.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
-            return port;
         }
     }
 }

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/SerializeModelModelHandlerTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/SerializeModelModelHandlerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.SerializeModelModel;
+import ch.qos.logback.core.model.processor.ModelInterpretationContext;
+import ch.qos.logback.core.model.processor.SerializeModelModelHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializeModelModelHandlerTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void handleSerializesTopModelToConfiguredFile() throws Exception {
+        ContextBase context = new ContextBase();
+        ModelInterpretationContext modelInterpretationContext = new ModelInterpretationContext(context);
+        Model topModel = new Model();
+        topModel.setTag("configuration");
+        topModel.setLineNumber(1);
+        modelInterpretationContext.setTopModel(topModel);
+
+        Path modelFile = temporaryDirectory.resolve("serialized-logback-model.scmo");
+        SerializeModelModel serializeModelModel = new SerializeModelModel();
+        serializeModelModel.setFile(modelFile.toString());
+
+        SerializeModelModelHandler handler = new SerializeModelModelHandler(context);
+        handler.handle(modelInterpretationContext, serializeModelModel);
+
+        assertThat(modelFile).exists();
+        assertThat(Files.size(modelFile)).isGreaterThan(0L);
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/StringToObjectConverterTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/StringToObjectConverterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import ch.qos.logback.core.joran.util.StringToObjectConverter;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringToObjectConverterTest {
+
+    @Test
+    void convertsTypeThatFollowsPublicStaticValueOfConvention() {
+        Method valueOfMethod = StringToObjectConverter.getValueOfMethod(ValueObject.class);
+
+        assertThat(valueOfMethod).isNotNull();
+        assertThat(StringToObjectConverter.canBeBuiltFromSimpleString(ValueObject.class)).isTrue();
+        assertThat(StringToObjectConverter.convertArg(new ContextAwareBase(), " configured ", ValueObject.class))
+                .isEqualTo(new ValueObject("configured"));
+    }
+
+    public record ValueObject(String value) {
+
+        public static ValueObject valueOf(String value) {
+            return new ValueObject(value);
+        }
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.util.VersionUtil;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class VersionUtilTest {
+
+    private static final String TEST_MODULE_NAME = "version-util-test";
+    private static final String TEST_MODULE_VERSION = "1.2.3-test";
+    private static final String TEST_DEPENDENCY_NAME = "version-util-dependency";
+    private static final String TEST_DEPENDENCY_VERSION = "4.5.6-test";
+
+    @Test
+    void readsArtifactVersionFromClassRelativeProperties() {
+        String version = VersionUtil.getArtifactVersionBySelfDeclaredProperties(
+                VersionUtilTest.class,
+                TEST_MODULE_NAME
+        );
+
+        assertThat(version).isEqualTo(TEST_MODULE_VERSION);
+    }
+
+    @Test
+    void comparesExpectedDependencyVersionFromClassLoaderProperties() {
+        ContextBase context = new ContextBase();
+
+        VersionUtil.compareExpectedAndFoundVersion(
+                context,
+                TEST_DEPENDENCY_VERSION,
+                VersionUtilTest.class,
+                TEST_MODULE_VERSION,
+                TEST_MODULE_NAME,
+                TEST_DEPENDENCY_NAME
+        );
+
+        List<Status> statuses = context.getStatusManager().getCopyOfStatusList();
+        assertThat(statuses).extracting(Status::getMessage).containsExactly(
+                "Found " + TEST_DEPENDENCY_NAME + " version " + TEST_DEPENDENCY_VERSION,
+                "Found " + TEST_MODULE_NAME + " version " + TEST_MODULE_VERSION
+        );
+        assertThat(statuses).extracting(Status::getLevel).containsOnly(Status.INFO);
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
@@ -22,21 +22,37 @@ public class VersionUtilTest {
     private static final String TEST_DEPENDENCY_VERSION = "4.5.6-test";
 
     @Test
-    void readsArtifactVersionFromClassRelativeProperties() {
-        String version = VersionUtil.getArtifactVersionBySelfDeclaredProperties(
-                VersionUtilTest.class,
-                TEST_MODULE_NAME
+    void reportsVersionMismatchWithWarning() {
+        ContextBase context = new ContextBase();
+
+        VersionUtil.checkForVersionEquality(
+                context,
+                TEST_MODULE_VERSION,
+                TEST_DEPENDENCY_VERSION,
+                TEST_MODULE_NAME,
+                TEST_DEPENDENCY_NAME
         );
 
-        assertThat(version).isEqualTo(TEST_MODULE_VERSION);
+        List<Status> statuses = context.getStatusManager().getCopyOfStatusList();
+        assertThat(statuses).extracting(Status::getMessage).containsExactly(
+                "Found " + TEST_MODULE_NAME + " version " + TEST_MODULE_VERSION,
+                "Found " + TEST_DEPENDENCY_NAME + " version " + TEST_DEPENDENCY_VERSION,
+                "Versions of " + TEST_DEPENDENCY_NAME + " and " + TEST_MODULE_VERSION
+                        + " are different or unknown."
+        );
+        assertThat(statuses).extracting(Status::getLevel).containsExactly(
+                Status.INFO,
+                Status.INFO,
+                Status.WARN
+        );
     }
 
     @Test
-    void comparesExpectedDependencyVersionFromClassLoaderProperties() {
+    void comparesExpectedDependencyVersion() {
         ContextBase context = new ContextBase();
+        TestVersionUtil versionUtil = new TestVersionUtil(context);
 
-        VersionUtil.compareExpectedAndFoundVersion(
-                context,
+        versionUtil.compareExpectedAndFoundVersion(
                 TEST_DEPENDENCY_VERSION,
                 VersionUtilTest.class,
                 TEST_MODULE_VERSION,
@@ -50,5 +66,21 @@ public class VersionUtilTest {
                 "Found " + TEST_MODULE_NAME + " version " + TEST_MODULE_VERSION
         );
         assertThat(statuses).extracting(Status::getLevel).containsOnly(Status.INFO);
+    }
+
+    private static final class TestVersionUtil extends VersionUtil {
+
+        private TestVersionUtil(ContextBase context) {
+            super(context);
+        }
+
+        @Override
+        protected String getExpectedVersionOfDependencyByProperties(Class<?> dependerClass,
+                String propertiesFileName, String dependencyNameAsKey) {
+            assertThat(dependerClass).isEqualTo(VersionUtilTest.class);
+            assertThat(propertiesFileName).isEqualTo(TEST_MODULE_NAME + "-dependencies.properties");
+            assertThat(dependencyNameAsKey).isEqualTo(TEST_DEPENDENCY_NAME);
+            return TEST_DEPENDENCY_VERSION;
+        }
     }
 }

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/org/codehaus/janino/ScriptEvaluator.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/org/codehaus/janino/ScriptEvaluator.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.codehaus.janino;
+
+public class ScriptEvaluator {
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/org/fusesource/jansi/AnsiConsole.java
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/org/fusesource/jansi/AnsiConsole.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.fusesource.jansi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+public final class AnsiConsole {
+    private static final ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+
+    private static int systemInstallCount;
+    private static int outCount;
+    private static int wrapSystemErrCount;
+
+    private AnsiConsole() {
+    }
+
+    public static void reset() {
+        outBuffer.reset();
+        errBuffer.reset();
+        systemInstallCount = 0;
+        outCount = 0;
+        wrapSystemErrCount = 0;
+    }
+
+    public static void systemInstall() {
+        systemInstallCount++;
+    }
+
+    public static PrintStream out() {
+        outCount++;
+        return new PrintStream(outBuffer, true, StandardCharsets.UTF_8);
+    }
+
+    public static OutputStream wrapSystemErr(PrintStream ignored) {
+        wrapSystemErrCount++;
+        return new PrintStream(errBuffer, true, StandardCharsets.UTF_8);
+    }
+
+    public static int systemInstallCount() {
+        return systemInstallCount;
+    }
+
+    public static int outCount() {
+        return outCount;
+    }
+
+    public static int wrapSystemErrCount() {
+        return wrapSystemErrCount;
+    }
+
+    public static String outContent() {
+        return outBuffer.toString(StandardCharsets.UTF_8);
+    }
+
+    public static String errContent() {
+        return errBuffer.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,58 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.AggregationAssessor"
+      },
+      "type" : "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type" : "ch_qos_logback.logback_core.AggregationAssessorTest$ConcreteComponent"
+    },
+    {
+      "type" : "ch_qos_logback.logback_core.HardenedObjectInputStreamTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.EnvUtil"
+      },
+      "type" : "org.codehaus.janino.ScriptEvaluator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.ConsoleAppender"
+      },
+      "type" : "org.fusesource.jansi.AnsiConsole",
+      "allPublicMethods" : true
+    }
+  ],
+  "serialization" : [
+    {
+      "type" : "ch_qos_logback.logback_core.HardenedObjectInputStreamTest$SerializablePayload"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.FileUtil"
+      },
+      "glob" : "version-util-test-dependencies.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.VersionUtil"
+      },
+      "glob" : "version-util-test-dependencies.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.VersionUtil"
+      },
+      "glob" : "ch_qos_logback/logback_core/version-util-test-version.properties"
+    }
+  ]
+}

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -28,6 +28,24 @@
       },
       "type" : "org.fusesource.jansi.AnsiConsole",
       "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type" : "ch_qos_logback.logback_core.OptionHelperTest$NamedComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.util.OptionHelper"
+      },
+      "type" : "ch_qos_logback.logback_core.OptionHelperTest$NoArgComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "ch.qos.logback.core.joran.util.StringToObjectConverter"
+      },
+      "type" : "ch_qos_logback.logback_core.StringToObjectConverterTest$ValueObject"
     }
   ],
   "serialization" : [

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/services/java.util.concurrent.Callable
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/META-INF/services/java.util.concurrent.Callable
@@ -1,0 +1,1 @@
+ch_qos_logback.logback_core.LoaderTest$IsolatedLoaderCallable

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/ch_qos_logback/logback_core/version-util-test-version.properties
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/ch_qos_logback/logback_core/version-util-test-version.properties
@@ -1,0 +1,1 @@
+version-util-test-version=1.2.3-test

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/version-util-test-dependencies.properties
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/resources/version-util-test-dependencies.properties
@@ -1,0 +1,1 @@
+version-util-dependency=4.5.6-test

--- a/tests/src/ch.qos.logback/logback-core/1.5.30/user-code-filter.json
+++ b/tests/src/ch.qos.logback/logback-core/1.5.30/user-code-filter.json
@@ -1,0 +1,19 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "ch.qos.logback.core.**"
+    },
+    {
+      "includeClasses" : "org.codehaus.janino.**"
+    },
+    {
+      "includeClasses" : "org.fusesource.jansi.**"
+    },
+    {
+      "includeClasses" : "ch_qos_logback.logback_core.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6302

This PR provides test fixes and new metadata for ch.qos.logback:logback-core:1.5.30, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 68755
- Cached input tokens: 534528
- Output tokens: 9057
- Metadata entries: 19
- Test-only metadata entries: 13
- Iterations: 2
- Library coverage percentage: 9.11
- Previous library version metadata entries: 23
- Previous library version test-only metadata entries: 10
- Previous library version coverage percentage: 9.27

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `94ec951aa69325f642f234a61b32460bfa57714c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- ch.qos.logback:logback-core:1.5.26: 37/37 covered calls (100.00%)
- ch.qos.logback:logback-core:1.5.30: 35/35 covered calls (100.00%)

**Reflection:**
- ch.qos.logback:logback-core:1.5.26: 32/32 covered calls (100.00%)
- ch.qos.logback:logback-core:1.5.30: 31/31 covered calls (100.00%)

**Resources:**
- ch.qos.logback:logback-core:1.5.26: 5/5 covered calls (100.00%)
- ch.qos.logback:logback-core:1.5.30: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- ch.qos.logback:logback-core:1.5.26: 3538/38742 (9.13%)
- ch.qos.logback:logback-core:1.5.30: 3471/38189 (9.09%)

**Line:**
- ch.qos.logback:logback-core:1.5.26: 999/10777 (9.27%)
- ch.qos.logback:logback-core:1.5.30: 966/10604 (9.11%)

**Method:**
- ch.qos.logback:logback-core:1.5.26: 265/2678 (9.90%)
- ch.qos.logback:logback-core:1.5.30: 256/2632 (9.73%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/CoreVersionUtilTest.java 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/CoreVersionUtilTest.java
new file mode 100644
index 0000000000..d9304cae06
--- /dev/null
+++ 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/CoreVersionUtilTest.java
@@ -0,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package ch_qos_logback.logback_core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.core.util.CoreVersionUtil;
+import org.junit.jupiter.api.Test;
+
+public class CoreVersionUtilTest {
+
+    @Test
+    void readsSelfDeclaredCoreVersionFromPackagedProperties() {
+        String coreVersion = CoreVersionUtil.getCoreVersionBySelfDeclaredProperties();
+
+        assertThat(coreVersion).isNotBlank();
+        assertThat(coreVersion).matches("\\d+\\.\\d+\\.\\d+.*");
+    }
+}
diff --git 1/tests/src/ch.qos.logback/logback-core/1.5.26/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
index ab44ac6abd..2421219569 100644
--- 1/tests/src/ch.qos.logback/logback-core/1.5.26/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
+++ 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/RemoteReceiverStreamClientTest.java
@@ -6,23 +6,16 @@
  */
 package ch_qos_logback.logback_core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import ch.qos.logback.core.ContextBase;
-import ch.qos.logback.core.net.server.AbstractServerSocketAppender;
+import ch.qos.logback.core.net.AbstractSocketAppender;
 import ch.qos.logback.core.spi.PreSerializationTransformer;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.net.ServerSocketFactory;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class RemoteReceiverStreamClientTest {
 
@@ -31,21 +24,22 @@ public class RemoteReceiverStreamClientTest {
     @Test
     void writesSerializedEventToConnectedReceiver() throws Exception {
         ContextBase context = new ContextBase();
-        context.setName("remote-receiver-stream-client-test-context");
-        LoopbackServerSocketFactory serverSocketFactory = new LoopbackServerSocketFactory();
-        StringServerSocketAppender appender = new StringServerSocketAppender(serverSocketFactory);
-        appender.setContext(context);
-        appender.setName("remote-receiver-stream-client-test");
-        appender.setPort(0);
+        context.setName("socket-appender-test-context");
+        StringSocketAppender appender = new StringSocketAppender();
+
+        try (ServerSocket serverSocket = new ServerSocket(0, 50,
+                InetAddress.getLoopbackAddress())) {
+            serverSocket.setSoTimeout(TIMEOUT_MILLIS);
+            appender.setContext(context);
+            appender.setName("socket-appender-test");
+            appender.setRemoteHost(InetAddress.getLoopbackAddress().getHostAddress());
+            appender.setPort(serverSocket.getLocalPort());
 
-        try {
             appender.start();
 
             assertThat(appender.isStarted()).isTrue();
 
-            try (Socket receiverSocket = new Socket()) {
-                receiverSocket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(),
-                        serverSocketFactory.awaitPort()), TIMEOUT_MILLIS);
+            try (Socket receiverSocket = serverSocket.accept()) {
                 receiverSocket.setSoTimeout(TIMEOUT_MILLIS);
 
                 try (ObjectInputStream inputStream = new ObjectInputStream(
@@ -61,14 +55,7 @@ public class RemoteReceiverStreamClientTest {
         }
     }
 
-    private static final class StringServerSocketAppender
-            extends AbstractServerSocketAppender<String> {
-
-        private final ServerSocketFactory serverSocketFactory;
-
-        private StringServerSocketAppender(ServerSocketFactory serverSocketFactory) {
-            this.serverSocketFactory = serverSocketFactory;
-        }
+    private static final class StringSocketAppender extends AbstractSocketAppender<String> {
 
         @Override
         protected void postProcessEvent(String event) {
@@ -78,47 +65,5 @@ public class RemoteReceiverStreamClientTest {
         protected PreSerializationTransformer<String> getPST() {
             return event -> event;
         }
-
-        @Override
-        protected ServerSocketFactory getServerSocketFactory() {
-            return serverSocketFactory;
-        }
-    }
-
-    private static final class LoopbackServerSocketFactory extends ServerSocketFactory {
-
-        private final CountDownLatch socketCreated = new CountDownLatch(1);
-
-        private volatile int port;
-
-        @Override
-        public ServerSocket createServerSocket(int port) throws IOException {
-            return createLoopbackServerSocket(0, 50);
-        }
-
-        @Override
-        public ServerSocket createServerSocket(int port, int backlog) throws IOException {
-            return createLoopbackServerSocket(0, backlog);
-        }
-
-        @Override
-        public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress)
-                throws IOException {
-            return createLoopbackServerSocket(0, backlog);
-        }
-
-        private ServerSocket createLoopbackServerSocket(int port, int backlog)
-                throws IOException {
-            ServerSocket serverSocket = new ServerSocket(port, backlog,
-                    InetAddress.getLoopbackAddress());
-            this.port = serverSocket.getLocalPort();
-            socketCreated.countDown();
-            return serverSocket;
-        }
-
-        private int awaitPort() throws InterruptedException {
-            assertThat(socketCreated.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)).isTrue();
-            return port;
-        }
     }
 }
diff --git 1/tests/src/ch.qos.logback/logback-core/1.5.26/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
index f7ac8cde5a..526e441096 100644
--- 1/tests/src/ch.qos.logback/logback-core/1.5.26/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
+++ 2/tests/src/ch.qos.logback/logback-core/1.5.30/src/test/java/ch_qos_logback/logback_core/VersionUtilTest.java
@@ -22,21 +22,37 @@ public class VersionUtilTest {
     private static final String TEST_DEPENDENCY_VERSION = "4.5.6-test";
 
     @Test
-    void readsArtifactVersionFromClassRelativeProperties() {
-        String version = VersionUtil.getArtifactVersionBySelfDeclaredProperties(
-                VersionUtilTest.class,
-                TEST_MODULE_NAME
+    void reportsVersionMismatchWithWarning() {
+        ContextBase context = new ContextBase();
+
+        VersionUtil.checkForVersionEquality(
+                context,
+                TEST_MODULE_VERSION,
+                TEST_DEPENDENCY_VERSION,
+                TEST_MODULE_NAME,
+                TEST_DEPENDENCY_NAME
         );
 
-        assertThat(version).isEqualTo(TEST_MODULE_VERSION);
+        List<Status> statuses = context.getStatusManager().getCopyOfStatusList();
+        assertThat(statuses).extracting(Status::getMessage).containsExactly(
+                "Found " + TEST_MODULE_NAME + " version " + TEST_MODULE_VERSION,
+                "Found " + TEST_DEPENDENCY_NAME + " version " + TEST_DEPENDENCY_VERSION,
+                "Versions of " + TEST_DEPENDENCY_NAME + " and " + TEST_MODULE_VERSION
+                        + " are different or unknown."
+        );
+        assertThat(statuses).extracting(Status::getLevel).containsExactly(
+                Status.INFO,
+                Status.INFO,
+                Status.WARN
+        );
     }
 
     @Test
-    void comparesExpectedDependencyVersionFromClassLoaderProperties() {
+    void comparesExpectedDependencyVersion() {
         ContextBase context = new ContextBase();
+        TestVersionUtil versionUtil = new TestVersionUtil(context);
 
-        VersionUtil.compareExpectedAndFoundVersion(
-                context,
+        versionUtil.compareExpectedAndFoundVersion(
                 TEST_DEPENDENCY_VERSION,
                 VersionUtilTest.class,
                 TEST_MODULE_VERSION,
@@ -51,4 +67,20 @@ public class VersionUtilTest {
         );
         assertThat(statuses).extracting(Status::getLevel).containsOnly(Status.INFO);
     }
+
+    private static final class TestVersionUtil extends VersionUtil {
+
+        private TestVersionUtil(ContextBase context) {
+            super(context);
+        }
+
+        @Override
+        protected String getExpectedVersionOfDependencyByProperties(Class<?> dependerClass,
+                String propertiesFileName, String dependencyNameAsKey) {
+            assertThat(dependerClass).isEqualTo(VersionUtilTest.class);
+            assertThat(propertiesFileName).isEqualTo(TEST_MODULE_NAME + "-dependencies.properties");
+            assertThat(dependencyNameAsKey).isEqualTo(TEST_DEPENDENCY_NAME);
+            return TEST_DEPENDENCY_VERSION;
+        }
+    }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
