### PR TITLE
[GenAI] Add support for org.apache.camel:camel-jackson:4.20.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json
+++ b/metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.impl.converter.BaseTypeConverterRegistry"
+      },
+      "type" : "org.apache.camel.component.jackson.converter.JacksonTypeConvertersLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.camel.support.ObjectHelper"
+      },
+      "type" : "org.apache.camel.component.jackson.converter.JacksonTypeConvertersLoader",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.apache.camel/camel-jackson/index.json
+++ b/metadata/org.apache.camel/camel-jackson/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.20.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/camel",
+    "test-code-url" : "https://github.com/apache/camel/tree/camel-$version$/components/camel-jackson/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-javadoc.jar",
+    "description" : "camel-jackson provides Apache Camel data format and type converter support for marshalling and unmarshalling route messages with Jackson JSON. It lets Camel routes bind message bodies to Java objects, collections, maps, and JSON trees while reusing Jackson ObjectMapper configuration.",
+    "tested-versions" : [
+      "4.20.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.camel.component.jackson"
+    ]
+  }
+]

--- a/metadata/org.apache.camel/camel-jackson/index.json
+++ b/metadata/org.apache.camel/camel-jackson/index.json
@@ -1,17 +1,19 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.20.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-sources.jar",
-    "repository-url" : "https://github.com/apache/camel",
-    "test-code-url" : "https://github.com/apache/camel/tree/camel-$version$/components/camel-jackson/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-javadoc.jar",
-    "description" : "camel-jackson provides Apache Camel data format and type converter support for marshalling and unmarshalling route messages with Jackson JSON. It lets Camel routes bind message bodies to Java objects, collections, maps, and JSON trees while reusing Jackson ObjectMapper configuration.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.20.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-sources.jar",
+    "repository-url": "https://github.com/apache/camel",
+    "test-code-url": "https://github.com/apache/camel/tree/camel-$version$/components/camel-jackson/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/apache/camel/camel-jackson/$version$/camel-jackson-$version$-javadoc.jar",
+    "description": "camel-jackson provides Apache Camel data format and type converter support for marshalling and unmarshalling route messages with Jackson JSON. It lets Camel routes bind message bodies to Java objects, collections, maps, and JSON trees while reusing Jackson ObjectMapper configuration.",
+    "tested-versions": [
       "4.20.0"
     ],
-    "allowed-packages" : [
-      "org.apache.camel.component.jackson"
+    "allowed-packages": [
+      "org.apache.camel.component.jackson",
+      "org.apache.camel.impl.converter",
+      "org.apache.camel.support"
     ]
   }
 ]

--- a/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
+++ b/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T00:33:56.151193Z",
+    "library": "org.apache.camel:camel-jackson:4.20.0",
+    "starting_commit": "b7d5d7eba1748ae318fb151b56d08e580c3ba591",
+    "ending_commit": "fca1884deb38c078c58f8f4ed26264f712ac0650",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.20.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1325,
+          "missed": 2157,
+          "ratio": 0.380528,
+          "total": 3482
+        },
+        "line": {
+          "covered": 341,
+          "missed": 538,
+          "ratio": 0.387941,
+          "total": 879
+        },
+        "method": {
+          "covered": 83,
+          "missed": 119,
+          "ratio": 0.410891,
+          "total": 202
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 226168,
+      "cached_input_tokens_used": 1587200,
+      "output_tokens_used": 24759,
+      "iterations": 5,
+      "cost_usd": 1.5364,
+      "generated_loc": 410,
+      "tested_library_loc": 341,
+      "metadata_entries": 3,
+      "code_coverage_percent": 38.79
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java",
+      "metadata_file": "metadata/org.apache.camel/camel-jackson/4.20.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.camel/camel-jackson/4.20.0/stats.json
+++ b/stats/org.apache.camel/camel-jackson/4.20.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.20.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1325,
+        "missed" : 2157,
+        "ratio" : 0.380528,
+        "total" : 3482
+      },
+      "line" : {
+        "covered" : 341,
+        "missed" : 538,
+        "ratio" : 0.387941,
+        "total" : 879
+      },
+      "method" : {
+        "covered" : 83,
+        "missed" : 119,
+        "ratio" : 0.410891,
+        "total" : 202
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/.gitignore
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/build.gradle
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.camel:camel-jackson:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/gradle.properties
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.camel:camel-jackson:4.20.0
+library.version = 4.20.0
+metadata.dir = org.apache.camel/camel-jackson/4.20.0/

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/settings.gradle
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.camel.camel-jackson_tests'

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_camel.camel_jackson;
+
+import org.junit.jupiter.api.Test;
+
+class Camel_jacksonTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -6,11 +6,368 @@
  */
 package org_apache_camel.camel_jackson;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.jackson.JacksonConstants;
+import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.apache.camel.component.jackson.ListJacksonDataFormat;
+import org.apache.camel.component.jackson.SchemaHelper;
+import org.apache.camel.component.jackson.converter.JacksonTypeConverters;
+import org.apache.camel.component.jackson.transform.Json;
+import org.apache.camel.component.jackson.transform.JsonDataTypeTransformer;
+import org.apache.camel.component.jackson.transform.JsonPojoDataTypeTransformer;
+import org.apache.camel.component.jackson.transform.JsonStructDataTypeTransformer;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.spi.MimeType;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.support.SimpleRegistry;
 import org.junit.jupiter.api.Test;
 
-class Camel_jacksonTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Camel_jacksonTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void jacksonDataFormatMarshalsJsonViewAndContentTypeHeader() throws Exception {
+        try (CamelContext camelContext = new DefaultCamelContext()) {
+            JacksonDataFormat dataFormat = new JacksonDataFormat(Account.class, PublicView.class);
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                Account account = new Account("A-1", "Checking", "internal-only");
+
+                String json = marshalToString(dataFormat, exchange, account);
+
+                assertThat(json).contains("\"id\":\"A-1\"");
+                assertThat(json).contains("\"name\":\"Checking\"");
+                assertThat(json).doesNotContain("internal-only");
+                assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JSON.type());
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void jacksonDataFormatUnmarshalsHeaderSelectedTypeWithConfiguredFeatures() throws Exception {
+        try (CamelContext camelContext = new DefaultCamelContext()) {
+            ObjectMapper objectMapper = new ObjectMapper()
+                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            JacksonDataFormat dataFormat = new JacksonDataFormat();
+            dataFormat.setObjectMapper(objectMapper);
+            dataFormat.setAllowUnmarshallType(true);
+            dataFormat.setNamingStrategy("SNAKE_CASE");
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                exchange.getMessage().setHeader(JacksonConstants.UNMARSHAL_TYPE, Customer.class.getName());
+                byte[] json = """
+                        {"customer_id":"C-7","display_name":"Ada Lovelace","ignored":"value"}
+                        """.getBytes(StandardCharsets.UTF_8);
+
+                Object unmarshalled = dataFormat.unmarshal(exchange, new ByteArrayInputStream(json));
+
+                assertThat(unmarshalled).isInstanceOf(Customer.class);
+                Customer customer = (Customer) unmarshalled;
+                assertThat(customer.getCustomerId()).isEqualTo("C-7");
+                assertThat(customer.getDisplayName()).isEqualTo("Ada Lovelace");
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void listJacksonDataFormatUnmarshalsTypedCollectionsFromByteArrays() throws Exception {
+        try (CamelContext camelContext = new DefaultCamelContext()) {
+            ListJacksonDataFormat dataFormat = new ListJacksonDataFormat(LineItem.class);
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                byte[] json = """
+                        [{"sku":"pencil","quantity":3},{"sku":"notebook","quantity":2}]
+                        """.getBytes(StandardCharsets.UTF_8);
+
+                Object unmarshalled = dataFormat.unmarshal(exchange, json);
+
+                assertThat(unmarshalled).isInstanceOf(List.class);
+                assertThat((List<?>) unmarshalled)
+                        .hasSize(2)
+                        .allSatisfy(item -> assertThat(item).isInstanceOf(LineItem.class));
+                LineItem first = (LineItem) ((List<?>) unmarshalled).get(0);
+                LineItem second = (LineItem) ((List<?>) unmarshalled).get(1);
+                assertThat(first.getSku()).isEqualTo("pencil");
+                assertThat(first.getQuantity()).isEqualTo(3);
+                assertThat(second.getSku()).isEqualTo("notebook");
+                assertThat(second.getQuantity()).isEqualTo(2);
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void registeredObjectMapperIsAutoDiscoveredForDataFormat() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.bind("customMapper", objectMapper);
+
+        try (CamelContext camelContext = new DefaultCamelContext(registry)) {
+            JacksonDataFormat dataFormat = new JacksonDataFormat(Customer.class);
+            dataFormat.setAutoDiscoverObjectMapper(true);
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                String json = "{"
+                        + "\"customerId\":\"C-8\","
+                        + "\"displayName\":\"Grace Hopper\","
+                        + "\"ignored\":true"
+                        + "}";
+
+                Object unmarshalled = dataFormat.unmarshal(exchange, json);
+
+                assertThat(dataFormat.getObjectMapper()).isSameAs(objectMapper);
+                assertThat(unmarshalled).isInstanceOf(Customer.class);
+                Customer customer = (Customer) unmarshalled;
+                assertThat(customer.getCustomerId()).isEqualTo("C-8");
+                assertThat(customer.getDisplayName()).isEqualTo("Grace Hopper");
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void jacksonTypeConverterHandlesJsonNodesAndPojoFallbackConversions() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            camelContext.getGlobalOptions().put(JacksonConstants.ENABLE_TYPE_CONVERTER, "true");
+            camelContext.getGlobalOptions().put(JacksonConstants.TYPE_CONVERTER_TO_POJO, "true");
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonTypeConverters converters = new JacksonTypeConverters();
+
+            JsonNode node = converters.toJsonNode("{\"answer\":42,\"enabled\":true}", exchange);
+            Map<String, Object> map = converters.toMap(node, exchange);
+            Integer integer = converters.toInteger(node.get("answer"), exchange);
+            Boolean bool = converters.toBoolean(node.get("enabled"), exchange);
+
+            assertThat(map).containsEntry("answer", 42).containsEntry("enabled", true);
+            assertThat(integer).isEqualTo(42);
+            assertThat(bool).isTrue();
+
+            Event event = converters.convertTo(Event.class, exchange, "{\"code\":\"E-1\",\"priority\":5}", null);
+            String eventJson = converters.convertTo(String.class, exchange, event, null);
+            ByteBuffer eventBytes = converters.convertTo(ByteBuffer.class, exchange, event, null);
+
+            assertThat(event.getCode()).isEqualTo("E-1");
+            assertThat(event.getPriority()).isEqualTo(5);
+            assertThat(eventJson).contains("\"code\":\"E-1\"", "\"priority\":5");
+            assertThat(StandardCharsets.UTF_8.decode(eventBytes).toString())
+                    .contains("\"code\":\"E-1\"", "\"priority\":5");
+        }
+    }
+
+    @Test
+    void directJacksonTypeConvertersUseSuppliedExchangeContext() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            JacksonTypeConverters converters = new JacksonTypeConverters();
+
+            JsonNode node = converters.toJsonNode(Map.of("name", "Camel", "count", 2), exchange);
+            byte[] bytes = converters.toByteArray(node, exchange);
+            Map<String, Object> map = converters.toMap(node, exchange);
+
+            assertThat(node.get("name").asText()).isEqualTo("Camel");
+            assertThat(new String(bytes, StandardCharsets.UTF_8)).contains("\"count\":2");
+            assertThat(map).containsEntry("name", "Camel").containsEntry("count", 2);
+            assertThat(converters.toString(Json.mapper().getNodeFactory().textNode("plain"), exchange))
+                    .isEqualTo("plain");
+        }
+    }
+
+    @Test
+    void jsonTransformersConvertBetweenJsonBytesStructsAndPojos() throws Exception {
+        try (DefaultCamelContext camelContext = new DefaultCamelContext()) {
+            Exchange exchange = new DefaultExchange(camelContext);
+            byte[] eventJson = "{\"code\":\"T-1\",\"priority\":9}".getBytes(StandardCharsets.UTF_8);
+            exchange.getMessage().setBody(new ByteArrayInputStream(eventJson));
+
+            new JsonStructDataTypeTransformer().transform(exchange.getMessage(), null, null);
+
+            assertThat(exchange.getMessage().getBody()).isInstanceOf(JsonNode.class);
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.STRUCT.type());
+            JsonNode struct = exchange.getMessage().getBody(JsonNode.class);
+            assertThat(struct.get("code").asText()).isEqualTo("T-1");
+
+            exchange.setProperty(SchemaHelper.CONTENT_CLASS, Event.class.getName());
+            exchange.getMessage().setBody(new ByteArrayInputStream(eventJson));
+            JsonPojoDataTypeTransformer pojoTransformer = new JsonPojoDataTypeTransformer();
+            pojoTransformer.setCamelContext(camelContext);
+            pojoTransformer.transform(exchange.getMessage(), null, null);
+
+            assertThat(exchange.getMessage().getBody()).isInstanceOf(Event.class);
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JAVA_OBJECT.type());
+            Event event = exchange.getMessage().getBody(Event.class);
+            assertThat(event.getCode()).isEqualTo("T-1");
+            assertThat(event.getPriority()).isEqualTo(9);
+
+            new JsonDataTypeTransformer().transform(exchange.getMessage(), null, null);
+
+            assertThat(exchange.getMessage().getBody()).isInstanceOf(byte[].class);
+            assertThat(exchange.getMessage().getHeader(Exchange.CONTENT_TYPE)).isEqualTo(MimeType.JSON.type());
+            assertThat(new String(exchange.getMessage().getBody(byte[].class), StandardCharsets.UTF_8))
+                    .contains("\"code\":\"T-1\"", "\"priority\":9");
+        }
+    }
+
+    @Test
+    void jsonUtilityRecognizesObjectsArraysAndSplitsArrayElements() throws Exception {
+        JsonNode array = Json.mapper().readTree("[{\"id\":1},{\"id\":2}]");
+
+        assertThat(Json.isJson(" {\"id\":1} ")).isTrue();
+        assertThat(Json.isJson(" [1,2] ")).isTrue();
+        assertThat(Json.isJson("not-json")).isFalse();
+        assertThat(Json.arrayToJsonBeans(array)).containsExactly("{\"id\":1}", "{\"id\":2}");
+    }
+
+    private static String marshalToString(
+            JacksonDataFormat dataFormat, Exchange exchange, Object body) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        dataFormat.marshal(exchange, body, output);
+        return output.toString(StandardCharsets.UTF_8);
+    }
+
+    public interface PublicView {
+    }
+
+    public interface InternalView extends PublicView {
+    }
+
+    public static class Account {
+        private String id;
+        private String name;
+        private String secret;
+
+        public Account() {
+        }
+
+        Account(String id, String name, String secret) {
+            this.id = id;
+            this.name = name;
+            this.secret = secret;
+        }
+
+        @JsonView(PublicView.class)
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @JsonView(PublicView.class)
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @JsonView(InternalView.class)
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+    }
+
+    public static class Customer {
+        private String customerId;
+        private String displayName;
+
+        public Customer() {
+        }
+
+        public String getCustomerId() {
+            return customerId;
+        }
+
+        public void setCustomerId(String customerId) {
+            this.customerId = customerId;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public void setDisplayName(String displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    public static class LineItem {
+        private String sku;
+        private int quantity;
+
+        public LineItem() {
+        }
+
+        public String getSku() {
+            return sku;
+        }
+
+        public void setSku(String sku) {
+            this.sku = sku;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+
+    public static class Event {
+        private String code;
+        private int priority;
+
+        public Event() {
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
     }
 }

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -8,15 +8,24 @@ package org_apache_camel.camel_jackson;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.jackson.JacksonConstants;
@@ -137,6 +146,42 @@ public class Camel_jacksonTest {
                 assertThat(json).contains("\n");
                 assertThat(json).contains("\"priority\" : 4");
                 assertThat(json).doesNotContain("code");
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
+    void jacksonDataFormatRegistersModulesFromRegistryReferences() throws Exception {
+        SimpleModule module = new SimpleModule("status-code-module");
+        module.addSerializer(StatusCode.class, new StatusCodeSerializer());
+        module.addDeserializer(StatusCode.class, new StatusCodeDeserializer());
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.bind("statusModule", module);
+
+        try (CamelContext camelContext = new DefaultCamelContext(registry)) {
+            JacksonDataFormat dataFormat = new JacksonDataFormat(StatusChange.class);
+            dataFormat.setModuleRefs("statusModule");
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                StatusChange statusChange = new StatusChange();
+                statusChange.setTicketId("T-4");
+                statusChange.setStatus(new StatusCode("open"));
+
+                String json = marshalToString(dataFormat, exchange, statusChange);
+
+                assertThat(json).contains("\"ticketId\":\"T-4\"");
+                assertThat(json).contains("\"status\":\"OPEN\"");
+
+                Object unmarshalled = dataFormat.unmarshal(exchange, "{\"ticketId\":\"T-5\",\"status\":\"CLOSED\"}");
+
+                assertThat(unmarshalled).isInstanceOf(StatusChange.class);
+                StatusChange change = (StatusChange) unmarshalled;
+                assertThat(change.getTicketId()).isEqualTo("T-5");
+                assertThat(change.getStatus().getCode()).isEqualTo("closed");
             } finally {
                 dataFormat.stop();
             }
@@ -392,6 +437,57 @@ public class Camel_jacksonTest {
 
         public void setPriority(int priority) {
             this.priority = priority;
+        }
+    }
+
+    public static class StatusChange {
+        private String ticketId;
+        private StatusCode status;
+
+        public StatusChange() {
+        }
+
+        public String getTicketId() {
+            return ticketId;
+        }
+
+        public void setTicketId(String ticketId) {
+            this.ticketId = ticketId;
+        }
+
+        public StatusCode getStatus() {
+            return status;
+        }
+
+        public void setStatus(StatusCode status) {
+            this.status = status;
+        }
+    }
+
+    public static class StatusCode {
+        private final String code;
+
+        StatusCode(String code) {
+            this.code = code;
+        }
+
+        public String getCode() {
+            return code;
+        }
+    }
+
+    public static class StatusCodeSerializer extends JsonSerializer<StatusCode> {
+        @Override
+        public void serialize(
+                StatusCode value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+            jsonGenerator.writeString(value.getCode().toUpperCase(Locale.ROOT));
+        }
+    }
+
+    public static class StatusCodeDeserializer extends JsonDeserializer<StatusCode> {
+        @Override
+        public StatusCode deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+            return new StatusCode(jsonParser.getValueAsString().toLowerCase(Locale.ROOT));
         }
     }
 }

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/src/test/java/org_apache_camel/camel_jackson/Camel_jacksonTest.java
@@ -120,6 +120,30 @@ public class Camel_jacksonTest {
     }
 
     @Test
+    void jacksonDataFormatAppliesSerializationInclusionAndPrettyPrintOptions() throws Exception {
+        try (CamelContext camelContext = new DefaultCamelContext()) {
+            JacksonDataFormat dataFormat = new JacksonDataFormat(Event.class);
+            dataFormat.setInclude("NON_NULL");
+            dataFormat.setPrettyPrint(true);
+            dataFormat.setCamelContext(camelContext);
+            dataFormat.start();
+            try {
+                Exchange exchange = new DefaultExchange(camelContext);
+                Event event = new Event();
+                event.setPriority(4);
+
+                String json = marshalToString(dataFormat, exchange, event);
+
+                assertThat(json).contains("\n");
+                assertThat(json).contains("\"priority\" : 4");
+                assertThat(json).doesNotContain("code");
+            } finally {
+                dataFormat.stop();
+            }
+        }
+    }
+
+    @Test
     void registeredObjectMapperIsAutoDiscoveredForDataFormat() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.camel.component.jackson.**"
+    }
+  ]
+}

--- a/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
+++ b/tests/src/org.apache.camel/camel-jackson/4.20.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.camel.component.jackson.**"
+      "includeClasses" : "org.apache.camel.component.jackson.**"
+    },
+    {
+      "includeClasses" : "org_apache_camel.camel_jackson.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4509

This PR introduces tests and metadata for org.apache.camel:camel-jackson:4.20.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 226168
- Cached input tokens: 1587200
- Output tokens: 24759
- Metadata entries: 3
- Iterations: 5
- Library coverage percentage: 38.79
- Generated lines of code: 410
- Tested library lines of code: 341

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `922092e67849e43d69ee91da74f7f10c100125e1`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1325/3482 (38.05%)
- Line: 341/879 (38.79%)
- Method: 83/202 (41.09%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
