### PR TITLE
[GenAI] Add support for io.smallrye:jandex-gizmo2:3.5.3 using gpt-5.5

### DIFF
--- a/metadata/io.smallrye/jandex-gizmo2/3.5.3/reachability-metadata.json
+++ b/metadata/io.smallrye/jandex-gizmo2/3.5.3/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.jandex.Utils"
+      },
+      "type" : "org.jboss.jandex.ClassInfo[]"
+    }
+  ]
+}

--- a/metadata/io.smallrye/jandex-gizmo2/index.json
+++ b/metadata/io.smallrye/jandex-gizmo2/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.5.3",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-sources.jar",
+    "repository-url" : "https://github.com/smallrye/jandex",
+    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/gizmo2/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-javadoc.jar",
+    "description" : "Jandex is a Java class file indexer and offline reflection library for building compact indexes of class, annotation, and type metadata. The jandex-gizmo2 module bridges Jandex metadata into the Quarkus Gizmo 2 code generation API, including helpers for converting types, annotations, fields, and methods.",
+    "tested-versions" : [
+      "3.5.3"
+    ],
+    "allowed-packages" : [
+      "org.jboss.jandex.gizmo2"
+    ]
+  }
+]

--- a/metadata/io.smallrye/jandex-gizmo2/index.json
+++ b/metadata/io.smallrye/jandex-gizmo2/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.5.3",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-sources.jar",
-    "repository-url" : "https://github.com/smallrye/jandex",
-    "test-code-url" : "https://github.com/smallrye/jandex/tree/$version$/gizmo2/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-javadoc.jar",
-    "description" : "Jandex is a Java class file indexer and offline reflection library for building compact indexes of class, annotation, and type metadata. The jandex-gizmo2 module bridges Jandex metadata into the Quarkus Gizmo 2 code generation API, including helpers for converting types, annotations, fields, and methods.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "3.5.3",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-sources.jar",
+    "repository-url": "https://github.com/smallrye/jandex",
+    "test-code-url": "https://github.com/smallrye/jandex/tree/$version$/gizmo2/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/smallrye/jandex-gizmo2/$version$/jandex-gizmo2-$version$-javadoc.jar",
+    "description": "Jandex is a Java class file indexer and offline reflection library for building compact indexes of class, annotation, and type metadata. The jandex-gizmo2 module bridges Jandex metadata into the Quarkus Gizmo 2 code generation API, including helpers for converting types, annotations, fields, and methods.",
+    "tested-versions": [
       "3.5.3"
     ],
-    "allowed-packages" : [
-      "org.jboss.jandex.gizmo2"
+    "allowed-packages": [
+      "org.jboss.jandex.gizmo2",
+      "org.jboss.jandex"
     ]
   }
 ]

--- a/stats/io.smallrye/jandex-gizmo2/3.5.3/execution-metrics.json
+++ b/stats/io.smallrye/jandex-gizmo2/3.5.3/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T08:19:46.867714Z",
+    "library": "io.smallrye:jandex-gizmo2:3.5.3",
+    "starting_commit": "8ed20e602ca7ab468524accd74d7201d3256770e",
+    "ending_commit": "9cd334feaf946a00a328bbe591a6c729b2871b76",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.5.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 808,
+          "missed": 692,
+          "ratio": 0.538667,
+          "total": 1500
+        },
+        "line": {
+          "covered": 169,
+          "missed": 126,
+          "ratio": 0.572881,
+          "total": 295
+        },
+        "method": {
+          "covered": 46,
+          "missed": 11,
+          "ratio": 0.807018,
+          "total": 57
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 254668,
+      "cached_input_tokens_used": 2627584,
+      "output_tokens_used": 25822,
+      "iterations": 5,
+      "cost_usd": 2.0885,
+      "generated_loc": 352,
+      "tested_library_loc": 169,
+      "metadata_entries": 1,
+      "code_coverage_percent": 57.29
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java",
+      "metadata_file": "metadata/io.smallrye/jandex-gizmo2/3.5.3/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.smallrye/jandex-gizmo2/3.5.3/stats.json
+++ b/stats/io.smallrye/jandex-gizmo2/3.5.3/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.5.3",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 808,
+        "missed" : 692,
+        "ratio" : 0.538667,
+        "total" : 1500
+      },
+      "line" : {
+        "covered" : 169,
+        "missed" : 126,
+        "ratio" : 0.572881,
+        "total" : 295
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 11,
+        "ratio" : 0.807018,
+        "total" : 57
+      }
+    }
+  } ]
+}

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/.gitignore
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/build.gradle
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.smallrye:jandex-gizmo2:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/gradle.properties
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.smallrye:jandex-gizmo2:3.5.3
+library.version = 3.5.3
+metadata.dir = io.smallrye/jandex-gizmo2/3.5.3/

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/settings.gradle
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.smallrye.jandex-gizmo2_tests'

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_smallrye.jandex_gizmo2;
+
+import org.junit.jupiter.api.Test;
+
+class Jandex_gizmo2Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
@@ -54,6 +54,7 @@ public class Jandex_gizmo2Test {
     private static final ClassDesc LIST_DESC = ClassDesc.of("java.util.List");
     private static final ClassDesc MAP_DESC = ClassDesc.of("java.util.Map");
     private static final ClassDesc NUMBER_DESC = ClassDesc.of("java.lang.Number");
+    private static final ClassDesc IO_EXCEPTION_DESC = ClassDesc.of("java.io.IOException");
 
     @Test
     void convertsDotNamesAndJandexTypesToClassDescriptors() {
@@ -128,6 +129,33 @@ public class Jandex_gizmo2Test {
 
         TypeArgument unbounded = Jandex2Gizmo.typeArgumentOf(WildcardType.UNBOUNDED);
         assertThat(unbounded.toString()).contains("?");
+    }
+
+    @Test
+    void convertsGenericThrowsClausesAndMethodTypeParameters() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo sample = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoSample");
+        MethodInfo risky = sample.firstMethod("risky");
+
+        GenericType.OfThrows throwsType = Jandex2Gizmo.genericTypeOfThrows(risky.exceptions().get(0), index);
+        assertThat(throwsType.desc()).isEqualTo(IO_EXCEPTION_DESC);
+        assertThat(throwsType.toString()).contains("E");
+        assertThat(throwsType.hasVisibleAnnotations()).isTrue();
+
+        Map<String, byte[]> generatedClasses = new LinkedHashMap<>();
+        Gizmo.create(generatedClasses::put).class_("io.smallrye.generated.CopiedThrowsMetadata", cc -> {
+            cc.abstract_();
+            cc.abstractMethod("copiedRisky", mc -> {
+                Jandex2Gizmo.copyModifiers(risky, mc);
+                Jandex2Gizmo.copyTypeParameters(risky, mc);
+                mc.parameter("value", Jandex2Gizmo.genericTypeOf(risky.parameterType(0), index));
+                mc.returning(Jandex2Gizmo.genericTypeOf(risky.returnType(), index));
+                mc.throws_(throwsType);
+            });
+        });
+
+        assertThat(generatedClasses).hasSize(1);
+        assertThat(generatedClasses.values()).allSatisfy(Jandex_gizmo2Test::assertClassFile);
     }
 
     @Test
@@ -297,6 +325,10 @@ class JandexGizmoSample<T extends Number & Comparable<T>> {
     }
 
     public <U extends CharSequence> U generic(U value) {
+        return value;
+    }
+
+    public <E extends IOException> String risky(String value) throws @RuntimeMarker(7) E {
         return value;
     }
 }

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
@@ -45,11 +45,13 @@ import io.quarkus.gizmo2.Gizmo;
 import io.quarkus.gizmo2.TypeArgument;
 import io.quarkus.gizmo2.desc.ConstructorDesc;
 import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.InterfaceMethodDesc;
 import io.quarkus.gizmo2.desc.MethodDesc;
 
 public class Jandex_gizmo2Test {
     private static final ClassDesc SAMPLE_DESC = ClassDesc.of("io_smallrye.jandex_gizmo2.JandexGizmoSample");
     private static final ClassDesc STATUS_DESC = ClassDesc.of("io_smallrye.jandex_gizmo2.JandexGizmoStatus");
+    private static final ClassDesc CONTRACT_DESC = ClassDesc.of("io_smallrye.jandex_gizmo2.JandexGizmoContract");
     private static final ClassDesc STRING_DESC = ClassDesc.of("java.lang.String");
     private static final ClassDesc LIST_DESC = ClassDesc.of("java.util.List");
     private static final ClassDesc MAP_DESC = ClassDesc.of("java.util.Map");
@@ -95,6 +97,21 @@ public class Jandex_gizmo2Test {
         ClassInfo status = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoStatus");
         assertThat(Jandex2Gizmo.constOfEnum(status.field("READY")).desc())
                 .isEqualTo(Enum.EnumDesc.of(STATUS_DESC, "READY"));
+    }
+
+    @Test
+    void createsInterfaceMethodDescriptorsFromIndexedInterfaces() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo contract = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoContract");
+
+        assertThat(Jandex2Gizmo.classDescOf(contract)).isEqualTo(CONTRACT_DESC);
+
+        MethodDesc describeDesc = Jandex2Gizmo.methodDescOf(contract.firstMethod("describe"));
+        assertThat(describeDesc).isInstanceOf(InterfaceMethodDesc.class);
+        assertThat(describeDesc.owner()).isEqualTo(CONTRACT_DESC);
+        assertThat(describeDesc.name()).isEqualTo("describe");
+        assertThat(describeDesc.returnType()).isEqualTo(STRING_DESC);
+        assertThat(describeDesc.parameterTypes()).containsExactly(STRING_DESC);
     }
 
     @Test
@@ -254,8 +271,8 @@ public class Jandex_gizmo2Test {
     }
 
     private static Index sampleIndex() throws IOException {
-        return Index.of(JandexGizmoSample.class, JandexGizmoStatus.class, RuntimeMarker.class,
-                ClassRetentionMarker.class, FieldOnlyMarker.class, NestedRuntimeMarker.class);
+        return Index.of(JandexGizmoSample.class, JandexGizmoStatus.class, JandexGizmoContract.class,
+                RuntimeMarker.class, ClassRetentionMarker.class, FieldOnlyMarker.class, NestedRuntimeMarker.class);
     }
 
     private static ClassInfo requireClass(Index index, String name) {
@@ -336,6 +353,10 @@ class JandexGizmoSample<T extends Number & Comparable<T>> {
 enum JandexGizmoStatus {
     READY,
     DONE
+}
+
+interface JandexGizmoContract {
+    String describe(String input);
 }
 
 @Target({ ElementType.TYPE, ElementType.TYPE_USE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/java/io_smallrye/jandex_gizmo2/Jandex_gizmo2Test.java
@@ -6,11 +6,372 @@
  */
 package io_smallrye.jandex_gizmo2;
 
+import static java.lang.constant.ConstantDescs.CD_int;
+import static java.lang.constant.ConstantDescs.CD_void;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.constant.ClassDesc;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.ArrayType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.VoidType;
+import org.jboss.jandex.WildcardType;
+import org.jboss.jandex.gizmo2.Jandex2Gizmo;
+import org.jboss.jandex.gizmo2.StringBuilderGen;
 import org.junit.jupiter.api.Test;
 
-class Jandex_gizmo2Test {
+import io.quarkus.gizmo2.ClassOutput;
+import io.quarkus.gizmo2.Const;
+import io.quarkus.gizmo2.GenericType;
+import io.quarkus.gizmo2.Gizmo;
+import io.quarkus.gizmo2.TypeArgument;
+import io.quarkus.gizmo2.desc.ConstructorDesc;
+import io.quarkus.gizmo2.desc.FieldDesc;
+import io.quarkus.gizmo2.desc.MethodDesc;
+
+public class Jandex_gizmo2Test {
+    private static final ClassDesc SAMPLE_DESC = ClassDesc.of("io_smallrye.jandex_gizmo2.JandexGizmoSample");
+    private static final ClassDesc STATUS_DESC = ClassDesc.of("io_smallrye.jandex_gizmo2.JandexGizmoStatus");
+    private static final ClassDesc STRING_DESC = ClassDesc.of("java.lang.String");
+    private static final ClassDesc LIST_DESC = ClassDesc.of("java.util.List");
+    private static final ClassDesc MAP_DESC = ClassDesc.of("java.util.Map");
+    private static final ClassDesc NUMBER_DESC = ClassDesc.of("java.lang.Number");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void convertsDotNamesAndJandexTypesToClassDescriptors() {
+        assertThat(Jandex2Gizmo.classDescOf(DotName.createSimple("int"))).isEqualTo(CD_int);
+        assertThat(Jandex2Gizmo.classDescOf(DotName.createSimple("void"))).isEqualTo(CD_void);
+        assertThat(Jandex2Gizmo.classDescOf(DotName.createSimple("java.lang.String"))).isEqualTo(STRING_DESC);
+        assertThat(Jandex2Gizmo.classDescOf(DotName.createSimple("[[I"))).isEqualTo(ClassDesc.ofDescriptor("[[I"));
+        assertThat(Jandex2Gizmo.classDescOf(DotName.createSimple("[[Ljava.lang.String;")))
+                .isEqualTo(STRING_DESC.arrayType(2));
+
+        assertThat(Jandex2Gizmo.classDescOf(PrimitiveType.BOOLEAN)).isEqualTo(ClassDesc.ofDescriptor("Z"));
+        assertThat(Jandex2Gizmo.classDescOf(VoidType.VOID)).isEqualTo(CD_void);
+        assertThat(Jandex2Gizmo.classDescOf(ArrayType.create(ClassType.STRING_TYPE, 3)))
+                .isEqualTo(STRING_DESC.arrayType(3));
     }
+
+    @Test
+    void createsFieldMethodConstructorAndEnumDescriptorsFromIndexedClasses() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo sample = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoSample");
+
+        FieldDesc names = Jandex2Gizmo.fieldDescOf(sample.field("names"));
+        assertThat(names.owner()).isEqualTo(SAMPLE_DESC);
+        assertThat(names.name()).isEqualTo("names");
+        assertThat(names.type()).isEqualTo(LIST_DESC);
+
+        MethodInfo transform = sample.firstMethod("transform");
+        MethodDesc transformDesc = Jandex2Gizmo.methodDescOf(transform);
+        assertThat(transformDesc.owner()).isEqualTo(SAMPLE_DESC);
+        assertThat(transformDesc.name()).isEqualTo("transform");
+        assertThat(transformDesc.returnType()).isEqualTo(MAP_DESC);
+        assertThat(transformDesc.parameterTypes()).containsExactly(LIST_DESC, CD_int.arrayType());
+
+        ConstructorDesc constructorDesc = Jandex2Gizmo.constructorDescOf(sample.constructors().get(0));
+        assertThat(constructorDesc.owner()).isEqualTo(SAMPLE_DESC);
+        assertThat(constructorDesc.parameterTypes()).containsExactly(CD_int, STRING_DESC);
+
+        ClassInfo status = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoStatus");
+        assertThat(Jandex2Gizmo.constOfEnum(status.field("READY")).desc())
+                .isEqualTo(Enum.EnumDesc.of(STATUS_DESC, "READY"));
+    }
+
+    @Test
+    void convertsGenericClassesArraysTypeVariablesAndWildcards() throws IOException {
+        Type listOfString = ParameterizedType.create(List.class, ClassType.STRING_TYPE);
+        GenericType.OfClass listType = Jandex2Gizmo.genericTypeOfClass(listOfString);
+        assertThat(listType.desc()).isEqualTo(LIST_DESC);
+        assertThat(listType.typeArguments()).hasSize(1);
+        assertThat(listType.typeArguments().get(0).toString()).contains("java.lang.String");
+
+        Type mapWithWildcards = ParameterizedType.create(Map.class,
+                WildcardType.createUpperBound(ClassType.create(Number.class)),
+                WildcardType.createLowerBound(ClassType.STRING_TYPE));
+        GenericType.OfClass mapType = Jandex2Gizmo.genericTypeOfClass(mapWithWildcards);
+        List<String> wildcardArguments = mapType.typeArguments().stream().map(Object::toString).toList();
+        assertThat(mapType.desc()).isEqualTo(MAP_DESC);
+        assertThat(wildcardArguments)
+                .anySatisfy(argument -> assertThat(argument).contains("extends").contains("java.lang.Number"))
+                .anySatisfy(argument -> assertThat(argument).contains("super").contains("java.lang.String"));
+
+        GenericType.OfArray arrayType = Jandex2Gizmo.genericTypeOfArray(ArrayType.create(listOfString, 2));
+        assertThat(arrayType.desc()).isEqualTo(LIST_DESC.arrayType(2));
+        assertThat(arrayType.componentType().desc()).isEqualTo(LIST_DESC.arrayType());
+
+        TypeVariable typeVariable = sampleIndex()
+                .getClassByName("io_smallrye.jandex_gizmo2.JandexGizmoSample")
+                .typeParameters()
+                .get(0);
+        GenericType.OfTypeVariable gizmoTypeVariable = Jandex2Gizmo.genericTypeOfTypeVariable(typeVariable);
+        assertThat(gizmoTypeVariable.name()).isEqualTo("T");
+        assertThat(gizmoTypeVariable.desc()).isEqualTo(NUMBER_DESC);
+
+        TypeArgument unbounded = Jandex2Gizmo.typeArgumentOf(WildcardType.UNBOUNDED);
+        assertThat(unbounded.toString()).contains("?");
+    }
+
+    @Test
+    void preservesRuntimeVisibleAndClassRetentionTypeAnnotations() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo sample = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoSample");
+
+        GenericType visibleType = Jandex2Gizmo.genericTypeOf(sample.field("visibleName").type(), index);
+        assertThat(visibleType.hasVisibleAnnotations()).isTrue();
+        assertThat(visibleType.hasInvisibleAnnotations()).isFalse();
+
+        GenericType invisibleType = Jandex2Gizmo.genericTypeOf(sample.field("invisibleName").type(), index);
+        assertThat(invisibleType.hasInvisibleAnnotations()).isTrue();
+        assertThat(invisibleType.hasVisibleAnnotations()).isFalse();
+    }
+
+    @Test
+    void copiesAnnotationsTypeParametersModifiersAndFieldTypesIntoGeneratedBytecode() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo sample = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoSample");
+        FieldInfo namesField = sample.field("names");
+        FieldInfo copiedAnnotationField = sample.field("copiedAnnotation");
+        FieldInfo constantField = sample.field("CONSTANT");
+        Map<String, byte[]> generatedClasses = new LinkedHashMap<>();
+
+        Gizmo.create(generatedClasses::put).class_("io.smallrye.generated.CopiedJandexMetadata", cc -> {
+            Jandex2Gizmo.copyAnnotations(copiedAnnotationField, index).accept(cc);
+            Jandex2Gizmo.copyTypeParameters(sample, cc);
+
+            cc.field("copiedNames", fc -> {
+                fc.setType(Jandex2Gizmo.genericTypeOf(namesField.type(), index));
+                Jandex2Gizmo.copyModifiers(namesField, fc);
+                Jandex2Gizmo.copyAnnotations(namesField, index).accept(fc);
+            });
+            cc.staticField("copiedConstant", fc -> {
+                fc.setType(Jandex2Gizmo.classDescOf(constantField.type()));
+                Jandex2Gizmo.copyModifiers(constantField, fc);
+                fc.setInitial("copied");
+            });
+        });
+
+        assertThat(generatedClasses).hasSize(1);
+        assertThat(generatedClasses.values()).allSatisfy(Jandex_gizmo2Test::assertClassFile);
+    }
+
+    @Test
+    void stringBuilderGeneratorEmitsAppendCodeWithoutLoadingGeneratedClasses() {
+        Map<String, byte[]> generatedClasses = new LinkedHashMap<>();
+        ClassOutput output = generatedClasses::put;
+
+        Gizmo.create(output).class_("io.smallrye.generated.GeneratedStringBuilderUser", cc -> {
+            cc.staticMethod("message", mc -> {
+                mc.returning(String.class);
+                mc.body(bc -> {
+                    StringBuilderGen builder = StringBuilderGen.ofNew(32, bc)
+                            .append("answer=")
+                            .append(Const.of(42))
+                            .append(',')
+                            .appendCodePoint(32)
+                            .append(bc.newArray(char.class, Const.of('o'), Const.of('k')));
+                    builder.setLength(12);
+                    bc.return_(builder.append('!').toString_());
+                });
+            });
+        });
+
+        assertThat(generatedClasses).hasSize(1);
+        assertThat(generatedClasses.values()).allSatisfy(Jandex_gizmo2Test::assertClassFile);
+    }
+
+    @Test
+    void rejectsJandexObjectsThatDoNotMatchRequestedGizmoDescriptorKind() throws IOException {
+        Index index = sampleIndex();
+        ClassInfo sample = requireClass(index, "io_smallrye.jandex_gizmo2.JandexGizmoSample");
+        MethodInfo constructor = sample.constructors().get(0);
+        MethodInfo method = sample.firstMethod("transform");
+
+        assertThatThrownBy(() -> Jandex2Gizmo.methodDescOf(constructor))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("constructor");
+        assertThatThrownBy(() -> Jandex2Gizmo.constructorDescOf(method))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("regular method");
+        assertThatThrownBy(() -> Jandex2Gizmo.genericTypeOfReference(PrimitiveType.INT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("reference");
+        assertThatThrownBy(() -> Jandex2Gizmo.genericTypeOfPrimitive(ClassType.STRING_TYPE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("primitive");
+        assertThatThrownBy(() -> Jandex2Gizmo.typeArgumentOf(PrimitiveType.INT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Primitive types");
+        assertThatThrownBy(() -> Jandex2Gizmo.constOfEnum(sample.field("count")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not an enum constant");
+    }
+
+    private static Index sampleIndex() throws IOException {
+        return Index.of(JandexGizmoSample.class, JandexGizmoStatus.class, RuntimeMarker.class,
+                ClassRetentionMarker.class, FieldOnlyMarker.class, NestedRuntimeMarker.class);
+    }
+
+    private static ClassInfo requireClass(Index index, String name) {
+        ClassInfo classInfo = index.getClassByName(name);
+        assertThat(classInfo).isNotNull();
+        return classInfo;
+    }
+
+    private static void assertClassFile(byte[] bytes) {
+        assertThat(bytes).hasSizeGreaterThan(32);
+        assertThat(bytes[0]).isEqualTo((byte) 0xCA);
+        assertThat(bytes[1]).isEqualTo((byte) 0xFE);
+        assertThat(bytes[2]).isEqualTo((byte) 0xBA);
+        assertThat(bytes[3]).isEqualTo((byte) 0xBE);
+    }
+}
+
+@RuntimeMarker(
+        value = 9,
+        enabled = true,
+        byteValue = 1,
+        shortValue = 2,
+        longValue = 3L,
+        floatValue = 4.5F,
+        doubleValue = 6.5D,
+        charValue = 'z',
+        name = "sample",
+        type = String.class,
+        status = JandexGizmoStatus.READY,
+        nested = @NestedRuntimeMarker("nested"),
+        booleans = {},
+        bytes = {},
+        shorts = {},
+        ints = {},
+        longs = {},
+        floats = {},
+        doubles = {},
+        chars = {},
+        tags = {},
+        types = {},
+        statuses = {},
+        nestedArray = {})
+@ClassRetentionMarker(number = 11)
+class JandexGizmoSample<T extends Number & Comparable<T>> {
+    public static final String CONSTANT = "constant";
+
+    public int count;
+
+    List<@RuntimeMarker(3) String> names;
+
+    @RuntimeMarker(4)
+    String visibleName;
+
+    @ClassRetentionMarker(number = 5)
+    String invisibleName;
+
+    @FieldOnlyMarker("copy-me")
+    String copiedAnnotation;
+
+    JandexGizmoSample(int count, String visibleName) {
+        this.count = count;
+        this.visibleName = visibleName;
+    }
+
+    public Map<String, ? extends Number> transform(List<? super String> input, int[] numbers) {
+        return Map.of();
+    }
+
+    public <U extends CharSequence> U generic(U value) {
+        return value;
+    }
+}
+
+enum JandexGizmoStatus {
+    READY,
+    DONE
+}
+
+@Target({ ElementType.TYPE, ElementType.TYPE_USE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@interface RuntimeMarker {
+    int value();
+
+    boolean enabled() default false;
+
+    byte byteValue() default 0;
+
+    short shortValue() default 0;
+
+    long longValue() default 0L;
+
+    float floatValue() default 0.0F;
+
+    double doubleValue() default 0.0D;
+
+    char charValue() default 'a';
+
+    String name() default "";
+
+    Class<?> type() default Object.class;
+
+    JandexGizmoStatus status() default JandexGizmoStatus.READY;
+
+    NestedRuntimeMarker nested() default @NestedRuntimeMarker("default");
+
+    boolean[] booleans() default {};
+
+    byte[] bytes() default {};
+
+    short[] shorts() default {};
+
+    int[] ints() default {};
+
+    long[] longs() default {};
+
+    float[] floats() default {};
+
+    double[] doubles() default {};
+
+    char[] chars() default {};
+
+    String[] tags() default {};
+
+    Class<?>[] types() default {};
+
+    JandexGizmoStatus[] statuses() default {};
+
+    NestedRuntimeMarker[] nestedArray() default {};
+}
+
+@Target({ ElementType.TYPE, ElementType.TYPE_USE, ElementType.FIELD })
+@Retention(RetentionPolicy.CLASS)
+@interface ClassRetentionMarker {
+    int number();
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@interface FieldOnlyMarker {
+    String value();
+}
+
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+@interface NestedRuntimeMarker {
+    String value();
 }

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/resources/META-INF/native-image/io.smallrye/jandex-gizmo2-tests-only/resource-config.json
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/src/test/resources/META-INF/native-image/io.smallrye/jandex-gizmo2-tests-only/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "io_smallrye/jandex_gizmo2/.*[.]class"
+      }
+    ]
+  }
+}

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/user-code-filter.json
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.jandex.gizmo2.**"
+      "includeClasses" : "org.jboss.jandex.gizmo2.**"
+    },
+    {
+      "includeClasses" : "io_smallrye.jandex_gizmo2.**"
     }
   ]
 }

--- a/tests/src/io.smallrye/jandex-gizmo2/3.5.3/user-code-filter.json
+++ b/tests/src/io.smallrye/jandex-gizmo2/3.5.3/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.jandex.gizmo2.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #3807

This PR introduces tests and metadata for io.smallrye:jandex-gizmo2:3.5.3, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 254668
- Cached input tokens: 2627584
- Output tokens: 25822
- Metadata entries: 1
- Iterations: 5
- Library coverage percentage: 57.29
- Generated lines of code: 352
- Tested library lines of code: 169

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c4d65d49d9ee78d92ced11fc27480f37a14ff1b2`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 808/1500 (53.87%)
- Line: 169/295 (57.29%)
- Method: 46/57 (80.70%)

### Local CI Verification

- Status: `success`
- Commands run: 19
- Fixup attempts: 1
