### PR TITLE
[GenAI] Test fix for jakarta.el:jakarta.el-api:4.0.0 using gpt-5.5

### DIFF
--- a/metadata/jakarta.el/jakarta.el-api/4.0.0/reachability-metadata.json
+++ b/metadata/jakarta.el/jakarta.el-api/4.0.0/reachability-metadata.json
@@ -1,0 +1,132 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELProcessor"
+      },
+      "type": "jakarta_el.jakarta_el_api.ELProcessorFunctionLibrary"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELUtil"
+      },
+      "type": "jakarta_el.jakarta_el_api.ELUtilTest$GreetingContract"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.StaticFieldELResolver"
+      },
+      "type": "jakarta_el.jakarta_el_api.ELUtilTest$Operations"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELUtil"
+      },
+      "type": "jakarta_el.jakarta_el_api.ELUtilTest$PublicBaseOperation"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELUtil"
+      },
+      "type": "jakarta_el.jakarta_el_api.ELUtilTest$PublicConstructable"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.FactoryFinder"
+      },
+      "type": "jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.StaticFieldELResolver"
+      },
+      "type": "jakarta_el.jakarta_el_api.StaticFieldELResolverTest$StaticFieldTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ImportHandler"
+      },
+      "type": "java.lang.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELProcessor"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELProcessor"
+      },
+      "type": "java.lang.String[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELUtil"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ImportHandler"
+      },
+      "type": "java.util.ArrayList"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "jakarta.el.FactoryFinder"
+      },
+      "glob": "META-INF/services/jakarta.el.ExpressionFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.el.ELUtil"
+      },
+      "bundle": "jakarta.el.PrivateMessages"
+    }
+  ]
+}

--- a/metadata/jakarta.el/jakarta.el-api/4.0.0/reachability-metadata.json
+++ b/metadata/jakarta.el/jakarta.el-api/4.0.0/reachability-metadata.json
@@ -1,132 +1,78 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      "condition" : {
+        "typeReached" : "jakarta.el.ImportHandler"
       },
-      "type": "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanBeanInfo"
+      "type" : "java.lang.ArrayList"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
       },
-      "type": "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanCustomizer"
+      "type" : "java.lang.Class"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ELProcessor"
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
       },
-      "type": "jakarta_el.jakarta_el_api.ELProcessorFunctionLibrary"
+      "type" : "java.lang.ObjectBeanInfo"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ELUtil"
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
       },
-      "type": "jakarta_el.jakarta_el_api.ELUtilTest$GreetingContract"
+      "type" : "java.lang.ObjectCustomizer"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.StaticFieldELResolver"
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
       },
-      "type": "jakarta_el.jakarta_el_api.ELUtilTest$Operations"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ELUtil"
+      "condition" : {
+        "typeReached" : "jakarta.el.ELProcessor"
       },
-      "type": "jakarta_el.jakarta_el_api.ELUtilTest$PublicBaseOperation"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ELUtil"
+      "condition" : {
+        "typeReached" : "jakarta.el.ELProcessor"
       },
-      "type": "jakarta_el.jakarta_el_api.ELUtilTest$PublicConstructable"
+      "type" : "java.lang.String[][]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.FactoryFinder"
+      "condition" : {
+        "typeReached" : "jakarta.el.ELUtil"
       },
-      "type": "jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.StaticFieldELResolver"
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
       },
-      "type": "jakarta_el.jakarta_el_api.StaticFieldELResolverTest$StaticFieldTarget"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ImportHandler"
+      "condition" : {
+        "typeReached" : "jakarta.el.ImportHandler"
       },
-      "type": "java.lang.ArrayList"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
-      },
-      "type": "java.lang.Class"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
-      },
-      "type": "java.lang.ObjectBeanInfo"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
-      },
-      "type": "java.lang.ObjectCustomizer"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.ELProcessor"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.ELProcessor"
-      },
-      "type": "java.lang.String[][]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.ELUtil"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.BeanELResolver$BeanProperties"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.el.ImportHandler"
-      },
-      "type": "java.util.ArrayList"
+      "type" : "java.util.ArrayList"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "jakarta.el.FactoryFinder"
+      "condition" : {
+        "typeReached" : "jakarta.el.FactoryFinder"
       },
-      "glob": "META-INF/services/jakarta.el.ExpressionFactory"
+      "glob" : "META-INF/services/jakarta.el.ExpressionFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.el.ELUtil"
+      "condition" : {
+        "typeReached" : "jakarta.el.ELUtil"
       },
-      "bundle": "jakarta.el.PrivateMessages"
+      "bundle" : "jakarta.el.PrivateMessages"
     }
   ]
 }

--- a/metadata/jakarta.el/jakarta.el-api/index.json
+++ b/metadata/jakarta.el/jakarta.el-api/index.json
@@ -17,6 +17,11 @@
   },
   {
     "metadata-version" : "4.0.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/expression-language",
+    "test-code-url" : "https://github.com/jakartaee/expression-language/tree/$version$-RELEASE/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-javadoc.jar",
+    "description" : "Jakarta Expression Language API defines the standard interfaces and classes for parsing, evaluating, and resolving Expression Language expressions. Jakarta EE technologies and compatible runtimes use it to expose property access, method invocation, type conversion, variable resolution, and function resolution through a common API.",
     "tested-versions" : [
       "4.0.0"
     ],

--- a/metadata/jakarta.el/jakarta.el-api/index.json
+++ b/metadata/jakarta.el/jakarta.el-api/index.json
@@ -14,5 +14,14 @@
     "allowed-packages" : [
       "javax.el"
     ]
+  },
+  {
+    "metadata-version" : "4.0.0",
+    "tested-versions" : [
+      "4.0.0"
+    ],
+    "allowed-packages" : [
+      "javax.el"
+    ]
   }
 ]

--- a/metadata/jakarta.el/jakarta.el-api/index.json
+++ b/metadata/jakarta.el/jakarta.el-api/index.json
@@ -1,32 +1,33 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.0.2",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/jakartaee/expression-language",
-    "test-code-url" : "https://github.com/jakartaee/expression-language/tree/$version$-RI-COMB-RELEASE/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-javadoc.jar",
-    "description" : "Jakarta Expression Language API defines the standard Expression Language interfaces and classes for parsing, evaluating, and resolving expressions. It is used by Jakarta EE technologies and compatible runtimes to expose property access, method invocation, type conversion, and variable and function resolution through a common API.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "3.0.2",
+    "source-code-url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-sources.jar",
+    "repository-url": "https://github.com/jakartaee/expression-language",
+    "test-code-url": "https://github.com/jakartaee/expression-language/tree/$version$-RI-COMB-RELEASE/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-javadoc.jar",
+    "description": "Jakarta Expression Language API defines the standard Expression Language interfaces and classes for parsing, evaluating, and resolving expressions. It is used by Jakarta EE technologies and compatible runtimes to expose property access, method invocation, type conversion, and variable and function resolution through a common API.",
+    "tested-versions": [
       "3.0.2",
       "3.0.3"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "javax.el"
     ]
   },
   {
-    "metadata-version" : "4.0.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/jakartaee/expression-language",
-    "test-code-url" : "https://github.com/jakartaee/expression-language/tree/$version$-RELEASE/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-javadoc.jar",
-    "description" : "Jakarta Expression Language API defines the standard interfaces and classes for parsing, evaluating, and resolving Expression Language expressions. Jakarta EE technologies and compatible runtimes use it to expose property access, method invocation, type conversion, variable resolution, and function resolution through a common API.",
-    "tested-versions" : [
+    "metadata-version": "4.0.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-sources.jar",
+    "repository-url": "https://github.com/jakartaee/expression-language",
+    "test-code-url": "https://github.com/jakartaee/expression-language/tree/$version$-RELEASE/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/$version$/jakarta.el-api-$version$-javadoc.jar",
+    "description": "Jakarta Expression Language API defines the standard interfaces and classes for parsing, evaluating, and resolving Expression Language expressions. Jakarta EE technologies and compatible runtimes use it to expose property access, method invocation, type conversion, variable resolution, and function resolution through a common API.",
+    "tested-versions": [
       "4.0.0"
     ],
-    "allowed-packages" : [
-      "javax.el"
+    "allowed-packages": [
+      "javax.el",
+      "jakarta.el"
     ]
   }
 ]

--- a/stats/jakarta.el/jakarta.el-api/4.0.0/execution-metrics.json
+++ b/stats/jakarta.el/jakarta.el-api/4.0.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T19:53:53.949078Z",
+    "library": "jakarta.el:jakarta.el-api:4.0.0",
+    "starting_commit": "706e60f71e7b2b0b92de778f5b2306f20979f691",
+    "ending_commit": "7b024455779a63401d2059caf1d601f64ad96a3a",
+    "previous_library": "jakarta.el:jakarta.el-api:3.0.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 26,
+            "totalCalls": 26
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 27,
+        "totalCalls": 27
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1847,
+          "missed": 3547,
+          "ratio": 0.342418,
+          "total": 5394
+        },
+        "line": {
+          "covered": 450,
+          "missed": 921,
+          "ratio": 0.328228,
+          "total": 1371
+        },
+        "method": {
+          "covered": 92,
+          "missed": 174,
+          "ratio": 0.345865,
+          "total": 266
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.0.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 25,
+            "totalCalls": 25
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 3,
+            "totalCalls": 3
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 28,
+        "totalCalls": 28
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1859,
+          "missed": 3585,
+          "ratio": 0.341477,
+          "total": 5444
+        },
+        "line": {
+          "covered": 469,
+          "missed": 959,
+          "ratio": 0.328431,
+          "total": 1428
+        },
+        "method": {
+          "covered": 92,
+          "missed": 175,
+          "ratio": 0.344569,
+          "total": 267
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 141142,
+      "cached_input_tokens_used": 1872384,
+      "output_tokens_used": 17887,
+      "iterations": 4,
+      "cost_usd": 1.4728,
+      "tested_library_loc": 450,
+      "metadata_entries": 12,
+      "test_only_metadata_entries": 29,
+      "previous_library_metadata_entries": 14,
+      "previous_library_test_only_metadata_entries": 20,
+      "code_coverage_percent": 32.82,
+      "previous_library_coverage_percent": 32.84
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java",
+      "metadata_file": "metadata/jakarta.el/jakarta.el-api/4.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.el/jakarta.el-api/4.0.0/stats.json
+++ b/stats/jakarta.el/jakarta.el-api/4.0.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.0.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 26,
+          "totalCalls" : 26
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 27,
+      "totalCalls" : 27
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1847,
+        "missed" : 3547,
+        "ratio" : 0.342418,
+        "total" : 5394
+      },
+      "line" : {
+        "covered" : 450,
+        "missed" : 921,
+        "ratio" : 0.328228,
+        "total" : 1371
+      },
+      "method" : {
+        "covered" : 92,
+        "missed" : 174,
+        "ratio" : 0.345865,
+        "total" : 266
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/.gitignore
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.el:jakarta.el-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+String expressionFactoryClassName = "jakarta_el.jakarta_el_api.FactoryFinderTest\$ServiceExpressionFactory"
+
+tasks.withType(Test).configureEach {
+    systemProperty "jakarta.el.ExpressionFactory", expressionFactoryClassName
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djakarta.el.ExpressionFactory=${expressionFactoryClassName}")
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/gradle.properties
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.el:jakarta.el-api:4.0.0
+library.version = 4.0.0
+metadata.dir = jakarta.el/jakarta.el-api/4.0.0/

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/settings.gradle
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.el.jakarta.el-api_tests'

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
@@ -8,11 +8,11 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.el.BeanELResolver;
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.FunctionMapper;
-import javax.el.VariableMapper;
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.FunctionMapper;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.el.BeanELResolver;
+import javax.el.ELContext;
+import javax.el.ELResolver;
+import javax.el.FunctionMapper;
+import javax.el.VariableMapper;
+
+import org.junit.jupiter.api.Test;
+
+public class BeanELResolverTest {
+
+    @Test
+    void getsJavaBeansPropertyValue() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+        SampleBean bean = new SampleBean("initial");
+
+        Object value = resolver.getValue(context, bean, "name");
+
+        assertThat(value).isEqualTo("initial");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void setsJavaBeansPropertyValue() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+        SampleBean bean = new SampleBean("initial");
+
+        resolver.setValue(context, bean, "name", "updated");
+
+        assertThat(bean.getName()).isEqualTo("updated");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static final class SampleBean {
+        private String name;
+
+        public SampleBean(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private static final class SimpleELContext extends ELContext {
+        @Override
+        public ELResolver getELResolver() {
+            return null;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import javax.el.ELContext;
+import javax.el.ELException;
+import javax.el.ELProcessor;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ELProcessorTest {
+    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static String previousExpressionFactory;
+
+    @BeforeAll
+    static void installExpressionFactory() {
+        previousExpressionFactory = System.getProperty(EXPRESSION_FACTORY_PROPERTY);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, ProcessorExpressionFactory.class.getName());
+    }
+
+    @AfterAll
+    static void restoreExpressionFactory() {
+        if (previousExpressionFactory == null) {
+            System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        } else {
+            System.setProperty(EXPRESSION_FACTORY_PROPERTY, previousExpressionFactory);
+        }
+    }
+
+    @Test
+    void definesFunctionByScanningDeclaredMethods() throws Exception {
+        ELProcessor processor = new ELProcessor();
+
+        processor.defineFunction("fn", "triple", ELProcessorFunctionLibrary.class.getName(), "triple");
+
+        Method mappedMethod = resolveFunction(processor, "triple");
+        assertThat(mappedMethod).isNotNull();
+        assertThat(mappedMethod.getDeclaringClass()).isEqualTo(ELProcessorFunctionLibrary.class);
+        assertThat(mappedMethod.getName()).isEqualTo("triple");
+    }
+
+    @Test
+    void definesFunctionFromSignatureWithObjectAndArrayParameterTypes() throws Exception {
+        ELProcessor processor = new ELProcessor();
+
+        processor.defineFunction(
+                "fn",
+                "describe",
+                ELProcessorFunctionLibrary.class.getName(),
+                "java.lang.String describe(java.lang.String,java.lang.String[],java.lang.String[][],int)");
+
+        Method mappedMethod = resolveFunction(processor, "describe");
+        assertThat(mappedMethod).isNotNull();
+        assertThat(mappedMethod.getName()).isEqualTo("describe");
+        assertThat(mappedMethod.getParameterTypes())
+                .containsExactly(String.class, String[].class, String[][].class, int.class);
+    }
+
+    private static Method resolveFunction(ELProcessor processor, String function) {
+        return processor.getELManager().getELContext().getFunctionMapper().resolveFunction("fn", function);
+    }
+
+    public static class ProcessorExpressionFactory extends ExpressionFactory {
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            if (targetType == null) {
+                throw new NullPointerException("targetType");
+            }
+            if (obj == null || targetType.isInstance(obj) || targetType == Object.class) {
+                return obj;
+            }
+            throw new ELException("Cannot coerce " + obj + " to " + targetType.getName());
+        }
+
+        @Override
+        public ELResolver getStreamELResolver() {
+            return null;
+        }
+    }
+}
+
+final class ELProcessorFunctionLibrary {
+    private ELProcessorFunctionLibrary() {
+    }
+
+    public static int triple(int value) {
+        return value * 3;
+    }
+
+    public static String describe(String value, String[] labels, String[][] matrix, int count) {
+        return value + ':' + labels.length + ':' + matrix.length + ':' + count;
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
@@ -10,20 +10,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELProcessor;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELProcessor;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.MethodExpression;
+import jakarta.el.ValueExpression;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ELProcessorTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
     private static String previousExpressionFactory;
 
     @BeforeAll

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.beans.FeatureDescriptor;
+import java.util.Iterator;
+import java.util.Locale;
+
+import javax.el.BeanELResolver;
+import javax.el.ELClass;
+import javax.el.ELContext;
+import javax.el.ELException;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.FunctionMapper;
+import javax.el.MethodExpression;
+import javax.el.PropertyNotFoundException;
+import javax.el.StaticFieldELResolver;
+import javax.el.ValueExpression;
+import javax.el.VariableMapper;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ELUtilTest {
+    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static String previousExpressionFactory;
+
+    @BeforeAll
+    static void installExpressionFactory() {
+        previousExpressionFactory = System.getProperty(EXPRESSION_FACTORY_PROPERTY);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, SimpleExpressionFactory.class.getName());
+    }
+
+    @AfterAll
+    static void restoreExpressionFactory() {
+        if (previousExpressionFactory == null) {
+            System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        } else {
+            System.setProperty(EXPRESSION_FACTORY_PROPERTY, previousExpressionFactory);
+        }
+    }
+
+    @Test
+    void invokesPublicStaticVarargsMethod() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object result = resolver.invoke(
+                context,
+                new ELClass(Operations.class),
+                "join",
+                null,
+                new Object[] {"letters", "a", "b" });
+
+        assertThat(result).isEqualTo("letters:a,b");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void invokesPublicConstructorResolvedFromNonPublicSubclass() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object result = resolver.invoke(
+                context,
+                new ELClass(NonPublicConstructable.class),
+                "<init>",
+                new Class<?>[] {String.class },
+                new Object[] {"created" });
+
+        assertThat(result).isInstanceOf(PublicConstructable.class);
+        assertThat(((PublicConstructable) result).getName()).isEqualTo("created");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void invokesPublicInterfaceMethodResolvedFromNonPublicBean() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object result = resolver.invoke(
+                context,
+                new NonPublicGreeter(),
+                "greet",
+                new Class<?>[] {String.class },
+                new Object[] {"Ada" });
+
+        assertThat(result).isEqualTo("Hello Ada");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void invokesPublicSuperclassMethodResolvedFromNonPublicBean() {
+        BeanELResolver resolver = new BeanELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object result = resolver.invoke(
+                context,
+                new NonPublicDerived(),
+                "describe",
+                new Class<?>[] {String.class },
+                new Object[] {"base" });
+
+        assertThat(result).isEqualTo("described base");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void loadsLocalizedMessageBundleForStaticFieldErrors() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+        context.setLocale(Locale.ENGLISH);
+
+        assertThatThrownBy(() -> resolver.getValue(context, new ELClass(Operations.class), "missingField"))
+                .isInstanceOf(PropertyNotFoundException.class)
+                .hasMessageContaining(Operations.class.getName())
+                .hasMessageContaining("missingField");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static class SimpleExpressionFactory extends ExpressionFactory {
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            return coerce(obj, targetType);
+        }
+
+        static Object coerce(Object obj, Class<?> targetType) {
+            if (targetType == null) {
+                throw new NullPointerException("targetType");
+            }
+            Class<?> boxedTargetType = box(targetType);
+            if (obj == null) {
+                return targetType.isPrimitive() ? primitiveDefault(targetType) : null;
+            }
+            if (boxedTargetType.isInstance(obj)) {
+                return obj;
+            }
+            if (boxedTargetType == String.class) {
+                return obj.toString();
+            }
+            throw new ELException("Cannot coerce " + obj + " to " + targetType.getName());
+        }
+
+        private static Class<?> box(Class<?> type) {
+            if (!type.isPrimitive()) {
+                return type;
+            }
+            if (type == boolean.class) {
+                return Boolean.class;
+            }
+            if (type == char.class) {
+                return Character.class;
+            }
+            if (type == byte.class) {
+                return Byte.class;
+            }
+            if (type == short.class) {
+                return Short.class;
+            }
+            if (type == int.class) {
+                return Integer.class;
+            }
+            if (type == long.class) {
+                return Long.class;
+            }
+            if (type == float.class) {
+                return Float.class;
+            }
+            return Double.class;
+        }
+
+        private static Object primitiveDefault(Class<?> type) {
+            if (type == boolean.class) {
+                return false;
+            }
+            if (type == char.class) {
+                return '\0';
+            }
+            if (type == byte.class) {
+                return (byte) 0;
+            }
+            if (type == short.class) {
+                return (short) 0;
+            }
+            if (type == int.class) {
+                return 0;
+            }
+            if (type == long.class) {
+                return 0L;
+            }
+            if (type == float.class) {
+                return 0.0F;
+            }
+            return 0.0D;
+        }
+    }
+
+    public static class Operations {
+        public static String join(String label, String... values) {
+            return label + ":" + String.join(",", values);
+        }
+    }
+
+    public static class PublicConstructable {
+        private final String name;
+
+        public PublicConstructable(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static class NonPublicConstructable extends PublicConstructable {
+        public NonPublicConstructable(String name) {
+            super(name);
+        }
+    }
+
+    public interface GreetingContract {
+        String greet(String name);
+    }
+
+    private static class NonPublicGreeter implements GreetingContract {
+        @Override
+        public String greet(String name) {
+            return "Hello " + name;
+        }
+    }
+
+    public static class PublicBaseOperation {
+        public String describe(String value) {
+            return "described " + value;
+        }
+    }
+
+    private static class NonPublicDerived extends PublicBaseOperation {
+    }
+
+    private static class SimpleELContext extends ELContext {
+        private final ELResolver resolver = new CoercingELResolver();
+
+        private SimpleELContext() {
+            putContext(ExpressionFactory.class, new SimpleExpressionFactory());
+        }
+
+        @Override
+        public ELResolver getELResolver() {
+            return resolver;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+    }
+
+    private static class CoercingELResolver extends ELResolver {
+        @Override
+        public Object getValue(ELContext context, Object base, Object property) {
+            return null;
+        }
+
+        @Override
+        public Class<?> getType(ELContext context, Object base, Object property) {
+            return null;
+        }
+
+        @Override
+        public void setValue(ELContext context, Object base, Object property, Object value) {
+        }
+
+        @Override
+        public boolean isReadOnly(ELContext context, Object base, Object property) {
+            return true;
+        }
+
+        @Override
+        public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
+            return null;
+        }
+
+        @Override
+        public Class<?> getCommonPropertyType(ELContext context, Object base) {
+            return null;
+        }
+
+        @Override
+        public Object convertToType(ELContext context, Object obj, Class<?> targetType) {
+            context.setPropertyResolved(true);
+            return SimpleExpressionFactory.coerce(obj, targetType);
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
@@ -13,25 +13,25 @@ import java.beans.FeatureDescriptor;
 import java.util.Iterator;
 import java.util.Locale;
 
-import javax.el.BeanELResolver;
-import javax.el.ELClass;
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.FunctionMapper;
-import javax.el.MethodExpression;
-import javax.el.PropertyNotFoundException;
-import javax.el.StaticFieldELResolver;
-import javax.el.ValueExpression;
-import javax.el.VariableMapper;
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.FunctionMapper;
+import jakarta.el.MethodExpression;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.el.StaticFieldELResolver;
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ELUtilTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
     private static String previousExpressionFactory;
 
     @BeforeAll

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import javax.el.ELContext;
+import javax.el.ELException;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FactoryFinderTest {
+    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+
+    private ClassLoader originalContextClassLoader;
+    private String originalExpressionFactoryProperty;
+
+    @BeforeEach
+    void captureThreadState() {
+        originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        originalExpressionFactoryProperty = System.getProperty(EXPRESSION_FACTORY_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreThreadState() {
+        Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        if (originalExpressionFactoryProperty == null) {
+            System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        } else {
+            System.setProperty(EXPRESSION_FACTORY_PROPERTY, originalExpressionFactoryProperty);
+        }
+    }
+
+    @Test
+    void looksUpServiceWithNullContextClassLoaderAndUsesPropertiesConstructor() {
+        Thread.currentThread().setContextClassLoader(null);
+        System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        assertThat(Thread.currentThread().getContextClassLoader()).isNull();
+
+        Properties properties = new Properties();
+        properties.setProperty("javax.el.cacheSize", "32");
+
+        ExpressionFactory expressionFactory = ExpressionFactory.newInstance(properties);
+
+        assertThat(expressionFactory).isInstanceOf(ServiceExpressionFactory.class);
+        ServiceExpressionFactory serviceExpressionFactory = (ServiceExpressionFactory) expressionFactory;
+        assertThat(serviceExpressionFactory.getConstructorMode()).isEqualTo("properties");
+        assertThat(serviceExpressionFactory.getProperties()).isSameAs(properties);
+        assertThat(serviceExpressionFactory.getProperties()).containsEntry("javax.el.cacheSize", "32");
+    }
+
+    public static final class ServiceExpressionFactory extends ExpressionFactory {
+        private final String constructorMode;
+        private final Properties properties;
+
+        public ServiceExpressionFactory() {
+            this.constructorMode = "default";
+            this.properties = null;
+        }
+
+        public ServiceExpressionFactory(Properties properties) {
+            this.constructorMode = "properties";
+            this.properties = properties;
+        }
+
+        String getConstructorMode() {
+            return constructorMode;
+        }
+
+        Properties getProperties() {
+            return properties;
+        }
+
+        @Override
+        public ValueExpression createValueExpression(ELContext context, String expression, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public ValueExpression createValueExpression(Object instance, Class<?> expectedType) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public MethodExpression createMethodExpression(
+                ELContext context,
+                String expression,
+                Class<?> expectedReturnType,
+                Class<?>[] expectedParamTypes) {
+            throw new UnsupportedOperationException("Expression parsing is not needed by these tests");
+        }
+
+        @Override
+        public Object coerceToType(Object obj, Class<?> targetType) {
+            if (targetType == null) {
+                throw new NullPointerException("targetType");
+            }
+            Class<?> boxedTargetType = box(targetType);
+            if (obj == null) {
+                return targetType.isPrimitive() ? primitiveDefault(targetType) : null;
+            }
+            if (boxedTargetType.isInstance(obj)) {
+                return obj;
+            }
+            if (boxedTargetType == String.class) {
+                return obj.toString();
+            }
+            throw new ELException("Cannot coerce " + obj + " to " + targetType.getName());
+        }
+
+        @Override
+        public ELResolver getStreamELResolver() {
+            return null;
+        }
+
+        private static Class<?> box(Class<?> type) {
+            if (!type.isPrimitive()) {
+                return type;
+            }
+            if (type == boolean.class) {
+                return Boolean.class;
+            }
+            if (type == char.class) {
+                return Character.class;
+            }
+            if (type == byte.class) {
+                return Byte.class;
+            }
+            if (type == short.class) {
+                return Short.class;
+            }
+            if (type == int.class) {
+                return Integer.class;
+            }
+            if (type == long.class) {
+                return Long.class;
+            }
+            if (type == float.class) {
+                return Float.class;
+            }
+            return Double.class;
+        }
+
+        private static Object primitiveDefault(Class<?> type) {
+            if (type == boolean.class) {
+                return false;
+            }
+            if (type == char.class) {
+                return '\0';
+            }
+            if (type == byte.class) {
+                return (byte) 0;
+            }
+            if (type == short.class) {
+                return (short) 0;
+            }
+            if (type == int.class) {
+                return 0;
+            }
+            if (type == long.class) {
+                return 0L;
+            }
+            if (type == float.class) {
+                return 0.0F;
+            }
+            return 0.0D;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
@@ -8,21 +8,25 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Properties;
 
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.MethodExpression;
+import jakarta.el.ValueExpression;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FactoryFinderTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
 
     private ClassLoader originalContextClassLoader;
     private String originalExpressionFactoryProperty;
@@ -44,13 +48,13 @@ public class FactoryFinderTest {
     }
 
     @Test
-    void looksUpServiceWithNullContextClassLoaderAndUsesPropertiesConstructor() {
+    void looksUpSystemPropertyWithNullContextClassLoaderAndPropertiesConstructor() {
         Thread.currentThread().setContextClassLoader(null);
-        System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, ServiceExpressionFactory.class.getName());
         assertThat(Thread.currentThread().getContextClassLoader()).isNull();
 
         Properties properties = new Properties();
-        properties.setProperty("javax.el.cacheSize", "32");
+        properties.setProperty("jakarta.el.cacheSize", "32");
 
         ExpressionFactory expressionFactory = ExpressionFactory.newInstance(properties);
 
@@ -58,7 +62,45 @@ public class FactoryFinderTest {
         ServiceExpressionFactory serviceExpressionFactory = (ServiceExpressionFactory) expressionFactory;
         assertThat(serviceExpressionFactory.getConstructorMode()).isEqualTo("properties");
         assertThat(serviceExpressionFactory.getProperties()).isSameAs(properties);
-        assertThat(serviceExpressionFactory.getProperties()).containsEntry("javax.el.cacheSize", "32");
+    }
+
+    @Test
+    void looksUpSystemPropertyWithContextClassLoaderAndDefaultConstructor() {
+        ClassLoader parentClassLoader = FactoryFinderTest.class.getClassLoader();
+        ClassLoader serviceHidingClassLoader = new ServiceHidingClassLoader(parentClassLoader);
+        Thread.currentThread().setContextClassLoader(serviceHidingClassLoader);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, ServiceExpressionFactory.class.getName());
+
+        ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
+
+        assertThat(expressionFactory).isInstanceOf(ServiceExpressionFactory.class);
+        ServiceExpressionFactory serviceExpressionFactory = (ServiceExpressionFactory) expressionFactory;
+        assertThat(serviceExpressionFactory.getConstructorMode()).isEqualTo("default");
+        assertThat(serviceExpressionFactory.getProperties()).isNull();
+    }
+
+    private static final class ServiceHidingClassLoader extends ClassLoader {
+        private static final String SERVICE_RESOURCE = "META-INF/services/" + ExpressionFactory.class.getName();
+
+        ServiceHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (SERVICE_RESOURCE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
     }
 
     public static final class ServiceExpressionFactory extends ExpressionFactory {

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+
+import javax.el.ImportHandler;
+
+import org.junit.jupiter.api.Test;
+
+public class ImportHandlerTest {
+    @Test
+    void resolvesConcretePublicClassFromImportedPackage() {
+        ImportHandler importHandler = new ImportHandler();
+        importHandler.importPackage("java.util");
+
+        Class<?> resolvedClass = importHandler.resolveClass("ArrayList");
+
+        assertThat(resolvedClass).isEqualTo(ArrayList.class);
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 
-import javax.el.ImportHandler;
+import jakarta.el.ImportHandler;
 
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
@@ -8,12 +8,12 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.el.ELClass;
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.FunctionMapper;
-import javax.el.StaticFieldELResolver;
-import javax.el.VariableMapper;
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.FunctionMapper;
+import jakarta.el.StaticFieldELResolver;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.Test;
 

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_el.jakarta_el_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.el.ELClass;
+import javax.el.ELContext;
+import javax.el.ELResolver;
+import javax.el.FunctionMapper;
+import javax.el.StaticFieldELResolver;
+import javax.el.VariableMapper;
+
+import org.junit.jupiter.api.Test;
+
+public class StaticFieldELResolverTest {
+
+    @Test
+    void readsPublicStaticFieldValue() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Object value = resolver.getValue(context, new ELClass(StaticFieldTarget.class), "GREETING");
+
+        assertThat(value).isEqualTo("hello");
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    @Test
+    void resolvesPublicStaticFieldType() {
+        StaticFieldELResolver resolver = new StaticFieldELResolver();
+        SimpleELContext context = new SimpleELContext();
+
+        Class<?> type = resolver.getType(context, new ELClass(StaticFieldTarget.class), "GREETING");
+
+        assertThat(type).isEqualTo(String.class);
+        assertThat(context.isPropertyResolved()).isTrue();
+    }
+
+    public static final class StaticFieldTarget {
+        public static final String GREETING = "hello";
+
+        private StaticFieldTarget() {
+        }
+    }
+
+    private static final class SimpleELContext extends ELContext {
+        @Override
+        public ELResolver getELResolver() {
+            return null;
+        }
+
+        @Override
+        public FunctionMapper getFunctionMapper() {
+            return null;
+        }
+
+        @Override
+        public VariableMapper getVariableMapper() {
+            return null;
+        }
+    }
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,134 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ELProcessor"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELProcessorFunctionLibrary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ExpressionFactory"
+      },
+      "type" : "jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.Properties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.FactoryFinder"
+      },
+      "type" : "jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ELUtil"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$Operations",
+      "methods" : [
+        {
+          "name" : "join",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.ELUtil"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$PublicConstructable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.StaticFieldELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$NonPublicConstructable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$GreetingContract",
+      "methods" : [
+        {
+          "name" : "greet",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.BeanELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$PublicBaseOperation",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "javax.el.StaticFieldELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.StaticFieldELResolverTest$StaticFieldTarget",
+      "fields" : [
+        {
+          "name" : "GREETING"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "javax.el.FactoryFinder"
+      },
+      "glob" : "META-INF/services/javax.el.ExpressionFactory"
+    }
+  ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -121,6 +121,60 @@
           "name" : "GREETING"
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.BeanELResolver$BeanProperties"
+      },
+      "type" : "jakarta_el.jakarta_el_api.BeanELResolverTest$SampleBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.ELProcessor"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELProcessorFunctionLibrary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.ELUtil"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$GreetingContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.StaticFieldELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$Operations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.ELUtil"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$PublicBaseOperation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.ELUtil"
+      },
+      "type" : "jakarta_el.jakarta_el_api.ELUtilTest$PublicConstructable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.FactoryFinder"
+      },
+      "type" : "jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.el.StaticFieldELResolver"
+      },
+      "type" : "jakarta_el.jakarta_el_api.StaticFieldELResolverTest$StaticFieldTarget"
     }
   ],
   "resources" : [

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/services/javax.el.ExpressionFactory
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/resources/META-INF/services/javax.el.ExpressionFactory
@@ -1,0 +1,1 @@
+jakarta_el.jakarta_el_api.FactoryFinderTest$ServiceExpressionFactory

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.el.**"
+    },
+    {
+      "includeClasses" : "jakarta_el.jakarta_el_api.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
+++ b/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.el.**"
+      "includeClasses" : "jakarta.el.**"
     },
     {
       "includeClasses" : "jakarta_el.jakarta_el_api.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #6377

This PR provides test fixes and new metadata for jakarta.el:jakarta.el-api:4.0.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 141142
- Cached input tokens: 1872384
- Output tokens: 17887
- Metadata entries: 12
- Test-only metadata entries: 29
- Iterations: 4
- Library coverage percentage: 32.82
- Previous library version metadata entries: 14
- Previous library version test-only metadata entries: 20
- Previous library version coverage percentage: 32.84

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `95d368e32b0b688675af2f44b5d8028f3b96bda4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.el:jakarta.el-api:3.0.2: 28/28 covered calls (100.00%)
- jakarta.el:jakarta.el-api:4.0.0: 27/27 covered calls (100.00%)

**Reflection:**
- jakarta.el:jakarta.el-api:3.0.2: 25/25 covered calls (100.00%)
- jakarta.el:jakarta.el-api:4.0.0: 26/26 covered calls (100.00%)

**Resources:**
- jakarta.el:jakarta.el-api:3.0.2: 3/3 covered calls (100.00%)
- jakarta.el:jakarta.el-api:4.0.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.el:jakarta.el-api:3.0.2: 1859/5444 (34.15%)
- jakarta.el:jakarta.el-api:4.0.0: 1847/5394 (34.24%)

**Line:**
- jakarta.el:jakarta.el-api:3.0.2: 469/1428 (32.84%)
- jakarta.el:jakarta.el-api:4.0.0: 450/1371 (32.82%)

**Method:**
- jakarta.el:jakarta.el-api:3.0.2: 92/267 (34.46%)
- jakarta.el:jakarta.el-api:4.0.0: 92/266 (34.59%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/build.gradle 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
index 8fa7ee658d..70580f078c 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/build.gradle
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/build.gradle
@@ -15,6 +15,16 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+String expressionFactoryClassName = "jakarta_el.jakarta_el_api.FactoryFinderTest\$ServiceExpressionFactory"
+
+tasks.withType(Test).configureEach {
+    systemProperty "jakarta.el.ExpressionFactory", expressionFactoryClassName
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djakarta.el.ExpressionFactory=${expressionFactoryClassName}")
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
index d78d82460d..d54c316204 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/BeanELResolverTest.java
@@ -8,11 +8,11 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.el.BeanELResolver;
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.FunctionMapper;
-import javax.el.VariableMapper;
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.FunctionMapper;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.Test;
 
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
index c18e2776dd..cafc3d2bbc 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELProcessorTest.java
@@ -10,20 +10,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELProcessor;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELProcessor;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.MethodExpression;
+import jakarta.el.ValueExpression;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ELProcessorTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
     private static String previousExpressionFactory;
 
     @BeforeAll
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
index 5cf2e08185..14b3355f8a 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ELUtilTest.java
@@ -13,25 +13,25 @@ import java.beans.FeatureDescriptor;
 import java.util.Iterator;
 import java.util.Locale;
 
-import javax.el.BeanELResolver;
-import javax.el.ELClass;
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.FunctionMapper;
-import javax.el.MethodExpression;
-import javax.el.PropertyNotFoundException;
-import javax.el.StaticFieldELResolver;
-import javax.el.ValueExpression;
-import javax.el.VariableMapper;
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.FunctionMapper;
+import jakarta.el.MethodExpression;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.el.StaticFieldELResolver;
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ELUtilTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
     private static String previousExpressionFactory;
 
     @BeforeAll
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
index 29a277babd..eb8404d5cd 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/FactoryFinderTest.java
@@ -8,21 +8,25 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Properties;
 
-import javax.el.ELContext;
-import javax.el.ELException;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.MethodExpression;
+import jakarta.el.ValueExpression;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FactoryFinderTest {
-    private static final String EXPRESSION_FACTORY_PROPERTY = "javax.el.ExpressionFactory";
+    private static final String EXPRESSION_FACTORY_PROPERTY = "jakarta.el.ExpressionFactory";
 
     private ClassLoader originalContextClassLoader;
     private String originalExpressionFactoryProperty;
@@ -44,13 +48,13 @@ public class FactoryFinderTest {
     }
 
     @Test
-    void looksUpServiceWithNullContextClassLoaderAndUsesPropertiesConstructor() {
+    void looksUpSystemPropertyWithNullContextClassLoaderAndPropertiesConstructor() {
         Thread.currentThread().setContextClassLoader(null);
-        System.clearProperty(EXPRESSION_FACTORY_PROPERTY);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, ServiceExpressionFactory.class.getName());
         assertThat(Thread.currentThread().getContextClassLoader()).isNull();
 
         Properties properties = new Properties();
-        properties.setProperty("javax.el.cacheSize", "32");
+        properties.setProperty("jakarta.el.cacheSize", "32");
 
         ExpressionFactory expressionFactory = ExpressionFactory.newInstance(properties);
 
@@ -58,7 +62,45 @@ public class FactoryFinderTest {
         ServiceExpressionFactory serviceExpressionFactory = (ServiceExpressionFactory) expressionFactory;
         assertThat(serviceExpressionFactory.getConstructorMode()).isEqualTo("properties");
         assertThat(serviceExpressionFactory.getProperties()).isSameAs(properties);
-        assertThat(serviceExpressionFactory.getProperties()).containsEntry("javax.el.cacheSize", "32");
+    }
+
+    @Test
+    void looksUpSystemPropertyWithContextClassLoaderAndDefaultConstructor() {
+        ClassLoader parentClassLoader = FactoryFinderTest.class.getClassLoader();
+        ClassLoader serviceHidingClassLoader = new ServiceHidingClassLoader(parentClassLoader);
+        Thread.currentThread().setContextClassLoader(serviceHidingClassLoader);
+        System.setProperty(EXPRESSION_FACTORY_PROPERTY, ServiceExpressionFactory.class.getName());
+
+        ExpressionFactory expressionFactory = ExpressionFactory.newInstance();
+
+        assertThat(expressionFactory).isInstanceOf(ServiceExpressionFactory.class);
+        ServiceExpressionFactory serviceExpressionFactory = (ServiceExpressionFactory) expressionFactory;
+        assertThat(serviceExpressionFactory.getConstructorMode()).isEqualTo("default");
+        assertThat(serviceExpressionFactory.getProperties()).isNull();
+    }
+
+    private static final class ServiceHidingClassLoader extends ClassLoader {
+        private static final String SERVICE_RESOURCE = "META-INF/services/" + ExpressionFactory.class.getName();
+
+        ServiceHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (SERVICE_RESOURCE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
     }
 
     public static final class ServiceExpressionFactory extends ExpressionFactory {
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
index 8e9e0e9f43..f0c6fcaa00 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/ImportHandlerTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 
-import javax.el.ImportHandler;
+import jakarta.el.ImportHandler;
 
 import org.junit.jupiter.api.Test;
 
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
index 2438fe0aa7..6da9611bab 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/src/test/java/jakarta_el/jakarta_el_api/StaticFieldELResolverTest.java
@@ -8,12 +8,12 @@ package jakarta_el.jakarta_el_api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.el.ELClass;
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.FunctionMapper;
-import javax.el.StaticFieldELResolver;
-import javax.el.VariableMapper;
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.FunctionMapper;
+import jakarta.el.StaticFieldELResolver;
+import jakarta.el.VariableMapper;
 
 import org.junit.jupiter.api.Test;
 
diff --git 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
index a3f4e01e7b..98fe8a8a8e 100644
--- 1/tests/src/jakarta.el/jakarta.el-api/3.0.2/user-code-filter.json
+++ 2/tests/src/jakarta.el/jakarta.el-api/4.0.0/user-code-filter.json
@@ -4,7 +4,7 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.el.**"
+      "includeClasses" : "jakarta.el.**"
     },
     {
       "includeClasses" : "jakarta_el.jakarta_el_api.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
