### PR TITLE
[GenAI] Test fix for org.seleniumhq.selenium:selenium-manager:4.11.0 using gpt-5.5

### DIFF
--- a/metadata/org.seleniumhq.selenium/selenium-manager/4.11.0/reachability-metadata.json
+++ b/metadata/org.seleniumhq.selenium/selenium-manager/4.11.0/reachability-metadata.json
@@ -1,0 +1,131 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "type" : "org.openqa.selenium.manager.SeleniumManagerOutput",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setLogs",
+          "parameterTypes" : [
+            "java.util.List"
+          ]
+        },
+        {
+          "name" : "setResult",
+          "parameterTypes" : [
+            "org.openqa.selenium.manager.SeleniumManagerOutput$Result"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "type" : "org.openqa.selenium.manager.SeleniumManagerOutput$Log",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setLevel",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setTimestamp",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "setMessage",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "type" : "org.openqa.selenium.manager.SeleniumManagerOutput$Result",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setCode",
+          "parameterTypes" : [
+            "int"
+          ]
+        },
+        {
+          "name" : "setMessage",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setDriverPath",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setBrowserPath",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "fromJson",
+          "parameterTypes" : [
+            "org.openqa.selenium.json.JsonInput"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "glob" : "org/openqa/selenium/manager/linux/selenium-manager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "glob" : "org/openqa/selenium/manager/macos/selenium-manager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.openqa.selenium.manager.SeleniumManager"
+      },
+      "glob" : "org/openqa/selenium/manager/windows/selenium-manager.exe"
+    }
+  ]
+}

--- a/metadata/org.seleniumhq.selenium/selenium-manager/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-manager/index.json
@@ -13,5 +13,14 @@
     "allowed-packages" : [
       "org.openqa.selenium.manager"
     ]
+  },
+  {
+    "metadata-version" : "4.11.0",
+    "tested-versions" : [
+      "4.11.0"
+    ],
+    "allowed-packages" : [
+      "org.openqa.selenium.manager"
+    ]
   }
 ]

--- a/metadata/org.seleniumhq.selenium/selenium-manager/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-manager/index.json
@@ -16,6 +16,11 @@
   },
   {
     "metadata-version" : "4.11.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-manager/$version$/selenium-manager-$version$-sources.jar",
+    "repository-url" : "https://github.com/SeleniumHQ/selenium/",
+    "test-code-url" : "https://github.com/SeleniumHQ/selenium/tree/selenium-$version$/rust/tests",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/seleniumhq/selenium/selenium-manager/$version$/selenium-manager-$version$-javadoc.jar",
+    "description" : "Selenium Manager provides the Java binding wrapper and bundled platform executables for Selenium's browser and driver management tool. It locates or downloads the browser driver required for Selenium WebDriver sessions and exposes the resolved driver path to the Java Selenium stack.",
     "tested-versions" : [
       "4.11.0"
     ],

--- a/stats/org.seleniumhq.selenium/selenium-manager/4.11.0/execution-metrics.json
+++ b/stats/org.seleniumhq.selenium/selenium-manager/4.11.0/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-05-08": {
+    "timestamp": "2026-05-08T09:01:23.263619Z",
+    "library": "org.seleniumhq.selenium:selenium-manager:4.11.0",
+    "starting_commit": "56662e3342385fb135a4b4b7923a7bde4266877c",
+    "ending_commit": "10d85d5a58d49288697c34539c9b6c434653a792",
+    "previous_library": "org.seleniumhq.selenium:selenium-manager:4.9.0",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.11.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 452,
+          "missed": 259,
+          "ratio": 0.635724,
+          "total": 711
+        },
+        "line": {
+          "covered": 116,
+          "missed": 70,
+          "ratio": 0.623656,
+          "total": 186
+        },
+        "method": {
+          "covered": 19,
+          "missed": 14,
+          "ratio": 0.575758,
+          "total": 33
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.9.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 298,
+          "missed": 184,
+          "ratio": 0.618257,
+          "total": 482
+        },
+        "line": {
+          "covered": 71,
+          "missed": 36,
+          "ratio": 0.663551,
+          "total": 107
+        },
+        "method": {
+          "covered": 18,
+          "missed": 9,
+          "ratio": 0.666667,
+          "total": 27
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 18862,
+      "cached_input_tokens_used": 41984,
+      "output_tokens_used": 722,
+      "iterations": 1,
+      "cost_usd": 0.0427,
+      "tested_library_loc": 116,
+      "metadata_entries": 20,
+      "previous_library_metadata_entries": 16,
+      "code_coverage_percent": 62.37,
+      "previous_library_coverage_percent": 66.36
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java",
+      "metadata_file": "metadata/org.seleniumhq.selenium/selenium-manager/4.11.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.seleniumhq.selenium/selenium-manager/4.11.0/stats.json
+++ b/stats/org.seleniumhq.selenium/selenium-manager/4.11.0/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "4.11.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 452,
+        "missed" : 259,
+        "ratio" : 0.635724,
+        "total" : 711
+      },
+      "line" : {
+        "covered" : 116,
+        "missed" : 70,
+        "ratio" : 0.623656,
+        "total" : 186
+      },
+      "method" : {
+        "covered" : 19,
+        "missed" : 14,
+        "ratio" : 0.575758,
+        "total" : 33
+      }
+    }
+  } ]
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/.gitignore
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/build.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.seleniumhq.selenium:selenium-manager:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/gradle.properties
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.seleniumhq.selenium:selenium-manager:4.11.0
+library.version = 4.11.0
+metadata.dir = org.seleniumhq.selenium/selenium-manager/4.11.0/

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/settings.gradle
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.seleniumhq.selenium.selenium-manager_tests'

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_seleniumhq_selenium.selenium_manager;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.manager.SeleniumManager;
+
+public class SeleniumManagerTest {
+    @Test
+    @Timeout(30)
+    void extractsBundledManagerBinaryBeforeRunningBrowserResolution() {
+        ImmutableCapabilities capabilities = new ImmutableCapabilities("browserName", "unknown-browser-for-test");
+
+        assertThatThrownBy(() -> SeleniumManager.getInstance().getDriverPath(capabilities))
+                .isInstanceOf(WebDriverException.class)
+                .hasMessageContaining("Invalid browser name: unknown-browser-for-test");
+    }
+}

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
@@ -20,7 +20,7 @@ public class SeleniumManagerTest {
     void extractsBundledManagerBinaryBeforeRunningBrowserResolution() {
         ImmutableCapabilities capabilities = new ImmutableCapabilities("browserName", "unknown-browser-for-test");
 
-        assertThatThrownBy(() -> SeleniumManager.getInstance().getDriverPath(capabilities))
+        assertThatThrownBy(() -> SeleniumManager.getInstance().getDriverPath(capabilities, false))
                 .isInstanceOf(WebDriverException.class)
                 .hasMessageContaining("Invalid browser name: unknown-browser-for-test");
     }

--- a/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/user-code-filter.json
+++ b/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.openqa.selenium.manager.**"
+    },
+    {
+      "includeClasses" : "org_seleniumhq_selenium.selenium_manager.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6530

This PR provides test fixes and new metadata for org.seleniumhq.selenium:selenium-manager:4.11.0, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 18862
- Cached input tokens: 41984
- Output tokens: 722
- Metadata entries: 20
- Iterations: 1
- Library coverage percentage: 62.37
- Previous library version metadata entries: 16
- Previous library version coverage percentage: 66.36

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1863992b1238d26a8907ba0efb207d994f8a93cb`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.seleniumhq.selenium:selenium-manager:4.9.0: 1/1 covered calls (100.00%)
- org.seleniumhq.selenium:selenium-manager:4.11.0: 1/1 covered calls (100.00%)

**Resources:**
- org.seleniumhq.selenium:selenium-manager:4.9.0: 1/1 covered calls (100.00%)
- org.seleniumhq.selenium:selenium-manager:4.11.0: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.seleniumhq.selenium:selenium-manager:4.9.0: 298/482 (61.83%)
- org.seleniumhq.selenium:selenium-manager:4.11.0: 452/711 (63.57%)

**Line:**
- org.seleniumhq.selenium:selenium-manager:4.9.0: 71/107 (66.36%)
- org.seleniumhq.selenium:selenium-manager:4.11.0: 116/186 (62.37%)

**Method:**
- org.seleniumhq.selenium:selenium-manager:4.9.0: 18/27 (66.67%)
- org.seleniumhq.selenium:selenium-manager:4.11.0: 19/33 (57.58%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.seleniumhq.selenium/selenium-manager/4.9.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java 2/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
index 739910b872..d13bad78c7 100644
--- 1/tests/src/org.seleniumhq.selenium/selenium-manager/4.9.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
+++ 2/tests/src/org.seleniumhq.selenium/selenium-manager/4.11.0/src/test/java/org_seleniumhq_selenium/selenium_manager/SeleniumManagerTest.java
@@ -20,7 +20,7 @@ public class SeleniumManagerTest {
     void extractsBundledManagerBinaryBeforeRunningBrowserResolution() {
         ImmutableCapabilities capabilities = new ImmutableCapabilities("browserName", "unknown-browser-for-test");
 
-        assertThatThrownBy(() -> SeleniumManager.getInstance().getDriverPath(capabilities))
+        assertThatThrownBy(() -> SeleniumManager.getInstance().getDriverPath(capabilities, false))
                 .isInstanceOf(WebDriverException.class)
                 .hasMessageContaining("Invalid browser name: unknown-browser-for-test");
     }

```

### Local CI Verification

- Status: `success`
- Commands run: 15
- Fixup attempts: 0
