### PR TITLE
[GenAI] Test fix for org.scala-lang.modules:scala-xml_2.13:2.0.0 using gpt-5.5

### DIFF
--- a/metadata/org.scala-lang.modules/scala-xml_2.13/2.0.0/reachability-metadata.json
+++ b/metadata/org.scala-lang.modules/scala-xml_2.13/2.0.0/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader$$anon$1"
+      },
+      "type": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader$$anon$1"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader"
+      },
+      "type": "short[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader$$anon$1"
+      },
+      "type": "short[][]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "scala.xml.factory.XMLLoader$$anon$1"
+      },
+      "glob": "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    }
+  ]
+}

--- a/metadata/org.scala-lang.modules/scala-xml_2.13/index.json
+++ b/metadata/org.scala-lang.modules/scala-xml_2.13/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.13/$version$/scala-xml_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/scala/scala-xml",
+    "test-code-url" : "https://github.com/scala/scala-xml/tree/v$version$/jvm/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.13/$version$/scala-xml_2.13-$version$-javadoc.jar",
+    "description" : "scala-xml is the standard Scala XML library, providing Scala APIs for XML literals, node trees, attributes, parsing, serialization, and pretty printing. It is distributed separately from the Scala compiler so Scala 2 applications can depend on XML support only when they need it.",
     "language" : {
       "name" : "scala",
       "version" : "2"

--- a/metadata/org.scala-lang.modules/scala-xml_2.13/index.json
+++ b/metadata/org.scala-lang.modules/scala-xml_2.13/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.0",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "2.0.0"
+    ],
+    "allowed-packages" : [
+      "scala.xml"
+    ]
+  },
+  {
     "metadata-version" : "1.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/scala-lang/modules/scala-xml_2.13/$version$/scala-xml_2.13-$version$-sources.jar",
     "repository-url" : "https://github.com/scala/scala-xml",

--- a/stats/org.scala-lang.modules/scala-xml_2.13/2.0.0/execution-metrics.json
+++ b/stats/org.scala-lang.modules/scala-xml_2.13/2.0.0/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T13:41:35.972611Z",
+    "library": "org.scala-lang.modules:scala-xml_2.13:2.0.0",
+    "starting_commit": "af73e5f02112df7bc41fd27dacbb8a1ffe568a18",
+    "ending_commit": "dcbd206da9fae2348d11f78967c2207435429547",
+    "previous_library": "org.scala-lang.modules:scala-xml_2.13:1.2.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5554,
+          "missed": 24378,
+          "ratio": 0.185554,
+          "total": 29932
+        },
+        "line": {
+          "covered": 714,
+          "missed": 1666,
+          "ratio": 0.3,
+          "total": 2380
+        },
+        "method": {
+          "covered": 484,
+          "missed": 2440,
+          "ratio": 0.165527,
+          "total": 2924
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5508,
+          "missed": 29894,
+          "ratio": 0.155584,
+          "total": 35402
+        },
+        "line": {
+          "covered": 688,
+          "missed": 2026,
+          "ratio": 0.2535,
+          "total": 2714
+        },
+        "method": {
+          "covered": 480,
+          "missed": 3170,
+          "ratio": 0.131507,
+          "total": 3650
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 27281,
+      "cached_input_tokens_used": 366592,
+      "output_tokens_used": 4313,
+      "iterations": 1,
+      "cost_usd": 0.3127,
+      "tested_library_loc": 714,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 30.0,
+      "previous_library_coverage_percent": 25.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/src/test/scala/org_scala_lang_modules/scala_xml_2_13/Scala_xml_2_13Test.scala",
+      "metadata_file": "metadata/org.scala-lang.modules/scala-xml_2.13/2.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scala-lang.modules/scala-xml_2.13/2.0.0/stats.json
+++ b/stats/org.scala-lang.modules/scala-xml_2.13/2.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5554,
+        "missed" : 24378,
+        "ratio" : 0.185554,
+        "total" : 29932
+      },
+      "line" : {
+        "covered" : 714,
+        "missed" : 1666,
+        "ratio" : 0.3,
+        "total" : 2380
+      },
+      "method" : {
+        "covered" : 484,
+        "missed" : 2440,
+        "ratio" : 0.165527,
+        "total" : 2924
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/.gitignore
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.scala-lang:scala-library:2.13.16'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/gradle.properties
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scala-lang.modules:scala-xml_2.13:2.0.0
+library.version = 2.0.0
+metadata.dir = org.scala-lang.modules/scala-xml_2.13/2.0.0/

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/settings.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scala-lang.modules.scala-xml_2.13_tests'

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/src/test/scala/org_scala_lang_modules/scala_xml_2_13/Scala_xml_2_13Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/src/test/scala/org_scala_lang_modules/scala_xml_2_13/Scala_xml_2_13Test.scala
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.xml.sax.SAXParseException
 
 import scala.jdk.CollectionConverters._
+import scala.xml.Document
 import scala.xml.Elem
 import scala.xml.Group
 import scala.xml.Node
@@ -28,10 +29,7 @@ import scala.xml.Utility
 import scala.xml.XML
 import scala.xml.dtd.DocType
 import scala.xml.dtd.SystemID
-import scala.xml.pull.EvElemEnd
-import scala.xml.pull.EvElemStart
-import scala.xml.pull.EvText
-import scala.xml.pull.XMLEventReader
+import scala.xml.parsing.ConstructingParser
 import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
 
@@ -188,29 +186,30 @@ class Scala_xml_2_13Test {
   }
 
   @Test
-  def streamsXmlAsPullEvents(): Unit = {
+  def constructsDocumentWithMarkupParser(): Unit = {
     val source: Source = Source.fromString(
-      """<orders><order id="o1"><item quantity="2">pencils</item></order><order id="o2"/></orders>"""
+      """<?xml version="1.0" encoding="UTF-8"?>
+        |<orders><order id="o1"><item quantity="2">pencils</item></order><order id="o2"/></orders>""".stripMargin
     )
 
     try {
-      val reader: XMLEventReader = new XMLEventReader(source)
-      val events: List[scala.xml.pull.XMLEvent] = reader.toList
+      val document: Document = ConstructingParser.fromSource(source, preserveWS = false).document()
+      val root: Elem = document.docElem.asInstanceOf[Elem]
 
-      val startLabels: Seq[String] = events.collect { case EvElemStart(_, label, _, _) => label }
-      assertThat(startLabels.asJava).containsExactly("orders", "order", "item", "order")
+      assertThat(document.version).isEqualTo(Some("1.0"))
+      assertThat(document.encoding).isEqualTo(Some("UTF-8"))
+      assertThat(root.label).isEqualTo("orders")
 
-      val orderIds: Seq[String] = events.collect { case EvElemStart(_, "order", attributes, _) => attributes.asAttrMap("id") }
+      val orderLabels: Seq[String] = (root \ "order").map(_.label)
+      assertThat(orderLabels.asJava).containsExactly("order", "order")
+
+      val orderIds: Seq[String] = (root \ "order").map(order => (order \ "@id").text)
       assertThat(orderIds.asJava).containsExactly("o1", "o2")
 
-      val itemQuantities: Seq[String] = events.collect {
-        case EvElemStart(_, "item", attributes, _) => attributes.asAttrMap("quantity")
-      }
-      assertThat(itemQuantities.asJava).containsExactly("2")
-      assertThat(events.collect { case EvText(text) => text }.asJava).containsExactly("pencils")
-
-      val endLabels: Seq[String] = events.collect { case EvElemEnd(_, label) => label }
-      assertThat(endLabels.asJava).containsExactly("item", "order", "order", "orders")
+      val items: NodeSeq = root \\ "item"
+      assertThat(items.map(item => (item \ "@quantity").text).asJava).containsExactly("2")
+      assertThat(items.map(_.text).asJava).containsExactly("pencils")
+      assertThat(root.child.collect { case elem: Elem => elem.label }.asJava).containsExactly("order", "order")
     } finally {
       source.close()
     }

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/src/test/scala/org_scala_lang_modules/scala_xml_2_13/Scala_xml_2_13Test.scala
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/src/test/scala/org_scala_lang_modules/scala_xml_2_13/Scala_xml_2_13Test.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scala_lang_modules.scala_xml_2_13
+
+import java.io.StringWriter
+
+import scala.io.Source
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.xml.sax.SAXParseException
+
+import scala.jdk.CollectionConverters._
+import scala.xml.Elem
+import scala.xml.Group
+import scala.xml.Node
+import scala.xml.NodeSeq
+import scala.xml.PCData
+import scala.xml.PrettyPrinter
+import scala.xml.Text
+import scala.xml.Unparsed
+import scala.xml.Utility
+import scala.xml.XML
+import scala.xml.dtd.DocType
+import scala.xml.dtd.SystemID
+import scala.xml.pull.EvElemEnd
+import scala.xml.pull.EvElemStart
+import scala.xml.pull.EvText
+import scala.xml.pull.XMLEventReader
+import scala.xml.transform.RewriteRule
+import scala.xml.transform.RuleTransformer
+
+class Scala_xml_2_13Test {
+  @Test
+  def parsesElementsAttributesNamespacesAndCharacterData(): Unit = {
+    val document: Elem = XML.loadString(
+      """<?xml version="1.0" encoding="UTF-8"?>
+        |<catalog xmlns:bk="urn:books" id="main">
+        |  <bk:book bk:isbn="978-0134685991" available="true">
+        |    <title>Effective Java</title>
+        |    <description><![CDATA[Generics & lambdas <guide>]]></description>
+        |  </bk:book>
+        |  <bk:book bk:isbn="978-1617290657" available="false">
+        |    <title>Functional Programming in Scala</title>
+        |  </bk:book>
+        |</catalog>
+        |""".stripMargin
+    )
+
+    assertThat(document.label).isEqualTo("catalog")
+    assertThat(document.attribute("id").map(_.text)).isEqualTo(Some("main"))
+    assertThat(document.scope.getURI("bk")).isEqualTo("urn:books")
+
+    val books: NodeSeq = document \\ "book"
+    assertThat(books.length).isEqualTo(2)
+    assertThat(books.head.prefix).isEqualTo("bk")
+    assertThat(books.head.namespace).isEqualTo("urn:books")
+    assertThat(books.head.attribute("urn:books", "isbn").map(_.text)).isEqualTo(Some("978-0134685991"))
+    assertThat((books.head \ "description").text).isEqualTo("Generics & lambdas <guide>")
+  }
+
+  @Test
+  def navigatesNodeSequencesAndFiltersByAttributes(): Unit = {
+    val library: Elem =
+      <library>
+        <section name="programming">
+          <book id="b1" available="true"><author>Ada</author><author>Grace</author></book>
+          <book id="b2" available="false"><author>Alan</author></book>
+        </section>
+        <section name="math">
+          <book id="b3" available="true"><author>Emmy</author></book>
+        </section>
+      </library>
+
+    val sectionNames: Seq[String] = (library \ "section").map(node => (node \ "@name").text)
+    assertThat(sectionNames.asJava).containsExactly("programming", "math")
+
+    val availableBookIds: Seq[String] = (library \\ "book")
+      .filter(book => (book \ "@available").text == "true")
+      .map(book => (book \ "@id").text)
+    assertThat(availableBookIds.asJava).containsExactly("b1", "b3")
+
+    val authors: Seq[String] = (library \\ "book").head \ "author" map (_.text)
+    assertThat(authors.asJava).containsExactly("Ada", "Grace")
+    assertThat((library \ "missing").isEmpty).isTrue
+  }
+
+  @Test
+  def constructsMixedContentAndRendersSpecialNodeTypes(): Unit = {
+    val groupedLinks: Group = Group(Seq(<a href="/one">one</a>, <a href="/two">two</a>))
+    val fragment: Elem =
+      <article>
+        <title>{Text("Escaped <title> & data")}</title>
+        <body>{PCData("<p>raw but protected & readable</p>")}{Unparsed("<br/>")}{groupedLinks}</body>
+      </article>
+
+    val rendered: String = fragment.toString()
+    assertThat(rendered).contains("Escaped &lt;title&gt; &amp; data")
+    assertThat(rendered).contains("<![CDATA[<p>raw but protected & readable</p>]]>")
+    assertThat(rendered).contains("<br/>")
+    assertThat(groupedLinks.nodes.map(node => (node \ "@href").text).asJava).containsExactly("/one", "/two")
+    assertThat(rendered).contains("raw but protected")
+  }
+
+  @Test
+  def copiesElementsWhilePreservingAttributesAndChildren(): Unit = {
+    val original: Elem = <book id="b1"><title>Old title</title><tags><tag>scala</tag></tags></book>
+    val updated: Elem = original.copy(
+      label = "updatedBook",
+      child = Seq(<title>New title</title>) ++ (original \ "tags") ++ Seq(<published year="2024"/>)
+    )
+
+    assertThat(updated.label).isEqualTo("updatedBook")
+    assertThat((updated \ "@id").text).isEqualTo("b1")
+    assertThat((updated \ "title").text).isEqualTo("New title")
+    assertThat((updated \\ "tag").text).isEqualTo("scala")
+    assertThat(((updated \ "published").head \ "@year").text).isEqualTo("2024")
+  }
+
+  @Test
+  def rewritesTreesWithRuleTransformer(): Unit = {
+    val catalog: Elem =
+      <catalog>
+        <book id="b1"><title>Old title</title><obsolete>true</obsolete></book>
+        <book id="b2"><title>Keep title</title><obsolete>false</obsolete></book>
+      </catalog>
+
+    val transformer: RuleTransformer = new RuleTransformer(new RewriteRule {
+      override def transform(node: Node): Seq[Node] = node match {
+        case elem: Elem if elem.label == "obsolete" => NodeSeq.Empty
+        case elem: Elem if elem.label == "title" && elem.text == "Old title" => elem.copy(child = Seq(Text("New title")))
+        case other => other
+      }
+    })
+
+    val transformed: Elem = transformer.transform(catalog).head.asInstanceOf[Elem]
+
+    assertThat((transformed \\ "obsolete").isEmpty).isTrue
+    assertThat((transformed \ "book").head.attribute("id").map(_.text)).isEqualTo(Some("b1"))
+    assertThat((transformed \\ "title").map(_.text).asJava).containsExactly("New title", "Keep title")
+  }
+
+  @Test
+  def trimsWhitespaceEscapesTextAndPrettyPrintsRoundTrippableXml(): Unit = {
+    val messy: Elem =
+      <root>
+        <item>
+          value
+        </item>
+        <empty></empty>
+      </root>
+
+    val trimmed: Node = Utility.trim(messy)
+    assertThat((trimmed \ "item").text).isEqualTo("value")
+    val escaped: String = Utility.escape("5 < 7 & 9 > 3")
+    assertThat(escaped).contains("&lt;").contains("&amp;").contains("&gt;")
+
+    val pretty: String = new PrettyPrinter(width = 80, step = 2).format(trimmed)
+    assertThat(pretty).contains("\n  <item>value</item>")
+    assertThat(pretty).contains("<empty")
+
+    val reparsed: Elem = XML.loadString(pretty)
+    assertThat((reparsed \ "item").text).isEqualTo("value")
+    assertThat((reparsed \ "empty").nonEmpty).isTrue
+  }
+
+  @Test
+  def writesCompleteXmlDocumentWithDeclarationAndDoctype(): Unit = {
+    val document: Elem =
+      <report>
+        <entry status="ok">completed</entry>
+      </report>
+    val doctype: DocType = DocType("report", SystemID("report.dtd"), Nil)
+    val writer: StringWriter = new StringWriter()
+
+    XML.write(writer, document, "UTF-8", true, doctype)
+
+    val written: String = writer.toString
+    assertThat(written).startsWith("<?xml version=")
+    assertThat(written).contains("UTF-8")
+    assertThat(written).contains("<!DOCTYPE report SYSTEM \"report.dtd\">")
+    assertThat(written).contains("<entry status=\"ok\">completed</entry>")
+  }
+
+  @Test
+  def streamsXmlAsPullEvents(): Unit = {
+    val source: Source = Source.fromString(
+      """<orders><order id="o1"><item quantity="2">pencils</item></order><order id="o2"/></orders>"""
+    )
+
+    try {
+      val reader: XMLEventReader = new XMLEventReader(source)
+      val events: List[scala.xml.pull.XMLEvent] = reader.toList
+
+      val startLabels: Seq[String] = events.collect { case EvElemStart(_, label, _, _) => label }
+      assertThat(startLabels.asJava).containsExactly("orders", "order", "item", "order")
+
+      val orderIds: Seq[String] = events.collect { case EvElemStart(_, "order", attributes, _) => attributes.asAttrMap("id") }
+      assertThat(orderIds.asJava).containsExactly("o1", "o2")
+
+      val itemQuantities: Seq[String] = events.collect {
+        case EvElemStart(_, "item", attributes, _) => attributes.asAttrMap("quantity")
+      }
+      assertThat(itemQuantities.asJava).containsExactly("2")
+      assertThat(events.collect { case EvText(text) => text }.asJava).containsExactly("pencils")
+
+      val endLabels: Seq[String] = events.collect { case EvElemEnd(_, label) => label }
+      assertThat(endLabels.asJava).containsExactly("item", "order", "order", "orders")
+    } finally {
+      source.close()
+    }
+  }
+
+  @Test
+  def reportsMalformedXmlWithParserException(): Unit = {
+    val error: SAXParseException = assertThrows(
+      classOf[SAXParseException],
+      () => {
+        XML.loadString("<root><unclosed></root>")
+        ()
+      }
+    )
+
+    assertThat(error.getMessage).contains("unclosed")
+  }
+}

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/user-code-filter.json
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "scala.xml.**"
+    },
+    {
+      "includeClasses" : "org_scala_lang_modules.scala_xml_2_13.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6320

This PR provides test fixes and new metadata for org.scala-lang.modules:scala-xml_2.13:2.0.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 27281
- Cached input tokens: 366592
- Output tokens: 4313
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 30.0
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 25.35

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `a933d66ee93f7a5f4115ee0e0c7191647e4ecccb`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.scala-lang.modules:scala-xml_2.13:1.2.0: 0/0 covered calls (100.00%)
- org.scala-lang.modules:scala-xml_2.13:2.0.0: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.scala-lang.modules:scala-xml_2.13:1.2.0: 5508/35402 (15.56%)
- org.scala-lang.modules:scala-xml_2.13:2.0.0: 5554/29932 (18.56%)

**Line:**
- org.scala-lang.modules:scala-xml_2.13:1.2.0: 688/2714 (25.35%)
- org.scala-lang.modules:scala-xml_2.13:2.0.0: 714/2380 (30.00%)

**Method:**
- org.scala-lang.modules:scala-xml_2.13:1.2.0: 480/3650 (13.15%)
- org.scala-lang.modules:scala-xml_2.13:2.0.0: 484/2924 (16.55%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
