### PR TITLE
[GenAI] Test fix for io.ktor:ktor-network-tls-jvm:3.4.1 using gpt-5.5

### DIFF
--- a/metadata/io.ktor/ktor-network-tls-jvm/3.4.1/reachability-metadata.json
+++ b/metadata/io.ktor/ktor-network-tls-jvm/3.4.1/reachability-metadata.json
@@ -1,0 +1,124 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilderKt"
+      },
+      "type": "com.sun.crypto.provider.PBES2Parameters$General"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.ByteChannel"
+      },
+      "type": "io.ktor.utils.io.ByteChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshake$handshakes$1"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshakeKt"
+      },
+      "type": "java.net.InetAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshakeKt"
+      },
+      "type": "java.net.InterfaceAddress[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshakeKt"
+      },
+      "type": "java.net.NetworkInterface[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilderKt"
+      },
+      "type": "java.security.cert.X509Certificate[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshake"
+      },
+      "type": "kotlinx.coroutines.CancellableContinuationImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientSessionJvmKt"
+      },
+      "type": "kotlinx.coroutines.CancelledContinuation"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshake"
+      },
+      "type": "kotlinx.coroutines.channels.BufferedChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshake"
+      },
+      "type": "kotlinx.coroutines.internal.ConcurrentLinkedListNode"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSClientHandshake"
+      },
+      "type": "kotlinx.coroutines.internal.Segment"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.ByteWriteChannelOperationsKt"
+      },
+      "type": "kotlinx.coroutines.scheduling.CoroutineScheduler$Worker"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.ByteWriteChannelOperationsKt"
+      },
+      "type": "kotlinx.coroutines.scheduling.WorkQueue"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.core.BytePacketBuilderKt"
+      },
+      "type": "kotlinx.io.RefCountingCopyTracker"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilder"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSKt"
+      },
+      "type": "sun.security.provider.SecureRandom"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilderKt"
+      },
+      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilderKt"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.network.tls.TLSConfigBuilderKt"
+      },
+      "type": "sun.security.util.DerValue[]"
+    }
+  ]
+}

--- a/metadata/io.ktor/ktor-network-tls-jvm/index.json
+++ b/metadata/io.ktor/ktor-network-tls-jvm/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.4.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
+    "repository-url" : "https://github.com/ktorio/ktor",
+    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-network/ktor-network-tls/jvm/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-javadoc.jar",
+    "description" : "ktor-network-tls-jvm provides the JVM implementation of Ktor's TLS support for network sockets, including TLS sessions, handshakes, records, cipher suites, and certificate/key handling. It lets Ktor networking code open TLS-protected client sessions over JVM sockets using Kotlin coroutine-based APIs.",
     "language" : {
       "name" : "kotlin",
       "version" : "2.1"

--- a/metadata/io.ktor/ktor-network-tls-jvm/index.json
+++ b/metadata/io.ktor/ktor-network-tls-jvm/index.json
@@ -1,38 +1,40 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.4.1",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
-    "repository-url" : "https://github.com/ktorio/ktor",
-    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-network/ktor-network-tls/jvm/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-javadoc.jar",
-    "description" : "ktor-network-tls-jvm provides the JVM implementation of Ktor's TLS support for network sockets, including TLS sessions, handshakes, records, cipher suites, and certificate/key handling. It lets Ktor networking code open TLS-protected client sessions over JVM sockets using Kotlin coroutine-based APIs.",
-    "language" : {
-      "name" : "kotlin",
-      "version" : "2.1"
+    "latest": true,
+    "metadata-version": "3.4.1",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
+    "repository-url": "https://github.com/ktorio/ktor",
+    "test-code-url": "https://github.com/ktorio/ktor/tree/$version$/ktor-network/ktor-network-tls/jvm/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-javadoc.jar",
+    "description": "ktor-network-tls-jvm provides the JVM implementation of Ktor's TLS support for network sockets, including TLS sessions, handshakes, records, cipher suites, and certificate/key handling. It lets Ktor networking code open TLS-protected client sessions over JVM sockets using Kotlin coroutine-based APIs.",
+    "language": {
+      "name": "kotlin",
+      "version": "2.1"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.4.1"
     ],
-    "allowed-packages" : [
-      "io.ktor.network.tls"
+    "allowed-packages": [
+      "io.ktor.network.tls",
+      "io.ktor.utils.io",
+      "io.ktor.utils.io.core"
     ]
   },
   {
-    "metadata-version" : "3.2.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
-    "repository-url" : "https://github.com/ktorio/ktor",
-    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-network/ktor-network-tls/jvm/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-javadoc.jar",
-    "description" : "ktor-network-tls-jvm provides the JVM implementation of Ktor's TLS support for network sockets, including TLS sessions, handshakes, records, cipher suites, and certificate/key handling. It lets Ktor networking code open TLS-protected client sessions over JVM sockets using Kotlin coroutine-based APIs.",
-    "language" : {
-      "name" : "kotlin",
-      "version" : "2.1"
+    "metadata-version": "3.2.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
+    "repository-url": "https://github.com/ktorio/ktor",
+    "test-code-url": "https://github.com/ktorio/ktor/tree/$version$/ktor-network/ktor-network-tls/jvm/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-javadoc.jar",
+    "description": "ktor-network-tls-jvm provides the JVM implementation of Ktor's TLS support for network sockets, including TLS sessions, handshakes, records, cipher suites, and certificate/key handling. It lets Ktor networking code open TLS-protected client sessions over JVM sockets using Kotlin coroutine-based APIs.",
+    "language": {
+      "name": "kotlin",
+      "version": "2.1"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.ktor.network.tls"
     ]
   }

--- a/metadata/io.ktor/ktor-network-tls-jvm/index.json
+++ b/metadata/io.ktor/ktor-network-tls-jvm/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.4.1",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.1"
+    },
+    "tested-versions" : [
+      "3.4.1"
+    ],
+    "allowed-packages" : [
+      "io.ktor.network.tls"
+    ]
+  },
+  {
     "metadata-version" : "3.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/$version$/ktor-network-tls-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/ktorio/ktor",

--- a/stats/io.ktor/ktor-network-tls-jvm/3.4.1/execution-metrics.json
+++ b/stats/io.ktor/ktor-network-tls-jvm/3.4.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-08": {
+    "timestamp": "2026-05-08T13:59:40.657358Z",
+    "library": "io.ktor:ktor-network-tls-jvm:3.4.1",
+    "starting_commit": "3f751663704e0e4b41198fa852af67bb5211586e",
+    "ending_commit": "64f3e08961141aa07031858a5f1e2e24bb464cf5",
+    "previous_library": "io.ktor:ktor-network-tls-jvm:3.2.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.4.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3733,
+          "missed": 6041,
+          "ratio": 0.381932,
+          "total": 9774
+        },
+        "line": {
+          "covered": 503,
+          "missed": 862,
+          "ratio": 0.368498,
+          "total": 1365
+        },
+        "method": {
+          "covered": 167,
+          "missed": 164,
+          "ratio": 0.504532,
+          "total": 331
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 3675,
+          "missed": 5561,
+          "ratio": 0.3979,
+          "total": 9236
+        },
+        "line": {
+          "covered": 502,
+          "missed": 866,
+          "ratio": 0.366959,
+          "total": 1368
+        },
+        "method": {
+          "covered": 167,
+          "missed": 164,
+          "ratio": 0.504532,
+          "total": 331
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 21394,
+      "cached_input_tokens_used": 97792,
+      "output_tokens_used": 938,
+      "iterations": 1,
+      "cost_usd": 0.077,
+      "tested_library_loc": 503,
+      "metadata_entries": 20,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 36.85,
+      "previous_library_coverage_percent": 36.7
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_network_tls_jvm/Ktor_network_tls_jvmTest.kt",
+      "metadata_file": "metadata/io.ktor/ktor-network-tls-jvm/3.4.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.ktor/ktor-network-tls-jvm/3.4.1/stats.json
+++ b/stats/io.ktor/ktor-network-tls-jvm/3.4.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.4.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 3733,
+        "missed" : 6041,
+        "ratio" : 0.381932,
+        "total" : 9774
+      },
+      "line" : {
+        "covered" : 503,
+        "missed" : 862,
+        "ratio" : 0.368498,
+        "total" : 1365
+      },
+      "method" : {
+        "covered" : 167,
+        "missed" : 164,
+        "ratio" : 0.504532,
+        "total" : 331
+      }
+    }
+  } ]
+}

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/.gitignore
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/gradle.properties
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.ktor:ktor-network-tls-jvm:3.4.1
+library.version = 3.4.1
+metadata.dir = io.ktor/ktor-network-tls-jvm/3.4.1/

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/settings.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.ktor.ktor-network-tls-jvm_tests'

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_network_tls_jvm/Ktor_network_tls_jvmTest.kt
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_network_tls_jvm/Ktor_network_tls_jvmTest.kt
@@ -179,7 +179,7 @@ public class Ktor_network_tls_jvmTest {
         assertThat(keysGenerationAlgorithm("SHA256withRSA")).isEqualTo("RSA")
         assertThatThrownBy { OID.fromAlgorithm("SHA3withRSA") }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Could't find OID")
+            .hasMessageContaining("Couldn't find OID")
         assertThatThrownBy { keysGenerationAlgorithm("Ed25519") }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Couldn't find KeyPairGenerator algorithm")

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_network_tls_jvm/Ktor_network_tls_jvmTest.kt
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_network_tls_jvm/Ktor_network_tls_jvmTest.kt
@@ -1,0 +1,428 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_ktor.ktor_network_tls_jvm
+
+import io.ktor.network.sockets.InetSocketAddress
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.SocketAddress
+import io.ktor.network.tls.CIOCipherSuites
+import io.ktor.network.tls.CipherType
+import io.ktor.network.tls.NoPrivateKeyException
+import io.ktor.network.tls.OID
+import io.ktor.network.tls.SecretExchangeType
+import io.ktor.network.tls.ServerKeyExchangeType
+import io.ktor.network.tls.TLSAlertLevel
+import io.ktor.network.tls.TLSAlertType
+import io.ktor.network.tls.TLSConfigBuilder
+import io.ktor.network.tls.TLSHandshakeType
+import io.ktor.network.tls.TLSRecordType
+import io.ktor.network.tls.TLSVersion
+import io.ktor.network.tls.addCertificateChain
+import io.ktor.network.tls.addKeyStore
+import io.ktor.network.tls.extensions.HashAlgorithm
+import io.ktor.network.tls.extensions.HashAndSign
+import io.ktor.network.tls.extensions.NamedCurve
+import io.ktor.network.tls.extensions.PointFormat
+import io.ktor.network.tls.extensions.SignatureAlgorithm
+import io.ktor.network.tls.extensions.SupportedNamedCurves
+import io.ktor.network.tls.extensions.SupportedPointFormats
+import io.ktor.network.tls.extensions.SupportedSignatureAlgorithms
+import io.ktor.network.tls.extensions.TLSExtensionType
+import io.ktor.network.tls.extensions.byCode
+import io.ktor.network.tls.keysGenerationAlgorithm
+import io.ktor.network.tls.takeFrom
+import io.ktor.network.tls.tls
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ReaderJob
+import io.ktor.utils.io.WriterJob
+import io.ktor.utils.io.reader
+import io.ktor.utils.io.writer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.EOFException
+import java.security.KeyFactory
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Duration
+import java.util.Base64
+import java.util.concurrent.CancellationException
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+public class Ktor_network_tls_jvmTest {
+    @Test
+    fun cipherSuitesExposeTlsParametersAndPlatformSupportedList(): Unit {
+        val suite = CIOCipherSuites.ECDHE_RSA_AES128_SHA256
+
+        assertThat(suite.code).isEqualTo(0xc02f.toShort())
+        assertThat(suite.name).isEqualTo("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+        assertThat(suite.openSSLName).isEqualTo("ECDHE-RSA-AES128-GCM-SHA256")
+        assertThat(suite.exchangeType).isEqualTo(SecretExchangeType.ECDHE)
+        assertThat(suite.exchangeType.jvmName).isEqualTo("ECDHE_ECDSA")
+        assertThat(suite.jdkCipherName).isEqualTo("AES/GCM/NoPadding")
+        assertThat(suite.keyStrength).isEqualTo(128)
+        assertThat(suite.keyStrengthInBytes).isEqualTo(16)
+        assertThat(suite.fixedIvLength).isEqualTo(4)
+        assertThat(suite.ivLength).isEqualTo(12)
+        assertThat(suite.cipherTagSizeInBytes).isEqualTo(16)
+        assertThat(suite.macName).isEqualTo("AEAD")
+        assertThat(suite.macStrengthInBytes).isZero()
+        assertThat(suite.hash).isEqualTo(HashAlgorithm.SHA256)
+        assertThat(suite.signatureAlgorithm).isEqualTo(SignatureAlgorithm.RSA)
+        assertThat(suite.cipherType).isEqualTo(CipherType.GCM)
+        assertThat(CIOCipherSuites.SupportedSuites).contains(suite)
+        assertThat(CIOCipherSuites.SupportedSuites).allSatisfy { supported ->
+            assertThat(supported.keyStrengthInBytes).isEqualTo(supported.keyStrength / 8)
+            assertThat(supported.macStrengthInBytes).isEqualTo(supported.macStrength / 8)
+        }
+    }
+
+    @Test
+    fun enumCompanionsDecodeValidCodesAndRejectUnknownCodes(): Unit {
+        assertThat(TLSVersion.byCode(0x0300)).isEqualTo(TLSVersion.SSL3)
+        assertThat(TLSVersion.byCode(0x0303)).isEqualTo(TLSVersion.TLS12)
+        assertThat(TLSRecordType.byCode(0x16)).isEqualTo(TLSRecordType.Handshake)
+        assertThat(TLSHandshakeType.byCode(0x10)).isEqualTo(TLSHandshakeType.ClientKeyExchange)
+        assertThat(ServerKeyExchangeType.byCode(3)).isEqualTo(ServerKeyExchangeType.NamedCurve)
+        assertThat(TLSAlertLevel.byCode(2)).isEqualTo(TLSAlertLevel.FATAL)
+        assertThat(TLSAlertType.byCode(48)).isEqualTo(TLSAlertType.UnknownCa)
+        assertThat(TLSExtensionType.byCode(13)).isEqualTo(TLSExtensionType.SIGNATURE_ALGORITHMS)
+
+        assertThatThrownBy { TLSVersion.byCode(0x0304) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS version code")
+        assertThatThrownBy { TLSRecordType.byCode(0xff) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS record type code")
+        assertThatThrownBy { TLSHandshakeType.byCode(0xff) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS handshake type code")
+        assertThatThrownBy { ServerKeyExchangeType.byCode(-1) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS ServerKeyExchange type code")
+        assertThatThrownBy { TLSAlertLevel.byCode(3) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS record type code")
+        assertThatThrownBy { TLSAlertType.byCode(255) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Invalid TLS record type code")
+        assertThatThrownBy { TLSExtensionType.byCode(255) }
+            .isInstanceOf(Exception::class.java)
+            .hasMessageContaining("Unknown server hello extension type")
+    }
+
+    @Test
+    fun tlsExtensionsAndSignatureAlgorithmsExposeSupportedValues(): Unit {
+        assertThat(NamedCurve.fromCode(23)).isEqualTo(NamedCurve.secp256r1)
+        assertThat(NamedCurve.fromCode(Short.MAX_VALUE)).isNull()
+        assertThat(NamedCurve.secp384r1.fieldSize).isEqualTo(384)
+        assertThat(SupportedNamedCurves).containsExactly(NamedCurve.secp256r1, NamedCurve.secp384r1)
+        assertThat(SupportedPointFormats).containsExactly(
+            PointFormat.UNCOMPRESSED,
+            PointFormat.ANSIX962_COMPRESSED_PRIME,
+            PointFormat.ANSIX962_COMPRESSED_CHAR2
+        )
+
+        assertThat(HashAlgorithm.byCode(4)).isEqualTo(HashAlgorithm.SHA256)
+        assertThat(HashAlgorithm.SHA384.openSSLName).isEqualTo("SHA-384")
+        assertThat(HashAlgorithm.SHA384.macName).isEqualTo("HmacSHA384")
+        assertThat(SignatureAlgorithm.byCode(1)).isEqualTo(SignatureAlgorithm.RSA)
+        assertThat(SignatureAlgorithm.byCode(Byte.MAX_VALUE)).isNull()
+
+        val known = HashAndSign.byCode(HashAlgorithm.SHA256.code, SignatureAlgorithm.RSA.code)
+        assertThat(known).isNotNull()
+        assertThat(known!!.name).isEqualTo("SHA256withRSA")
+        assertThat(known.oid).isEqualTo(OID.RSAwithSHA256Encryption)
+        assertThat(SupportedSignatureAlgorithms).contains(known)
+
+        val syntacticallyValidButUnsupported = HashAndSign.byCode(
+            HashAlgorithm.SHA512.code,
+            SignatureAlgorithm.ECDSA.code
+        )
+        assertThat(syntacticallyValidButUnsupported).isNotNull()
+        assertThat(syntacticallyValidButUnsupported!!.name).isEqualTo("SHA512withECDSA")
+        assertThat(syntacticallyValidButUnsupported.oid).isNull()
+
+        assertThatThrownBy { HashAlgorithm.byCode(Byte.MAX_VALUE) }
+            .isInstanceOf(Exception::class.java)
+            .hasMessageContaining("Unknown hash algorithm")
+        assertThatThrownBy { HashAndSign.byCode(HashAlgorithm.SHA256.code, SignatureAlgorithm.ANON.code) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Anonymous signature not allowed")
+    }
+
+    @Test
+    fun oidAndKeyGenerationHelpersMapStandardAlgorithms(): Unit {
+        val rsaEncryption = OID.RSAEncryption
+        assertThat(rsaEncryption.identifier).isEqualTo("1 2 840 113549 1 1 1")
+        assertThat(rsaEncryption.asArray.toList()).containsExactly(1, 2, 840, 113549, 1, 1, 1)
+        assertThat(OID.CommonName.asArray.toList()).containsExactly(2, 5, 4, 3)
+        assertThat(OID.fromAlgorithm("SHA384withECDSA")).isEqualTo(OID.ECDSAwithSHA384Encryption)
+        assertThat(OID.fromAlgorithm("SHA256withRSA")).isEqualTo(OID.RSAwithSHA256Encryption)
+
+        assertThat(keysGenerationAlgorithm("SHA256withECDSA")).isEqualTo("EC")
+        assertThat(keysGenerationAlgorithm("SHA256withDSA")).isEqualTo("DSA")
+        assertThat(keysGenerationAlgorithm("SHA256withRSA")).isEqualTo("RSA")
+        assertThatThrownBy { OID.fromAlgorithm("SHA3withRSA") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Could't find OID")
+        assertThatThrownBy { keysGenerationAlgorithm("Ed25519") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Couldn't find KeyPairGenerator algorithm")
+    }
+
+    @Test
+    fun tlsConfigBuilderProvidesDefaultsAndRejectsUnsupportedTrustManagers(): Unit {
+        val defaultConfig = TLSConfigBuilder().build()
+
+        assertThat(defaultConfig.random).isNotNull()
+        assertThat(defaultConfig.trustManager).isInstanceOf(X509TrustManager::class.java)
+        assertThat(defaultConfig.cipherSuites).containsExactlyElementsOf(CIOCipherSuites.SupportedSuites)
+        assertThat(defaultConfig.certificates).isEmpty()
+        assertThat(defaultConfig.serverName).isNull()
+
+        assertThatThrownBy {
+            TLSConfigBuilder().trustManager = object : TrustManager { }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Only [X509TrustManager] supported")
+    }
+
+    @Test
+    fun tlsConfigBuilderCopiesExplicitSettingsAndLoadsCertificateChains(): Unit {
+        val random = SecureRandom.getInstance("SHA1PRNG")
+        val trustManager = trustAllManager()
+        val certificate = testCertificate()
+        val privateKey = testPrivateKey()
+        val source = TLSConfigBuilder().apply {
+            this.random = random
+            this.trustManager = trustManager
+            this.cipherSuites = listOf(CIOCipherSuites.ECDHE_RSA_AES128_SHA256)
+            this.serverName = "source.example.test"
+            addCertificateChain(arrayOf(certificate), privateKey)
+        }
+
+        val copiedConfig = TLSConfigBuilder().apply { takeFrom(source) }.build()
+
+        assertThat(copiedConfig.random).isSameAs(random)
+        assertThat(copiedConfig.trustManager).isSameAs(trustManager)
+        assertThat(copiedConfig.cipherSuites).containsExactly(CIOCipherSuites.ECDHE_RSA_AES128_SHA256)
+        assertThat(copiedConfig.serverName).isEqualTo("source.example.test")
+        assertThat(copiedConfig.certificates).hasSize(1)
+        assertThat(copiedConfig.certificates.single().certificateChain).containsExactly(certificate)
+        assertThat(copiedConfig.certificates.single().key).isSameAs(privateKey)
+
+        val keyStoreConfig = TLSConfigBuilder().apply {
+            addKeyStore(testKeyStore(), KEY_PASSWORD, TEST_KEY_ALIAS)
+        }.build()
+
+        assertThat(keyStoreConfig.certificates).hasSize(1)
+        assertThat(keyStoreConfig.certificates.single().certificateChain.single().subjectX500Principal.name)
+            .contains("CN=localhost")
+    }
+
+    @Test
+    fun keyStoreLoadingFailsForMissingAlias(): Unit {
+        assertThatThrownBy {
+            TLSConfigBuilder().addKeyStore(testKeyStore(), KEY_PASSWORD, "missing")
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .isNotInstanceOf(NoPrivateKeyException::class.java)
+            .hasMessageContaining("Fail to get the certificate chain")
+    }
+
+    @Test
+    fun keyStoreLoadingWithoutExplicitAliasLoadsAllCertificateEntries(): Unit {
+        val keyStore = KeyStore.getInstance("PKCS12").apply {
+            load(null, null)
+            setKeyEntry(
+                "primary",
+                testPrivateKey(),
+                KEY_PASSWORD,
+                arrayOf<java.security.cert.Certificate>(testCertificate())
+            )
+            setKeyEntry(
+                "secondary",
+                testPrivateKey(),
+                KEY_PASSWORD,
+                arrayOf<java.security.cert.Certificate>(testCertificate())
+            )
+        }
+
+        val config = TLSConfigBuilder().apply {
+            addKeyStore(keyStore, KEY_PASSWORD)
+        }.build()
+
+        assertThat(config.certificates).hasSize(2)
+        assertThat(config.certificates)
+            .allSatisfy { certificateAndKey ->
+                assertThat(certificateAndKey.certificateChain.single().subjectX500Principal.name)
+                    .contains("CN=localhost")
+                assertThat(certificateAndKey.key.algorithm).isEqualTo("RSA")
+            }
+    }
+
+    @Test
+    fun tlsClosesUnderlyingSocketWhenHandshakeChannelFails(): Unit = runBlocking {
+        val socket = ImmediateEofSocket()
+        var failure: Throwable? = null
+
+        try {
+            withTimeout(Duration.ofSeconds(5).toMillis()) {
+                socket.tls(coroutineContext) {
+                    trustManager = trustAllManager()
+                    random = SecureRandom.getInstance("SHA1PRNG")
+                    cipherSuites = listOf(CIOCipherSuites.ECDHE_RSA_AES128_SHA256)
+                    serverName = "localhost"
+                }
+            }
+        } catch (cause: Throwable) {
+            failure = cause
+        }
+
+        assertThat(failure).isNotNull()
+        assertThat(failure).isNotInstanceOf(kotlinx.coroutines.TimeoutCancellationException::class.java)
+        assertThat(socket.closeCount).isGreaterThanOrEqualTo(1)
+    }
+
+    private class ImmediateEofSocket : Socket {
+        private val job = Job()
+        private var readChannel: ByteChannel? = null
+        private var writeChannel: ByteChannel? = null
+
+        var closeCount: Int = 0
+            private set
+
+        override val coroutineContext = Dispatchers.IO + job
+        override val socketContext: Job = job
+        override val localAddress: SocketAddress = InetSocketAddress("127.0.0.1", 0)
+        override val remoteAddress: SocketAddress = InetSocketAddress("127.0.0.1", 443)
+
+        override fun attachForReading(channel: ByteChannel): WriterJob {
+            readChannel = channel
+            channel.cancel(EOFException("server closed before TLS handshake"))
+            return writer(Dispatchers.IO, channel) { }
+        }
+
+        override fun attachForWriting(channel: ByteChannel): ReaderJob {
+            writeChannel = channel
+            channel.cancel(EOFException("client write channel unavailable during TLS handshake"))
+            return reader(Dispatchers.IO, channel) { }
+        }
+
+        override fun close(): Unit {
+            closeCount++
+            readChannel?.cancel(CancellationException("socket closed"))
+            writeChannel?.cancel(CancellationException("socket closed"))
+            job.complete()
+        }
+    }
+
+    private companion object {
+        private const val TEST_KEY_ALIAS = "server"
+        private val KEY_PASSWORD: CharArray = "changeit".toCharArray()
+
+        private val SERVER_CERTIFICATE_PEM: String = """
+            -----BEGIN CERTIFICATE-----
+            MIIDJTCCAg2gAwIBAgIUPPa6hVVTJaywj5yZetvBaz5mVUIwDQYJKoZIhvcNAQEL
+            BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDUwNzIwNDUyNFoXDTM2MDUw
+            NDIwNDUyNFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+            AAOCAQ8AMIIBCgKCAQEAkMpij8TxXz2PKnesm9FSH7TKGq6T3f6DyUPmNHohWbSj
+            wHAYyDijjfI8zSiqXmJU11pZViUyOTo8uMEAcgyRbrZYvwB+setS+hi2pbq4wOz8
+            PHSPoWDDydMnU1y2KHthk+Uu4sTVPxwJGBYMuDTFJR4dh0IA8fJc3gVVyxYgvZgE
+            ar0sYt+jY0fiGHTKUujGAfqLmvDKQSvGeIDerB8kgtmO9kR7sgdeTtojPTq0gOba
+            WpTIAaRbQ3rFf6adeFCVdv3M/bEddfNg3T4pOmKkKT1F+DYiI7H+Wk8okueWh6ZY
+            fp9nykFpSIidskUHn3Mdu99rZZEWYDOC+5pJUrIwwwIDAQABo28wbTAdBgNVHQ4E
+            FgQUVkaMHo9a7zPJcT8cm/V80Zgsa9gwHwYDVR0jBBgwFoAUVkaMHo9a7zPJcT8c
+            m/V80Zgsa9gwDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+            BH8AAAEwDQYJKoZIhvcNAQELBQADggEBABXWme4hV2zDwTZq0+0paflYs+jiezni
+            rVIe3UGwLncVimhUmwARuHSZ431zGsmaY7t4i8zK3IVxn+TdTnuwkeAbqyHseg5R
+            B6TrQerOZ7oEhP9rrLHbtP13LkikAykB1jwfR7/omd89cvtT/SjY5R+a6vUhRYlr
+            yJhBAOLDAHR1vbVOgLpecngzI32PTCWT4W/t390HXY48zu45S9QL1CGVCgAN8ZyY
+            77Ekym/dANdQj57FMEU419NEUsi2+6UlYm6V2szlPGRPcChHrinh/LKj+AVaaKIS
+            TbHg9IQVGufETJIiVcckUpjIKZoflZAwmyI5mPQmKNKyMKddvJMHmB0=
+            -----END CERTIFICATE-----
+        """.trimIndent()
+
+        private val SERVER_PRIVATE_KEY_PEM: String = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCQymKPxPFfPY8q
+            d6yb0VIftMoarpPd/oPJQ+Y0eiFZtKPAcBjIOKON8jzNKKpeYlTXWllWJTI5Ojy4
+            wQByDJFutli/AH6x61L6GLalurjA7Pw8dI+hYMPJ0ydTXLYoe2GT5S7ixNU/HAkY
+            Fgy4NMUlHh2HQgDx8lzeBVXLFiC9mARqvSxi36NjR+IYdMpS6MYB+oua8MpBK8Z4
+            gN6sHySC2Y72RHuyB15O2iM9OrSA5tpalMgBpFtDesV/pp14UJV2/cz9sR1182Dd
+            Pik6YqQpPUX4NiIjsf5aTyiS55aHplh+n2fKQWlIiJ2yRQefcx2732tlkRZgM4L7
+            mklSsjDDAgMBAAECggEAAcOdgM/u+vCWkndj0IAz5nP+9GVFIvLLa0PbBa+pQV0M
+            k7cp7iKWh4+4gu1oaf77tqYAqaaJXp4hiES9uyYBDZ7GJQmeAY/y8l4jt5A3WQ5q
+            IlhvOZGiwQ5ED+V0yLh8H1+u+w9X4811JOh73jCyaDneNTwuI8SGsiPRgEh0PKsd
+            TaDgEHCa38+qzwvgauc9BRngCoMCWWWmFlA2n9c5RuwmKDNANk4VliUG+LYPEXwr
+            Du3wOErzNnF5l9IwYTmERdwtLti7fufmPq14yUZamikPJWFxDgNAouKK5surEmQ2
+            s+txSAijSoso8MdjpPV7KaelivAICJiLWxQG4a2SwQKBgQDAwWvuu3F3abL50Sv6
+            OprD685rLv2+mMXRcu/wo8AoynsesDeNgD3HuTWvPmaLBGbsofyoiocPOgnBownZ
+            UPKzO5NLYUUhVcS1ZWlZd1YnwF7BMxIfy8jdbcAsiV2pceN5TE1nXx+/l8rC750g
+            r5CAkxJTniF+gtb6DCkON4u5wQKBgQDATCAgieF8yxTJ6cUOrsbmPuwfA+XyCi6o
+            kg2p4zrgvinVocWf8yzZW0GrtB5zsQCi1FPJeFelCbOwQBGPmlXela51vcqc3OPC
+            2OdrA5rfT31wRVpfLAzT74wB3Ca+GQk2rYt8LZoaze6XSyBP+4wDOiy6ng36urYo
+            ji1vx3zjgwKBgQC9tuG7U2PHKxJLjNNi8oFW6eT9W3/FMuooTp7X0uOTgk6RktDq
+            hVjJFYJAHAOjOc7vgjOB0u5BT1dA7W4JJQHq5G0BmRgISjlUbB63PpxefZkFQHXL
+            M7BcN+QYMY8s8fn4beAVKOu/j++x01JsVD++PIKiKBZBRRe/fW5/Hq54QQKBgCwr
+            0F1pDqCpzXar+hXrU8jjvz1ImfNFH36dPgI+LfId/GIULN8W7sBm0+jrEOumRu0g
+            NLbcq9U/K0VbEi2YWA0u+MoW9Imfu7mwNUhBpbuR+NBnPeEKr0+ngNOUjFmySomC
+            x72YhAOQNjQOj7ePopPDMy8Sy0dCyED8l7dLbYadAoGAcchQQ34oJGZXLpDg7T7j
+            g9HzNHJILRleHVzXBVKQ8m8igY7a0kOzGY+cVpQyUbDp1dsAj5RsaDd9YTcoDRiw
+            SgHeve9rNsmAaXxxZcm9bjiGuik8TLgN6QT6YqPhynu719rfOJjjUDHPcZjYRNBM
+            CZcAEPCHQNKWutGvlVz+5A4=
+            -----END PRIVATE KEY-----
+        """.trimIndent()
+
+        private fun testCertificate(): X509Certificate {
+            val certificateFactory = CertificateFactory.getInstance("X.509")
+            return certificateFactory.generateCertificate(ByteArrayInputStream(pemBytes(SERVER_CERTIFICATE_PEM)))
+                as X509Certificate
+        }
+
+        private fun testPrivateKey(): PrivateKey {
+            val keySpec = PKCS8EncodedKeySpec(pemBytes(SERVER_PRIVATE_KEY_PEM))
+            return KeyFactory.getInstance("RSA").generatePrivate(keySpec)
+        }
+
+        private fun testKeyStore(): KeyStore = KeyStore.getInstance("PKCS12").apply {
+            load(null, null)
+            setKeyEntry(
+                TEST_KEY_ALIAS,
+                testPrivateKey(),
+                KEY_PASSWORD,
+                arrayOf<java.security.cert.Certificate>(testCertificate())
+            )
+        }
+
+        private fun trustAllManager(): X509TrustManager = object : X509TrustManager {
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+
+            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String): Unit = Unit
+
+            override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String): Unit = Unit
+        }
+
+        private fun pemBytes(pem: String): ByteArray {
+            val base64 = pem.lineSequence()
+                .filterNot { it.startsWith("-----") }
+                .joinToString(separator = "") { it.trim() }
+            return Base64.getMimeDecoder().decode(base64)
+        }
+    }
+}

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/user-code-filter.json
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.ktor.network.tls.**"
+    },
+    {
+      "includeClasses" : "io_ktor.ktor_network_tls_jvm.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6522

This PR provides test fixes and new metadata for io.ktor:ktor-network-tls-jvm:3.4.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 21394
- Cached input tokens: 97792
- Output tokens: 938
- Metadata entries: 20
- Iterations: 1
- Library coverage percentage: 36.85
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 36.7

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e3ee8d33381cef5870bf665620bb7708e6867101`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.ktor:ktor-network-tls-jvm:3.2.0: 0/0 covered calls (100.00%)
- io.ktor:ktor-network-tls-jvm:3.4.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.ktor:ktor-network-tls-jvm:3.2.0: 3675/9236 (39.79%)
- io.ktor:ktor-network-tls-jvm:3.4.1: 3733/9774 (38.19%)

**Line:**
- io.ktor:ktor-network-tls-jvm:3.2.0: 502/1368 (36.70%)
- io.ktor:ktor-network-tls-jvm:3.4.1: 503/1365 (36.85%)

**Method:**
- io.ktor:ktor-network-tls-jvm:3.2.0: 167/331 (50.45%)
- io.ktor:ktor-network-tls-jvm:3.4.1: 167/331 (50.45%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
