### PR TITLE
Avoid bulk status rollup fetches for PR reviews

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -662,9 +662,39 @@ def get_pull_requests_with_labels(labels: list[str], fetch_limit: int) -> list[d
         *label_args,
         "--state", "open",
         "--limit", str(fetch_limit),
-        "--json", "number,title,url,author,labels,statusCheckRollup",
+        "--json", "number,title,url,author,labels",
     )
     return data
+
+
+def get_pull_request_status_check_rollup(pr_number: int) -> list[dict]:
+    """Fetch status check details for one pull request."""
+    data = gh_json(
+        "pr", "view",
+        str(pr_number),
+        "--repo", REPO,
+        "--json", "statusCheckRollup",
+    )
+    status_checks = data.get("statusCheckRollup")
+    return status_checks if isinstance(status_checks, list) else []
+
+
+def attach_pull_request_status_check_rollup(
+        pull_request: dict,
+        status_check_cache: dict[int, list[dict]],
+) -> dict:
+    """Return a pull request payload enriched with status check details."""
+    pr_number = pull_request.get("number")
+    if not isinstance(pr_number, int):
+        print("ERROR: Missing pull request number while fetching status checks.", file=sys.stderr)
+        raise RuntimeError("Missing pull request number while fetching status checks")
+
+    if pr_number not in status_check_cache:
+        status_check_cache[pr_number] = get_pull_request_status_check_rollup(pr_number)
+
+    enriched_pull_request = dict(pull_request)
+    enriched_pull_request["statusCheckRollup"] = status_check_cache[pr_number]
+    return enriched_pull_request
 
 
 def issue_has_label(issue: dict, label_name: str) -> bool:
@@ -1906,13 +1936,54 @@ def reconcile_reviewed_pull_request(pr_number: int) -> bool:
         return False
 
 
-def is_review_pull_request_eligible(pull_request: dict, authenticated_user: str) -> bool:
-    """Return True when the review queue may process the pull request."""
+def is_review_pull_request_base_eligible(
+        pull_request: dict,
+        authenticated_user: str,
+        excluded_labels: tuple[str, ...] = (),
+) -> bool:
+    """Return True when cheap pull request fields do not exclude review processing."""
     return (
         not is_authored_by_user(pull_request, authenticated_user)
         and not pull_request_has_label(pull_request, LABEL_HUMAN_INTERVENTION)
+        and not any(pull_request_has_label(pull_request, label) for label in excluded_labels)
+    )
+
+
+def is_review_pull_request_eligible(pull_request: dict, authenticated_user: str) -> bool:
+    """Return True when the review queue may process the pull request."""
+    return (
+        is_review_pull_request_base_eligible(pull_request, authenticated_user)
         and has_completed_ci_tasks(pull_request)
     )
+
+
+def select_ci_complete_review_pull_requests(
+        pull_requests: list[dict],
+        authenticated_user: str,
+        limit: int,
+        status_check_cache: dict[int, list[dict]],
+        excluded_labels: tuple[str, ...] = (),
+) -> tuple[list[dict], int]:
+    """Select review candidates, fetching CI details only after cheap filters pass."""
+    selected_pull_requests: list[dict] = []
+    incomplete_ci_count = 0
+
+    for pull_request in pull_requests:
+        if len(selected_pull_requests) >= limit:
+            break
+        if not is_review_pull_request_base_eligible(pull_request, authenticated_user, excluded_labels):
+            continue
+
+        enriched_pull_request = attach_pull_request_status_check_rollup(
+            pull_request,
+            status_check_cache,
+        )
+        if has_completed_ci_tasks(enriched_pull_request):
+            selected_pull_requests.append(enriched_pull_request)
+        else:
+            incomplete_ci_count += 1
+
+    return selected_pull_requests, incomplete_ci_count
 
 
 def get_review_log_path(pr_number: int, coordinates: str | None = None) -> str:
@@ -2138,15 +2209,18 @@ def process_pull_requests_with_label(
         review_model: str,
 ) -> None:
     """Review labeled pull requests that are CI-complete, not self-authored, and need no human intervention."""
+    status_check_cache: dict[int, list[dict]] = {}
     fetch_limit = max(limit, 20)
     fixed_pull_requests = get_pull_requests_with_labels(
         [label, LABEL_HUMAN_INTERVENTION_FIXED],
         fetch_limit,
     )
-    fixed_candidate_pull_requests = [
-        pull_request for pull_request in fixed_pull_requests
-        if is_review_pull_request_eligible(pull_request, authenticated_user)
-    ]
+    fixed_candidate_pull_requests, fixed_incomplete_ci_count = select_ci_complete_review_pull_requests(
+        fixed_pull_requests,
+        authenticated_user,
+        limit,
+        status_check_cache,
+    )
     while len(fixed_candidate_pull_requests) < limit and len(fixed_pull_requests) == fetch_limit:
         print(
             f"[Found {len(fixed_candidate_pull_requests)} eligible "
@@ -2159,13 +2233,20 @@ def process_pull_requests_with_label(
             [label, LABEL_HUMAN_INTERVENTION_FIXED],
             fetch_limit,
         )
-        fixed_candidate_pull_requests = [
-            pull_request for pull_request in fixed_pull_requests
-            if is_review_pull_request_eligible(pull_request, authenticated_user)
-        ]
+        fixed_candidate_pull_requests, fixed_incomplete_ci_count = select_ci_complete_review_pull_requests(
+            fixed_pull_requests,
+            authenticated_user,
+            limit,
+            status_check_cache,
+        )
 
     failed_reviews: list[int] = []
     fixed_pull_requests_to_merge = fixed_candidate_pull_requests[:limit]
+    if fixed_incomplete_ci_count:
+        print(
+            f"[Skipping {fixed_incomplete_ci_count} '{LABEL_HUMAN_INTERVENTION_FIXED}' "
+            "candidate PR(s) without completed CI tasks.]"
+        )
     for pull_request in fixed_pull_requests_to_merge:
         pr_number = pull_request["number"]
         print(
@@ -2207,11 +2288,13 @@ def process_pull_requests_with_label(
 
     fetch_limit = max(remaining_limit, 20)
     pull_requests = get_pull_requests_with_label(label, fetch_limit)
-    candidate_pull_requests = [
-        pull_request for pull_request in pull_requests
-        if is_review_pull_request_eligible(pull_request, authenticated_user)
-        and not pull_request_has_label(pull_request, LABEL_HUMAN_INTERVENTION_FIXED)
-    ]
+    candidate_pull_requests, incomplete_ci_count = select_ci_complete_review_pull_requests(
+        pull_requests,
+        authenticated_user,
+        remaining_limit,
+        status_check_cache,
+        excluded_labels=(LABEL_HUMAN_INTERVENTION_FIXED,),
+    )
     while len(candidate_pull_requests) < remaining_limit and len(pull_requests) == fetch_limit:
         print(
             f"[Found {len(candidate_pull_requests)} eligible PR(s) after filtering "
@@ -2219,11 +2302,13 @@ def process_pull_requests_with_label(
         )
         fetch_limit *= 2
         pull_requests = get_pull_requests_with_label(label, fetch_limit)
-        candidate_pull_requests = [
-            pull_request for pull_request in pull_requests
-            if is_review_pull_request_eligible(pull_request, authenticated_user)
-            and not pull_request_has_label(pull_request, LABEL_HUMAN_INTERVENTION_FIXED)
-        ]
+        candidate_pull_requests, incomplete_ci_count = select_ci_complete_review_pull_requests(
+            pull_requests,
+            authenticated_user,
+            remaining_limit,
+            status_check_cache,
+            excluded_labels=(LABEL_HUMAN_INTERVENTION_FIXED,),
+        )
 
     authored_pull_requests = [
         pull_request for pull_request in pull_requests
@@ -2232,10 +2317,6 @@ def process_pull_requests_with_label(
     human_intervention_pull_requests = [
         pull_request for pull_request in pull_requests
         if pull_request_has_label(pull_request, LABEL_HUMAN_INTERVENTION)
-    ]
-    incomplete_ci_pull_requests = [
-        pull_request for pull_request in pull_requests
-        if not has_completed_ci_tasks(pull_request)
     ]
     filtered_pull_requests = candidate_pull_requests[:remaining_limit]
 
@@ -2246,8 +2327,8 @@ def process_pull_requests_with_label(
             f"[Skipping {len(human_intervention_pull_requests)} PR(s) labeled "
             f"'{LABEL_HUMAN_INTERVENTION}'.]"
         )
-    if incomplete_ci_pull_requests:
-        print(f"[Skipping {len(incomplete_ci_pull_requests)} PR(s) without completed CI tasks.]")
+    if incomplete_ci_count:
+        print(f"[Skipping {incomplete_ci_count} candidate PR(s) without completed CI tasks.]")
 
     if not filtered_pull_requests and not fixed_pull_requests_to_merge:
         print(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -71,6 +71,27 @@ def _search_issue(number: int, label_names: list[str] | None = None) -> dict:
     }
 
 
+def _pull_request(
+        number: int,
+        label_names: list[str] | None = None,
+        author: str = "contributor",
+) -> dict:
+    return {
+        "number": number,
+        "title": f"Pull request {number}",
+        "url": f"https://github.com/oracle/graalvm-reachability-metadata/pull/{number}",
+        "author": {"login": author},
+        "labels": [
+            {"name": label_name}
+            for label_name in (label_names or [])
+        ],
+    }
+
+
+def _completed_status_check_rollup() -> list[dict]:
+    return [{"status": "COMPLETED"}]
+
+
 def _preflight(
         *,
         issue_number: int = 1412,
@@ -1368,6 +1389,74 @@ class WorkQueueSchedulerTests(unittest.TestCase):
         validate_environment.assert_not_called()
         process_issues.assert_not_called()
         process_reviews.assert_not_called()
+
+
+class PullRequestReviewSelectionTests(unittest.TestCase):
+    def test_bulk_pull_request_list_omits_status_check_rollup(self) -> None:
+        with patch.object(forge_metadata, "gh_json", return_value=[]) as gh_json:
+            self.assertEqual(
+                [],
+                forge_metadata.get_pull_requests_with_label(forge_metadata.LABEL_LIBRARY_NEW, 20),
+            )
+
+        args = gh_json.call_args.args
+        self.assertEqual("number,title,url,author,labels", args[-1])
+        self.assertNotIn("statusCheckRollup", args)
+
+    def test_process_pull_requests_fetches_ci_only_after_cheap_filters(self) -> None:
+        buried_pull_requests = [
+            _pull_request(
+                number,
+                [
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    forge_metadata.LABEL_HUMAN_INTERVENTION,
+                ],
+            )
+            for number in range(1, 21)
+        ]
+        eligible_pull_request = _pull_request(100, [forge_metadata.LABEL_LIBRARY_NEW])
+
+        with patch.object(forge_metadata, "get_pull_requests_with_labels", return_value=[]), \
+                patch.object(
+                    forge_metadata,
+                    "get_pull_requests_with_label",
+                    side_effect=[
+                        buried_pull_requests,
+                        [*buried_pull_requests, eligible_pull_request],
+                    ],
+                ) as get_pull_requests, \
+                patch.object(
+                    forge_metadata,
+                    "get_pull_request_status_check_rollup",
+                    return_value=_completed_status_check_rollup(),
+                ) as get_status_checks, \
+                patch.object(forge_metadata, "review_pull_request", return_value=True) as review_pull_request, \
+                patch.object(
+                    forge_metadata,
+                    "reconcile_reviewed_pull_request",
+                    return_value=True,
+                ) as reconcile_reviewed_pull_request:
+            forge_metadata.process_pull_requests_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                1,
+                "/tmp/reachability",
+                "automation-user",
+                "review-model",
+            )
+
+        get_pull_requests.assert_has_calls([
+            call(forge_metadata.LABEL_LIBRARY_NEW, 20),
+            call(forge_metadata.LABEL_LIBRARY_NEW, 40),
+        ])
+        get_status_checks.assert_called_once_with(100)
+        review_pull_request.assert_called_once_with(
+            100,
+            "/tmp/reachability",
+            "review-model",
+            "https://github.com/oracle/graalvm-reachability-metadata/pull/100",
+            None,
+        )
+        reconcile_reviewed_pull_request.assert_called_once_with(100)
 
 
 class IssueClaimCacheTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- list PR review candidates without `statusCheckRollup` in the bulk `gh pr list` query
- filter self-authored, human-intervention, and excluded-label PRs before fetching CI details
- fetch and cache `statusCheckRollup` only for candidate PRs that survive cheap filtering
- add regression coverage for buried human-intervention PRs

## Testing
- `.venv/bin/python -m unittest tests.test_forge_metadata.PullRequestReviewSelectionTests`
- `.venv/bin/python -m py_compile forge_metadata.py tests/test_forge_metadata.py`
- `git diff --check -- forge/forge_metadata.py forge/tests/test_forge_metadata.py`

Closes #6550