### PR TITLE
[GenAI] Add support for io.quarkus:quarkus-builder:3.33.1 using gpt-5.5

### DIFF
--- a/metadata/io.quarkus/quarkus-builder/3.33.1/reachability-metadata.json
+++ b/metadata/io.quarkus/quarkus-builder/3.33.1/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.quarkus.builder.Execution"
+      },
+      "type": "org.jboss.threads.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.quarkus/quarkus-builder/index.json
+++ b/metadata/io.quarkus/quarkus-builder/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.33.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/$version$/quarkus-builder-$version$-sources.jar",
+    "repository-url" : "https://github.com/quarkusio/quarkus",
+    "test-code-url" : "https://github.com/quarkusio/quarkus/tree/$version$/core/builder/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-builder/$version$/quarkus-builder-$version$-javadoc.jar",
+    "description" : "Quarkus Builder provides the build chain and build step execution APIs used by Quarkus to coordinate extension build-time processing. It models build items, producers, consumers, diagnostics, and execution results so build steps can be ordered and run consistently.",
+    "tested-versions" : [
+      "3.33.1"
+    ],
+    "allowed-packages" : [
+      "io.quarkus.builder"
+    ]
+  }
+]

--- a/stats/io.quarkus/quarkus-builder/3.33.1/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-builder/3.33.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T08:06:30.491071Z",
+    "library": "io.quarkus:quarkus-builder:3.33.1",
+    "starting_commit": "9b6d94ea66ecbcbd341288e019da2eceab535149",
+    "ending_commit": "2e0eeb6f01bb00de10b1cd9cfa8f8eaaff84eba9",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.33.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3129,
+          "missed": 2886,
+          "ratio": 0.5202,
+          "total": 6015
+        },
+        "line": {
+          "covered": 730,
+          "missed": 712,
+          "ratio": 0.506241,
+          "total": 1442
+        },
+        "method": {
+          "covered": 184,
+          "missed": 147,
+          "ratio": 0.555891,
+          "total": 331
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 219118,
+      "cached_input_tokens_used": 2897408,
+      "output_tokens_used": 24799,
+      "iterations": 4,
+      "cost_usd": 2.1927,
+      "generated_loc": 491,
+      "tested_library_loc": 730,
+      "metadata_entries": 2,
+      "code_coverage_percent": 50.62
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java",
+      "metadata_file": "metadata/io.quarkus/quarkus-builder/3.33.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.quarkus/quarkus-builder/3.33.1/stats.json
+++ b/stats/io.quarkus/quarkus-builder/3.33.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.33.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3129,
+        "missed" : 2886,
+        "ratio" : 0.5202,
+        "total" : 6015
+      },
+      "line" : {
+        "covered" : 730,
+        "missed" : 712,
+        "ratio" : 0.506241,
+        "total" : 1442
+      },
+      "method" : {
+        "covered" : 184,
+        "missed" : 147,
+        "ratio" : 0.555891,
+        "total" : 331
+      }
+    }
+  } ]
+}

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/.gitignore
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/build.gradle
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.quarkus:quarkus-builder:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/gradle.properties
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.quarkus:quarkus-builder:3.33.1
+library.version = 3.33.1
+metadata.dir = io.quarkus/quarkus-builder/3.33.1/

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/settings.gradle
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.quarkus.quarkus-builder_tests'

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
@@ -180,6 +180,31 @@ public class Quarkus_builderTest {
     }
 
     @Test
+    void acceptsMultipleInitialMultiBuildItemsForEachExecution() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+        builder.addInitial(InitialFeatureItem.class);
+        builder.addBuildStep(new NamedStep("initial-feature-summary", context -> {
+            List<InitialFeatureItem> featureItems = context.consumeMulti(InitialFeatureItem.class);
+            context.produce(new InitialFeatureSummaryItem(featureItems.stream()
+                    .map(InitialFeatureItem::name)
+                    .toList()));
+        })).consumes(InitialFeatureItem.class).produces(InitialFeatureSummaryItem.class).build();
+        builder.addFinal(InitialFeatureSummaryItem.class);
+
+        BuildResult result = builder.build()
+                .createExecutionBuilder("initial-multi-build")
+                .produce(new InitialFeatureItem("security"))
+                .produce(InitialFeatureItem.class, new InitialFeatureItem("observability"))
+                .execute();
+
+        assertThat(result.consume(InitialFeatureSummaryItem.class).names())
+                .containsExactly("security", "observability");
+        assertThat(result.consumeMulti(InitialFeatureItem.class))
+                .extracting(InitialFeatureItem::name)
+                .containsExactly("security", "observability");
+    }
+
+    @Test
     void supportsOptionalConsumesOverridableProducersAndFlagSets() throws Exception {
         BuildChainBuilder builder = BuildChain.builder();
         AtomicBoolean overridableRan = new AtomicBoolean(false);
@@ -479,6 +504,30 @@ public class Quarkus_builderTest {
     }
 
     private static final class MissingRequiredItem extends SimpleBuildItem {
+    }
+
+    private static final class InitialFeatureItem extends MultiBuildItem {
+        private final String name;
+
+        private InitialFeatureItem(String name) {
+            this.name = name;
+        }
+
+        private String name() {
+            return name;
+        }
+    }
+
+    private static final class InitialFeatureSummaryItem extends SimpleBuildItem {
+        private final List<String> names;
+
+        private InitialFeatureSummaryItem(List<String> names) {
+            this.names = List.copyOf(names);
+        }
+
+        private List<String> names() {
+            return names;
+        }
     }
 
     private static final class OptionalOutputItem extends SimpleBuildItem {

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_quarkus.quarkus_builder;
+
+import org.junit.jupiter.api.Test;
+
+class Quarkus_builderTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
@@ -135,6 +135,51 @@ public class Quarkus_builderTest {
     }
 
     @Test
+    void honorsOrderOnlyConstraintsAroundItemConsumersAndProducers() throws Exception {
+        List<String> events = Collections.synchronizedList(new ArrayList<>());
+        AtomicBoolean inputProduced = new AtomicBoolean(false);
+        AtomicBoolean beforeConsumerRan = new AtomicBoolean(false);
+        AtomicBoolean afterProducerRan = new AtomicBoolean(false);
+        BuildChainBuilder builder = BuildChain.builder();
+
+        builder.addBuildStep(new NamedStep("before-consume", context -> {
+            beforeConsumerRan.set(true);
+            events.add("before-consume");
+        })).beforeConsume(OrderedInputItem.class).build();
+        builder.addBuildStep(new NamedStep("producer", context -> {
+            inputProduced.set(true);
+            events.add("producer");
+            context.produce(new OrderedInputItem("configured"));
+        })).produces(OrderedInputItem.class).build();
+        builder.addBuildStep(new NamedStep("after-produce", context -> {
+            assertThat(inputProduced).isTrue();
+            afterProducerRan.set(true);
+            events.add("after-produce");
+            context.produce(new OrderedGateItem());
+        })).afterProduce(OrderedInputItem.class).produces(OrderedGateItem.class).build();
+        builder.addBuildStep(new NamedStep("consumer", context -> {
+            assertThat(beforeConsumerRan).isTrue();
+            assertThat(afterProducerRan).isTrue();
+            OrderedInputItem input = context.consume(OrderedInputItem.class);
+            context.consume(OrderedGateItem.class);
+            events.add("consumer");
+            context.produce(new OrderedResultItem(input.value() + ":consumed"));
+        })).consumes(OrderedInputItem.class)
+                .consumes(OrderedGateItem.class)
+                .produces(OrderedResultItem.class)
+                .build();
+        builder.addFinal(OrderedResultItem.class);
+
+        BuildResult result = builder.build().createExecutionBuilder("order-only-build").execute();
+
+        assertThat(result.consume(OrderedResultItem.class).value()).isEqualTo("configured:consumed");
+        assertThat(events).containsExactlyInAnyOrder("before-consume", "producer", "after-produce", "consumer");
+        assertThat(events.indexOf("before-consume")).isLessThan(events.indexOf("consumer"));
+        assertThat(events.indexOf("producer")).isLessThan(events.indexOf("after-produce"));
+        assertThat(events.indexOf("after-produce")).isLessThan(events.indexOf("consumer"));
+    }
+
+    @Test
     void supportsOptionalConsumesOverridableProducersAndFlagSets() throws Exception {
         BuildChainBuilder builder = BuildChain.builder();
         AtomicBoolean overridableRan = new AtomicBoolean(false);
@@ -404,6 +449,33 @@ public class Quarkus_builderTest {
     }
 
     private static final class MissingOptionalItem extends SimpleBuildItem {
+    }
+
+    private static final class OrderedInputItem extends SimpleBuildItem {
+        private final String value;
+
+        private OrderedInputItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class OrderedGateItem extends SimpleBuildItem {
+    }
+
+    private static final class OrderedResultItem extends SimpleBuildItem {
+        private final String value;
+
+        private OrderedResultItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
     }
 
     private static final class MissingRequiredItem extends SimpleBuildItem {

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/src/test/java/io_quarkus/quarkus_builder/Quarkus_builderTest.java
@@ -6,11 +6,457 @@
  */
 package io_quarkus.quarkus_builder;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.quarkus.builder.BuildChain;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildException;
+import io.quarkus.builder.BuildExecutionBuilder;
+import io.quarkus.builder.BuildResult;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.builder.BuildStepBuilder;
+import io.quarkus.builder.ChainBuildException;
+import io.quarkus.builder.ConsumeFlag;
+import io.quarkus.builder.ConsumeFlags;
+import io.quarkus.builder.ProduceFlag;
+import io.quarkus.builder.Version;
+import io.quarkus.builder.diag.Diagnostic;
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.builder.item.SimpleBuildItem;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
-class Quarkus_builderTest {
+public class Quarkus_builderTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void executesBuildChainWithInitialItemsMultiItemsDiagnosticsAndResourceCleanup() throws Exception {
+        List<String> executionOrder = Collections.synchronizedList(new ArrayList<>());
+        AtomicBoolean closed = new AtomicBoolean(false);
+        ClassLoader deploymentClassLoader = new MarkerClassLoader(getClass().getClassLoader());
+        BuildChainBuilder builder = BuildChain.builder();
+        builder.setClassLoader(deploymentClassLoader);
+        builder.addInitial(ConfigurationItem.class);
+
+        builder.addBuildStep(new NamedStep("setup", context -> {
+            assertThat(context.getBuildTargetName()).isEqualTo("integration-build");
+            assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(deploymentClassLoader);
+            ConfigurationItem configuration = context.consume(ConfigurationItem.class);
+            context.note(null, "building %s", configuration.name());
+            context.warn(null, "warning for %s", configuration.name());
+            executionOrder.add("setup");
+            context.produce(new BaseItem(configuration.name() + ":base"));
+            context.produce(List.of(new GeneratedItem("base-one"), new GeneratedItem("base-two")));
+            context.produce(new CloseableResourceItem(closed));
+        })).consumes(ConfigurationItem.class)
+                .produces(BaseItem.class)
+                .produces(GeneratedItem.class)
+                .produces(CloseableResourceItem.class)
+                .build();
+
+        builder.addBuildStep(new NamedStep("feature", context -> {
+            BaseItem base = context.consume(BaseItem.class);
+            executionOrder.add("feature:" + base.value());
+            context.produce(new FeatureItem(base.value() + ":feature"));
+            context.produce(new GeneratedItem("feature"));
+        })).consumes(BaseItem.class)
+                .produces(FeatureItem.class)
+                .produces(GeneratedItem.class)
+                .build();
+
+        builder.addBuildStep(new NamedStep("summary", context -> {
+            BaseItem base = context.consume(BaseItem.class);
+            FeatureItem feature = context.consume(FeatureItem.class);
+            List<GeneratedItem> generatedItems = context.consumeMulti(GeneratedItem.class);
+            assertThatThrownBy(() -> generatedItems.add(new GeneratedItem("not-allowed")))
+                    .isInstanceOf(UnsupportedOperationException.class);
+            executionOrder.add("summary");
+            context.produce(new SummaryItem(base.value(), feature.value(), generatedItems.stream()
+                    .map(GeneratedItem::value)
+                    .toList()));
+        })).consumes(BaseItem.class)
+                .consumes(FeatureItem.class)
+                .consumes(GeneratedItem.class)
+                .produces(SummaryItem.class)
+                .build();
+
+        builder.addFinal(SummaryItem.class);
+        builder.addFinal(CloseableResourceItem.class);
+        BuildChain chain = builder.build();
+        BuildExecutionBuilder executionBuilder = chain.createExecutionBuilder("integration-build");
+        assertThat(executionBuilder.getBuildTargetName()).isEqualTo("integration-build");
+        BuildResult result = executionBuilder.produce(new ConfigurationItem("app")).execute();
+
+        SummaryItem summary = result.consume(SummaryItem.class);
+        assertThat(summary.base()).isEqualTo("app:base");
+        assertThat(summary.feature()).isEqualTo("app:base:feature");
+        assertThat(summary.generated()).containsExactly("base-one", "base-two", "feature");
+        assertThat(result.consumeMulti(GeneratedItem.class))
+                .extracting(GeneratedItem::value)
+                .containsExactly("base-one", "base-two", "feature");
+        assertThat(result.consumeOptional(UnusedItem.class)).isNull();
+        assertThat(result.getDiagnostics())
+                .extracting(Diagnostic::toString)
+                .containsExactly("[note]: building app", "[warning]: warning for app");
+        assertThat(result.getDeploymentClassLoader()).isSameAs(deploymentClassLoader);
+        assertThat(result.getDuration(java.util.concurrent.TimeUnit.NANOSECONDS)).isGreaterThanOrEqualTo(0L);
+        assertThat(executionOrder).containsExactly("setup", "feature:app:base", "summary");
+
+        CloseableResourceItem closeable = result.consume(CloseableResourceItem.class);
+        assertThat(closeable.closed()).isFalse();
+
+        BuildChain closeOnlyChain = BuildChain.builder()
+                .addBuildStep(new NamedStep("closeable",
+                        context -> context.produce(new CloseableResourceItem(closed))))
+                .produces(CloseableResourceItem.class)
+                .build()
+                .addFinal(CloseableResourceItem.class)
+                .build();
+        BuildResult closeOnlyResult = closeOnlyChain.createExecutionBuilder("close-only-build").execute();
+        CloseableResourceItem closeOnlyItem = closeOnlyResult.consume(CloseableResourceItem.class);
+        closeOnlyResult.closeAll();
+        assertThat(closeOnlyItem.closed()).isTrue();
+        assertThat(closed).isTrue();
+    }
+
+    @Test
+    void prioritizesMultiItemProducerOrderForConsumers() throws Exception {
+        List<String> consumedOrder = new ArrayList<>();
+        BuildChainBuilder builder = newPriorityChain(consumedOrder);
+        builder.addPriorityItem(LoggingSetupItem.class);
+
+        BuildResult result = builder.build().createExecutionBuilder("priority-build").execute();
+
+        assertThat(result.consume(BundleItem.class)).isNotNull();
+        assertThat(consumedOrder).containsExactly("bytecode-from-base", "bytecode-from-logging", "bytecode-from-feature");
+    }
+
+    @Test
+    void supportsOptionalConsumesOverridableProducersAndFlagSets() throws Exception {
+        BuildChainBuilder builder = BuildChain.builder();
+        AtomicBoolean overridableRan = new AtomicBoolean(false);
+
+        builder.addBuildStep(new NamedStep("overridable", context -> {
+            overridableRan.set(true);
+            context.produce(new OptionalOutputItem("overridable"));
+        })).produces(OptionalOutputItem.class, ProduceFlag.OVERRIDABLE).build();
+        builder.addBuildStep(new NamedStep("real", context -> context.produce(new OptionalOutputItem("real"))))
+                .produces(OptionalOutputItem.class)
+                .build();
+        builder.addBuildStep(new NamedStep("optional-consumer", context -> {
+            assertThat(context.consume(MissingOptionalItem.class)).isNull();
+            OptionalOutputItem output = context.consume(OptionalOutputItem.class);
+            context.produce(new OptionalSummaryItem(output.value()));
+        })).consumes(MissingOptionalItem.class, ConsumeFlags.of(ConsumeFlag.OPTIONAL))
+                .consumes(OptionalOutputItem.class)
+                .produces(OptionalSummaryItem.class)
+                .build();
+        builder.addFinal(OptionalSummaryItem.class);
+
+        BuildResult result = builder.build().createExecutionBuilder("optional-build").execute();
+
+        assertThat(result.consume(OptionalSummaryItem.class).value()).isEqualTo("real");
+        assertThat(overridableRan).isFalse();
+        assertThat(ConsumeFlags.NONE.contains(ConsumeFlag.OPTIONAL)).isFalse();
+        assertThat(ConsumeFlags.of(ConsumeFlag.OPTIONAL).contains(ConsumeFlag.OPTIONAL)).isTrue();
+    }
+
+    @Test
+    void reportsContextErrorsAndThrownFailuresAsDiagnostics() throws Exception {
+        BuildChainBuilder reportedErrorBuilder = BuildChain.builder();
+        reportedErrorBuilder.addBuildStep(new NamedStep("reported-error", context -> {
+            context.note(null, "starting");
+            context.error(null, "invalid %s", "state");
+            context.produce(new ErrorResultItem());
+        })).produces(ErrorResultItem.class).build();
+        reportedErrorBuilder.addFinal(ErrorResultItem.class);
+
+        assertThatThrownBy(() -> reportedErrorBuilder.build().createExecutionBuilder("reported-error-build").execute())
+                .isInstanceOf(BuildException.class)
+                .satisfies(error -> {
+                    BuildException buildException = (BuildException) error;
+                    assertThat(buildException.getDiagnostics())
+                            .extracting(Diagnostic::getLevel)
+                            .containsExactly(Diagnostic.Level.NOTE, Diagnostic.Level.ERROR);
+                    assertThat(buildException.getMessage()).contains("[error]: invalid state");
+                });
+
+        BuildChainBuilder thrownFailureBuilder = BuildChain.builder();
+        IllegalStateException failure = new IllegalStateException("boom");
+        thrownFailureBuilder.addBuildStep(new NamedStep("throwing-step", context -> {
+            throw failure;
+        })).produces(ErrorResultItem.class).build();
+        thrownFailureBuilder.addFinal(ErrorResultItem.class);
+
+        assertThatThrownBy(() -> thrownFailureBuilder.build().createExecutionBuilder("thrown-error-build").execute())
+                .isInstanceOf(BuildException.class)
+                .satisfies(error -> {
+                    BuildException buildException = (BuildException) error;
+                    assertThat(buildException.getDiagnostics()).hasSize(1);
+                    Diagnostic diagnostic = buildException.getDiagnostics().get(0);
+                    assertThat(diagnostic.getLevel()).isEqualTo(Diagnostic.Level.ERROR);
+                    assertThat(diagnostic.getThrown()).isSameAs(failure);
+                    assertThat(diagnostic.toString()).contains("Build step throwing-step threw an exception", "boom");
+                });
+    }
+
+    @Test
+    void rejectsInvalidDeclarationsAndUndeclaredItems() throws Exception {
+        BuildStepBuilder missingProduces = BuildChain.builder()
+                .addBuildStep(new NamedStep("missing-produces", context -> assertThat(context).isNotNull()));
+        assertThatThrownBy(missingProduces::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Build step 'missing-produces'")
+                .hasMessageContaining("does not produce any build item");
+
+        BuildChainBuilder missingRequiredProducer = BuildChain.builder();
+        missingRequiredProducer.addBuildStep(new NamedStep("requires-missing", context -> {
+            context.consume(MissingRequiredItem.class);
+            context.produce(new OptionalSummaryItem("unreachable"));
+        })).consumes(MissingRequiredItem.class).produces(OptionalSummaryItem.class).build();
+        missingRequiredProducer.addFinal(OptionalSummaryItem.class);
+        assertThatThrownBy(missingRequiredProducer::build)
+                .isInstanceOf(ChainBuildException.class)
+                .hasMessageContaining("No producers for required item");
+
+        BuildChainBuilder duplicateProducer = BuildChain.builder();
+        duplicateProducer.addBuildStep(new NamedStep("first", context -> context.produce(new BaseItem("first"))))
+                .produces(BaseItem.class)
+                .build();
+        duplicateProducer.addBuildStep(new NamedStep("second", context -> context.produce(new BaseItem("second"))))
+                .produces(BaseItem.class)
+                .build();
+        duplicateProducer.addFinal(BaseItem.class);
+        assertThatThrownBy(duplicateProducer::build)
+                .isInstanceOf(ChainBuildException.class)
+                .hasMessageContaining("Multiple producers of item");
+
+        BuildChain chain = BuildChain.builder().addInitial(ConfigurationItem.class).build();
+        assertThatThrownBy(() -> chain.createExecutionBuilder("undeclared-initial").produce(new BaseItem("bad")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Undeclared build item");
+    }
+
+    @Test
+    void exposesVersionInformationFromPackagedResources() {
+        assertThat(Version.getJarName()).isEqualTo("quarkus-builder");
+        assertThat(Version.getVersion()).isNotBlank().isNotEqualTo("(unknown)");
+    }
+
+    private static BuildChainBuilder newPriorityChain(List<String> consumedOrder) {
+        BuildChainBuilder builder = BuildChain.builder();
+        builder.addBuildStep(new NamedStep("base-config", context -> {
+            context.produce(new BaseConfigItem());
+            context.produce(new GeneratedBytecodeItem("bytecode-from-base"));
+        })).produces(BaseConfigItem.class).produces(GeneratedBytecodeItem.class).build();
+        builder.addBuildStep(new NamedStep("logging-setup", context -> {
+            context.consume(BaseConfigItem.class);
+            context.produce(new LoggingSetupItem());
+            context.produce(new GeneratedBytecodeItem("bytecode-from-logging"));
+        })).consumes(BaseConfigItem.class).produces(LoggingSetupItem.class).produces(GeneratedBytecodeItem.class).build();
+        builder.addBuildStep(new NamedStep("feature-init", context -> {
+            context.produce(new FeatureMetadataItem());
+            context.produce(new GeneratedBytecodeItem("bytecode-from-feature"));
+        })).produces(FeatureMetadataItem.class).produces(GeneratedBytecodeItem.class).build();
+        builder.addBuildStep(new NamedStep("bundle", context -> {
+            context.consume(LoggingSetupItem.class);
+            context.consume(FeatureMetadataItem.class);
+            context.consumeMulti(GeneratedBytecodeItem.class).forEach(item -> consumedOrder.add(item.label()));
+            context.produce(new BundleItem());
+        })).consumes(LoggingSetupItem.class)
+                .consumes(FeatureMetadataItem.class)
+                .consumes(GeneratedBytecodeItem.class)
+                .produces(BundleItem.class)
+                .build();
+        builder.addFinal(BundleItem.class);
+        return builder;
+    }
+
+    private static final class NamedStep implements BuildStep {
+        private final String id;
+        private final StepAction action;
+
+        private NamedStep(String id, StepAction action) {
+            this.id = id;
+            this.action = action;
+        }
+
+        @Override
+        public void execute(BuildContext context) {
+            action.execute(context);
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return id;
+        }
+    }
+
+    @FunctionalInterface
+    private interface StepAction {
+        void execute(BuildContext context);
+    }
+
+    private static final class MarkerClassLoader extends ClassLoader {
+        private MarkerClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+    }
+
+    private static final class ConfigurationItem extends SimpleBuildItem {
+        private final String name;
+
+        private ConfigurationItem(String name) {
+            this.name = name;
+        }
+
+        private String name() {
+            return name;
+        }
+    }
+
+    private static final class BaseItem extends SimpleBuildItem {
+        private final String value;
+
+        private BaseItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class FeatureItem extends SimpleBuildItem {
+        private final String value;
+
+        private FeatureItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class SummaryItem extends SimpleBuildItem {
+        private final String base;
+        private final String feature;
+        private final List<String> generated;
+
+        private SummaryItem(String base, String feature, List<String> generated) {
+            this.base = base;
+            this.feature = feature;
+            this.generated = List.copyOf(generated);
+        }
+
+        private String base() {
+            return base;
+        }
+
+        private String feature() {
+            return feature;
+        }
+
+        private List<String> generated() {
+            return generated;
+        }
+    }
+
+    private static final class GeneratedItem extends MultiBuildItem {
+        private final String value;
+
+        private GeneratedItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class CloseableResourceItem extends SimpleBuildItem implements AutoCloseable {
+        private final AtomicBoolean closed;
+
+        private CloseableResourceItem(AtomicBoolean closed) {
+            this.closed = closed;
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        private boolean closed() {
+            return closed.get();
+        }
+    }
+
+    private static final class UnusedItem extends SimpleBuildItem {
+    }
+
+    private static final class MissingOptionalItem extends SimpleBuildItem {
+    }
+
+    private static final class MissingRequiredItem extends SimpleBuildItem {
+    }
+
+    private static final class OptionalOutputItem extends SimpleBuildItem {
+        private final String value;
+
+        private OptionalOutputItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class OptionalSummaryItem extends SimpleBuildItem {
+        private final String value;
+
+        private OptionalSummaryItem(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+    }
+
+    private static final class ErrorResultItem extends SimpleBuildItem {
+    }
+
+    private static final class BaseConfigItem extends SimpleBuildItem {
+    }
+
+    private static final class LoggingSetupItem extends SimpleBuildItem {
+    }
+
+    private static final class FeatureMetadataItem extends SimpleBuildItem {
+    }
+
+    private static final class BundleItem extends SimpleBuildItem {
+    }
+
+    private static final class GeneratedBytecodeItem extends MultiBuildItem {
+        private final String label;
+
+        private GeneratedBytecodeItem(String label) {
+            this.label = label;
+        }
+
+        private String label() {
+            return label;
+        }
     }
 }

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.quarkus.builder.**"
+      "includeClasses" : "io.quarkus.builder.**"
+    },
+    {
+      "includeClasses" : "io_quarkus.quarkus_builder.**"
     }
   ]
 }

--- a/tests/src/io.quarkus/quarkus-builder/3.33.1/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-builder/3.33.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.quarkus.builder.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3811

This PR introduces tests and metadata for io.quarkus:quarkus-builder:3.33.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 219118
- Cached input tokens: 2897408
- Output tokens: 24799
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 50.62
- Generated lines of code: 491
- Tested library lines of code: 730

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `12552da3b84ea40c278c507487f70f76fc3627ca`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 3129/6015 (52.02%)
- Line: 730/1442 (50.62%)
- Method: 184/331 (55.59%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
