### PR TITLE
[GenAI] Add support for io.quarkus:quarkus-hibernate-validator-spi:3.33.1 using gpt-5.5

### DIFF
--- a/metadata/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/reachability-metadata.json
+++ b/metadata/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/reachability-metadata.json
@@ -1,0 +1,18 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem"
+      },
+      "type": "org.jboss.threads.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.quarkus/quarkus-hibernate-validator-spi/index.json
+++ b/metadata/io.quarkus/quarkus-hibernate-validator-spi/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.33.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-hibernate-validator-spi/$version$/quarkus-hibernate-validator-spi-$version$-sources.jar",
+    "repository-url" : "https://github.com/quarkusio/quarkus",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/quarkus/quarkus-hibernate-validator-spi/$version$/quarkus-hibernate-validator-spi-$version$-javadoc.jar",
+    "description" : "Quarkus Hibernate Validator SPI provides build items used by Quarkus extensions to exchange Hibernate Validator and Bean Validation metadata during build processing. It exposes APIs for additional constrained classes, discovered validation annotations, and replacement traversable resolver logic without depending on the full extension deployment implementation.",
+    "tested-versions" : [
+      "3.33.1"
+    ],
+    "allowed-packages" : [
+      "io.quarkus.hibernate.validator.spi"
+    ]
+  }
+]

--- a/stats/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T08:15:23.806208Z",
+    "library": "io.quarkus:quarkus-hibernate-validator-spi:3.33.1",
+    "starting_commit": "1d0e8cc4a03d4d4b3d72e4e76f74ed82018dcd84",
+    "ending_commit": "39e8ec0b6de23c8a4257b0df461b70e504e43038",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.33.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 88,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 88
+        },
+        "line": {
+          "covered": 29,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 29
+        },
+        "method": {
+          "covered": 15,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 15
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 153502,
+      "cached_input_tokens_used": 1283072,
+      "output_tokens_used": 14028,
+      "iterations": 4,
+      "cost_usd": 1.0623,
+      "generated_loc": 112,
+      "tested_library_loc": 29,
+      "metadata_entries": 2,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java",
+      "metadata_file": "metadata/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/stats.json
+++ b/stats/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.33.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 88,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 88
+      },
+      "line" : {
+        "covered" : 29,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 29
+      },
+      "method" : {
+        "covered" : 15,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 15
+      }
+    }
+  } ]
+}

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/.gitignore
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/build.gradle
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.quarkus:quarkus-hibernate-validator-spi:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/gradle.properties
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.quarkus:quarkus-hibernate-validator-spi:3.33.1
+library.version = 3.33.1
+metadata.dir = io.quarkus/quarkus-hibernate-validator-spi/3.33.1/

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/settings.gradle
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.quarkus.quarkus-hibernate-validator-spi_tests'

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_quarkus.quarkus_hibernate_validator_spi;
+
+import org.junit.jupiter.api.Test;
+
+class Quarkus_hibernate_validator_spiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
@@ -16,6 +16,8 @@ import java.util.function.BiPredicate;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
 import io.quarkus.hibernate.validator.spi.BeanValidationAnnotationsBuildItem;
 import io.quarkus.hibernate.validator.spi.BeanValidationTraversableResolverBuildItem;
@@ -72,6 +74,20 @@ public class Quarkus_hibernate_validator_spiTest {
                 .isInstanceOf(UnsupportedOperationException.class);
         assertThatThrownBy(() -> item.getAllAnnotations().remove(valid))
                 .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void buildItemsExposeQuarkusBuildItemMultiplicity() {
+        AdditionalConstrainedClassBuildItem additionalClass = AdditionalConstrainedClassBuildItem.of(
+                SampleConstrainedBean.class);
+        BeanValidationAnnotationsBuildItem annotations = new BeanValidationAnnotationsBuildItem(
+                DotName.createSimple("jakarta.validation.Valid"), Set.of(), Set.of());
+        BeanValidationTraversableResolverBuildItem traversableResolver = new BeanValidationTraversableResolverBuildItem(
+                (bean, attributeName) -> true);
+
+        assertThat(additionalClass).isInstanceOf(MultiBuildItem.class);
+        assertThat(annotations).isInstanceOf(SimpleBuildItem.class).isNotInstanceOf(MultiBuildItem.class);
+        assertThat(traversableResolver).isInstanceOf(SimpleBuildItem.class).isNotInstanceOf(MultiBuildItem.class);
     }
 
     @Test

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
@@ -6,11 +6,91 @@
  */
 package io_quarkus.quarkus_hibernate_validator_spi;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 
-class Quarkus_hibernate_validator_spiTest {
+import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
+import io.quarkus.hibernate.validator.spi.BeanValidationAnnotationsBuildItem;
+import io.quarkus.hibernate.validator.spi.BeanValidationTraversableResolverBuildItem;
+
+public class Quarkus_hibernate_validator_spiTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void additionalConstrainedClassFromClassExposesClassMetadata() {
+        AdditionalConstrainedClassBuildItem item = AdditionalConstrainedClassBuildItem.of(SampleConstrainedBean.class);
+
+        assertThat(item.isGenerated()).isFalse();
+        assertThat(item.getClazz()).isSameAs(SampleConstrainedBean.class);
+        assertThat(item.getName()).isEqualTo(SampleConstrainedBean.class.getName());
+        assertThat(item.getBytes()).isEmpty();
+    }
+
+    @Test
+    void additionalConstrainedClassFromGeneratedBytesExposesGeneratedMetadata() {
+        byte[] generatedClassBytes = new byte[] { 0x01, 0x23, 0x45 };
+
+        AdditionalConstrainedClassBuildItem item = AdditionalConstrainedClassBuildItem.of(
+                "com.example.GeneratedConstrainedBean", generatedClassBytes);
+
+        assertThat(item.isGenerated()).isTrue();
+        assertThat(item.getClazz()).isNull();
+        assertThat(item.getName()).isEqualTo("com.example.GeneratedConstrainedBean");
+        assertThat(item.getBytes()).isSameAs(generatedClassBytes).containsExactly(0x01, 0x23, 0x45);
+    }
+
+    @Test
+    void beanValidationAnnotationsExposeValidConstraintAndAllAnnotationSets() {
+        DotName valid = DotName.createSimple("jakarta.validation.Valid");
+        DotName notNull = DotName.createSimple("jakarta.validation.constraints.NotNull");
+        DotName size = DotName.createSimple("jakarta.validation.constraints.Size");
+        DotName customConstraint = DotName.createSimple("com.example.validation.CustomConstraint");
+        Set<DotName> constraints = new LinkedHashSet<>(Set.of(notNull, size, customConstraint));
+        Set<DotName> allAnnotations = new LinkedHashSet<>(Set.of(valid, notNull, size, customConstraint));
+
+        BeanValidationAnnotationsBuildItem item = new BeanValidationAnnotationsBuildItem(valid, constraints, allAnnotations);
+
+        assertThat(item.getValidAnnotation()).isEqualTo(valid);
+        assertThat(item.getConstraintAnnotations()).containsExactlyInAnyOrder(notNull, size, customConstraint);
+        assertThat(item.getAllAnnotations()).containsExactlyInAnyOrder(valid, notNull, size, customConstraint);
+    }
+
+    @Test
+    void beanValidationAnnotationSetsAreReadOnly() {
+        DotName valid = DotName.createSimple("jakarta.validation.Valid");
+        DotName notBlank = DotName.createSimple("jakarta.validation.constraints.NotBlank");
+        DotName email = DotName.createSimple("jakarta.validation.constraints.Email");
+        BeanValidationAnnotationsBuildItem item = new BeanValidationAnnotationsBuildItem(
+                valid, Set.of(notBlank), Set.of(valid, notBlank));
+
+        assertThatThrownBy(() -> item.getConstraintAnnotations().add(email))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> item.getAllAnnotations().remove(valid))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void traversableResolverBuildItemRetainsAndUsesAttributeLoadedPredicate() {
+        SampleConstrainedBean loadedBean = new SampleConstrainedBean(true);
+        SampleConstrainedBean unloadedBean = new SampleConstrainedBean(false);
+        BiPredicate<Object, String> predicate = (bean, attributeName) -> bean instanceof SampleConstrainedBean sample
+                && sample.loaded()
+                && "validatedProperty".equals(attributeName);
+
+        BeanValidationTraversableResolverBuildItem item = new BeanValidationTraversableResolverBuildItem(predicate);
+
+        assertThat(item.getAttributeLoadedPredicate()).isSameAs(predicate);
+        assertThat(item.getAttributeLoadedPredicate().test(loadedBean, "validatedProperty")).isTrue();
+        assertThat(item.getAttributeLoadedPredicate().test(loadedBean, "otherProperty")).isFalse();
+        assertThat(item.getAttributeLoadedPredicate().test(unloadedBean, "validatedProperty")).isFalse();
+        assertThat(item.getAttributeLoadedPredicate().test("not a bean", "validatedProperty")).isFalse();
+    }
+
+    private record SampleConstrainedBean(boolean loaded) {
     }
 }

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
@@ -16,6 +16,8 @@ import java.util.function.BiPredicate;
 import org.jboss.jandex.DotName;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.builder.BuildChain;
+import io.quarkus.builder.BuildResult;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.hibernate.validator.spi.AdditionalConstrainedClassBuildItem;
@@ -44,6 +46,26 @@ public class Quarkus_hibernate_validator_spiTest {
         assertThat(item.getClazz()).isNull();
         assertThat(item.getName()).isEqualTo("com.example.GeneratedConstrainedBean");
         assertThat(item.getBytes()).isSameAs(generatedClassBytes).containsExactly(0x01, 0x23, 0x45);
+    }
+
+    @Test
+    void additionalConstrainedClassesCanBeCollectedAsMultipleBuildItems() throws Exception {
+        AdditionalConstrainedClassBuildItem beanItem = AdditionalConstrainedClassBuildItem.of(SampleConstrainedBean.class);
+        AdditionalConstrainedClassBuildItem generatedItem = AdditionalConstrainedClassBuildItem.of(
+                "com.example.GeneratedConstrainedBean", new byte[] { 0x11, 0x22 });
+        BuildChain chain = BuildChain.builder()
+                .addBuildStep(context -> {
+                    context.produce(beanItem);
+                    context.produce(generatedItem);
+                })
+                .produces(AdditionalConstrainedClassBuildItem.class)
+                .build()
+                .addFinal(AdditionalConstrainedClassBuildItem.class)
+                .build();
+        BuildResult result = chain.createExecutionBuilder("validation-build-items").execute();
+
+        assertThat(result.consumeMulti(AdditionalConstrainedClassBuildItem.class))
+                .containsExactlyInAnyOrder(beanItem, generatedItem);
     }
 
     @Test

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/src/test/java/io_quarkus/quarkus_hibernate_validator_spi/Quarkus_hibernate_validator_spiTest.java
@@ -37,7 +37,7 @@ public class Quarkus_hibernate_validator_spiTest {
 
     @Test
     void additionalConstrainedClassFromGeneratedBytesExposesGeneratedMetadata() {
-        byte[] generatedClassBytes = new byte[] { 0x01, 0x23, 0x45 };
+        byte[] generatedClassBytes = new byte[] {0x01, 0x23, 0x45 };
 
         AdditionalConstrainedClassBuildItem item = AdditionalConstrainedClassBuildItem.of(
                 "com.example.GeneratedConstrainedBean", generatedClassBytes);
@@ -52,7 +52,7 @@ public class Quarkus_hibernate_validator_spiTest {
     void additionalConstrainedClassesCanBeCollectedAsMultipleBuildItems() throws Exception {
         AdditionalConstrainedClassBuildItem beanItem = AdditionalConstrainedClassBuildItem.of(SampleConstrainedBean.class);
         AdditionalConstrainedClassBuildItem generatedItem = AdditionalConstrainedClassBuildItem.of(
-                "com.example.GeneratedConstrainedBean", new byte[] { 0x11, 0x22 });
+                "com.example.GeneratedConstrainedBean", new byte[] {0x11, 0x22 });
         BuildChain chain = BuildChain.builder()
                 .addBuildStep(context -> {
                     context.produce(beanItem);

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.quarkus.hibernate.validator.spi.**"
+      "includeClasses" : "io.quarkus.hibernate.validator.spi.**"
+    },
+    {
+      "includeClasses" : "io_quarkus.quarkus_hibernate_validator_spi.**"
     }
   ]
 }

--- a/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/user-code-filter.json
+++ b/tests/src/io.quarkus/quarkus-hibernate-validator-spi/3.33.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.quarkus.hibernate.validator.spi.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3806

This PR introduces tests and metadata for io.quarkus:quarkus-hibernate-validator-spi:3.33.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 153502
- Cached input tokens: 1283072
- Output tokens: 14028
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 100.0
- Generated lines of code: 112
- Tested library lines of code: 29

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 88/88 (100.00%)
- Line: 29/29 (100.00%)
- Method: 15/15 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
