### PR TITLE
[GenAI] Add support for software.amazon.awssdk:apache-client:2.34.0 using gpt-5.5

### DIFF
--- a/metadata/software.amazon.awssdk/apache-client/2.34.0/reachability-metadata.json
+++ b/metadata/software.amazon.awssdk/apache-client/2.34.0/reachability-metadata.json
@@ -1,0 +1,23 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.http.apache.ApacheHttpClient"
+      },
+      "type": "java.lang.String",
+      "fields": [
+        {
+          "name": "serialVersionUID"
+        }
+      ]
+    }
+  ],
+  "serialization": [
+    {
+      "condition": {
+        "typeReached": "software.amazon.awssdk.http.apache.ApacheHttpClient"
+      },
+      "type": "java.lang.String"
+    }
+  ]
+}

--- a/metadata/software.amazon.awssdk/apache-client/index.json
+++ b/metadata/software.amazon.awssdk/apache-client/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.34.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/apache-client/$version$/apache-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/aws/aws-sdk-java-v2",
+    "test-code-url" : "https://github.com/aws/aws-sdk-java-v2/tree/$version$/http-clients/apache-client/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/software/amazon/awssdk/apache-client/$version$/apache-client-$version$-javadoc.jar",
+    "description" : "This module provides the Apache HTTP client implementation for AWS SDK for Java 2.x synchronous clients. It adapts Apache HttpClient to the SDK HTTP client SPI, handling connection pooling, proxy and TLS configuration, and request execution for AWS service clients.",
+    "tested-versions" : [
+      "2.34.0"
+    ],
+    "allowed-packages" : [
+      "software.amazon.awssdk.http.apache"
+    ]
+  }
+]

--- a/stats/software.amazon.awssdk/apache-client/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/apache-client/2.34.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-07": {
+    "timestamp": "2026-05-07T22:49:28.815459Z",
+    "library": "software.amazon.awssdk:apache-client:2.34.0",
+    "starting_commit": "590077e3e512dc8b034bbff9b16a0f78b003d673",
+    "ending_commit": "f67dd0ca57bcc8e9b339ffec8e718e2f1292038f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.34.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1650,
+          "missed": 1854,
+          "ratio": 0.47089,
+          "total": 3504
+        },
+        "line": {
+          "covered": 416,
+          "missed": 470,
+          "ratio": 0.469526,
+          "total": 886
+        },
+        "method": {
+          "covered": 134,
+          "missed": 231,
+          "ratio": 0.367123,
+          "total": 365
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 117490,
+      "cached_input_tokens_used": 1670144,
+      "output_tokens_used": 18686,
+      "iterations": 3,
+      "cost_usd": 1.3957,
+      "generated_loc": 339,
+      "tested_library_loc": 416,
+      "metadata_entries": 2,
+      "code_coverage_percent": 46.95
+    },
+    "artifacts": {
+      "test_file": "tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java",
+      "metadata_file": "metadata/software.amazon.awssdk/apache-client/2.34.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/software.amazon.awssdk/apache-client/2.34.0/stats.json
+++ b/stats/software.amazon.awssdk/apache-client/2.34.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.34.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1650,
+        "missed" : 1854,
+        "ratio" : 0.47089,
+        "total" : 3504
+      },
+      "line" : {
+        "covered" : 416,
+        "missed" : 470,
+        "ratio" : 0.469526,
+        "total" : 886
+      },
+      "method" : {
+        "covered" : 134,
+        "missed" : 231,
+        "ratio" : 0.367123,
+        "total" : 365
+      }
+    }
+  } ]
+}

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/.gitignore
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/build.gradle
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "software.amazon.awssdk:apache-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/gradle.properties
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = software.amazon.awssdk:apache-client:2.34.0
+library.version = 2.34.0
+metadata.dir = software.amazon.awssdk/apache-client/2.34.0/

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/settings.gradle
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'software.amazon.awssdk.apache-client_tests'

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
@@ -28,7 +28,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.conn.DnsResolver;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import software.amazon.awssdk.http.AbortableInputStream;
@@ -183,6 +186,54 @@ public class Apache_clientTest {
             assertThat(readResponse(response)).isEqualTo("from-origin");
             assertThat(originRequests).hasValue(1);
             assertThat(proxyRequests).hasValue(0);
+        }
+    }
+
+    @Test
+    void apacheClientUsesConfiguredCredentialsProviderForOriginAuthentication() throws Exception {
+        String expectedAuthorization = "Basic "
+                + Base64.getEncoder().encodeToString("originUser:secret".getBytes(UTF_8));
+        AtomicInteger requests = new AtomicInteger();
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            requests.incrementAndGet();
+            assertThat(exchange.getRequestMethod()).isEqualTo("GET");
+            assertThat(exchange.getRequestURI().getPath()).isEqualTo("/authenticated");
+
+            String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+            if (authorization == null) {
+                exchange.getResponseHeaders().add("WWW-Authenticate", "Basic realm=\"origin\"");
+                writeResponse(exchange, 401, "credentials required");
+                return;
+            }
+
+            assertThat(authorization).isEqualTo(expectedAuthorization);
+            writeResponse(exchange, 200, "authenticated");
+        })) {
+            BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(
+                    new AuthScope(server.uri("").getHost(), server.port()),
+                    new UsernamePasswordCredentials("originUser", "secret"));
+
+            try (SdkHttpClient client = ApacheHttpClient.builder()
+                    .connectionTimeout(SHORT_TIMEOUT)
+                    .socketTimeout(SHORT_TIMEOUT)
+                    .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                    .useIdleConnectionReaper(false)
+                    .credentialsProvider(credentialsProvider)
+                    .build()) {
+                SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                        .method(SdkHttpMethod.GET)
+                        .uri(server.uri("/authenticated"))
+                        .build();
+
+                HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                        .request(request)
+                        .build()).call();
+
+                assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+                assertThat(readResponse(response)).isEqualTo("authenticated");
+                assertThat(requests).hasValue(2);
+            }
         }
     }
 

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package software_amazon_awssdk.apache_client;
+
+import org.junit.jupiter.api.Test;
+
+class Apache_clientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
@@ -243,7 +243,7 @@ public class Apache_clientTest {
         DnsResolver resolver = host -> {
             resolvedHost.set(host);
             if ("aws.test".equals(host)) {
-                return new InetAddress[] { InetAddress.getLoopbackAddress() };
+                return new InetAddress[] {InetAddress.getLoopbackAddress()};
             }
             return InetAddress.getAllByName(host);
         };

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
@@ -6,11 +6,277 @@
  */
 package software_amazon_awssdk.apache_client;
 
-import org.junit.jupiter.api.Test;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Apache_clientTest {
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.http.conn.DnsResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.Header;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpService;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
+import software.amazon.awssdk.http.apache.ProxyConfiguration;
+
+@Timeout(60)
+public class Apache_clientTest {
+    private static final Duration SHORT_TIMEOUT = Duration.ofSeconds(2);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void apacheClientExecutesGetRequestAndExposesResponseMetadata() throws Exception {
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            assertThat(exchange.getRequestMethod()).isEqualTo("GET");
+            assertThat(exchange.getRequestURI().getPath()).isEqualTo("/hello");
+            assertThat(exchange.getRequestURI().getRawQuery()).contains("greeting=hello", "symbol=");
+            assertThat(exchange.getRequestHeaders().get("X-Test")).containsExactly("one", "two");
+            assertThat(exchange.getRequestHeaders().getFirst("Accept")).isEqualTo("text/plain");
+
+            exchange.getResponseHeaders().put("X-Reply", List.of("alpha", "beta"));
+            writeResponse(exchange, 201, "hello from apache");
+        }); SdkHttpClient client = newClient()) {
+            SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.GET)
+                    .uri(server.uri("/hello"))
+                    .appendRawQueryParameter("greeting", "hello world")
+                    .appendRawQueryParameter("symbol", "a+b&c=d")
+                    .appendHeader("X-Test", "one")
+                    .appendHeader("X-Test", "two")
+                    .putHeader(Header.ACCEPT, "text/plain")
+                    .build();
+
+            HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                    .request(request)
+                    .build()).call();
+
+            assertThat(response.httpResponse().statusCode()).isEqualTo(201);
+            assertThat(response.httpResponse().isSuccessful()).isTrue();
+            assertThat(response.httpResponse().firstMatchingHeader("X-Reply")).contains("alpha");
+            assertThat(readResponse(response)).isEqualTo("hello from apache");
+        }
+    }
+
+    @Test
+    void apacheClientSendsRepeatablePostBodies() throws Exception {
+        AtomicInteger requests = new AtomicInteger();
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            int requestNumber = requests.incrementAndGet();
+            assertThat(exchange.getRequestMethod()).isEqualTo("POST");
+            assertThat(exchange.getRequestURI().getPath()).isEqualTo("/submit");
+            assertThat(exchange.getRequestHeaders().getFirst(Header.CONTENT_TYPE))
+                    .isEqualTo("text/plain; charset=utf-8");
+            assertThat(new String(exchange.getRequestBody().readAllBytes(), UTF_8))
+                    .isEqualTo("payload-" + requestNumber);
+            writeResponse(exchange, 200, "accepted-" + requestNumber);
+        }); SdkHttpClient client = newClient()) {
+            assertThat(postPayload(client, server.uri("/submit"), "payload-1")).isEqualTo("accepted-1");
+            assertThat(postPayload(client, server.uri("/submit"), "payload-2")).isEqualTo("accepted-2");
+            assertThat(requests).hasValue(2);
+        }
+    }
+
+    @Test
+    void apacheClientUsesConfiguredHttpProxyAndProxyCredentials() throws Exception {
+        String expectedAuthorization = "Basic "
+                + Base64.getEncoder().encodeToString("proxyUser:secret".getBytes(UTF_8));
+        AtomicInteger proxyRequests = new AtomicInteger();
+        try (TestHttpServer proxy = TestHttpServer.create(exchange -> {
+            proxyRequests.incrementAndGet();
+            assertThat(exchange.getRequestMethod()).isEqualTo("GET");
+            assertThat(exchange.getRequestURI().toString()).contains("/proxied");
+            assertThat(exchange.getRequestURI().getRawQuery()).contains("via=proxy");
+            assertThat(exchange.getRequestHeaders().getFirst("Host")).contains("example.com");
+            if (exchange.getRequestHeaders().getFirst("Proxy-Authorization") == null) {
+                exchange.getResponseHeaders().add("Proxy-Authenticate", "Basic realm=\"apache-client-test\"");
+                writeResponse(exchange, 407, "proxy authentication required");
+                return;
+            }
+            assertThat(exchange.getRequestHeaders().getFirst("Proxy-Authorization")).isEqualTo(expectedAuthorization);
+            writeResponse(exchange, 200, "from-proxy");
+        }); SdkHttpClient client = ApacheHttpClient.builder()
+                .connectionTimeout(SHORT_TIMEOUT)
+                .socketTimeout(SHORT_TIMEOUT)
+                .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                .useIdleConnectionReaper(false)
+                .proxyConfiguration(ProxyConfiguration.builder()
+                        .endpoint(proxy.uri(""))
+                        .username("proxyUser")
+                        .password("secret")
+                        .preemptiveBasicAuthenticationEnabled(true)
+                        .nonProxyHosts(Set.of("localhost"))
+                        .useSystemPropertyValues(false)
+                        .useEnvironmentVariableValues(false)
+                        .build())
+                .build()) {
+            SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.GET)
+                    .uri(URI.create("http://example.com/proxied?via=proxy"))
+                    .build();
+
+            assertThat(readResponse(client.prepareRequest(HttpExecuteRequest.builder()
+                    .request(request)
+                    .build()).call())).isEqualTo("from-proxy");
+            assertThat(proxyRequests.get()).isBetween(1, 2);
+        }
+    }
+
+    @Test
+    void apacheClientUsesCustomDnsResolver() throws Exception {
+        AtomicReference<String> resolvedHost = new AtomicReference<>();
+        DnsResolver resolver = host -> {
+            resolvedHost.set(host);
+            if ("aws.test".equals(host)) {
+                return new InetAddress[] { InetAddress.getLoopbackAddress() };
+            }
+            return InetAddress.getAllByName(host);
+        };
+
+        try (TestHttpServer server = TestHttpServer.create(exchange -> {
+            assertThat(exchange.getRequestURI().getPath()).isEqualTo("/resolved");
+            assertThat(exchange.getRequestHeaders().getFirst("Host")).startsWith("aws.test:");
+            writeResponse(exchange, 200, "resolved");
+        }); SdkHttpClient client = ApacheHttpClient.builder()
+                .connectionTimeout(SHORT_TIMEOUT)
+                .socketTimeout(SHORT_TIMEOUT)
+                .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                .useIdleConnectionReaper(false)
+                .dnsResolver(resolver)
+                .build()) {
+            SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.GET)
+                    .uri(URI.create("http://aws.test:" + server.port() + "/resolved"))
+                    .build();
+
+            assertThat(readResponse(client.prepareRequest(HttpExecuteRequest.builder()
+                    .request(request)
+                    .build()).call())).isEqualTo("resolved");
+            assertThat(resolvedHost).hasValue("aws.test");
+        }
+    }
+
+    @Test
+    void apacheHttpServiceIsDiscoverableAndCreatesApacheClientBuilder() {
+        Optional<SdkHttpService> service = ServiceLoader.load(SdkHttpService.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(ApacheSdkHttpService.class::isInstance)
+                .findFirst();
+
+        assertThat(service).isPresent();
+        assertThat(service.orElseThrow().createHttpClientBuilder()).isInstanceOf(ApacheHttpClient.Builder.class);
+        try (SdkHttpClient client = ((ApacheHttpClient.Builder) service.orElseThrow().createHttpClientBuilder())
+                .connectionTimeout(SHORT_TIMEOUT)
+                .socketTimeout(SHORT_TIMEOUT)
+                .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                .useIdleConnectionReaper(false)
+                .build()) {
+            assertThat(client.clientName()).isEqualTo(ApacheHttpClient.CLIENT_NAME);
+        }
+    }
+
+    private static SdkHttpClient newClient() {
+        return ApacheHttpClient.builder()
+                .connectionTimeout(SHORT_TIMEOUT)
+                .socketTimeout(SHORT_TIMEOUT)
+                .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                .maxConnections(4)
+                .useIdleConnectionReaper(false)
+                .build();
+    }
+
+    private static String postPayload(SdkHttpClient client, URI uri, String body) throws IOException {
+        ContentStreamProvider content = ContentStreamProvider.fromUtf8String(body);
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.POST)
+                .uri(uri)
+                .putHeader(Header.CONTENT_TYPE, "text/plain; charset=utf-8")
+                .putHeader(Header.CONTENT_LENGTH, Integer.toString(body.getBytes(UTF_8).length))
+                .build();
+        ExecutableHttpRequest executable = client.prepareRequest(HttpExecuteRequest.builder()
+                .request(request)
+                .contentStreamProvider(content)
+                .build());
+        return readResponse(executable.call());
+    }
+
+    private static String readResponse(HttpExecuteResponse response) throws IOException {
+        try (AbortableInputStream stream = response.responseBody().orElseThrow()) {
+            return new String(stream.readAllBytes(), UTF_8);
+        }
+    }
+
+    private static void writeResponse(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] bytes = body.getBytes(UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream responseBody = exchange.getResponseBody()) {
+            responseBody.write(bytes);
+        }
+    }
+
+    private static final class TestHttpServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+
+        private TestHttpServer(HttpServer server, ExecutorService executor) {
+            this.server = server;
+            this.executor = executor;
+        }
+
+        static TestHttpServer create(HttpHandler handler) throws IOException {
+            HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "apache-client-test-server");
+                thread.setDaemon(true);
+                return thread;
+            });
+            server.createContext("/", exchange -> {
+                try (exchange) {
+                    handler.handle(exchange);
+                }
+            });
+            server.setExecutor(executor);
+            server.start();
+            return new TestHttpServer(server, executor);
+        }
+
+        URI uri(String path) {
+            return URI.create("http://" + server.getAddress().getHostString() + ":" + port() + path);
+        }
+
+        int port() {
+            return server.getAddress().getPort();
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            server.stop(0);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
     }
 }

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/src/test/java/software_amazon_awssdk/apache_client/Apache_clientTest.java
@@ -147,6 +147,46 @@ public class Apache_clientTest {
     }
 
     @Test
+    void apacheClientBypassesProxyForConfiguredNonProxyHosts() throws Exception {
+        AtomicInteger originRequests = new AtomicInteger();
+        AtomicInteger proxyRequests = new AtomicInteger();
+        try (TestHttpServer origin = TestHttpServer.create(exchange -> {
+            originRequests.incrementAndGet();
+            assertThat(exchange.getRequestMethod()).isEqualTo("GET");
+            assertThat(exchange.getRequestURI().getPath()).isEqualTo("/direct");
+            writeResponse(exchange, 200, "from-origin");
+        }); TestHttpServer proxy = TestHttpServer.create(exchange -> {
+            proxyRequests.incrementAndGet();
+            writeResponse(exchange, 502, "proxy should not be used");
+        }); SdkHttpClient client = ApacheHttpClient.builder()
+                .connectionTimeout(SHORT_TIMEOUT)
+                .socketTimeout(SHORT_TIMEOUT)
+                .connectionAcquisitionTimeout(SHORT_TIMEOUT)
+                .useIdleConnectionReaper(false)
+                .proxyConfiguration(ProxyConfiguration.builder()
+                        .endpoint(proxy.uri(""))
+                        .nonProxyHosts(Set.of(origin.uri("").getHost()))
+                        .useSystemPropertyValues(false)
+                        .useEnvironmentVariableValues(false)
+                        .build())
+                .build()) {
+            SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.GET)
+                    .uri(origin.uri("/direct"))
+                    .build();
+
+            HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                    .request(request)
+                    .build()).call();
+
+            assertThat(response.httpResponse().statusCode()).isEqualTo(200);
+            assertThat(readResponse(response)).isEqualTo("from-origin");
+            assertThat(originRequests).hasValue(1);
+            assertThat(proxyRequests).hasValue(0);
+        }
+    }
+
+    @Test
     void apacheClientUsesCustomDnsResolver() throws Exception {
         AtomicReference<String> resolvedHost = new AtomicReference<>();
         DnsResolver resolver = host -> {

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/user-code-filter.json
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "software.amazon.awssdk.http.apache.**"
+      "includeClasses" : "software.amazon.awssdk.http.apache.**"
+    },
+    {
+      "includeClasses" : "software_amazon_awssdk.apache_client.**"
     }
   ]
 }

--- a/tests/src/software.amazon.awssdk/apache-client/2.34.0/user-code-filter.json
+++ b/tests/src/software.amazon.awssdk/apache-client/2.34.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "software.amazon.awssdk.http.apache.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #4473

This PR introduces tests and metadata for software.amazon.awssdk:apache-client:2.34.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 117490
- Cached input tokens: 1670144
- Output tokens: 18686
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 46.95
- Generated lines of code: 339
- Tested library lines of code: 416

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1650/3504 (47.09%)
- Line: 416/886 (46.95%)
- Method: 134/365 (36.71%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
