### PR TITLE
[GenAI] Add support for org.eclipse.microprofile.config:microprofile-config-api:3.1.1-RC1 using gpt-5.5

### DIFF
--- a/metadata/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/reachability-metadata.json
+++ b/metadata/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.eclipse.microprofile.config.inject.ConfigProperties$Literal"
+      },
+      "type" : "org.eclipse.microprofile.config.inject.ConfigProperties",
+      "methods" : [
+        {
+          "name" : "prefix",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.eclipse.microprofile.config/microprofile-config-api/index.json
+++ b/metadata/org.eclipse.microprofile.config/microprofile-config-api/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.1.1-RC1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/$version$/microprofile-config-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/microprofile/microprofile-config",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-tck/$version$/microprofile-config-tck-$version$-sources.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-api/$version$/microprofile-config-api-$version$-javadoc.jar",
+    "description" : "MicroProfile Config API defines a standard Java API for retrieving configuration values from multiple configuration sources in MicroProfile applications. It supports typed conversion, programmatic lookup, and CDI injection of configuration properties so applications can remain portable across compliant runtimes.",
+    "tested-versions" : [
+      "3.1.1-RC1"
+    ],
+    "allowed-packages" : [
+      "org.eclipse.microprofile.config"
+    ]
+  }
+]

--- a/stats/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/execution-metrics.json
+++ b/stats/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/execution-metrics.json
@@ -1,0 +1,62 @@
+{
+  "add_new_library_support:2026-05-08": {
+    "timestamp": "2026-05-08T08:44:36.945061Z",
+    "library": "org.eclipse.microprofile.config:microprofile-config-api:3.1.1-RC1",
+    "starting_commit": "62c4dec85cf5fc869f2f7a017f992a1ec472de90",
+    "ending_commit": "31daa1b5f463408eeefe3342406ab79e9d5f3c1a",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.1.1-RC1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 94,
+          "missed": 36,
+          "ratio": 0.723077,
+          "total": 130
+        },
+        "line": {
+          "covered": 27,
+          "missed": 10,
+          "ratio": 0.72973,
+          "total": 37
+        },
+        "method": {
+          "covered": 15,
+          "missed": 1,
+          "ratio": 0.9375,
+          "total": 16
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 158053,
+      "cached_input_tokens_used": 1015808,
+      "output_tokens_used": 25385,
+      "iterations": 4,
+      "cost_usd": 1.2695,
+      "generated_loc": 420,
+      "tested_library_loc": 27,
+      "metadata_entries": 2,
+      "code_coverage_percent": 72.97
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java",
+      "metadata_file": "metadata/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/stats.json
+++ b/stats/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.1.1-RC1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 94,
+        "missed" : 36,
+        "ratio" : 0.723077,
+        "total" : 130
+      },
+      "line" : {
+        "covered" : 27,
+        "missed" : 10,
+        "ratio" : 0.72973,
+        "total" : 37
+      },
+      "method" : {
+        "covered" : 15,
+        "missed" : 1,
+        "ratio" : 0.9375,
+        "total" : 16
+      }
+    }
+  } ]
+}

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/.gitignore
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/build.gradle
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.eclipse.microprofile.config:microprofile-config-api:$libraryVersion"
+    testImplementation 'jakarta.enterprise:jakarta.enterprise.cdi-api:4.0.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/build.gradle
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.eclipse.microprofile.config:microprofile-config-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/gradle.properties
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.eclipse.microprofile.config:microprofile-config-api:3.1.1-RC1
+library.version = 3.1.1-RC1
+metadata.dir = org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/settings.gradle
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.eclipse.microprofile.config.microprofile-config-api_tests'

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_microprofile_config.microprofile_config_api;
+
+import org.junit.jupiter.api.Test;
+
+class Microprofile_config_apiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
@@ -203,6 +203,18 @@ public class Microprofile_config_apiTest {
         assertThat(Config.PROFILE).isEqualTo("mp.config.profile");
         assertThat(Config.PROPERTY_EXPRESSIONS_ENABLED).isEqualTo("mp.config.property.expressions.enabled");
     }
+
+    @Test
+    void configPropertiesLiteralSupportsQualifierAnnotationSemantics() {
+        ConfigProperties.Literal server = ConfigProperties.Literal.of("server");
+        ConfigProperties.Literal matchingServer = ConfigProperties.Literal.of("server");
+        ConfigProperties.Literal client = ConfigProperties.Literal.of("client");
+
+        assertThat(server).isInstanceOf(ConfigProperties.class);
+        assertThat(server).isEqualTo(matchingServer);
+        assertThat(server).hasSameHashCodeAs(matchingServer);
+        assertThat(server).isNotEqualTo(client);
+    }
 }
 
 final class MapBackedConfigSource implements ConfigSource {

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
@@ -6,11 +6,438 @@
  */
 package org_eclipse_microprofile_config.microprofile_config_api;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Microprofile_config_apiTest {
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@Timeout(10)
+public class Microprofile_config_apiTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void configSourceDefaultMethodsExposePropertiesAndOrdinalFallbacks() {
+        MapBackedConfigSource source = new MapBackedConfigSource("test-source", Map.of(
+                "alpha", "one",
+                "beta", "two",
+                ConfigSource.CONFIG_ORDINAL, "275"));
+
+        assertThat(source.getProperties())
+                .containsEntry("alpha", "one")
+                .containsEntry("beta", "two")
+                .containsEntry(ConfigSource.CONFIG_ORDINAL, "275");
+        assertThat(source.getOrdinal()).isEqualTo(275);
+
+        MapBackedConfigSource sourceWithoutOrdinal = new MapBackedConfigSource(
+                "default-ordinal", Map.of("alpha", "one"));
+        MapBackedConfigSource sourceWithInvalidOrdinal = new MapBackedConfigSource("invalid-ordinal", Map.of(
+                ConfigSource.CONFIG_ORDINAL, "not-an-integer"));
+
+        assertThat(sourceWithoutOrdinal.getOrdinal()).isEqualTo(ConfigSource.DEFAULT_ORDINAL);
+        assertThat(sourceWithInvalidOrdinal.getOrdinal()).isEqualTo(ConfigSource.DEFAULT_ORDINAL);
     }
+
+    @Test
+    void configDefaultListMethodsUseArrayLookups() {
+        InMemoryConfig config = InMemoryConfig.builder()
+                .withSources(new MapBackedConfigSource("lists", Map.of(
+                        "colors", "red,green,blue",
+                        "numbers", "1,2,3")))
+                .build();
+
+        assertThat(config.getValues("colors", String.class)).containsExactly("red", "green", "blue");
+        assertThat(config.getOptionalValues("numbers", Integer.class))
+                .hasValueSatisfying(values -> assertThat(values).containsExactly(1, 2, 3));
+        assertThat(config.getOptionalValues("missing", String.class)).isEmpty();
+    }
+
+    @Test
+    void configReadsHighestOrdinalSourceAndConvertsValues() {
+        MapBackedConfigSource lowPriority = new MapBackedConfigSource("low", Map.of(
+                ConfigSource.CONFIG_ORDINAL, "100",
+                "answer", "low",
+                "only.low", "present"));
+        MapBackedConfigSource highPriority = new MapBackedConfigSource("high", Map.of(
+                ConfigSource.CONFIG_ORDINAL, "500",
+                "answer", "high",
+                "enabled", "true",
+                "message", "microprofile"));
+
+        InMemoryConfig config = InMemoryConfig.builder()
+                .withSources(lowPriority, highPriority)
+                .withConverter(UpperCaseValue.class, 100, value -> new UpperCaseValue(value.toUpperCase()))
+                .build();
+
+        assertThat(config.getValue("answer", String.class)).isEqualTo("high");
+        assertThat(config.getValue("enabled", Boolean.class)).isTrue();
+        assertThat(config.getValue("message", UpperCaseValue.class).value()).isEqualTo("MICROPROFILE");
+        assertThat(config.getConverter(UpperCaseValue.class))
+                .hasValueSatisfying(converter -> assertThat(converter.convert("api").value()).isEqualTo("API"));
+        assertThat(config.getOptionalValue("missing", String.class)).isEmpty();
+        assertThatThrownBy(() -> config.getValue("missing", String.class)).isInstanceOf(NoSuchElementException.class);
+        assertThat(config.getPropertyNames()).containsExactlyInAnyOrder(
+                ConfigSource.CONFIG_ORDINAL, "answer", "only.low", "enabled", "message");
+        assertThat(config.getConfigSources()).containsExactly(highPriority, lowPriority);
+        assertThat(config.unwrap(InMemoryConfig.class)).isSameAs(config);
+    }
+
+    @Test
+    void configValueDescribesResolvedSourceMetadata() {
+        MapBackedConfigSource source = new MapBackedConfigSource("metadata", Map.of(
+                ConfigSource.CONFIG_ORDINAL, "350",
+                "host", "localhost"));
+        InMemoryConfig config = InMemoryConfig.builder().withSources(source).build();
+
+        ConfigValue value = config.getConfigValue("host");
+
+        assertThat(value.getName()).isEqualTo("host");
+        assertThat(value.getRawValue()).isEqualTo("localhost");
+        assertThat(value.getValue()).isEqualTo("localhost");
+        assertThat(value.getSourceName()).isEqualTo("metadata");
+        assertThat(value.getSourceOrdinal()).isEqualTo(350);
+
+        ConfigValue missing = config.getConfigValue("missing");
+        assertThat(missing.getName()).isEqualTo("missing");
+        assertThat(missing.getRawValue()).isNull();
+        assertThat(missing.getSourceName()).isNull();
+    }
+
+    @Test
+    void configSourceProviderReturnsConfiguredSources() {
+        MapBackedConfigSource source = new MapBackedConfigSource("provided", Map.of("key", "value"));
+        StaticConfigSourceProvider provider = new StaticConfigSourceProvider(List.of(source));
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Iterable<ConfigSource> configSources = provider.getConfigSources(classLoader);
+
+        assertThat(configSources).containsExactly(source);
+    }
+
+    @Test
+    @ResourceLock("microprofile-config-provider-resolver")
+    void configProviderDelegatesToConfiguredResolverAndBuilder() {
+        SimpleConfigProviderResolver resolver = new SimpleConfigProviderResolver();
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader testClassLoader = originalClassLoader;
+        ConfigProviderResolver.setInstance(resolver);
+        try {
+            Config config = resolver.getBuilder()
+                    .forClassLoader(testClassLoader)
+                    .addDefaultSources()
+                    .addDiscoveredSources()
+                    .addDiscoveredConverters()
+                    .withSources(new MapBackedConfigSource("provider", Map.of("name", "configured")))
+                    .build();
+            resolver.registerConfig(config, testClassLoader);
+
+            assertThat(ConfigProvider.getConfig()).isSameAs(config);
+            assertThat(ConfigProvider.getConfig(testClassLoader)).isSameAs(config);
+
+            resolver.releaseConfig(config);
+            assertThatThrownBy(() -> ConfigProvider.getConfig(testClassLoader))
+                    .isInstanceOf(IllegalStateException.class);
+        } finally {
+            ConfigProviderResolver.setInstance(null);
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void configPropertiesLiteralAndConstantsExposeSpecifiedSentinels() {
+        ConfigProperties.Literal literal = ConfigProperties.Literal.of("server");
+
+        assertThat(literal.prefix()).isEqualTo("server");
+        assertThat(ConfigProperties.Literal.NO_PREFIX.prefix()).isEqualTo(ConfigProperties.UNCONFIGURED_PREFIX);
+        assertThat(ConfigProperty.UNCONFIGURED_VALUE)
+                .isEqualTo("org.eclipse.microprofile.config.configproperty.unconfigureddvalue");
+        assertThat(Config.PROFILE).isEqualTo("mp.config.profile");
+        assertThat(Config.PROPERTY_EXPRESSIONS_ENABLED).isEqualTo("mp.config.property.expressions.enabled");
+    }
+}
+
+final class MapBackedConfigSource implements ConfigSource {
+    private final String name;
+    private final Map<String, String> properties;
+
+    MapBackedConfigSource(String name, Map<String, String> properties) {
+        this.name = name;
+        this.properties = new LinkedHashMap<>(properties);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return new LinkedHashSet<>(properties.keySet());
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}
+
+final class StaticConfigSourceProvider implements ConfigSourceProvider {
+    private final List<ConfigSource> sources;
+
+    StaticConfigSourceProvider(List<ConfigSource> sources) {
+        this.sources = List.copyOf(sources);
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+        return sources;
+    }
+}
+
+final class InMemoryConfig implements Config {
+    private final List<ConfigSource> sources;
+    private final Map<Class<?>, Converter<?>> converters;
+
+    InMemoryConfig(List<ConfigSource> sources, Map<Class<?>, Converter<?>> converters) {
+        this.sources = List.copyOf(sources);
+        this.converters = Map.copyOf(converters);
+    }
+
+    static InMemoryConfigBuilder builder() {
+        return new InMemoryConfigBuilder();
+    }
+
+    @Override
+    public <T> T getValue(String propertyName, Class<T> propertyType) {
+        return getOptionalValue(propertyName, propertyType)
+                .orElseThrow(() -> new NoSuchElementException(propertyName));
+    }
+
+    @Override
+    public ConfigValue getConfigValue(String propertyName) {
+        for (ConfigSource source : sources) {
+            String rawValue = source.getValue(propertyName);
+            if (rawValue != null) {
+                return new SimpleConfigValue(propertyName, rawValue, source.getName(), source.getOrdinal());
+            }
+        }
+        return new SimpleConfigValue(propertyName, null, null, 0);
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        String rawValue = getConfigValue(propertyName).getRawValue();
+        if (rawValue == null) {
+            return Optional.empty();
+        }
+        return Optional.of(convert(rawValue, propertyType));
+    }
+
+    @Override
+    public Iterable<String> getPropertyNames() {
+        Set<String> names = new LinkedHashSet<>();
+        for (ConfigSource source : sources) {
+            names.addAll(source.getPropertyNames());
+        }
+        return names;
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources() {
+        return sources;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+        return Optional.ofNullable((Converter<T>) converters.get(forType));
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        if (InMemoryConfig.class.equals(type) || Config.class.equals(type)) {
+            return type.cast(this);
+        }
+        throw new IllegalArgumentException("Unsupported unwrap type: " + type.getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T convert(String rawValue, Class<T> propertyType) {
+        Converter<T> converter = (Converter<T>) converters.get(propertyType);
+        if (converter != null) {
+            return converter.convert(rawValue);
+        }
+        if (String.class.equals(propertyType)) {
+            return propertyType.cast(rawValue);
+        }
+        if (Integer.class.equals(propertyType)) {
+            return propertyType.cast(Integer.valueOf(rawValue));
+        }
+        if (Boolean.class.equals(propertyType)) {
+            return propertyType.cast(Boolean.valueOf(rawValue));
+        }
+        if (String[].class.equals(propertyType)) {
+            return propertyType.cast(split(rawValue));
+        }
+        if (Integer[].class.equals(propertyType)) {
+            String[] parts = split(rawValue);
+            Integer[] values = new Integer[parts.length];
+            for (int i = 0; i < parts.length; i++) {
+                values[i] = Integer.valueOf(parts[i]);
+            }
+            return propertyType.cast(values);
+        }
+        throw new IllegalArgumentException("Unsupported conversion type: " + propertyType.getName());
+    }
+
+    private String[] split(String rawValue) {
+        String[] parts = rawValue.split(",");
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = parts[i].trim();
+        }
+        return parts;
+    }
+}
+
+final class InMemoryConfigBuilder implements ConfigBuilder {
+    private final List<ConfigSource> sources = new ArrayList<>();
+    private final Map<Class<?>, Converter<?>> converters = new HashMap<>();
+
+    @Override
+    public InMemoryConfigBuilder addDefaultSources() {
+        return this;
+    }
+
+    @Override
+    public InMemoryConfigBuilder addDiscoveredSources() {
+        return this;
+    }
+
+    @Override
+    public InMemoryConfigBuilder addDiscoveredConverters() {
+        return this;
+    }
+
+    @Override
+    public InMemoryConfigBuilder forClassLoader(ClassLoader classLoader) {
+        return this;
+    }
+
+    @Override
+    public InMemoryConfigBuilder withSources(ConfigSource... configSources) {
+        sources.addAll(List.of(configSources));
+        return this;
+    }
+
+    @Override
+    public InMemoryConfigBuilder withConverters(Converter<?>... converters) {
+        return this;
+    }
+
+    @Override
+    public <T> InMemoryConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter) {
+        converters.put(type, converter);
+        return this;
+    }
+
+    @Override
+    public InMemoryConfig build() {
+        List<ConfigSource> orderedSources = new ArrayList<>(sources);
+        orderedSources.sort(Comparator.comparingInt(ConfigSource::getOrdinal).reversed());
+        return new InMemoryConfig(orderedSources, converters);
+    }
+}
+
+final class SimpleConfigProviderResolver extends ConfigProviderResolver {
+    private final Map<ClassLoader, Config> configs = new HashMap<>();
+
+    @Override
+    public Config getConfig() {
+        return getConfig(Thread.currentThread().getContextClassLoader());
+    }
+
+    @Override
+    public Config getConfig(ClassLoader classLoader) {
+        Config config = configs.get(classLoader);
+        if (config == null) {
+            throw new IllegalStateException("No config registered for class loader");
+        }
+        return config;
+    }
+
+    @Override
+    public ConfigBuilder getBuilder() {
+        return InMemoryConfig.builder();
+    }
+
+    @Override
+    public void registerConfig(Config config, ClassLoader classLoader) {
+        configs.put(classLoader, config);
+    }
+
+    @Override
+    public void releaseConfig(Config config) {
+        configs.values().removeIf(config::equals);
+    }
+}
+
+final class SimpleConfigValue implements ConfigValue {
+    private final String name;
+    private final String value;
+    private final String sourceName;
+    private final int sourceOrdinal;
+
+    SimpleConfigValue(String name, String value, String sourceName, int sourceOrdinal) {
+        this.name = name;
+        this.value = value;
+        this.sourceName = sourceName;
+        this.sourceOrdinal = sourceOrdinal;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getRawValue() {
+        return value;
+    }
+
+    @Override
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    @Override
+    public int getSourceOrdinal() {
+        return sourceOrdinal;
+    }
+}
+
+record UpperCaseValue(String value) {
 }

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/src/test/java/org_eclipse_microprofile_config/microprofile_config_api/Microprofile_config_apiTest.java
@@ -163,6 +163,36 @@ public class Microprofile_config_apiTest {
     }
 
     @Test
+    @ResourceLock("microprofile-config-provider-resolver")
+    void configProviderResolvesConfigsByThreadContextAndExplicitClassLoaders() {
+        SimpleConfigProviderResolver resolver = new SimpleConfigProviderResolver();
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = new IsolatedClassLoader(originalClassLoader);
+        ClassLoader explicitClassLoader = new IsolatedClassLoader(originalClassLoader);
+        ConfigProviderResolver.setInstance(resolver);
+        try {
+            Config contextConfig = InMemoryConfig.builder()
+                    .withSources(new MapBackedConfigSource("context", Map.of("scope", "thread-context")))
+                    .build();
+            Config explicitConfig = InMemoryConfig.builder()
+                    .withSources(new MapBackedConfigSource("explicit", Map.of("scope", "explicit")))
+                    .build();
+            resolver.registerConfig(contextConfig, contextClassLoader);
+            resolver.registerConfig(explicitConfig, explicitClassLoader);
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+
+            assertThat(ConfigProvider.getConfig()).isSameAs(contextConfig);
+            assertThat(ConfigProvider.getConfig().getValue("scope", String.class)).isEqualTo("thread-context");
+            assertThat(ConfigProvider.getConfig(explicitClassLoader)).isSameAs(explicitConfig);
+            assertThat(ConfigProvider.getConfig(explicitClassLoader).getValue("scope", String.class))
+                    .isEqualTo("explicit");
+        } finally {
+            ConfigProviderResolver.setInstance(null);
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
     void configPropertiesLiteralAndConstantsExposeSpecifiedSentinels() {
         ConfigProperties.Literal literal = ConfigProperties.Literal.of("server");
 
@@ -210,6 +240,12 @@ final class StaticConfigSourceProvider implements ConfigSourceProvider {
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
         return sources;
+    }
+}
+
+final class IsolatedClassLoader extends ClassLoader {
+    IsolatedClassLoader(ClassLoader parent) {
+        super(parent);
     }
 }
 

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/user-code-filter.json
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.eclipse.microprofile.config.**"
+    }
+  ]
+}

--- a/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/user-code-filter.json
+++ b/tests/src/org.eclipse.microprofile.config/microprofile-config-api/3.1.1-RC1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.eclipse.microprofile.config.**"
+      "includeClasses" : "org.eclipse.microprofile.config.**"
+    },
+    {
+      "includeClasses" : "org_eclipse_microprofile_config.microprofile_config_api.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3799

This PR introduces tests and metadata for org.eclipse.microprofile.config:microprofile-config-api:3.1.1-RC1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 158053
- Cached input tokens: 1015808
- Output tokens: 25385
- Metadata entries: 2
- Iterations: 4
- Library coverage percentage: 72.97
- Generated lines of code: 420
- Tested library lines of code: 27

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `ai/vjovanov/human-intervention/issue-5418-library-new-request-com.typesafe.akka-akka-slf4j_2.13-2.6.21-821e2fdd`
- Forge commit hash: `455927c56274f70ee7b38e681ae72cbcb1adb56f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 2/2 covered calls (100.00%)
- Reflection: 2/2 covered calls (100.00%)

Library coverage:
- Instruction: 94/130 (72.31%)
- Line: 27/37 (72.97%)
- Method: 15/16 (93.75%)

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
