### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-reactor-netty as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-reactor-netty/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-reactor-netty/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-reactor-netty JAR for 2.7.18 contains only META-INF license/notice/manifest files and no JVM class files; its POM only pulls in io.projectreactor.netty:reactor-netty-http:1.0.39.",
+    "replacement": "io.projectreactor.netty:reactor-netty-http:1.0.39"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3808

This PR records `org.springframework.boot:spring-boot-starter-reactor-netty` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-reactor-netty JAR for 2.7.18 contains only META-INF license/notice/manifest files and no JVM class files; its POM only pulls in io.projectreactor.netty:reactor-netty-http:1.0.39.

Replacement guidance:
- io.projectreactor.netty:reactor-netty-http:1.0.39

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`

### Local CI Verification

- Status: `success`
- Commands run: 7
- Fixup attempts: 0
