### PR TITLE
[GenAI] Test fix for org.eclipse.jetty:jetty-alpn-client:12.0.31 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.jetty/jetty-alpn-client/12.0.31/reachability-metadata.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/12.0.31/reachability-metadata.json
@@ -1,0 +1,30 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.TypeUtil"
+      },
+      "type": "java.lang.invoke.MethodHandle[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.util.ServiceLoaderSpliterator"
+      },
+      "glob": "META-INF/services/org.eclipse.jetty.io.ssl.ALPNProcessor$Client"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.jetty.io.IdleTimeout"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    }
+  ]
+}

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "12.0.31",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/jetty/jetty.project",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
     "tested-versions" : [
       "12.0.31"
     ],

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,6 +1,16 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "12.0.31",
+    "tested-versions" : [
+      "12.0.31"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.jetty.alpn.client",
+      "org.eclipse.jetty.util"
+    ]
+  },
+  {
     "metadata-version" : "11.0.12",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,28 +1,29 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "12.0.31",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
-    "repository-url" : "https://github.com/jetty/jetty.project",
-    "test-code-url" : "N/A",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
-    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "12.0.31",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url": "https://github.com/jetty/jetty.project",
+    "test-code-url": "N/A",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description": "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
+    "tested-versions": [
       "12.0.31"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.eclipse.jetty.alpn.client",
-      "org.eclipse.jetty.util"
+      "org.eclipse.jetty.util",
+      "org.eclipse.jetty.io"
     ]
   },
   {
-    "metadata-version" : "11.0.12",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
-    "repository-url" : "https://github.com/jetty/jetty.project",
-    "test-code-url" : "N/A",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
-    "description" : "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
-    "tested-versions" : [
+    "metadata-version": "11.0.12",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
+    "repository-url": "https://github.com/jetty/jetty.project",
+    "test-code-url": "N/A",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-javadoc.jar",
+    "description": "Jetty ALPN Client provides the client-side connection factory used by Eclipse Jetty to negotiate application protocols such as HTTP/1.1 and HTTP/2 during TLS handshakes. It discovers available Jetty ALPN processors and configures SSL client connections so the selected protocol can hand off to the appropriate client connection implementation.",
+    "tested-versions": [
       "11.0.12",
       "11.0.13",
       "11.0.14",
@@ -70,7 +71,7 @@
       "12.0.29",
       "12.0.30"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "org.eclipse.jetty.alpn.client",
       "org.eclipse.jetty.util"
     ]

--- a/stats/org.eclipse.jetty/jetty-alpn-client/12.0.31/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/12.0.31/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T13:32:24.285945Z",
+    "library": "org.eclipse.jetty:jetty-alpn-client:12.0.31",
+    "starting_commit": "9e3b07b47bb3ac2d8f81a71ff9b79caee733212b",
+    "ending_commit": "e5f636c5d7a04f6f2a8555464ddbeb3e7fc63fcc",
+    "previous_library": "org.eclipse.jetty:jetty-alpn-client:11.0.12",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "12.0.31",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 65,
+          "missed": 118,
+          "ratio": 0.355191,
+          "total": 183
+        },
+        "line": {
+          "covered": 18,
+          "missed": 28,
+          "ratio": 0.391304,
+          "total": 46
+        },
+        "method": {
+          "covered": 5,
+          "missed": 2,
+          "ratio": 0.714286,
+          "total": 7
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "11.0.12",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 65,
+          "missed": 117,
+          "ratio": 0.357143,
+          "total": 182
+        },
+        "line": {
+          "covered": 18,
+          "missed": 28,
+          "ratio": 0.391304,
+          "total": 46
+        },
+        "method": {
+          "covered": 5,
+          "missed": 2,
+          "ratio": 0.714286,
+          "total": 7
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 64892,
+      "cached_input_tokens_used": 359936,
+      "output_tokens_used": 4968,
+      "iterations": 1,
+      "cost_usd": 0.329,
+      "tested_library_loc": 18,
+      "metadata_entries": 4,
+      "previous_library_metadata_entries": 14,
+      "code_coverage_percent": 39.13,
+      "previous_library_coverage_percent": 39.13
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java",
+      "metadata_file": "metadata/org.eclipse.jetty/jetty-alpn-client/12.0.31/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.jetty/jetty-alpn-client/12.0.31/stats.json
+++ b/stats/org.eclipse.jetty/jetty-alpn-client/12.0.31/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "12.0.31",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 65,
+        "missed" : 118,
+        "ratio" : 0.355191,
+        "total" : 183
+      },
+      "line" : {
+        "covered" : 18,
+        "missed" : 28,
+        "ratio" : 0.391304,
+        "total" : 46
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 2,
+        "ratio" : 0.714286,
+        "total" : 7
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/.gitignore
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/build.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.jetty:jetty-alpn-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/gradle.properties
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.jetty:jetty-alpn-client:12.0.31
+library.version = 12.0.31
+metadata.dir = org.eclipse.jetty/jetty-alpn-client/12.0.31/

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/settings.gradle
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.jetty.jetty-alpn-client_tests'

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_jetty.jetty_alpn_client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.alpn.client.ALPNClientConnection;
+import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
+import org.eclipse.jetty.io.AbstractConnection;
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class Jetty_alpn_clientTest {
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+    private static final List<String> PROTOCOLS = List.of("h2", "http/1.1");
+
+    @Test
+    void clientConnectionExposesSslEngineAndConfiguredProtocols() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        SSLEngine sslEngine = newClientEngine();
+        Map<String, Object> context = new HashMap<>();
+        ALPNClientConnection connection = new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                sslEngine,
+                context,
+                PROTOCOLS);
+
+        assertThat(connection.getSSLEngine()).isSameAs(sslEngine);
+        assertThat(connection.getProtocols()).containsExactly("h2", "http/1.1");
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolIsRecordedWithoutImmediatelyReplacingTheConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        context.put("test.name", "selectedProtocolBeforeOpenUpgradesEndPointToProtocolConnection");
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("http/1.1");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("http/1.1");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void selectedProtocolOnFillableUpgradesEndPointToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void onFillableKeepsWaitingWhenNegotiationHasNotCompletedAndNoBytesAreAvailable() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isFillInterested()).isTrue();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+    }
+
+    @Test
+    void endOfInputCompletesNegotiationAndUpgradesToProtocolConnection() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        Map<String, Object> context = new HashMap<>();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
+        endPoint.setConnection(connection);
+        endPoint.addInputEOF();
+
+        connection.onFillable();
+
+        assertThat(connection.getProtocol()).isNull();
+        assertThat(connectionFactory.createdConnections).hasSize(1);
+        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
+        assertThat(connectionFactory.seenContexts).containsExactly(context);
+        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
+        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+    }
+
+    @Test
+    void closeShutsDownEndPointOutput() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
+        ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.close();
+
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
+    void failedProtocolConnectionCreationClosesEndPoint() throws Exception {
+        ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        ClientConnectionFactory failingConnectionFactory = (ignoredEndPoint, ignoredContext) -> {
+            throw new IOException("Unable to create protocol connection");
+        };
+        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, new HashMap<>());
+        endPoint.setConnection(connection);
+
+        connection.selected("h2");
+        connection.onOpen();
+
+        assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
+    }
+
+    @Test
+    void clientConnectionFactoryRejectsEmptyProtocolListBeforeLookingUpProcessors() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        List.of()))
+                .withMessage("ALPN protocol list cannot be empty");
+    }
+
+    @Test
+    void clientConnectionFactoryReportsMissingProcessorWhenNoClientAlpnProcessorServiceIsPresent() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> new ALPNClientConnectionFactory(
+                        DIRECT_EXECUTOR,
+                        new TestClientConnectionFactory(),
+                        PROTOCOLS))
+                .withMessage("No Client ALPNProcessors!");
+    }
+
+    private static ALPNClientConnection newAlpnConnection(
+            EndPoint endPoint,
+            ClientConnectionFactory connectionFactory,
+            Map<String, Object> context) throws Exception {
+        return new ALPNClientConnection(
+                endPoint,
+                DIRECT_EXECUTOR,
+                connectionFactory,
+                newClientEngine(),
+                context,
+                PROTOCOLS);
+    }
+
+    private static SSLEngine newClientEngine() throws Exception {
+        SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine("localhost", 443);
+        sslEngine.setUseClientMode(true);
+        return sslEngine;
+    }
+
+    private static final class TestClientConnectionFactory implements ClientConnectionFactory {
+        private final List<EndPoint> seenEndPoints = new ArrayList<>();
+        private final List<Map<String, Object>> seenContexts = new ArrayList<>();
+        private final List<RecordingConnection> createdConnections = new ArrayList<>();
+
+        @Override
+        public Connection newConnection(EndPoint endPoint, Map<String, Object> context) throws IOException {
+            seenEndPoints.add(endPoint);
+            seenContexts.add(context);
+            RecordingConnection connection = new RecordingConnection(endPoint);
+            createdConnections.add(connection);
+            return connection;
+        }
+    }
+
+    private static final class RecordingConnection extends AbstractConnection {
+        private boolean opened;
+
+        private RecordingConnection(EndPoint endPoint) {
+            super(endPoint, DIRECT_EXECUTOR);
+        }
+
+        @Override
+        public void onOpen() {
+            super.onOpen();
+            opened = true;
+        }
+
+        @Override
+        public void onFillable() {
+        }
+    }
+}

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -14,14 +14,17 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.alpn.client.ALPNClientConnection;
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteArrayEndPoint;
 import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.Promise;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,9 +123,10 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
-    void endOfInputCompletesNegotiationAndUpgradesToProtocolConnection() throws Exception {
+    void endOfInputFailsConnectionPromiseAndClosesEndPoint() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
-        Map<String, Object> context = new HashMap<>();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
         TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
         ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
         endPoint.setConnection(connection);
@@ -131,11 +135,13 @@ public class Jetty_alpn_clientTest {
         connection.onFillable();
 
         assertThat(connection.getProtocol()).isNull();
-        assertThat(connectionFactory.createdConnections).hasSize(1);
-        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
-        assertThat(connectionFactory.seenContexts).containsExactly(context);
-        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
-        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(SSLHandshakeException.class)
+                .hasMessage("Abruptly closed by peer");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
     }
 
     @Test
@@ -154,16 +160,21 @@ public class Jetty_alpn_clientTest {
     @Test
     void failedProtocolConnectionCreationClosesEndPoint() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
         ClientConnectionFactory failingConnectionFactory = (ignoredEndPoint, ignoredContext) -> {
             throw new IOException("Unable to create protocol connection");
         };
-        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, new HashMap<>());
+        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, context);
         endPoint.setConnection(connection);
 
         connection.selected("h2");
         connection.onOpen();
 
         assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Unable to create protocol connection");
         assertThat(endPoint.getConnection()).isSameAs(connection);
         assertThat(endPoint.isOutputShutdown()).isTrue();
         assertThat(endPoint.isOpen()).isFalse();
@@ -206,6 +217,21 @@ public class Jetty_alpn_clientTest {
         SSLEngine sslEngine = SSLContext.getDefault().createSSLEngine("localhost", 443);
         sslEngine.setUseClientMode(true);
         return sslEngine;
+    }
+
+    private static Map<String, Object> newContextWithConnectionPromise(RecordingPromise connectionPromise) {
+        Map<String, Object> context = new HashMap<>();
+        context.put(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY, connectionPromise);
+        return context;
+    }
+
+    private static final class RecordingPromise implements Promise<Connection> {
+        private Throwable failure;
+
+        @Override
+        public void failed(Throwable failure) {
+            this.failure = failure;
+        }
     }
 
     private static final class TestClientConnectionFactory implements ClientConnectionFactory {

--- a/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/user-code-filter.json
+++ b/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.eclipse.jetty.alpn.client.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_jetty.jetty_alpn_client.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6316

This PR provides test fixes and new metadata for org.eclipse.jetty:jetty-alpn-client:12.0.31, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 64892
- Cached input tokens: 359936
- Output tokens: 4968
- Metadata entries: 4
- Iterations: 1
- Library coverage percentage: 39.13
- Previous library version metadata entries: 14
- Previous library version coverage percentage: 39.13

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `94ec951aa69325f642f234a61b32460bfa57714c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.eclipse.jetty:jetty-alpn-client:11.0.12: 0/0 covered calls (100.00%)
- org.eclipse.jetty:jetty-alpn-client:12.0.31: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.eclipse.jetty:jetty-alpn-client:11.0.12: 65/182 (35.71%)
- org.eclipse.jetty:jetty-alpn-client:12.0.31: 65/183 (35.52%)

**Line:**
- org.eclipse.jetty:jetty-alpn-client:11.0.12: 18/46 (39.13%)
- org.eclipse.jetty:jetty-alpn-client:12.0.31: 18/46 (39.13%)

**Method:**
- org.eclipse.jetty:jetty-alpn-client:11.0.12: 5/7 (71.43%)
- org.eclipse.jetty:jetty-alpn-client:12.0.31: 5/7 (71.43%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java 2/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
index 57624ee0e8..3fb2c0f9fd 100644
--- 1/tests/src/org.eclipse.jetty/jetty-alpn-client/11.0.12/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
+++ 2/tests/src/org.eclipse.jetty/jetty-alpn-client/12.0.31/src/test/java/org_eclipse_jetty/jetty_alpn_client/Jetty_alpn_clientTest.java
@@ -14,14 +14,17 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.alpn.client.ALPNClientConnection;
 import org.eclipse.jetty.alpn.client.ALPNClientConnectionFactory;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.ByteArrayEndPoint;
 import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.Promise;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,9 +123,10 @@ public class Jetty_alpn_clientTest {
     }
 
     @Test
-    void endOfInputCompletesNegotiationAndUpgradesToProtocolConnection() throws Exception {
+    void endOfInputFailsConnectionPromiseAndClosesEndPoint() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
-        Map<String, Object> context = new HashMap<>();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
         TestClientConnectionFactory connectionFactory = new TestClientConnectionFactory();
         ALPNClientConnection connection = newAlpnConnection(endPoint, connectionFactory, context);
         endPoint.setConnection(connection);
@@ -131,11 +135,13 @@ public class Jetty_alpn_clientTest {
         connection.onFillable();
 
         assertThat(connection.getProtocol()).isNull();
-        assertThat(connectionFactory.createdConnections).hasSize(1);
-        assertThat(connectionFactory.seenEndPoints).containsExactly(endPoint);
-        assertThat(connectionFactory.seenContexts).containsExactly(context);
-        assertThat(endPoint.getConnection()).isSameAs(connectionFactory.createdConnections.get(0));
-        assertThat(connectionFactory.createdConnections.get(0).opened).isTrue();
+        assertThat(connectionFactory.createdConnections).isEmpty();
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(SSLHandshakeException.class)
+                .hasMessage("Abruptly closed by peer");
+        assertThat(endPoint.getConnection()).isSameAs(connection);
+        assertThat(endPoint.isOutputShutdown()).isTrue();
+        assertThat(endPoint.isOpen()).isFalse();
     }
 
     @Test
@@ -154,16 +160,21 @@ public class Jetty_alpn_clientTest {
     @Test
     void failedProtocolConnectionCreationClosesEndPoint() throws Exception {
         ByteArrayEndPoint endPoint = new ByteArrayEndPoint();
+        RecordingPromise connectionPromise = new RecordingPromise();
+        Map<String, Object> context = newContextWithConnectionPromise(connectionPromise);
         ClientConnectionFactory failingConnectionFactory = (ignoredEndPoint, ignoredContext) -> {
             throw new IOException("Unable to create protocol connection");
         };
-        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, new HashMap<>());
+        ALPNClientConnection connection = newAlpnConnection(endPoint, failingConnectionFactory, context);
         endPoint.setConnection(connection);
 
         connection.selected("h2");
         connection.onOpen();
 
         assertThat(connection.getProtocol()).isEqualTo("h2");
+        assertThat(connectionPromise.failure)
+                .isInstanceOf(IOException.class)
+                .hasMessage("Unable to create protocol connection");
         assertThat(endPoint.getConnection()).isSameAs(connection);
         assertThat(endPoint.isOutputShutdown()).isTrue();
         assertThat(endPoint.isOpen()).isFalse();
@@ -208,6 +219,21 @@ public class Jetty_alpn_clientTest {
         return sslEngine;
     }
 
+    private static Map<String, Object> newContextWithConnectionPromise(RecordingPromise connectionPromise) {
+        Map<String, Object> context = new HashMap<>();
+        context.put(ClientConnector.CONNECTION_PROMISE_CONTEXT_KEY, connectionPromise);
+        return context;
+    }
+
+    private static final class RecordingPromise implements Promise<Connection> {
+        private Throwable failure;
+
+        @Override
+        public void failed(Throwable failure) {
+            this.failure = failure;
+        }
+    }
+
     private static final class TestClientConnectionFactory implements ClientConnectionFactory {
         private final List<EndPoint> seenEndPoints = new ArrayList<>();
         private final List<Map<String, Object>> seenContexts = new ArrayList<>();

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
