### PR TITLE
[GenAI] Test fix for com.beust:jcommander:1.78 using gpt-5.5

### DIFF
--- a/metadata/com.beust/jcommander/1.78/reachability-metadata.json
+++ b/metadata/com.beust/jcommander/1.78/reachability-metadata.json
@@ -1,122 +1,92 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": "com.beust.jcommander.converters.StringConverter",
-      "methods": [
+      "type" : "com.beust.jcommander.converters.StringConverter",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com.beust.jcommander.validators.NoValidator",
-      "methods": [
+      "type" : "com.beust.jcommander.validators.NoValidator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com.beust.jcommander.validators.NoValueValidator",
-      "methods": [
+      "type" : "com.beust.jcommander.validators.NoValueValidator",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.internal.JDK6Console"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+      "type" : "java.lang.Integer"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.WrappedParameter"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": "com_beust.jcommander.ParameterizedTest$CommandOptions"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": "java.lang.Integer"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.util.Map"
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.WrappedParameter"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.WrappedParameter"
       },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
-      },
-      "type": "java.util.Map"
-    },
-    {
-      "condition": {
-        "typeReached": "com.beust.jcommander.WrappedParameter"
-      },
-      "type": "java.util.Map",
-      "methods": [
+      "type" : "java.util.Map",
+      "methods" : [
         {
-          "name": "put",
-          "parameterTypes": [
+          "name" : "put",
+          "parameterTypes" : [
             "java.lang.Object",
             "java.lang.Object"
           ]
@@ -124,122 +94,122 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.DynamicParameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameters"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.Parameters"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.ResourceBundle"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.beust.jcommander.SubParameter"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Inherited"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.JCommander"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.JCommander"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.Parameterized"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.ParameterDescription"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "jdk.internal.vm.annotation.Stable"
         ]
       }
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.beust.jcommander.DefaultUsageFormatter"
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.DefaultUsageFormatter"
       },
-      "bundle": "com_beust.jcommander.parameter_descriptions"
+      "bundle" : "com_beust.jcommander.parameter_descriptions"
     }
   ]
 }

--- a/metadata/com.beust/jcommander/1.78/reachability-metadata.json
+++ b/metadata/com.beust/jcommander/1.78/reachability-metadata.json
@@ -1,0 +1,245 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": "com.beust.jcommander.converters.StringConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com.beust.jcommander.validators.NoValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com.beust.jcommander.validators.NoValueValidator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.internal.JDK6Console"
+      },
+      "type": "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "com_beust.jcommander.ParameterizedTest$CommandOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "java.lang.Integer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.WrappedParameter"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": "java.util.Map"
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.WrappedParameter"
+      },
+      "type": "java.util.Map",
+      "methods": [
+        {
+          "name": "put",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.DynamicParameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameters"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.Parameters"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.ResourceBundle"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "com.beust.jcommander.SubParameter"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Inherited"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.JCommander"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.Parameterized"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.ParameterDescription"
+      },
+      "type": {
+        "proxy": [
+          "jdk.internal.vm.annotation.Stable"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.beust.jcommander.DefaultUsageFormatter"
+      },
+      "bundle": "com_beust.jcommander.parameter_descriptions"
+    }
+  ]
+}

--- a/metadata/com.beust/jcommander/index.json
+++ b/metadata/com.beust/jcommander/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "1.78",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-sources.jar",
+    "repository-url" : "https://github.com/cbeust/jcommander",
+    "test-code-url" : "https://github.com/cbeust/jcommander/tree/$version$/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-javadoc.jar",
+    "description" : "JCommander is an annotation-based command-line parsing framework for Java applications. It maps command-line arguments onto Java objects, supports typed converters and validators, and helps generate usage output for command-line tools.",
     "tested-versions" : [
       "1.78"
     ],

--- a/metadata/com.beust/jcommander/index.json
+++ b/metadata/com.beust/jcommander/index.json
@@ -15,6 +15,15 @@
     ]
   },
   {
+    "metadata-version" : "1.78",
+    "tested-versions" : [
+      "1.78"
+    ],
+    "allowed-packages" : [
+      "com.beust.jcommander"
+    ]
+  },
+  {
     "metadata-version" : "1.75",
     "source-code-url" : "https://repo1.maven.org/maven2/com/beust/jcommander/$version$/jcommander-$version$-sources.jar",
     "repository-url" : "https://github.com/cbeust/jcommander",

--- a/stats/com.beust/jcommander/1.78/execution-metrics.json
+++ b/stats/com.beust/jcommander/1.78/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_javac_fail:2026-05-07": {
+    "timestamp": "2026-05-07T20:22:42.016526Z",
+    "library": "com.beust:jcommander:1.78",
+    "starting_commit": "5b11b1240b2f85c125667922d91afd0034b4b26b",
+    "ending_commit": "31e3cd48c4bd3f1b1dcc3c161d6e7aca13ae28b8",
+    "previous_library": "com.beust:jcommander:1.72",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.78",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 28,
+            "totalCalls": 28
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 32,
+        "totalCalls": 32
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2975,
+          "missed": 4209,
+          "ratio": 0.414115,
+          "total": 7184
+        },
+        "line": {
+          "covered": 667,
+          "missed": 832,
+          "ratio": 0.444963,
+          "total": 1499
+        },
+        "method": {
+          "covered": 139,
+          "missed": 181,
+          "ratio": 0.434375,
+          "total": 320
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.72",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 27,
+            "totalCalls": 27
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 31,
+        "totalCalls": 31
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2859,
+          "missed": 3633,
+          "ratio": 0.440388,
+          "total": 6492
+        },
+        "line": {
+          "covered": 643,
+          "missed": 715,
+          "ratio": 0.47349,
+          "total": 1358
+        },
+        "method": {
+          "covered": 134,
+          "missed": 156,
+          "ratio": 0.462069,
+          "total": 290
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 83457,
+      "cached_input_tokens_used": 610304,
+      "output_tokens_used": 8006,
+      "iterations": 4,
+      "cost_usd": 0.5454,
+      "tested_library_loc": 667,
+      "metadata_entries": 27,
+      "test_only_metadata_entries": 6,
+      "previous_library_metadata_entries": 29,
+      "previous_library_test_only_metadata_entries": 6,
+      "code_coverage_percent": 44.5,
+      "previous_library_coverage_percent": 47.35
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java",
+      "metadata_file": "metadata/com.beust/jcommander/1.78/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.beust/jcommander/1.78/stats.json
+++ b/stats/com.beust/jcommander/1.78/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "1.78",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 28,
+          "totalCalls" : 28
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 32,
+      "totalCalls" : 32
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2975,
+        "missed" : 4209,
+        "ratio" : 0.414115,
+        "total" : 7184
+      },
+      "line" : {
+        "covered" : 667,
+        "missed" : 832,
+        "ratio" : 0.444963,
+        "total" : 1499
+      },
+      "method" : {
+        "covered" : 139,
+        "missed" : 181,
+        "ratio" : 0.434375,
+        "total" : 320
+      }
+    }
+  } ]
+}

--- a/tests/src/com.beust/jcommander/1.78/.gitignore
+++ b/tests/src/com.beust/jcommander/1.78/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.beust/jcommander/1.78/build.gradle
+++ b/tests/src/com.beust/jcommander/1.78/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.beust:jcommander:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/gradle.properties
+++ b/tests/src/com.beust/jcommander/1.78/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.beust:jcommander:1.78
+library.version = 1.78
+metadata.dir = com.beust/jcommander/1.78/

--- a/tests/src/com.beust/jcommander/1.78/settings.gradle
+++ b/tests/src/com.beust/jcommander/1.78/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.beust.jcommander_tests'

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JDK6ConsoleTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.internal.JDK6Console;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDK6ConsoleTest {
+    @Test
+    void delegatesToConsoleWriterAndReadsWithEcho() throws Exception {
+        RecordingConsole console = new RecordingConsole("typed value", "secret".toCharArray());
+        JDK6Console jdk6Console = new JDK6Console(console);
+
+        jdk6Console.print("prompt: ");
+        char[] password = jdk6Console.readPassword(true);
+        jdk6Console.println("done");
+
+        assertThat(password).containsExactly('t', 'y', 'p', 'e', 'd', ' ', 'v', 'a', 'l', 'u', 'e');
+        assertThat(console.output()).isEqualTo("prompt: done" + System.lineSeparator());
+        assertThat(console.readLineCalls).isEqualTo(1);
+        assertThat(console.readPasswordCalls).isZero();
+    }
+
+    @Test
+    void delegatesToConsoleReadPasswordWhenEchoIsDisabled() throws Exception {
+        RecordingConsole console = new RecordingConsole("ignored", "secret".toCharArray());
+        JDK6Console jdk6Console = new JDK6Console(console);
+
+        char[] password = jdk6Console.readPassword(false);
+
+        assertThat(password).containsExactly('s', 'e', 'c', 'r', 'e', 't');
+        assertThat(console.readLineCalls).isZero();
+        assertThat(console.readPasswordCalls).isEqualTo(1);
+    }
+
+    public static class RecordingConsole {
+        private final String line;
+        private final char[] password;
+        private final StringWriter output = new StringWriter();
+        private final PrintWriter writer = new PrintWriter(output);
+        private int readLineCalls;
+        private int readPasswordCalls;
+
+        RecordingConsole(String line, char[] password) {
+            this.line = line;
+            this.password = password;
+        }
+
+        public PrintWriter writer() {
+            return writer;
+        }
+
+        public String readLine() {
+            readLineCalls++;
+            return line;
+        }
+
+        public char[] readPassword() {
+            readPasswordCalls++;
+            return password;
+        }
+
+        String output() {
+            writer.flush();
+            return output.toString();
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -6,7 +6,9 @@
  */
 package com_beust.jcommander;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JcommanderTest {
     @Test
     void createsConsoleThroughJdkConsoleLookup() {
-        assertThat(JCommander.getConsole()).isNotNull();
+        JCommander commander = new JCommander();
+
+        assertThat(commander.getConsole()).isNotNull();
     }
 
     @Test
@@ -23,9 +27,27 @@ public class JcommanderTest {
         JCommander commander = new JCommander(new RootCommand());
         commander.addCommand(new LocalizedCommand());
 
-        String description = commander.getCommandDescription("localized");
+        String description = commander.getUsageFormatter().getCommandDescription("localized");
 
         assertThat(description).isEqualTo("localized command description");
+    }
+
+    @Test
+    void instantiatesParameterConverterThroughDefaultConstructor() {
+        DefaultConstructorConverterCommand command = new DefaultConstructorConverterCommand();
+
+        new JCommander(command, "--answer", "41");
+
+        assertThat(command.answer).isEqualTo(42);
+    }
+
+    @Test
+    void instantiatesParameterConverterThroughOptionNameConstructor() {
+        OptionNameConstructorConverterCommand command = new OptionNameConstructorConverterCommand();
+
+        new JCommander(command, "--count", "7");
+
+        assertThat(command.count).isEqualTo("--count=7");
     }
 
     public static class RootCommand {
@@ -37,5 +59,35 @@ public class JcommanderTest {
             commandDescriptionKey = "command.description",
             resourceBundle = "com_beust.jcommander.parameter_descriptions")
     public static class LocalizedCommand {
+    }
+
+    public static class DefaultConstructorConverterCommand {
+        @Parameter(names = "--answer", converter = DefaultConstructorIntegerConverter.class)
+        private Integer answer;
+    }
+
+    public static class DefaultConstructorIntegerConverter implements IStringConverter<Integer> {
+        @Override
+        public Integer convert(String value) {
+            return Integer.parseInt(value) + 1;
+        }
+    }
+
+    public static class OptionNameConstructorConverterCommand {
+        @Parameter(names = "--count", converter = OptionNameStringConverter.class)
+        private String count;
+    }
+
+    public static class OptionNameStringConverter implements IStringConverter<String> {
+        private final String optionName;
+
+        public OptionNameStringConverter(String optionName) {
+            this.optionName = optionName;
+        }
+
+        @Override
+        public String convert(String value) {
+            return optionName + "=" + value;
+        }
     }
 }

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JcommanderTest {
+    @Test
+    void createsConsoleThroughJdkConsoleLookup() {
+        assertThat(JCommander.getConsole()).isNotNull();
+    }
+
+    @Test
+    void resolvesCommandDescriptionFromParametersResourceBundle() {
+        JCommander commander = new JCommander(new RootCommand());
+        commander.addCommand(new LocalizedCommand());
+
+        String description = commander.getCommandDescription("localized");
+
+        assertThat(description).isEqualTo("localized command description");
+    }
+
+    public static class RootCommand {
+    }
+
+    @Parameters(
+            commandNames = "localized",
+            commandDescription = "fallback command description",
+            commandDescriptionKey = "command.description",
+            resourceBundle = "com_beust.jcommander.parameter_descriptions")
+    public static class LocalizedCommand {
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterDescriptionTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterDescriptionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.IParameterValidator2;
+import com.beust.jcommander.IValueValidator;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.SubParameter;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterDescriptionTest {
+    @Test
+    void parsesOrderedSubParametersIntoValueObject() {
+        CoordinateCommand command = new CoordinateCommand();
+
+        new JCommander(command, "--coordinate", "10", "20");
+
+        assertThat(command.coordinate).isNotNull();
+        assertThat(command.coordinate.x).isEqualTo("10");
+        assertThat(command.coordinate.y).isEqualTo("20");
+    }
+
+    @Test
+    void invokesParameterAndValueValidatorsDeclaredOnParameter() {
+        RecordingParameterValidator.invocations.set(0);
+        RecordingParameterValidator.contextInvocations.set(0);
+        RecordingValueValidator.invocations.set(0);
+        ValidatedCommand command = new ValidatedCommand();
+
+        new JCommander(command, "--name", "jcommander");
+
+        assertThat(command.name).isEqualTo("jcommander");
+        assertThat(RecordingParameterValidator.invocations.get()).isEqualTo(1);
+        assertThat(RecordingParameterValidator.contextInvocations.get()).isEqualTo(1);
+        assertThat(RecordingValueValidator.invocations.get()).isEqualTo(2);
+    }
+
+    @Test
+    void readsParameterDescriptionsFromParametersResourceBundle() {
+        ParametersBundleCommand command = new ParametersBundleCommand();
+        JCommander commander = new JCommander(command);
+
+        ParameterDescription description = parameterDescription(commander, "--from-parameters");
+
+        assertThat(description.getDescription()).isEqualTo("description loaded from @Parameters");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void readsParameterDescriptionsFromDeprecatedResourceBundleAnnotation() {
+        DeprecatedBundleCommand command = new DeprecatedBundleCommand();
+        JCommander commander = new JCommander(command);
+
+        ParameterDescription description = parameterDescription(
+                commander,
+                "--from-deprecated-bundle");
+
+        assertThat(description.getDescription())
+                .isEqualTo("description loaded from @ResourceBundle");
+    }
+
+    private static ParameterDescription parameterDescription(JCommander commander, String name) {
+        return commander.getParameters().stream()
+                .filter(description -> description.getNames().contains(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing parameter description for " + name));
+    }
+
+    public static class CoordinateCommand {
+        @Parameter(names = "--coordinate", arity = 2)
+        private Coordinate coordinate;
+    }
+
+    public static class Coordinate {
+        @SubParameter(order = 0)
+        public String x;
+
+        @SubParameter(order = 1)
+        public String y;
+    }
+
+    public static class ValidatedCommand {
+        @Parameter(
+                names = "--name",
+                validateWith = RecordingParameterValidator.class,
+                validateValueWith = RecordingValueValidator.class)
+        private String name;
+    }
+
+    public static class RecordingParameterValidator implements IParameterValidator2 {
+        private static final AtomicInteger invocations = new AtomicInteger();
+        private static final AtomicInteger contextInvocations = new AtomicInteger();
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            invocations.incrementAndGet();
+        }
+
+        @Override
+        public void validate(String name, String value, ParameterDescription parameterDescription)
+                throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            assertThat(parameterDescription.getNames()).contains("--name");
+            contextInvocations.incrementAndGet();
+        }
+    }
+
+    public static class RecordingValueValidator implements IValueValidator<String> {
+        private static final AtomicInteger invocations = new AtomicInteger();
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            assertThat(name).isEqualTo("--name");
+            assertThat(value).isEqualTo("jcommander");
+            invocations.incrementAndGet();
+        }
+    }
+
+    @Parameters(resourceBundle = "com_beust.jcommander.parameter_descriptions")
+    public static class ParametersBundleCommand {
+        @Parameter(names = "--from-parameters", descriptionKey = "parameters.description")
+        private String value;
+    }
+
+    @com.beust.jcommander.ResourceBundle("com_beust.jcommander.parameter_descriptions")
+    public static class DeprecatedBundleCommand {
+        @Parameter(names = "--from-deprecated-bundle", descriptionKey = "deprecated.description")
+        private String value;
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -44,6 +44,16 @@ public class ParameterizedTest {
         assertThat(parameterized.get(options)).isEqualTo("secret-token");
     }
 
+    @Test
+    void booleanMethodBackedParameterUsesIsGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setEnabled");
+
+        parameterized.set(options, true);
+
+        assertThat(parameterized.get(options)).isEqualTo(true);
+    }
+
     private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
         return parameters.stream()
                 .filter(parameterized -> name.equals(parameterized.getName()))
@@ -59,6 +69,8 @@ public class ParameterizedTest {
 
         private String token;
 
+        private boolean enabled;
+
         @Parameter(names = "--level")
         public void setLevel(int level) {
             this.level = level;
@@ -71,6 +83,15 @@ public class ParameterizedTest {
         @Parameter(names = "--token")
         public void setToken(String token) {
             this.token = token;
+        }
+
+        @Parameter(names = "--enabled")
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
         }
     }
 }

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameterized;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterizedTest {
+    @Test
+    void fieldBackedParameterCanBeReadAndWritten() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "fieldValue");
+
+        parameterized.set(options, "configured");
+
+        assertThat(parameterized.get(options)).isEqualTo("configured");
+    }
+
+    @Test
+    void methodBackedParameterCanUseSetterAndMatchingGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setLevel");
+
+        parameterized.set(options, 42);
+
+        assertThat(parameterized.get(options)).isEqualTo(42);
+    }
+
+    @Test
+    void methodBackedParameterFallsBackToMatchingFieldWhenGetterIsMissing() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setToken");
+
+        parameterized.set(options, "secret-token");
+
+        assertThat(parameterized.get(options)).isEqualTo("secret-token");
+    }
+
+    private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
+        return parameters.stream()
+                .filter(parameterized -> name.equals(parameterized.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing parameterized member: " + name));
+    }
+
+    public static class CommandOptions {
+        @Parameter(names = "--field")
+        private String fieldValue;
+
+        private int level;
+
+        private String token;
+
+        @Parameter(names = "--level")
+        public void setLevel(int level) {
+            this.level = level;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+
+        @Parameter(names = "--token")
+        public void setToken(String token) {
+            this.token = token;
+        }
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/WrappedParameterTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/WrappedParameterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander;
+
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.JCommander;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WrappedParameterTest {
+    @Test
+    void parsesDynamicParametersIntoMap() {
+        DynamicParametersCommand command = new DynamicParametersCommand();
+
+        new JCommander(command, "-D", "host=localhost", "-Dport=8080");
+
+        assertThat(command.definitions)
+                .containsEntry("host", "localhost")
+                .containsEntry("port", "8080");
+    }
+
+    public static class DynamicParametersCommand {
+        @DynamicParameter(names = "-D")
+        private Map<String, String> definitions = new LinkedHashMap<>();
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/defaultprovider/PropertyFileDefaultProviderTest.java
+++ b/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/defaultprovider/PropertyFileDefaultProviderTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_beust.jcommander.defaultprovider;
+
+import com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFileDefaultProviderTest {
+    @Test
+    void loadsDefaultValuesFromClasspathPropertyFile() {
+        PropertyFileDefaultProvider provider = new PropertyFileDefaultProvider();
+
+        assertThat(provider.getDefaultValueFor("--host")).isEqualTo("localhost");
+        assertThat(provider.getDefaultValueFor("-port")).isEqualTo("8080");
+    }
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.beust/jcommander/1.78/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,42 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.internal.JDK6Console"
+      },
+      "type" : "com_beust.jcommander.JDK6ConsoleTest$RecordingConsole"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$Coordinate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$RecordingParameterValidator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.ParameterDescription"
+      },
+      "type" : "com_beust.jcommander.ParameterDescriptionTest$RecordingValueValidator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.Parameterized"
+      },
+      "type" : "com_beust.jcommander.ParameterizedTest$CommandOptions"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider"
+      },
+      "glob" : "jcommander.properties"
+    }
+  ]
+}

--- a/tests/src/com.beust/jcommander/1.78/src/test/resources/com_beust/jcommander/parameter_descriptions.properties
+++ b/tests/src/com.beust/jcommander/1.78/src/test/resources/com_beust/jcommander/parameter_descriptions.properties
@@ -1,0 +1,3 @@
+parameters.description=description loaded from @Parameters
+deprecated.description=description loaded from @ResourceBundle
+command.description=localized command description

--- a/tests/src/com.beust/jcommander/1.78/src/test/resources/jcommander.properties
+++ b/tests/src/com.beust/jcommander/1.78/src/test/resources/jcommander.properties
@@ -1,0 +1,2 @@
+host=localhost
+port=8080

--- a/tests/src/com.beust/jcommander/1.78/user-code-filter.json
+++ b/tests/src/com.beust/jcommander/1.78/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "com.beust.jcommander.**"
+    },
+    {
+      "includeClasses" : "com_beust.jcommander.**"
+    },
+    {
+      "includeClasses" : "com_beust.jcommander.defaultprovider.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6371

This PR provides test fixes and new metadata for com.beust:jcommander:1.78, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 83457
- Cached input tokens: 610304
- Output tokens: 8006
- Metadata entries: 27
- Test-only metadata entries: 6
- Iterations: 4
- Library coverage percentage: 44.5
- Previous library version metadata entries: 29
- Previous library version test-only metadata entries: 6
- Previous library version coverage percentage: 47.35

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `95d368e32b0b688675af2f44b5d8028f3b96bda4`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.beust:jcommander:1.72: 31/31 covered calls (100.00%)
- com.beust:jcommander:1.78: 32/32 covered calls (100.00%)

**Reflection:**
- com.beust:jcommander:1.72: 27/27 covered calls (100.00%)
- com.beust:jcommander:1.78: 28/28 covered calls (100.00%)

**Resources:**
- com.beust:jcommander:1.72: 4/4 covered calls (100.00%)
- com.beust:jcommander:1.78: 4/4 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.beust:jcommander:1.72: 2859/6492 (44.04%)
- com.beust:jcommander:1.78: 2975/7184 (41.41%)

**Line:**
- com.beust:jcommander:1.72: 643/1358 (47.35%)
- com.beust:jcommander:1.78: 667/1499 (44.50%)

**Method:**
- com.beust:jcommander:1.72: 134/290 (46.21%)
- com.beust:jcommander:1.78: 139/320 (43.44%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/JcommanderTest.java 2/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
index ef7d9e6122..b61bd85acc 100644
--- 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/JcommanderTest.java
+++ 2/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/JcommanderTest.java
@@ -6,7 +6,9 @@
  */
 package com_beust.jcommander;
 
+import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JcommanderTest {
     @Test
     void createsConsoleThroughJdkConsoleLookup() {
-        assertThat(JCommander.getConsole()).isNotNull();
+        JCommander commander = new JCommander();
+
+        assertThat(commander.getConsole()).isNotNull();
     }
 
     @Test
@@ -23,11 +27,29 @@ public class JcommanderTest {
         JCommander commander = new JCommander(new RootCommand());
         commander.addCommand(new LocalizedCommand());
 
-        String description = commander.getCommandDescription("localized");
+        String description = commander.getUsageFormatter().getCommandDescription("localized");
 
         assertThat(description).isEqualTo("localized command description");
     }
 
+    @Test
+    void instantiatesParameterConverterThroughDefaultConstructor() {
+        DefaultConstructorConverterCommand command = new DefaultConstructorConverterCommand();
+
+        new JCommander(command, "--answer", "41");
+
+        assertThat(command.answer).isEqualTo(42);
+    }
+
+    @Test
+    void instantiatesParameterConverterThroughOptionNameConstructor() {
+        OptionNameConstructorConverterCommand command = new OptionNameConstructorConverterCommand();
+
+        new JCommander(command, "--count", "7");
+
+        assertThat(command.count).isEqualTo("--count=7");
+    }
+
     public static class RootCommand {
     }
 
@@ -38,4 +60,34 @@ public class JcommanderTest {
             resourceBundle = "com_beust.jcommander.parameter_descriptions")
     public static class LocalizedCommand {
     }
+
+    public static class DefaultConstructorConverterCommand {
+        @Parameter(names = "--answer", converter = DefaultConstructorIntegerConverter.class)
+        private Integer answer;
+    }
+
+    public static class DefaultConstructorIntegerConverter implements IStringConverter<Integer> {
+        @Override
+        public Integer convert(String value) {
+            return Integer.parseInt(value) + 1;
+        }
+    }
+
+    public static class OptionNameConstructorConverterCommand {
+        @Parameter(names = "--count", converter = OptionNameStringConverter.class)
+        private String count;
+    }
+
+    public static class OptionNameStringConverter implements IStringConverter<String> {
+        private final String optionName;
+
+        public OptionNameStringConverter(String optionName) {
+            this.optionName = optionName;
+        }
+
+        @Override
+        public String convert(String value) {
+            return optionName + "=" + value;
+        }
+    }
 }
diff --git 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/ParameterizedTest.java 2/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
index 3d34bc1b6a..afe3371f38 100644
--- 1/tests/src/com.beust/jcommander/1.72/src/test/java/com_beust/jcommander/ParameterizedTest.java
+++ 2/tests/src/com.beust/jcommander/1.78/src/test/java/com_beust/jcommander/ParameterizedTest.java
@@ -44,6 +44,16 @@ public class ParameterizedTest {
         assertThat(parameterized.get(options)).isEqualTo("secret-token");
     }
 
+    @Test
+    void booleanMethodBackedParameterUsesIsGetter() {
+        CommandOptions options = new CommandOptions();
+        Parameterized parameterized = parameterNamed(Parameterized.parseArg(options), "setEnabled");
+
+        parameterized.set(options, true);
+
+        assertThat(parameterized.get(options)).isEqualTo(true);
+    }
+
     private static Parameterized parameterNamed(List<Parameterized> parameters, String name) {
         return parameters.stream()
                 .filter(parameterized -> name.equals(parameterized.getName()))
@@ -59,6 +69,8 @@ public class ParameterizedTest {
 
         private String token;
 
+        private boolean enabled;
+
         @Parameter(names = "--level")
         public void setLevel(int level) {
             this.level = level;
@@ -72,5 +84,14 @@ public class ParameterizedTest {
         public void setToken(String token) {
             this.token = token;
         }
+
+        @Parameter(names = "--enabled")
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
     }
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
