### PR TITLE
[GenAI] Add support for org.sonatype.plexus:plexus-build-api:0.0.7 using gpt-5.5

### DIFF
--- a/metadata/org.sonatype.plexus/plexus-build-api/0.0.7/reachability-metadata.json
+++ b/metadata/org.sonatype.plexus/plexus-build-api/0.0.7/reachability-metadata.json
@@ -1,0 +1,430 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.DefaultPlexusContainer",
+      "allDeclaredFields" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.AbstractLifecycleHandler",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.factory.AbstractComponentFactory",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.AbstractComponentComposer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.manager.AbstractComponentManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.AbstractComponentConfigurator",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.AbstractComponentDiscoverer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.logging.AbstractLogEnabled",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.repository.DefaultComponentRepository",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultCompositionResolver",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscovererManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.DefaultComponentDiscoverer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.discovery.PlexusXmlComponentDiscoverer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.manager.DefaultComponentManagerManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.manager.PerLookupComponentManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.manager.ClassicSingletonComponentManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.manager.KeepAliveSingletonComponentManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.DefaultLifecycleHandlerManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.PlexusLifecycleHandler",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogEnablePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.CompositionPhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ContextualizePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.AutoConfigurePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ServiceablePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StartPhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.SuspendPhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ResumePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.StopPhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.DisposePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.LogDisablePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.BasicLifecycleHandler",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.personality.plexus.lifecycle.phase.ConfigurablePhase",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.lifecycle.PassiveLifecycleHandler",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.factory.DefaultComponentFactoryManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.factory.java.JavaComponentFactory",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.DefaultComponentComposerManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.FieldComponentComposer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.SetterComponentComposer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.MapOrientedComponentComposer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.composition.NoOpComponentComposer",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.logging.console.ConsoleLoggerManager",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.BasicComponentConfigurator",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.MapOrientedComponentConfigurator",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "type" : "org.sonatype.plexus.build.incremental.DefaultBuildContext",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "allPublicMethods" : true
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "glob" : "org/codehaus/plexus/plexus-bootstrap.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.codehaus.plexus.DefaultPlexusContainer"
+      },
+      "glob" : "META-INF/plexus/components.xml"
+    }
+  ]
+}

--- a/metadata/org.sonatype.plexus/plexus-build-api/index.json
+++ b/metadata/org.sonatype.plexus/plexus-build-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.0.7",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-build-api",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-javadoc.jar",
+    "description" : "Plexus Build API provides a small Java/Plexus API for build plugins to detect incremental changes, scan changed or deleted files, and refresh generated outputs. It also supplies default and thread-local build context implementations for recording build messages and preserving state across incremental mojo executions.",
+    "tested-versions" : [
+      "0.0.7"
+    ],
+    "allowed-packages" : [
+      "org.sonatype.plexus.build.incremental"
+    ]
+  }
+]

--- a/metadata/org.sonatype.plexus/plexus-build-api/index.json
+++ b/metadata/org.sonatype.plexus/plexus-build-api/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "0.0.7",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-sources.jar",
-    "repository-url" : "https://github.com/codehaus-plexus/plexus-build-api",
-    "test-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-tests.jar",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-javadoc.jar",
-    "description" : "Plexus Build API provides a small Java/Plexus API for build plugins to detect incremental changes, scan changed or deleted files, and refresh generated outputs. It also supplies default and thread-local build context implementations for recording build messages and preserving state across incremental mojo executions.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "0.0.7",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-sources.jar",
+    "repository-url": "https://github.com/codehaus-plexus/plexus-build-api",
+    "test-code-url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-tests.jar",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/$version$/plexus-build-api-$version$-javadoc.jar",
+    "description": "Plexus Build API provides a small Java/Plexus API for build plugins to detect incremental changes, scan changed or deleted files, and refresh generated outputs. It also supplies default and thread-local build context implementations for recording build messages and preserving state across incremental mojo executions.",
+    "tested-versions": [
       "0.0.7"
     ],
-    "allowed-packages" : [
-      "org.sonatype.plexus.build.incremental"
+    "allowed-packages": [
+      "org.sonatype.plexus.build.incremental",
+      "org.codehaus.plexus"
     ]
   }
 ]

--- a/stats/org.sonatype.plexus/plexus-build-api/0.0.7/execution-metrics.json
+++ b/stats/org.sonatype.plexus/plexus-build-api/0.0.7/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T03:11:49.688114Z",
+    "library": "org.sonatype.plexus:plexus-build-api:0.0.7",
+    "starting_commit": "e363dd06246e70a19e61aff889ecef0a04b35da2",
+    "ending_commit": "a83ae9932b331391db2f08ecd4ceb181e64fa793",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.0.7",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 263,
+          "missed": 4,
+          "ratio": 0.985019,
+          "total": 267
+        },
+        "line": {
+          "covered": 71,
+          "missed": 1,
+          "ratio": 0.986111,
+          "total": 72
+        },
+        "method": {
+          "covered": 46,
+          "missed": 1,
+          "ratio": 0.978723,
+          "total": 47
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 100785,
+      "cached_input_tokens_used": 1010688,
+      "output_tokens_used": 15940,
+      "iterations": 3,
+      "cost_usd": 0.9835,
+      "generated_loc": 290,
+      "tested_library_loc": 71,
+      "metadata_entries": 184,
+      "code_coverage_percent": 98.61
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java",
+      "metadata_file": "metadata/org.sonatype.plexus/plexus-build-api/0.0.7/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.sonatype.plexus/plexus-build-api/0.0.7/stats.json
+++ b/stats/org.sonatype.plexus/plexus-build-api/0.0.7/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.0.7",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 263,
+        "missed" : 4,
+        "ratio" : 0.985019,
+        "total" : 267
+      },
+      "line" : {
+        "covered" : 71,
+        "missed" : 1,
+        "ratio" : 0.986111,
+        "total" : 72
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 1,
+        "ratio" : 0.978723,
+        "total" : 47
+      }
+    }
+  } ]
+}

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/.gitignore
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/build.gradle
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.sonatype.plexus:plexus-build-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/build.gradle
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.sonatype.plexus:plexus-build-api:$libraryVersion"
+    testImplementation 'org.codehaus.plexus:plexus-container-default:1.0-alpha-9'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/gradle.properties
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.sonatype.plexus:plexus-build-api:0.0.7
+library.version = 0.0.7
+metadata.dir = org.sonatype.plexus/plexus-build-api/0.0.7/

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/settings.gradle
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.sonatype.plexus.plexus-build-api_tests'

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
@@ -6,11 +6,284 @@
  */
 package org_sonatype_plexus.plexus_build_api;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Plexus_build_apiTest {
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.codehaus.plexus.util.Scanner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonatype.plexus.build.incremental.BuildContext;
+import org.sonatype.plexus.build.incremental.DefaultBuildContext;
+import org.sonatype.plexus.build.incremental.EmptyScanner;
+import org.sonatype.plexus.build.incremental.ThreadBuildContext;
+
+public class Plexus_build_apiTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @AfterEach
+    void resetThreadBuildContext() {
+        ThreadBuildContext.setThreadBuildContext(new DefaultBuildContext());
+    }
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultContextTreatsEveryInputAsChangedAndStoresNoValues() throws IOException {
+        DefaultBuildContext context = new DefaultBuildContext();
+        File file = Files.createFile(temporaryDirectory.resolve("input.txt")).toFile();
+        List<File> files = List.of(file);
+
+        assertThat(context.hasDelta("src/main/resources/application.properties")).isTrue();
+        assertThat(context.hasDelta(file)).isTrue();
+        assertThat(context.hasDelta(files)).isTrue();
+        assertThat(context.isIncremental()).isFalse();
+
+        context.setValue("answer", 42);
+
+        assertThat(context.getValue("answer")).isNull();
+        assertThatCode(() -> context.refresh(file)).doesNotThrowAnyException();
+        assertThatCode(() -> context.removeMessages(file)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void defaultContextCreatesOutputStreamsForRegularFiles() throws IOException {
+        DefaultBuildContext context = new DefaultBuildContext();
+        Path output = temporaryDirectory.resolve("generated.txt");
+
+        try (OutputStream stream = context.newFileOutputStream(output.toFile())) {
+            stream.write("generated content".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertThat(Files.readString(output, StandardCharsets.UTF_8)).isEqualTo("generated content");
+    }
+
+    @Test
+    void defaultScannerScansBaseDirectoryWithConfiguredPatterns() throws IOException {
+        DefaultBuildContext context = new DefaultBuildContext();
+        Files.writeString(temporaryDirectory.resolve("root.txt"), "root", StandardCharsets.UTF_8);
+        Files.createDirectories(temporaryDirectory.resolve("nested"));
+        Files.writeString(temporaryDirectory.resolve("nested/child.txt"), "child", StandardCharsets.UTF_8);
+        Files.writeString(temporaryDirectory.resolve("nested/excluded.txt"), "excluded", StandardCharsets.UTF_8);
+        Files.writeString(temporaryDirectory.resolve("nested/child.bin"), "binary", StandardCharsets.UTF_8);
+
+        Scanner scanner = context.newScanner(temporaryDirectory.toFile(), true);
+        scanner.setIncludes(new String[] {"*.txt", "**/*.txt"});
+        scanner.setExcludes(new String[] {"nested/excluded.txt"});
+        scanner.scan();
+
+        assertThat(scanner.getBasedir()).isEqualTo(temporaryDirectory.toFile());
+        assertThat(normalized(scanner.getIncludedFiles()))
+                .containsExactlyInAnyOrder("root.txt", "nested/child.txt");
+    }
+
+    @Test
+    void deleteScannerAndEmptyScannerNeverReportIncludedPaths() {
+        DefaultBuildContext context = new DefaultBuildContext();
+        File baseDirectory = temporaryDirectory.toFile();
+
+        Scanner deleteScanner = context.newDeleteScanner(baseDirectory);
+        deleteScanner.setIncludes(new String[] {"*", "**/*"});
+        deleteScanner.setExcludes(new String[] {"ignored"});
+        deleteScanner.addDefaultExcludes();
+        deleteScanner.scan();
+
+        assertThat(deleteScanner).isInstanceOf(EmptyScanner.class);
+        assertThat(deleteScanner.getBasedir()).isEqualTo(baseDirectory);
+        assertThat(deleteScanner.getIncludedFiles()).isEmpty();
+        assertThat(deleteScanner.getIncludedDirectories()).isEmpty();
+
+        EmptyScanner emptyScanner = new EmptyScanner(baseDirectory);
+        emptyScanner.scan();
+
+        assertThat(emptyScanner.getBasedir()).isEqualTo(baseDirectory);
+        assertThat(emptyScanner.getIncludedFiles()).isEmpty();
+        assertThat(emptyScanner.getIncludedDirectories()).isEmpty();
+    }
+
+    @Test
+    void uptodateCheckRequiresExistingNewerTargetAndExistingSource() throws IOException {
+        DefaultBuildContext context = new DefaultBuildContext();
+        File older = Files.createFile(temporaryDirectory.resolve("older.txt")).toFile();
+        File newer = Files.createFile(temporaryDirectory.resolve("newer.txt")).toFile();
+        assertThat(older.setLastModified(10_000L)).isTrue();
+        assertThat(newer.setLastModified(20_000L)).isTrue();
+
+        assertThat(context.isUptodate(newer, older)).isTrue();
+        assertThat(context.isUptodate(older, newer)).isFalse();
+        assertThat(context.isUptodate(null, older)).isFalse();
+        assertThat(context.isUptodate(newer, null)).isFalse();
+        assertThat(context.isUptodate(new File(temporaryDirectory.toFile(), "missing.txt"), older)).isFalse();
+    }
+
+    @Test
+    void defaultContextLogsSupportedMessageSeveritiesAndRejectsUnknownSeverity() throws IOException {
+        DefaultBuildContext context = new DefaultBuildContext();
+        context.enableLogging(new ConsoleLogger(Logger.LEVEL_DISABLED, "test"));
+        File file = Files.createFile(temporaryDirectory.resolve("messages.txt")).toFile();
+        RuntimeException cause = new RuntimeException("diagnostic cause");
+
+        assertThatCode(() -> context.addWarning(file, 7, 3, "warning message", cause)).doesNotThrowAnyException();
+        assertThatCode(() -> context.addError(file, 8, 4, "error message", cause)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> context.addMessage(file, 1, 1, "unknown", 99, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("severity=99");
+    }
+
+    @Test
+    void threadBuildContextDelegatesAllOperationsToConfiguredContext() throws IOException {
+        RecordingBuildContext recordingContext = new RecordingBuildContext();
+        ThreadBuildContext.setThreadBuildContext(recordingContext);
+        ThreadBuildContext context = new ThreadBuildContext();
+        File file = Files.createFile(temporaryDirectory.resolve("delegated.txt")).toFile();
+        List<File> files = List.of(file);
+
+        assertThat(context.hasDelta("path")).isFalse();
+        assertThat(recordingContext.lastOperation).isEqualTo("hasDelta(String):path");
+        assertThat(context.hasDelta(file)).isTrue();
+        assertThat(recordingContext.lastOperation).isEqualTo("hasDelta(File):delegated.txt");
+        assertThat(context.hasDelta(files)).isFalse();
+        assertThat(recordingContext.lastOperation).isEqualTo("hasDelta(List):1");
+        assertThat(context.isIncremental()).isTrue();
+
+        context.setValue("key", "value");
+        assertThat(recordingContext.getValue("key")).isEqualTo("value");
+        try (OutputStream stream = context.newFileOutputStream(file)) {
+            stream.write('x');
+        }
+        assertThat(recordingContext.output.toString(StandardCharsets.UTF_8)).isEqualTo("x");
+
+        assertThat(context.newScanner(file)).isSameAs(recordingContext.scanner);
+        assertThat(context.newScanner(file, false)).isSameAs(recordingContext.scanner);
+        assertThat(context.newDeleteScanner(file)).isSameAs(recordingContext.deleteScanner);
+        assertThat(context.isUptodate(file, file)).isTrue();
+
+        context.refresh(file);
+        assertThat(recordingContext.lastOperation).isEqualTo("refresh:delegated.txt");
+        context.addWarning(file, 1, 2, "warning", null);
+        assertThat(recordingContext.lastOperation).isEqualTo("message:1:warning");
+        context.addError(file, 3, 4, "error", null);
+        assertThat(recordingContext.lastOperation).isEqualTo("message:2:error");
+        context.removeMessages(file);
+        assertThat(recordingContext.lastOperation).isEqualTo("removeMessages:delegated.txt");
+    }
+
+    private static List<String> normalized(String[] paths) {
+        return Arrays.stream(paths)
+                .map(path -> path.replace(File.separatorChar, '/'))
+                .toList();
+    }
+
+    private static final class RecordingBuildContext implements BuildContext {
+        private final Scanner scanner = new EmptyScanner(new File("scan-base"));
+        private final Scanner deleteScanner = new EmptyScanner(new File("delete-base"));
+        private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        private String key;
+        private Object value;
+        private String lastOperation;
+
+        @Override
+        public boolean hasDelta(String relpath) {
+            lastOperation = "hasDelta(String):" + relpath;
+            return false;
+        }
+
+        @Override
+        public boolean hasDelta(File file) {
+            lastOperation = "hasDelta(File):" + file.getName();
+            return true;
+        }
+
+        @Override
+        public boolean hasDelta(List relpaths) {
+            lastOperation = "hasDelta(List):" + relpaths.size();
+            return false;
+        }
+
+        @Override
+        public void refresh(File file) {
+            lastOperation = "refresh:" + file.getName();
+        }
+
+        @Override
+        public OutputStream newFileOutputStream(File file) {
+            lastOperation = "newFileOutputStream:" + file.getName();
+            return output;
+        }
+
+        @Override
+        public Scanner newScanner(File basedir) {
+            lastOperation = "newScanner:" + basedir.getName();
+            return scanner;
+        }
+
+        @Override
+        public Scanner newDeleteScanner(File basedir) {
+            lastOperation = "newDeleteScanner:" + basedir.getName();
+            return deleteScanner;
+        }
+
+        @Override
+        public Scanner newScanner(File basedir, boolean ignoreDelta) {
+            lastOperation = "newScanner:" + basedir.getName() + ':' + ignoreDelta;
+            return scanner;
+        }
+
+        @Override
+        public boolean isIncremental() {
+            lastOperation = "isIncremental";
+            return true;
+        }
+
+        @Override
+        public void setValue(String key, Object value) {
+            this.key = key;
+            this.value = value;
+            lastOperation = "setValue:" + key;
+        }
+
+        @Override
+        public Object getValue(String key) {
+            lastOperation = "getValue:" + key;
+            return key.equals(this.key) ? value : null;
+        }
+
+        @Override
+        public void addWarning(File file, int line, int column, String message, Throwable cause) {
+            addMessage(file, line, column, message, SEVERITY_WARNING, cause);
+        }
+
+        @Override
+        public void addError(File file, int line, int column, String message, Throwable cause) {
+            addMessage(file, line, column, message, SEVERITY_ERROR, cause);
+        }
+
+        @Override
+        public void addMessage(File file, int line, int column, String message, int severity, Throwable cause) {
+            lastOperation = "message:" + severity + ':' + message;
+        }
+
+        @Override
+        public void removeMessages(File file) {
+            lastOperation = "removeMessages:" + file.getName();
+        }
+
+        @Override
+        public boolean isUptodate(File target, File source) {
+            lastOperation = "isUptodate:" + target.getName() + ':' + source.getName();
+            return true;
+        }
     }
 }

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
@@ -19,6 +19,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
@@ -140,6 +144,41 @@ public class Plexus_build_apiTest {
         assertThatThrownBy(() -> context.addMessage(file, 1, 1, "unknown", 99, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("severity=99");
+    }
+
+    @Test
+    void threadBuildContextKeepsContextsIsolatedPerThreadAndFallsBackToDefault() throws Exception {
+        ThreadBuildContext.setThreadBuildContext(null);
+        BuildContext defaultContext = ThreadBuildContext.getContext();
+
+        assertThat(defaultContext).isInstanceOf(DefaultBuildContext.class);
+        assertThat(defaultContext.hasDelta("unconfigured-thread.txt")).isTrue();
+
+        RecordingBuildContext mainThreadContext = new RecordingBuildContext();
+        ThreadBuildContext.setThreadBuildContext(mainThreadContext);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> result = executor.submit(() -> {
+                try {
+                    BuildContext workerDefaultContext = ThreadBuildContext.getContext();
+                    assertThat(workerDefaultContext).isInstanceOf(DefaultBuildContext.class);
+                    assertThat(workerDefaultContext).isNotSameAs(mainThreadContext);
+
+                    RecordingBuildContext workerThreadContext = new RecordingBuildContext();
+                    ThreadBuildContext.setThreadBuildContext(workerThreadContext);
+
+                    assertThat(ThreadBuildContext.getContext()).isSameAs(workerThreadContext);
+                } finally {
+                    ThreadBuildContext.setThreadBuildContext(null);
+                }
+            });
+            result.get(10, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(ThreadBuildContext.getContext()).isSameAs(mainThreadContext);
     }
 
     @Test

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_plexus.plexus_build_api;
+
+import org.junit.jupiter.api.Test;
+
+class Plexus_build_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/src/test/java/org_sonatype_plexus/plexus_build_api/Plexus_build_apiTest.java
@@ -24,6 +24,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.Scanner;
@@ -144,6 +146,21 @@ public class Plexus_build_apiTest {
         assertThatThrownBy(() -> context.addMessage(file, 1, 1, "unknown", 99, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("severity=99");
+    }
+
+    @Test
+    void plexusContainerDiscoversDefaultBuildContextComponent() throws Exception {
+        PlexusContainer container = new DefaultPlexusContainer();
+        try {
+            container.initialize();
+            container.start();
+            String role = BuildContext.class.getName();
+
+            assertThat(container.hasComponent(role, "default")).isTrue();
+            assertThat(container.lookup(role, "default")).isInstanceOf(DefaultBuildContext.class);
+        } finally {
+            container.dispose();
+        }
     }
 
     @Test

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/user-code-filter.json
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.sonatype.plexus.build.incremental.**"
+    }
+  ]
+}

--- a/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/user-code-filter.json
+++ b/tests/src/org.sonatype.plexus/plexus-build-api/0.0.7/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.sonatype.plexus.build.incremental.**"
+      "includeClasses" : "org.sonatype.plexus.build.incremental.**"
+    },
+    {
+      "includeClasses" : "org_sonatype_plexus.plexus_build_api.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3846

This PR introduces tests and metadata for org.sonatype.plexus:plexus-build-api:0.0.7, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 100785
- Cached input tokens: 1010688
- Output tokens: 15940
- Metadata entries: 184
- Iterations: 3
- Library coverage percentage: 98.61
- Generated lines of code: 290
- Tested library lines of code: 71

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 263/267 (98.50%)
- Line: 71/72 (98.61%)
- Method: 46/47 (97.87%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
