### PR TITLE
[GenAI] Add support for org.codehaus.plexus:plexus-cipher:2.0 using gpt-5.5

### DIFF
--- a/metadata/org.codehaus.plexus/plexus-cipher/2.0/reachability-metadata.json
+++ b/metadata/org.codehaus.plexus/plexus-cipher/2.0/reachability-metadata.json
@@ -1,0 +1,48 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PBECipher"
+      },
+      "type": "java.security.SecureRandomParameters"
+    },
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PBECipher"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PBECipher"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.sonatype.plexus.components.cipher.PBECipher"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.codehaus.plexus/plexus-cipher/index.json
+++ b/metadata/org.codehaus.plexus/plexus-cipher/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-cipher/$version$/plexus-cipher-$version$-sources.jar",
+    "repository-url" : "https://github.com/codehaus-plexus/plexus-cipher",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-cipher/$version$/plexus-cipher-$version$-source-release.zip",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-cipher/$version$/plexus-cipher-$version$-javadoc.jar",
+    "description" : "Plexus Cipher is a Java component for encrypting and decrypting strings with passphrases and Base64-encoded output. It also supports Maven/Plexus-style decorated encrypted values wrapped in braces so callers can detect, decorate, and undecorate stored secrets.",
+    "tested-versions" : [
+      "2.0"
+    ],
+    "allowed-packages" : [
+      "org.sonatype.plexus.components.cipher"
+    ]
+  }
+]

--- a/stats/org.codehaus.plexus/plexus-cipher/2.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-cipher/2.0/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T08:05:29.465700Z",
+    "library": "org.codehaus.plexus:plexus-cipher:2.0",
+    "starting_commit": "19dcb17c4a65512435cdf9832401123982d68592",
+    "ending_commit": "3b167e581528cb02b0623385a9f7d773f8132be2",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1378,
+          "missed": 117,
+          "ratio": 0.921739,
+          "total": 1495
+        },
+        "line": {
+          "covered": 254,
+          "missed": 23,
+          "ratio": 0.916968,
+          "total": 277
+        },
+        "method": {
+          "covered": 33,
+          "missed": 3,
+          "ratio": 0.916667,
+          "total": 36
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 162421,
+      "cached_input_tokens_used": 1083392,
+      "output_tokens_used": 14253,
+      "iterations": 3,
+      "cost_usd": 0.9693,
+      "generated_loc": 181,
+      "tested_library_loc": 254,
+      "metadata_entries": 7,
+      "code_coverage_percent": 91.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java",
+      "metadata_file": "metadata/org.codehaus.plexus/plexus-cipher/2.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.codehaus.plexus/plexus-cipher/2.0/stats.json
+++ b/stats/org.codehaus.plexus/plexus-cipher/2.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1378,
+        "missed" : 117,
+        "ratio" : 0.921739,
+        "total" : 1495
+      },
+      "line" : {
+        "covered" : 254,
+        "missed" : 23,
+        "ratio" : 0.916968,
+        "total" : 277
+      },
+      "method" : {
+        "covered" : 33,
+        "missed" : 3,
+        "ratio" : 0.916667,
+        "total" : 36
+      }
+    }
+  } ]
+}

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/.gitignore
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/build.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.codehaus.plexus:plexus-cipher:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/gradle.properties
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.codehaus.plexus:plexus-cipher:2.0
+library.version = 2.0
+metadata.dir = org.codehaus.plexus/plexus-cipher/2.0/

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/settings.gradle
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.codehaus.plexus.plexus-cipher_tests'

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -6,11 +6,173 @@
  */
 package org_codehaus_plexus.plexus_cipher;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-class Plexus_cipherTest {
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.plexus.components.cipher.Base64;
+import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
+import org.sonatype.plexus.components.cipher.PBECipher;
+import org.sonatype.plexus.components.cipher.PlexusCipher;
+import org.sonatype.plexus.components.cipher.PlexusCipherException;
+
+public class Plexus_cipherTest {
+    private static final String PASSPHRASE = "correct horse battery staple";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void defaultCipherEncryptsAndDecryptsTextWithUnicodeContent() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+        String plaintext = "secret value with unicode π, emoji 🚀, and\nmultiple lines";
+
+        String encrypted = cipher.encrypt(plaintext, PASSPHRASE);
+        String secondEncrypted = cipher.encrypt(plaintext, PASSPHRASE);
+
+        assertThat(encrypted).isNotBlank().isNotEqualTo(plaintext);
+        assertThat(secondEncrypted).isNotBlank().isNotEqualTo(plaintext);
+        assertThat(Base64.isArrayByteBase64(encrypted.getBytes(StandardCharsets.US_ASCII))).isTrue();
+        assertThat(cipher.decrypt(encrypted, PASSPHRASE)).isEqualTo(plaintext);
+        assertThat(cipher.decrypt(secondEncrypted, PASSPHRASE)).isEqualTo(plaintext);
+    }
+
+    @Test
+    void decoratedEncryptionRoundTripsAndSupportsDecoratorUtilities() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+        String plaintext = "decorated secret";
+
+        String decorated = cipher.encryptAndDecorate(plaintext, PASSPHRASE);
+        String undecorated = cipher.unDecorate(decorated);
+
+        assertThat(decorated).startsWith("{").endsWith("}");
+        assertThat(cipher.isEncryptedString(decorated)).isTrue();
+        assertThat(cipher.isEncryptedString("prefix " + decorated + " suffix")).isTrue();
+        assertThat(cipher.unDecorate("prefix " + decorated + " suffix")).isEqualTo(undecorated);
+        assertThat(cipher.decryptDecorated(decorated, PASSPHRASE)).isEqualTo(plaintext);
+        assertThat(cipher.decryptDecorated(undecorated, PASSPHRASE)).isEqualTo(plaintext);
+        assertThat(cipher.decorate("plain-token")).isEqualTo("{plain-token}");
+        assertThat(cipher.unDecorate("{plain-token}")).isEqualTo("plain-token");
+    }
+
+    @Test
+    void cipherPreservesNullAndEmptyInputsWhereApiDefinesPassThrough() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+
+        assertThat(cipher.encrypt(null, PASSPHRASE)).isNull();
+        assertThat(cipher.decrypt(null, PASSPHRASE)).isNull();
+        assertThat(cipher.decryptDecorated(null, PASSPHRASE)).isNull();
+        assertThat(cipher.encrypt("", PASSPHRASE)).isEmpty();
+        assertThat(cipher.decrypt("", PASSPHRASE)).isEmpty();
+        assertThat(cipher.decryptDecorated("", PASSPHRASE)).isEmpty();
+        assertThat(cipher.decorate(null)).isEqualTo("{}");
+        assertThat(cipher.encryptAndDecorate(null, PASSPHRASE)).isEqualTo("{}");
+        assertThat(cipher.isEncryptedString(null)).isFalse();
+        assertThat(cipher.isEncryptedString("")).isFalse();
+    }
+
+    @Test
+    void invalidDecoratedOrEncryptedValuesReportPlexusCipherExceptions() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+
+        assertThatExceptionOfType(PlexusCipherException.class)
+                .isThrownBy(() -> cipher.unDecorate("not decorated"))
+                .withMessage("default.plexus.cipher.badEncryptedPassword");
+        assertThatExceptionOfType(PlexusCipherException.class)
+                .isThrownBy(() -> cipher.decrypt("AA==", PASSPHRASE));
+    }
+
+    @Test
+    void pbeCipherEncryptsToBase64AndDecryptsWithMatchingPassword() throws Exception {
+        PBECipher cipher = new PBECipher();
+        String plaintext = "direct PBE payload";
+
+        String encrypted = cipher.encrypt64(plaintext, PASSPHRASE);
+
+        assertThat(Base64.isArrayByteBase64(encrypted.getBytes(StandardCharsets.US_ASCII))).isTrue();
+        assertThat(cipher.decrypt64(encrypted, PASSPHRASE)).isEqualTo(plaintext);
+        assertThatExceptionOfType(PlexusCipherException.class)
+                .isThrownBy(() -> cipher.decrypt64("AA==", PASSPHRASE));
+    }
+
+    @Test
+    void base64StaticMethodsEncodeDecodeAndValidateCommonBytePatterns() {
+        byte[][] inputs = {
+                new byte[0],
+                "f".getBytes(StandardCharsets.US_ASCII),
+                "fo".getBytes(StandardCharsets.US_ASCII),
+                "foo".getBytes(StandardCharsets.US_ASCII),
+                "hello world".getBytes(StandardCharsets.UTF_8),
+                new byte[] {(byte) 0x00, (byte) 0x7f, (byte) 0x80, (byte) 0xff}
+        };
+
+        for (byte[] input : inputs) {
+            byte[] encoded = Base64.encodeBase64(input);
+
+            assertThat(encoded).isEqualTo(java.util.Base64.getEncoder().encode(input));
+            assertThat(Base64.isArrayByteBase64(encoded)).isTrue();
+            assertThat(Base64.decodeBase64(encoded)).isEqualTo(input);
+        }
+
+        assertThat(Base64.isBase64((byte) 'A')).isTrue();
+        assertThat(Base64.isBase64((byte) '+')).isTrue();
+        assertThat(Base64.isBase64((byte) '/')).isTrue();
+        assertThat(Base64.isBase64((byte) '=')).isTrue();
+        assertThat(Base64.isBase64((byte) '-')).isFalse();
+        assertThat(Base64.isBase64((byte) 0xff)).isFalse();
+        assertThat(Base64.isArrayByteBase64(" YWJj\r\n".getBytes(StandardCharsets.US_ASCII))).isTrue();
+        assertThat(Base64.isArrayByteBase64("YWJj!".getBytes(StandardCharsets.US_ASCII))).isFalse();
+        assertThat(Base64.decodeBase64("Y!W@J#j".getBytes(StandardCharsets.US_ASCII)))
+                .isEqualTo("abc".getBytes(StandardCharsets.US_ASCII));
+    }
+
+    @Test
+    void chunkedBase64UsesMimeLineSeparatorsAndStillDecodes() {
+        byte[] input = new byte[120];
+        for (int i = 0; i < input.length; i++) {
+            input[i] = (byte) i;
+        }
+
+        byte[] chunked = Base64.encodeBase64Chunked(input);
+        byte[] explicitlyChunked = Base64.encodeBase64(input, true);
+
+        assertThat(chunked).isEqualTo(explicitlyChunked);
+        assertThat(new String(chunked, StandardCharsets.US_ASCII)).contains("\r\n");
+        assertThat(Base64.isArrayByteBase64(chunked)).isTrue();
+        assertThat(Base64.decodeBase64(chunked)).isEqualTo(input);
+    }
+
+    @Test
+    void base64InstanceMethodsAcceptOnlyByteArrays() {
+        Base64 codec = new Base64();
+        byte[] input = "instance codec".getBytes(StandardCharsets.UTF_8);
+        byte[] encoded = codec.encode(input);
+
+        assertThat(encoded).isEqualTo(Base64.encodeBase64(input));
+        assertThat(codec.decode(encoded)).isEqualTo(input);
+        assertThat((byte[]) codec.encode((Object) input)).isEqualTo(encoded);
+        assertThat((byte[]) codec.decode((Object) encoded)).isEqualTo(input);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> codec.encode("not bytes"))
+                .withMessage("Parameter supplied to Base64 encode is not a byte[]");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> codec.decode("not bytes"))
+                .withMessage("Parameter supplied to Base64 decode is not a byte[]");
+    }
+
+    @Test
+    void securityProviderDiscoveryReturnsAvailableServiceTypesAndImplementations() {
+        String[] serviceTypes = DefaultPlexusCipher.getServiceTypes();
+        String[] digestImplementations = DefaultPlexusCipher.getCryptoImpls("MessageDigest");
+        String[] cipherImplementations = DefaultPlexusCipher.getCryptoImpls("Cipher");
+
+        assertThat(serviceTypes).isNotEmpty().doesNotContainNull();
+        assertThat(Arrays.asList(serviceTypes)).contains("MessageDigest", "Cipher");
+        assertThat(digestImplementations).isNotEmpty().doesNotContainNull();
+        assertThat(cipherImplementations).isNotEmpty().doesNotContainNull();
+        assertThat(Arrays.asList(digestImplementations)).anySatisfy(implementation ->
+                assertThat(implementation).containsIgnoringCase("SHA"));
+        assertThat(Arrays.asList(cipherImplementations)).anySatisfy(implementation ->
+                assertThat(implementation).containsIgnoringCase("AES"));
     }
 }

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -56,6 +56,20 @@ public class Plexus_cipherTest {
     }
 
     @Test
+    void escapedDecorationDelimitersAreHandledWhenDetectingEncryptedValues() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+        String escapedBraces = "\\{not encrypted\\}";
+        String mixedBraces = "Comment {foo\\{inner secret\\}} trailing text with }";
+
+        assertThat(cipher.isEncryptedString(escapedBraces)).isFalse();
+        assertThat(cipher.isEncryptedString(mixedBraces)).isTrue();
+        assertThat(cipher.unDecorate(mixedBraces)).isEqualTo("foo\\{inner secret\\}");
+        assertThatExceptionOfType(PlexusCipherException.class)
+                .isThrownBy(() -> cipher.unDecorate(escapedBraces))
+                .withMessage("default.plexus.cipher.badEncryptedPassword");
+    }
+
+    @Test
     void cipherPreservesNullAndEmptyInputsWhereApiDefinesPassThrough() throws Exception {
         PlexusCipher cipher = new DefaultPlexusCipher();
 

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -38,6 +38,21 @@ public class Plexus_cipherTest {
     }
 
     @Test
+    void encryptedTextCannotBeRecoveredWithDifferentPassphrase() throws Exception {
+        PlexusCipher cipher = new DefaultPlexusCipher();
+        String plaintext = "passphrase protected secret";
+
+        String encrypted = cipher.encrypt(plaintext, PASSPHRASE);
+
+        try {
+            String decrypted = cipher.decrypt(encrypted, "different " + PASSPHRASE);
+            assertThat(decrypted).isNotEqualTo(plaintext);
+        } catch (PlexusCipherException expected) {
+            assertThat(expected).hasCauseInstanceOf(Exception.class);
+        }
+    }
+
+    @Test
     void decoratedEncryptionRoundTripsAndSupportsDecoratorUtilities() throws Exception {
         PlexusCipher cipher = new DefaultPlexusCipher();
         String plaintext = "decorated secret";

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_codehaus_plexus.plexus_cipher;
+
+import org.junit.jupiter.api.Test;
+
+class Plexus_cipherTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/src/test/java/org_codehaus_plexus/plexus_cipher/Plexus_cipherTest.java
@@ -8,6 +8,7 @@ package org_codehaus_plexus.plexus_cipher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -25,7 +26,7 @@ public class Plexus_cipherTest {
     @Test
     void defaultCipherEncryptsAndDecryptsTextWithUnicodeContent() throws Exception {
         PlexusCipher cipher = new DefaultPlexusCipher();
-        String plaintext = "secret value with unicode π, emoji 🚀, and\nmultiple lines";
+        String plaintext = "secret value with unicode \u03c0, emoji \ud83d\ude80, and\nmultiple lines";
 
         String encrypted = cipher.encrypt(plaintext, PASSPHRASE);
         String secondEncrypted = cipher.encrypt(plaintext, PASSPHRASE);
@@ -107,8 +108,7 @@ public class Plexus_cipherTest {
         assertThatExceptionOfType(PlexusCipherException.class)
                 .isThrownBy(() -> cipher.unDecorate("not decorated"))
                 .withMessage("default.plexus.cipher.badEncryptedPassword");
-        assertThatExceptionOfType(PlexusCipherException.class)
-                .isThrownBy(() -> cipher.decrypt("AA==", PASSPHRASE));
+        assertMalformedCiphertextFails(() -> cipher.decrypt("AA==", PASSPHRASE));
     }
 
     @Test
@@ -120,8 +120,7 @@ public class Plexus_cipherTest {
 
         assertThat(Base64.isArrayByteBase64(encrypted.getBytes(StandardCharsets.US_ASCII))).isTrue();
         assertThat(cipher.decrypt64(encrypted, PASSPHRASE)).isEqualTo(plaintext);
-        assertThatExceptionOfType(PlexusCipherException.class)
-                .isThrownBy(() -> cipher.decrypt64("AA==", PASSPHRASE));
+        assertMalformedCiphertextFails(() -> cipher.decrypt64("AA==", PASSPHRASE));
     }
 
     @Test
@@ -203,5 +202,15 @@ public class Plexus_cipherTest {
                 assertThat(implementation).containsIgnoringCase("SHA"));
         assertThat(Arrays.asList(cipherImplementations)).anySatisfy(implementation ->
                 assertThat(implementation).containsIgnoringCase("AES"));
+    }
+
+    private static void assertMalformedCiphertextFails(ThrowingCallable callable) {
+        assertThatThrownBy(callable::call)
+                .isInstanceOfAny(PlexusCipherException.class, ArrayIndexOutOfBoundsException.class);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingCallable {
+        void call() throws Exception;
     }
 }

--- a/tests/src/org.codehaus.plexus/plexus-cipher/2.0/user-code-filter.json
+++ b/tests/src/org.codehaus.plexus/plexus-cipher/2.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.sonatype.plexus.components.cipher.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3787

This PR introduces tests and metadata for org.codehaus.plexus:plexus-cipher:2.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 162421
- Cached input tokens: 1083392
- Output tokens: 14253
- Metadata entries: 7
- Iterations: 3
- Library coverage percentage: 91.7
- Generated lines of code: 181
- Tested library lines of code: 254

### Metadata Forge

- Forge monitored branch: `origin/forge/shared-issue-search-cache`
- Forge branch: `master`
- Forge commit hash: `0d7f1ac496d758456ac5885710982fc775d89e05`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1378/1495 (92.17%)
- Line: 254/277 (91.70%)
- Method: 33/36 (91.67%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
