### PR TITLE
[GenAI] Test fix for dev.profunktor:redis4cats-core_3:2.0.2 using gpt-5.5

### DIFF
--- a/metadata/dev.profunktor/redis4cats-core_3/2.0.2/reachability-metadata.json
+++ b/metadata/dev.profunktor/redis4cats-core_3/2.0.2/reachability-metadata.json
@@ -1,0 +1,106 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.buffer.AbstractReferenceCountedByteBuf"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.buffer.AdaptivePoolingAllocator$Chunk"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.buffer.AdaptivePoolingAllocator$Magazine"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.util.internal.CleanerJava25$CleanableDirectBufferImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueConsumerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "io.netty.util.internal.shaded.org.jctools.queues.atomic.MpmcAtomicArrayQueueProducerIndexField"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.Module"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.foreign.Arena"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.foreign.MemorySegment"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.foreign.SegmentAllocator"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.invoke.LambdaForm$Name[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.management.RuntimeMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "dev.profunktor.redis4cats.codecs.Codecs$$anon$1"
+      },
+      "type": "sun.invoke.util.ValueConversions"
+    }
+  ]
+}

--- a/metadata/dev.profunktor/redis4cats-core_3/index.json
+++ b/metadata/dev.profunktor/redis4cats-core_3/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "2.0.2",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "2.0.2"
+    ],
+    "allowed-packages" : [
+      "dev.profunktor.redis4cats"
+    ]
+  },
+  {
     "metadata-version" : "1.7.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/dev/profunktor/redis4cats-core_3/$version$/redis4cats-core_3-$version$-sources.jar",
     "repository-url" : "https://github.com/profunktor/redis4cats",

--- a/metadata/dev.profunktor/redis4cats-core_3/index.json
+++ b/metadata/dev.profunktor/redis4cats-core_3/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "2.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/dev/profunktor/redis4cats-core_3/$version$/redis4cats-core_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/profunktor/redis4cats",
+    "test-code-url" : "https://github.com/profunktor/redis4cats/tree/v$version$/modules/core/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/dev/profunktor/redis4cats-core_3/$version$/redis4cats-core_3-$version$-javadoc.jar",
+    "description" : "redis4cats-core_3 provides the core Scala 3 API for a Redis client built on Cats Effect, FS2, and the Lettuce Java client. It defines the command abstractions, codecs, connection support, and effect integration used by Redis4Cats modules and applications.",
     "language" : {
       "name" : "scala",
       "version" : "3"

--- a/stats/dev.profunktor/redis4cats-core_3/2.0.2/execution-metrics.json
+++ b/stats/dev.profunktor/redis4cats-core_3/2.0.2/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-07": {
+    "timestamp": "2026-05-07T13:57:33.693221Z",
+    "library": "dev.profunktor:redis4cats-core_3:2.0.2",
+    "starting_commit": "430aa16873a84195305d9bfdbd900b5eab33747b",
+    "ending_commit": "16eae298ad4769f4684e67942b18587911e27090",
+    "previous_library": "dev.profunktor:redis4cats-core_3:1.7.2",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 6249,
+          "ratio": 0.049582,
+          "total": 6575
+        },
+        "line": {
+          "covered": 39,
+          "missed": 304,
+          "ratio": 0.113703,
+          "total": 343
+        },
+        "method": {
+          "covered": 49,
+          "missed": 904,
+          "ratio": 0.051417,
+          "total": 953
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.7.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 326,
+          "missed": 5928,
+          "ratio": 0.052127,
+          "total": 6254
+        },
+        "line": {
+          "covered": 39,
+          "missed": 297,
+          "ratio": 0.116071,
+          "total": 336
+        },
+        "method": {
+          "covered": 49,
+          "missed": 855,
+          "ratio": 0.054204,
+          "total": 904
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 25634,
+      "cached_input_tokens_used": 380416,
+      "output_tokens_used": 3846,
+      "iterations": 1,
+      "cost_usd": 0.3056,
+      "tested_library_loc": 39,
+      "metadata_entries": 17,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 11.37,
+      "previous_library_coverage_percent": 11.61
+    },
+    "artifacts": {
+      "test_file": "tests/src/dev.profunktor/redis4cats-core_3/2.0.2/src/test/scala/dev_profunktor/redis4cats_core_3/Redis4cats_core_3Test.scala",
+      "metadata_file": "metadata/dev.profunktor/redis4cats-core_3/2.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/dev.profunktor/redis4cats-core_3/2.0.2/stats.json
+++ b/stats/dev.profunktor/redis4cats-core_3/2.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 326,
+        "missed" : 6249,
+        "ratio" : 0.049582,
+        "total" : 6575
+      },
+      "line" : {
+        "covered" : 39,
+        "missed" : 304,
+        "ratio" : 0.113703,
+        "total" : 343
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 904,
+        "ratio" : 0.051417,
+        "total" : 953
+      }
+    }
+  } ]
+}

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/.gitignore
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/gradle.properties
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = dev.profunktor:redis4cats-core_3:2.0.2
+library.version = 2.0.2
+metadata.dir = dev.profunktor/redis4cats-core_3/2.0.2/

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/settings.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'dev.profunktor.redis4cats-core_3_tests'

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/src/test/scala/dev_profunktor/redis4cats_core_3/Redis4cats_core_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/src/test/scala/dev_profunktor/redis4cats_core_3/Redis4cats_core_3Test.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dev_profunktor.redis4cats_core_3
+
+import dev.profunktor.redis4cats.codecs.Codecs
+import dev.profunktor.redis4cats.codecs.splits.{SplitEpi, SplitMono}
+import dev.profunktor.redis4cats.connection.{InvalidRedisURI, RedisURI}
+import dev.profunktor.redis4cats.data.RedisCodec
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotSame, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+class Redis4cats_core_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+
+  @Test
+  def splitEpiAndSplitMonoComposeAndReversePureTransformations(): Unit = {
+    val parseNumber: SplitEpi[String, Int] = SplitEpi[String, Int](_.toInt, _.toString)
+    val numberToCounter: SplitEpi[Int, CounterValue] = SplitEpi[Int, CounterValue](value => CounterValue(value.toLong), _.value.toInt)
+    val parseCounter: SplitEpi[String, CounterValue] = parseNumber.andThen(numberToCounter)
+    val counterToString: SplitMono[CounterValue, String] = parseCounter.reverse
+
+    assertEquals(CounterValue(7L), parseCounter("7"))
+    assertEquals("7", parseCounter.reverseGet(CounterValue(7L)))
+    assertEquals("7", counterToString(CounterValue(7L)))
+    assertEquals(CounterValue(7L), counterToString.reverseGet("7"))
+    assertNotSame(parseCounter, parseCounter.copy())
+  }
+
+  @Test
+  def splitMonoCompositionPreservesBidirectionalConversions(): Unit = {
+    val trimInput: SplitMono[String, String] = SplitMono[String, String](_.trim, identity)
+    val lengthValue: SplitMono[String, StringLength] = SplitMono[String, StringLength](value => StringLength(value.length), length => "x" * length.value)
+    val trimmedLength: SplitMono[String, StringLength] = trimInput.andThen(lengthValue)
+    val lengthToString: SplitEpi[StringLength, String] = trimmedLength.reverse
+
+    assertEquals(StringLength(5), trimmedLength("  redis  "))
+    assertEquals("xxx", trimmedLength.reverseGet(StringLength(3)))
+    assertEquals("xxxx", lengthToString(StringLength(4)))
+    assertEquals(StringLength(4), lengthToString.reverseGet("data"))
+    assertEquals("SplitMono", trimmedLength.productPrefix)
+  }
+
+  @Test
+  def redisUriParsesValidUrisAndReportsInvalidOnes(): Unit = {
+    val validUri: RedisURI = RedisURI.fromString("rediss://:secret@localhost:6380/2").toOption.get
+
+    assertEquals("localhost", validUri.underlying.getHost)
+    assertEquals(6380, validUri.underlying.getPort)
+    assertEquals(2, validUri.underlying.getDatabase)
+    assertEquals("secret", new String(validUri.underlying.getPassword))
+    assertTrue(validUri.underlying.isSsl)
+
+    val invalidUri: String = "ftp://localhost:6379"
+    val invalidResult: Either[InvalidRedisURI, RedisURI] = RedisURI.fromString(invalidUri)
+    assertTrue(invalidResult.isLeft)
+    val error: InvalidRedisURI = invalidResult.swap.toOption.get
+    assertEquals(invalidUri, error.uri)
+    assertTrue(error.getMessage.nonEmpty)
+  }
+
+  @Test
+  def derivedCodecTransformsValuesWhileKeepingBaseKeyEncoding(): Unit = {
+    val counterSplit: SplitEpi[String, CounterValue] =
+      SplitEpi[String, CounterValue](value => CounterValue(value.toLong), _.value.toString)
+    val codec: RedisCodec[String, CounterValue] = Codecs.derive(RedisCodec.Utf8, counterSplit)
+
+    assertEquals("counter:primary", utf8String(codec.underlying.encodeKey("counter:primary")))
+    assertEquals("12", utf8String(codec.underlying.encodeValue(CounterValue(12L))))
+    assertEquals("counter:secondary", codec.underlying.decodeKey(utf8Buffer("counter:secondary")))
+    assertEquals(CounterValue(34L), codec.underlying.decodeValue(utf8Buffer("34")))
+  }
+
+  @Test
+  def derivedCodecTransformsKeysAndValues(): Unit = {
+    val cacheKeySplit: SplitEpi[String, CacheKey] =
+      SplitEpi[String, CacheKey](CacheKey.parse, key => s"${key.namespace}:${key.id}")
+    val usernameSplit: SplitEpi[String, Username] =
+      SplitEpi[String, Username](Username.apply, _.value)
+    val codec: RedisCodec[CacheKey, Username] =
+      Codecs.derive(RedisCodec.Utf8, cacheKeySplit, usernameSplit)
+
+    assertEquals("user:42", utf8String(codec.underlying.encodeKey(CacheKey("user", 42L))))
+    assertEquals("alice", utf8String(codec.underlying.encodeValue(Username("alice"))))
+    assertEquals(CacheKey("session", 7L), codec.underlying.decodeKey(utf8Buffer("session:7")))
+    assertEquals(Username("bob"), codec.underlying.decodeValue(utf8Buffer("bob")))
+  }
+
+  private def utf8Buffer(value: String): ByteBuffer =
+    ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8))
+
+  private def utf8String(buffer: ByteBuffer): String = {
+    val readableBuffer: ByteBuffer = buffer.asReadOnlyBuffer()
+    val bytes: Array[Byte] = new Array[Byte](readableBuffer.remaining())
+    readableBuffer.get(bytes)
+    new String(bytes, StandardCharsets.UTF_8)
+  }
+}
+
+final case class CounterValue(value: Long)
+
+final case class StringLength(value: Int)
+
+final case class CacheKey(namespace: String, id: Long)
+
+object CacheKey {
+  def parse(value: String): CacheKey = {
+    val parts: Array[String] = value.split(":", 2)
+    CacheKey(parts(0), parts(1).toLong)
+  }
+}
+
+final case class Username(value: String)

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/src/test/scala/dev_profunktor/redis4cats_core_3/Redis4cats_core_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/src/test/scala/dev_profunktor/redis4cats_core_3/Redis4cats_core_3Test.scala
@@ -10,11 +10,13 @@ import dev.profunktor.redis4cats.codecs.Codecs
 import dev.profunktor.redis4cats.codecs.splits.{SplitEpi, SplitMono}
 import dev.profunktor.redis4cats.connection.{InvalidRedisURI, RedisURI}
 import dev.profunktor.redis4cats.data.RedisCodec
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotSame, assertTrue}
+import io.lettuce.core.RedisCredentials
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertNotSame, assertTrue}
 import org.junit.jupiter.api.Test
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import java.time.Duration
 
 class Redis4cats_core_3Test {
   @Test
@@ -57,7 +59,11 @@ class Redis4cats_core_3Test {
     assertEquals("localhost", validUri.underlying.getHost)
     assertEquals(6380, validUri.underlying.getPort)
     assertEquals(2, validUri.underlying.getDatabase)
-    assertEquals("secret", new String(validUri.underlying.getPassword))
+    val credentials: RedisCredentials =
+      validUri.underlying.getCredentialsProvider.resolveCredentials().block(Duration.ofSeconds(5L))
+    assertNotNull(credentials)
+    assertTrue(credentials.hasPassword)
+    assertEquals("secret", new String(credentials.getPassword))
     assertTrue(validUri.underlying.isSsl)
 
     val invalidUri: String = "ftp://localhost:6379"

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/user-code-filter.json
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "dev.profunktor.redis4cats.**"
+    },
+    {
+      "includeClasses" : "dev_profunktor.redis4cats_core_3.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6306

This PR provides test fixes and new metadata for dev.profunktor:redis4cats-core_3:2.0.2, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 25634
- Cached input tokens: 380416
- Output tokens: 3846
- Metadata entries: 17
- Iterations: 1
- Library coverage percentage: 11.37
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 11.61

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `94ec951aa69325f642f234a61b32460bfa57714c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- dev.profunktor:redis4cats-core_3:1.7.2: 0/0 covered calls (100.00%)
- dev.profunktor:redis4cats-core_3:2.0.2: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- dev.profunktor:redis4cats-core_3:1.7.2: 326/6254 (5.21%)
- dev.profunktor:redis4cats-core_3:2.0.2: 326/6575 (4.96%)

**Line:**
- dev.profunktor:redis4cats-core_3:1.7.2: 39/336 (11.61%)
- dev.profunktor:redis4cats-core_3:2.0.2: 39/343 (11.37%)

**Method:**
- dev.profunktor:redis4cats-core_3:1.7.2: 49/904 (5.42%)
- dev.profunktor:redis4cats-core_3:2.0.2: 49/953 (5.14%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
