### PR TITLE
[GenAI] Add support for io.grpc:grpc-protobuf:1.70.0 using gpt-5.5

### DIFF
--- a/metadata/io.grpc/grpc-protobuf/1.70.0/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-protobuf/1.70.0/reachability-metadata.json
@@ -1,0 +1,88 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.grpc.protobuf.ProtoUtils"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.protobuf.ProtoUtils"
+      },
+      "type": "com.google.protobuf.StringValue$Builder",
+      "methods": [
+        {
+          "name": "clearValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setValueBytes",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.protobuf.StatusProto"
+      },
+      "type": "com.google.protobuf.StringValue",
+      "methods": [
+        {
+          "name": "getDefaultInstance",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.protobuf.StatusProto"
+      },
+      "type": "com.google.protobuf.StringValue$Builder",
+      "methods": [
+        {
+          "name": "clearValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "getValue",
+          "parameterTypes": []
+        },
+        {
+          "name": "setValue",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setValueBytes",
+          "parameterTypes": [
+            "com.google.protobuf.ByteString"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.grpc/grpc-protobuf/index.json
+++ b/metadata/io.grpc/grpc-protobuf/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.70.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-protobuf/$version$/grpc-protobuf-$version$-sources.jar",
+    "repository-url" : "https://github.com/grpc/grpc-java",
+    "test-code-url" : "https://github.com/grpc/grpc-java/tree/v$version$/protobuf/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/grpc/grpc-protobuf/$version$/grpc-protobuf-$version$-javadoc.jar",
+    "description" : "gRPC Protobuf provides gRPC-Java utilities for marshalling and unmarshalling Protocol Buffers messages in gRPC method descriptors. It also exposes protobuf descriptor supplier interfaces and status helpers used by generated or reflection-aware gRPC Java code.",
+    "tested-versions" : [
+      "1.70.0"
+    ],
+    "allowed-packages" : [
+      "io.grpc.protobuf"
+    ]
+  }
+]

--- a/stats/io.grpc/grpc-protobuf/1.70.0/execution-metrics.json
+++ b/stats/io.grpc/grpc-protobuf/1.70.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-07": {
+    "timestamp": "2026-05-07T21:08:17.820510Z",
+    "library": "io.grpc:grpc-protobuf:1.70.0",
+    "starting_commit": "b47acb9950c630f2038f816b726c71b668e6ee18",
+    "ending_commit": "c1596b71da4785546c26cb6d282cab0a1190db5e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.70.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 174,
+          "missed": 17,
+          "ratio": 0.910995,
+          "total": 191
+        },
+        "line": {
+          "covered": 45,
+          "missed": 3,
+          "ratio": 0.9375,
+          "total": 48
+        },
+        "method": {
+          "covered": 14,
+          "missed": 2,
+          "ratio": 0.875,
+          "total": 16
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 102085,
+      "cached_input_tokens_used": 747008,
+      "output_tokens_used": 17838,
+      "iterations": 4,
+      "cost_usd": 0.9086,
+      "generated_loc": 276,
+      "tested_library_loc": 45,
+      "metadata_entries": 15,
+      "code_coverage_percent": 93.75
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java",
+      "metadata_file": "metadata/io.grpc/grpc-protobuf/1.70.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.grpc/grpc-protobuf/1.70.0/stats.json
+++ b/stats/io.grpc/grpc-protobuf/1.70.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.70.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 174,
+        "missed" : 17,
+        "ratio" : 0.910995,
+        "total" : 191
+      },
+      "line" : {
+        "covered" : 45,
+        "missed" : 3,
+        "ratio" : 0.9375,
+        "total" : 48
+      },
+      "method" : {
+        "covered" : 14,
+        "missed" : 2,
+        "ratio" : 0.875,
+        "total" : 16
+      }
+    }
+  } ]
+}

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/.gitignore
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/build.gradle
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.grpc:grpc-protobuf:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/gradle.properties
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.grpc:grpc-protobuf:1.70.0
+library.version = 1.70.0
+metadata.dir = io.grpc/grpc-protobuf/1.70.0/

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/settings.gradle
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.grpc.grpc-protobuf_tests'

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
@@ -6,11 +6,254 @@
  */
 package io_grpc.grpc_protobuf;
 
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.Descriptors.MethodDescriptor;
+import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Value;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoMethodDescriptorSupplier;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.protobuf.StatusProto;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import org.junit.jupiter.api.Test;
 
-class Grpc_protobufTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Grpc_protobufTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void protoMarshallerStreamsAndParsesFullProtobufMessages() throws IOException {
+        StringValue message = StringValue.newBuilder().setValue("hello from grpc-protobuf").build();
+        Marshaller<StringValue> marshaller = ProtoUtils.marshaller(StringValue.getDefaultInstance());
+
+        byte[] bytes = readAllBytes(marshaller.stream(message));
+        StringValue parsedFromMarshallerStream = marshaller.parse(new ByteArrayInputStream(bytes));
+        StringValue parsedFromRegularStream = marshaller.parse(new ByteArrayInputStream(message.toByteArray()));
+
+        assertThat(parsedFromMarshallerStream).isEqualTo(message);
+        assertThat(parsedFromRegularStream).isEqualTo(message);
+    }
+
+    @Test
+    void protobufMessagesCanBeStoredInGrpcMetadataWithGeneratedBinaryKey() {
+        StringValue value = StringValue.newBuilder().setValue("metadata payload").build();
+        Metadata metadata = new Metadata();
+        Metadata.Key<StringValue> key = ProtoUtils.keyForProto(StringValue.getDefaultInstance());
+
+        metadata.put(key, value);
+
+        assertThat(metadata.get(key)).isEqualTo(value);
+        assertThat(metadata.keys()).contains(key.name());
+    }
+
+    @Test
+    void metadataMarshallerRoundTripsRawHeaderBytes() {
+        StringValue value = StringValue.newBuilder().setValue("raw header bytes").build();
+        Metadata.BinaryMarshaller<StringValue> marshaller = ProtoUtils.metadataMarshaller(
+                StringValue.getDefaultInstance());
+
+        byte[] bytes = marshaller.toBytes(value);
+        StringValue parsed = marshaller.parseBytes(bytes);
+
+        assertThat(parsed).isEqualTo(value);
+    }
+
+    @Test
+    void marshallerWithRecursionLimitParsesNestedMessagesWhenLimitIsSufficient() {
+        Value nestedValue = nestedListValue(8);
+        Marshaller<Value> marshaller = ProtoUtils.marshallerWithRecursionLimit(Value.getDefaultInstance(), 64);
+
+        Value parsed = marshaller.parse(new ByteArrayInputStream(nestedValue.toByteArray()));
+
+        assertThat(parsed).isEqualTo(nestedValue);
+    }
+
+    @Test
+    void marshallerWithRecursionLimitRejectsMessagesPastConfiguredDepth() {
+        Value nestedValue = nestedListValue(20);
+        Marshaller<Value> marshaller = ProtoUtils.marshallerWithRecursionLimit(Value.getDefaultInstance(), 4);
+
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class,
+                () -> marshaller.parse(new ByteArrayInputStream(nestedValue.toByteArray())));
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(io.grpc.Status.Code.INTERNAL);
+    }
+
+    @Test
+    void extensionRegistryCanBeConfiguredWithoutChangingNormalParsing() {
+        StringValue value = StringValue.newBuilder().setValue("uses configured registry").build();
+        ProtoUtils.setExtensionRegistry(ExtensionRegistry.newInstance());
+
+        Marshaller<StringValue> marshaller = ProtoUtils.marshaller(StringValue.getDefaultInstance());
+        StringValue parsed = marshaller.parse(new ByteArrayInputStream(value.toByteArray()));
+
+        assertThat(parsed).isEqualTo(value);
+    }
+
+    @Test
+    void statusProtoConvertsRpcStatusToRuntimeExceptionAndBack() {
+        Status rpcStatus = Status.newBuilder()
+                .setCode(Code.INVALID_ARGUMENT.getNumber())
+                .setMessage("invalid request")
+                .build();
+        Metadata.Key<byte[]> customKey = Metadata.Key.of("custom-bin", Metadata.BINARY_BYTE_MARSHALLER);
+        Metadata trailers = new Metadata();
+        trailers.put(customKey, new byte[] {1, 2, 3});
+
+        StatusRuntimeException exception = StatusProto.toStatusRuntimeException(rpcStatus, trailers);
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(io.grpc.Status.Code.INVALID_ARGUMENT);
+        assertThat(exception.getStatus().getDescription()).isEqualTo("invalid request");
+        assertThat(exception.getTrailers().get(customKey)).containsExactly(1, 2, 3);
+        assertThat(StatusProto.fromThrowable(exception)).isEqualTo(rpcStatus);
+        Status extractedStatus = StatusProto.fromStatusAndTrailers(exception.getStatus(), exception.getTrailers());
+        assertThat(extractedStatus).isEqualTo(rpcStatus);
+    }
+
+    @Test
+    void statusProtoCreatesCheckedExceptionWithTrailersAndCause() {
+        Status rpcStatus = Status.newBuilder()
+                .setCode(Code.NOT_FOUND.getNumber())
+                .setMessage("missing resource")
+                .build();
+        Metadata.Key<String> textKey = Metadata.Key.of("resource-id", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata trailers = new Metadata();
+        trailers.put(textKey, "item-123");
+        IllegalStateException cause = new IllegalStateException("repository lookup failed");
+
+        StatusException exception = StatusProto.toStatusException(rpcStatus, trailers, cause);
+
+        assertThat(exception.getStatus().getCode()).isEqualTo(io.grpc.Status.Code.NOT_FOUND);
+        assertThat(exception.getStatus().getDescription()).isEqualTo("missing resource");
+        assertThat(exception.getTrailers().get(textKey)).isEqualTo("item-123");
+        assertThat(exception).hasCause(cause);
+        assertThat(StatusProto.fromThrowable(exception)).isEqualTo(rpcStatus);
+    }
+
+    @Test
+    void statusProtoConvertsPlainGrpcStatusWhenThrowableDoesNotContainRpcStatusDetails() {
+        StatusRuntimeException exception = io.grpc.Status.UNKNOWN
+                .withDescription("transport failed")
+                .asRuntimeException();
+
+        Status status = StatusProto.fromThrowable(exception);
+
+        assertThat(status.getCode()).isEqualTo(Code.UNKNOWN.getNumber());
+        assertThat(status.getMessage()).isEqualTo("transport failed");
+    }
+
+    @Test
+    void descriptorSupplierInterfacesExposeFileServiceAndMethodDescriptors() throws Exception {
+        FileDescriptor fileDescriptor = buildGreeterFileDescriptor();
+        ServiceDescriptor serviceDescriptor = fileDescriptor.findServiceByName("Greeter");
+        MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName("SayHello");
+        TestMethodDescriptorSupplier supplier = new TestMethodDescriptorSupplier(fileDescriptor, serviceDescriptor,
+                methodDescriptor);
+
+        assertThat(supplier.getFileDescriptor().getName()).isEqualTo("testing/greeter.proto");
+        assertThat(supplier.getServiceDescriptor().getFullName()).isEqualTo("testing.Greeter");
+        assertThat(supplier.getMethodDescriptor().getFullName()).isEqualTo("testing.Greeter.SayHello");
+        assertThat(supplier.getMethodDescriptor().getInputType().getFullName()).isEqualTo("testing.HelloRequest");
+        assertThat(supplier.getMethodDescriptor().getOutputType().getFullName()).isEqualTo("testing.HelloReply");
+    }
+
+    private static byte[] readAllBytes(InputStream inputStream) throws IOException {
+        try (InputStream stream = inputStream; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[128];
+            int read = stream.read(buffer);
+            while (read != -1) {
+                output.write(buffer, 0, read);
+                read = stream.read(buffer);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    private static Value nestedListValue(int depth) {
+        Value value = Value.newBuilder().setStringValue("leaf").build();
+        for (int index = 0; index < depth; index++) {
+            value = Value.newBuilder()
+                    .setListValue(ListValue.newBuilder().addValues(value))
+                    .build();
+        }
+        return value;
+    }
+
+    private static FileDescriptor buildGreeterFileDescriptor() throws Exception {
+        DescriptorProto request = DescriptorProto.newBuilder()
+                .setName("HelloRequest")
+                .addField(FieldDescriptorProto.newBuilder()
+                        .setName("name")
+                        .setNumber(1)
+                        .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+        DescriptorProto response = DescriptorProto.newBuilder()
+                .setName("HelloReply")
+                .addField(FieldDescriptorProto.newBuilder()
+                        .setName("message")
+                        .setNumber(1)
+                        .setType(FieldDescriptorProto.Type.TYPE_STRING))
+                .build();
+        MethodDescriptorProto method = MethodDescriptorProto.newBuilder()
+                .setName("SayHello")
+                .setInputType(".testing.HelloRequest")
+                .setOutputType(".testing.HelloReply")
+                .build();
+        ServiceDescriptorProto service = ServiceDescriptorProto.newBuilder()
+                .setName("Greeter")
+                .addMethod(method)
+                .build();
+        FileDescriptorProto file = FileDescriptorProto.newBuilder()
+                .setName("testing/greeter.proto")
+                .setPackage("testing")
+                .addMessageType(request)
+                .addMessageType(response)
+                .addService(service)
+                .build();
+        return FileDescriptor.buildFrom(file, new FileDescriptor[0]);
+    }
+
+    private static final class TestMethodDescriptorSupplier implements ProtoMethodDescriptorSupplier {
+        private final FileDescriptor fileDescriptor;
+        private final ServiceDescriptor serviceDescriptor;
+        private final MethodDescriptor methodDescriptor;
+
+        private TestMethodDescriptorSupplier(FileDescriptor fileDescriptor, ServiceDescriptor serviceDescriptor,
+                MethodDescriptor methodDescriptor) {
+            this.fileDescriptor = fileDescriptor;
+            this.serviceDescriptor = serviceDescriptor;
+            this.methodDescriptor = methodDescriptor;
+        }
+
+        @Override
+        public FileDescriptor getFileDescriptor() {
+            return fileDescriptor;
+        }
+
+        @Override
+        public ServiceDescriptor getServiceDescriptor() {
+            return serviceDescriptor;
+        }
+
+        @Override
+        public MethodDescriptor getMethodDescriptor() {
+            return methodDescriptor;
+        }
     }
 }

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
@@ -7,13 +7,17 @@
 package io_grpc.grpc_protobuf;
 
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.StringValue;
@@ -107,6 +111,26 @@ public class Grpc_protobufTest {
     }
 
     @Test
+    void extensionRegistryParsesRegisteredExtensions() throws Exception {
+        FileDescriptor fileDescriptor = buildExtendedMessageFileDescriptor();
+        Descriptor hostDescriptor = fileDescriptor.findMessageTypeByName("Host");
+        FieldDescriptor extensionField = fileDescriptor.findExtensionByName("label");
+        DynamicMessage defaultInstance = DynamicMessage.getDefaultInstance(hostDescriptor);
+        DynamicMessage message = DynamicMessage.newBuilder(hostDescriptor)
+                .setField(extensionField, "registered extension")
+                .build();
+        ExtensionRegistry registry = ExtensionRegistry.newInstance();
+        registry.add(extensionField);
+        ProtoUtils.setExtensionRegistry(registry);
+
+        Marshaller<DynamicMessage> marshaller = ProtoUtils.marshaller(defaultInstance);
+        DynamicMessage parsed = marshaller.parse(new ByteArrayInputStream(message.toByteArray()));
+
+        assertThat(parsed.getField(extensionField)).isEqualTo("registered extension");
+        assertThat(parsed.getAllFields()).containsEntry(extensionField, "registered extension");
+    }
+
+    @Test
     void statusProtoConvertsRpcStatusToRuntimeExceptionAndBack() {
         Status rpcStatus = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT.getNumber())
@@ -193,6 +217,27 @@ public class Grpc_protobufTest {
                     .build();
         }
         return value;
+    }
+
+    private static FileDescriptor buildExtendedMessageFileDescriptor() throws Exception {
+        DescriptorProto host = DescriptorProto.newBuilder()
+                .setName("Host")
+                .addExtensionRange(ExtensionRange.newBuilder().setStart(100).setEnd(101))
+                .build();
+        FieldDescriptorProto extension = FieldDescriptorProto.newBuilder()
+                .setName("label")
+                .setNumber(100)
+                .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                .setExtendee(".testing.Host")
+                .build();
+        FileDescriptorProto file = FileDescriptorProto.newBuilder()
+                .setName("testing/extended-message.proto")
+                .setPackage("testing")
+                .addMessageType(host)
+                .addExtension(extension)
+                .build();
+        return FileDescriptor.buildFrom(file, new FileDescriptor[0]);
     }
 
     private static FileDescriptor buildGreeterFileDescriptor() throws Exception {

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
@@ -6,6 +6,7 @@
  */
 package io_grpc.grpc_protobuf;
 
+import com.google.protobuf.Any;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
@@ -180,6 +181,23 @@ public class Grpc_protobufTest {
 
         assertThat(status.getCode()).isEqualTo(Code.UNKNOWN.getNumber());
         assertThat(status.getMessage()).isEqualTo("transport failed");
+    }
+
+    @Test
+    void statusProtoFindsRichRpcStatusInThrowableCauseChain() throws Exception {
+        StringValue detail = StringValue.newBuilder().setValue("missing permission").build();
+        Status rpcStatus = Status.newBuilder()
+                .setCode(Code.PERMISSION_DENIED.getNumber())
+                .setMessage("access denied")
+                .addDetails(Any.pack(detail))
+                .build();
+        RuntimeException wrapper = new RuntimeException("top level",
+                new IllegalArgumentException("middle level", StatusProto.toStatusException(rpcStatus)));
+
+        Status extracted = StatusProto.fromThrowable(wrapper);
+
+        assertThat(extracted).isEqualTo(rpcStatus);
+        assertThat(extracted.getDetails(0).unpack(StringValue.class)).isEqualTo(detail);
     }
 
     @Test

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/src/test/java/io_grpc/grpc_protobuf/Grpc_protobufTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_protobuf;
+
+import org.junit.jupiter.api.Test;
+
+class Grpc_protobufTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.grpc.protobuf.**"
+    }
+  ]
+}

--- a/tests/src/io.grpc/grpc-protobuf/1.70.0/user-code-filter.json
+++ b/tests/src/io.grpc/grpc-protobuf/1.70.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.grpc.protobuf.**"
+      "includeClasses" : "io.grpc.protobuf.**"
+    },
+    {
+      "includeClasses" : "io_grpc.grpc_protobuf.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2662

This PR introduces tests and metadata for io.grpc:grpc-protobuf:1.70.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 102085
- Cached input tokens: 747008
- Output tokens: 17838
- Metadata entries: 15
- Iterations: 4
- Library coverage percentage: 93.75
- Generated lines of code: 276
- Tested library lines of code: 45

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `2403519f9be853a68e23fd05aeeeee6d0b1ba2e8`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 174/191 (91.10%)
- Line: 45/48 (93.75%)
- Method: 14/16 (87.50%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
