### PR TITLE
Make tested version updates idempotent

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -138,7 +138,9 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
         for (int i = 0; i < entries.size(); i++) {
             MetadataVersionsIndexEntry entry = entries.get(i);
 
-            if (entry.testedVersions() != null && entry.testedVersions().contains(getLastSupportedVersion().get())) {
+            if (entry.testedVersions() != null
+                    && entry.testedVersions().contains(getLastSupportedVersion().get())
+                    && !entry.testedVersions().contains(newVersion)) {
                 entry.testedVersions().add(newVersion);
                 entry.testedVersions().sort(Comparator.comparing(VersionNumber::parse));
 

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
@@ -326,6 +326,29 @@ class TestedVersionUpdaterTaskTests {
         }
     }
 
+    @Test
+    void runDoesNotAddExistingTestedVersionAgain() throws IOException {
+        String group = "com.example";
+        String artifact = "demo";
+        String oldVersion = "1.0.0";
+        String newVersion = "1.1.0";
+
+        writeIndex(group, artifact, oldVersion);
+        Path indexFile = tempDir.resolve("metadata/" + group + "/" + artifact + "/index.json");
+
+        TestTestedVersionUpdaterTask task = createTask();
+        task.setCoordinates(group + ":" + artifact + ":" + newVersion);
+        task.getLastSupportedVersion().set(oldVersion);
+
+        task.run();
+        String indexAfterFirstRun = Files.readString(indexFile);
+        task.run();
+
+        List<Map<String, Object>> indexEntries = readIndex(group, artifact);
+        assertThat(indexEntries.get(0)).containsEntry("tested-versions", List.of(oldVersion, newVersion));
+        assertThat(Files.readString(indexFile)).isEqualTo(indexAfterFirstRun);
+    }
+
     private TestTestedVersionUpdaterTask createTask() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())


### PR DESCRIPTION
This makes `addTestedVersion` skip versions that are already present in the target `tested-versions` entry, so rerunning the compatibility workflow cannot append the same successful batch again.

It also adds a regression test that runs the same update twice and verifies the second run leaves the index unchanged.

Verification:
- `./gradlew :tck-build-logic:test --tests org.graalvm.internal.tck.TestedVersionUpdaterTaskTests --stacktrace`

Fixes #6231