### PR TITLE
[GenAI] Test fix for io.ktor:ktor-http-cio-jvm:3.4.1 using gpt-5.5

### DIFF
--- a/metadata/io.ktor/ktor-http-cio-jvm/3.4.1/reachability-metadata.json
+++ b/metadata/io.ktor/ktor-http-cio-jvm/3.4.1/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.ByteChannel"
+      },
+      "type": "io.ktor.utils.io.ByteChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.pool.DefaultPool"
+      },
+      "type": "io.ktor.utils.io.pool.DefaultPool"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.http.cio.MultipartKt"
+      },
+      "type": "kotlinx.coroutines.channels.BufferedChannel"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.http.cio.MultipartKt"
+      },
+      "type": "kotlinx.coroutines.internal.ConcurrentLinkedListNode"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.http.cio.MultipartKt"
+      },
+      "type": "kotlinx.coroutines.internal.Segment"
+    },
+    {
+      "condition": {
+        "typeReached": "io.ktor.utils.io.ByteReadChannelOperationsKt"
+      },
+      "type": "kotlinx.io.RefCountingCopyTracker"
+    }
+  ]
+}

--- a/metadata/io.ktor/ktor-http-cio-jvm/index.json
+++ b/metadata/io.ktor/ktor-http-cio-jvm/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "3.4.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
+    "repository-url" : "https://github.com/ktorio/ktor",
+    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-http/ktor-http-cio/jvm/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-javadoc.jar",
+    "description" : "Ktor HTTP CIO provides the coroutine-based HTTP parsing, headers, chunked transfer, and multipart handling primitives used by Ktor's CIO networking stack on the JVM. It supplies low-level request and response builders and parsers that support Ktor client and server components built on Coroutine I/O.",
     "language" : {
       "name" : "kotlin",
       "version" : "2.1"

--- a/metadata/io.ktor/ktor-http-cio-jvm/index.json
+++ b/metadata/io.ktor/ktor-http-cio-jvm/index.json
@@ -1,38 +1,40 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "3.4.1",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
-    "repository-url" : "https://github.com/ktorio/ktor",
-    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-http/ktor-http-cio/jvm/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-javadoc.jar",
-    "description" : "Ktor HTTP CIO provides the coroutine-based HTTP parsing, headers, chunked transfer, and multipart handling primitives used by Ktor's CIO networking stack on the JVM. It supplies low-level request and response builders and parsers that support Ktor client and server components built on Coroutine I/O.",
-    "language" : {
-      "name" : "kotlin",
-      "version" : "2.1"
+    "latest": true,
+    "metadata-version": "3.4.1",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
+    "repository-url": "https://github.com/ktorio/ktor",
+    "test-code-url": "https://github.com/ktorio/ktor/tree/$version$/ktor-http/ktor-http-cio/jvm/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-javadoc.jar",
+    "description": "Ktor HTTP CIO provides the coroutine-based HTTP parsing, headers, chunked transfer, and multipart handling primitives used by Ktor's CIO networking stack on the JVM. It supplies low-level request and response builders and parsers that support Ktor client and server components built on Coroutine I/O.",
+    "language": {
+      "name": "kotlin",
+      "version": "2.1"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.4.1"
     ],
-    "allowed-packages" : [
-      "io.ktor.http.cio"
+    "allowed-packages": [
+      "io.ktor.http.cio",
+      "io.ktor.utils.io",
+      "io.ktor.utils.io.pool"
     ]
   },
   {
-    "metadata-version" : "3.2.0",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
-    "repository-url" : "https://github.com/ktorio/ktor",
-    "test-code-url" : "https://github.com/ktorio/ktor/tree/$version$/ktor-http/ktor-http-cio/jvm/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-javadoc.jar",
-    "description" : "Ktor HTTP CIO provides the coroutine-based HTTP parsing, headers, chunked transfer, and multipart handling primitives used by Ktor's CIO networking stack on the JVM. It supplies low-level request and response builders and parsers that support Ktor client and server components built on Coroutine I/O.",
-    "language" : {
-      "name" : "kotlin",
-      "version" : "2.1"
+    "metadata-version": "3.2.0",
+    "source-code-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
+    "repository-url": "https://github.com/ktorio/ktor",
+    "test-code-url": "https://github.com/ktorio/ktor/tree/$version$/ktor-http/ktor-http-cio/jvm/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-javadoc.jar",
+    "description": "Ktor HTTP CIO provides the coroutine-based HTTP parsing, headers, chunked transfer, and multipart handling primitives used by Ktor's CIO networking stack on the JVM. It supplies low-level request and response builders and parsers that support Ktor client and server components built on Coroutine I/O.",
+    "language": {
+      "name": "kotlin",
+      "version": "2.1"
     },
-    "tested-versions" : [
+    "tested-versions": [
       "3.2.0"
     ],
-    "allowed-packages" : [
+    "allowed-packages": [
       "io.ktor.http.cio"
     ]
   }

--- a/metadata/io.ktor/ktor-http-cio-jvm/index.json
+++ b/metadata/io.ktor/ktor-http-cio-jvm/index.json
@@ -1,6 +1,19 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "3.4.1",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.1"
+    },
+    "tested-versions" : [
+      "3.4.1"
+    ],
+    "allowed-packages" : [
+      "io.ktor.http.cio"
+    ]
+  },
+  {
     "metadata-version" : "3.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/$version$/ktor-http-cio-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/ktorio/ktor",

--- a/stats/io.ktor/ktor-http-cio-jvm/3.4.1/execution-metrics.json
+++ b/stats/io.ktor/ktor-http-cio-jvm/3.4.1/execution-metrics.json
@@ -1,0 +1,87 @@
+{
+  "fix_java_run_fail:2026-05-08": {
+    "timestamp": "2026-05-08T14:23:51.113342Z",
+    "library": "io.ktor:ktor-http-cio-jvm:3.4.1",
+    "starting_commit": "2837e776eaecbbe4fe344ab619247401900c829b",
+    "ending_commit": "895609063f518486e72d587a4e596f15afd315a6",
+    "previous_library": "io.ktor:ktor-http-cio-jvm:3.2.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.4.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 5382,
+          "missed": 2544,
+          "ratio": 0.679031,
+          "total": 7926
+        },
+        "line": {
+          "covered": 791,
+          "missed": 243,
+          "ratio": 0.76499,
+          "total": 1034
+        },
+        "method": {
+          "covered": 192,
+          "missed": 65,
+          "ratio": 0.747082,
+          "total": 257
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "3.2.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 4891,
+          "missed": 2005,
+          "ratio": 0.709252,
+          "total": 6896
+        },
+        "line": {
+          "covered": 786,
+          "missed": 235,
+          "ratio": 0.769833,
+          "total": 1021
+        },
+        "method": {
+          "covered": 199,
+          "missed": 62,
+          "ratio": 0.762452,
+          "total": 261
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 26403,
+      "cached_input_tokens_used": 168448,
+      "output_tokens_used": 1931,
+      "iterations": 1,
+      "cost_usd": 0.1421,
+      "tested_library_loc": 791,
+      "metadata_entries": 6,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 76.5,
+      "previous_library_coverage_percent": 76.98
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_http_cio_jvm/Ktor_http_cio_jvmTest.kt",
+      "metadata_file": "metadata/io.ktor/ktor-http-cio-jvm/3.4.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.ktor/ktor-http-cio-jvm/3.4.1/stats.json
+++ b/stats/io.ktor/ktor-http-cio-jvm/3.4.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.4.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 5382,
+        "missed" : 2544,
+        "ratio" : 0.679031,
+        "total" : 7926
+      },
+      "line" : {
+        "covered" : 791,
+        "missed" : 243,
+        "ratio" : 0.76499,
+        "total" : 1034
+      },
+      "method" : {
+        "covered" : 192,
+        "missed" : 65,
+        "ratio" : 0.747082,
+        "total" : 257
+      }
+    }
+  } ]
+}

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/.gitignore
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "21"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/gradle.properties
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.ktor:ktor-http-cio-jvm:3.4.1
+library.version = 3.4.1
+metadata.dir = io.ktor/ktor-http-cio-jvm/3.4.1/

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/settings.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.ktor.ktor-http-cio-jvm_tests'

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_http_cio_jvm/Ktor_http_cio_jvmTest.kt
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_http_cio_jvm/Ktor_http_cio_jvmTest.kt
@@ -34,6 +34,7 @@ import kotlinx.io.Source
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.io.IOException
 import java.nio.ByteBuffer
 
 public class Ktor_http_cio_jvmTest {
@@ -212,7 +213,8 @@ public class Ktor_http_cio_jvmTest {
                 runBlocking {
                     decodeChunked(ByteReadChannel("1\r\na\r\nnot-a-size\r\n"), ByteChannel(autoFlush = true))
                 }
-            }.isInstanceOf(NumberFormatException::class.java)
+            }.isInstanceOf(IOException::class.java)
+                .hasMessageContaining("Invalid chunk size character")
         }
     }
 
@@ -293,7 +295,7 @@ public class Ktor_http_cio_jvmTest {
     }
 
     @Test
-    fun exposesParsedHeadersThroughIndexedAndOffsetAccessors(): Unit = runBlocking {
+    fun exposesParsedHeadersThroughOffsetAccessors(): Unit = runBlocking {
         withTimeout(10_000) {
             val headers = parseHeaders(
                 ByteReadChannel(
@@ -304,15 +306,12 @@ public class Ktor_http_cio_jvmTest {
                 )
             )
             try {
-                val indexedPairs: List<String> = (0 until headers.size)
-                    .map { "${headers.nameAt(it)}: ${headers.valueAt(it)}" }
                 val offsets: List<Int> = headers.offsets().toList()
                 val offsetPairs: List<String> = offsets
                     .map { "${headers.nameAtOffset(it)}: ${headers.valueAtOffset(it)}" }
 
                 assertThat(offsets).hasSize(headers.size)
-                assertThat(indexedPairs).containsExactlyInAnyOrder("Alpha: one", "Beta: two", "Alpha: three")
-                assertThat(offsetPairs).containsExactlyElementsOf(indexedPairs)
+                assertThat(offsetPairs).containsExactlyInAnyOrder("Alpha: one", "Beta: two", "Alpha: three")
             } finally {
                 headers.release()
             }

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_http_cio_jvm/Ktor_http_cio_jvmTest.kt
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/src/test/kotlin/io_ktor/ktor_http_cio_jvm/Ktor_http_cio_jvmTest.kt
@@ -1,0 +1,378 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_ktor.ktor_http_cio_jvm
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.cio.CIOHeaders
+import io.ktor.http.cio.ConnectionOptions
+import io.ktor.http.cio.MultipartEvent
+import io.ktor.http.cio.ParserException
+import io.ktor.http.cio.RequestResponseBuilder
+import io.ktor.http.cio.decodeChunked
+import io.ktor.http.cio.encodeChunked
+import io.ktor.http.cio.expectHttpBody
+import io.ktor.http.cio.expectHttpUpgrade
+import io.ktor.http.cio.parseHeaders
+import io.ktor.http.cio.parseHttpBody
+import io.ktor.http.cio.parseMultipart
+import io.ktor.http.cio.parseRequest
+import io.ktor.http.cio.parseResponse
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.core.readText
+import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.toByteArray
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.Source
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+public class Ktor_http_cio_jvmTest {
+    @Test
+    fun parsesRequestsHeadersAndBodyExpectations(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val rawRequest: String = """
+
+                GET /submit?name=alice HTTP/1.1
+                Host: example.com
+                Connection: keep-alive, Upgrade, X-Hop
+                Upgrade: websocket
+                Content-Length: 7
+                X-Custom: first
+                x-custom: second
+
+                payload-extra
+            """.trimIndent().replace("\n", "\r\n")
+            val channel = ByteReadChannel(rawRequest)
+            val request = parseRequest(channel) ?: error("Expected a request")
+
+            try {
+                assertThat(request.method).isEqualTo(HttpMethod.Get)
+                assertThat(request.uri.toString()).isEqualTo("/submit?name=alice")
+                assertThat(request.version.toString()).isEqualTo("HTTP/1.1")
+                assertThat(request.headers[HttpHeaders.Host].toString()).isEqualTo("example.com")
+                assertThat(request.headers.getAll("X-Custom").map { it.toString() }.toList())
+                    .containsExactly("first", "second")
+
+                val cioHeaders = CIOHeaders(request.headers)
+                assertThat(cioHeaders.caseInsensitiveName).isTrue()
+                assertThat(cioHeaders.get("x-custom")).isEqualTo("first")
+                assertThat(cioHeaders.getAll("X-CUSTOM")).containsExactly("first", "second")
+                assertThat(cioHeaders.contains("host", "example.com")).isTrue()
+                assertThat(cioHeaders.names()).contains("Host", "Connection", "Upgrade", "Content-Length", "X-Custom")
+
+                val connection = ConnectionOptions.parse(request.headers[HttpHeaders.Connection])
+                assertThat(connection).isEqualTo(
+                    ConnectionOptions(keepAlive = true, upgrade = true, extraOptions = listOf("X-Hop"))
+                )
+                assertThat(connection.toString()).isEqualTo("keep-alive, Upgrade, X-Hop")
+                assertThat(expectHttpUpgrade(request)).isTrue()
+                assertThat(expectHttpBody(request)).isTrue()
+
+                val body = ByteChannel(autoFlush = true)
+                parseHttpBody(request.headers, channel, body)
+                body.flushAndClose()
+                assertThat(body.toByteArray().decodeToString()).isEqualTo("payload")
+            } finally {
+                request.release()
+            }
+        }
+    }
+
+    @Test
+    fun parsesResponsesBuiltWithRequestResponseBuilder(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val builder = RequestResponseBuilder()
+            try {
+                builder.responseLine("HTTP/1.1", 201, "Created")
+                builder.headerLine("Content-Type", "text/plain")
+                builder.headerLine("Set-Cookie", "a=1")
+                builder.headerLine("Set-Cookie", "b=2")
+                builder.emptyLine()
+                builder.bytes("accepted".encodeToByteArray())
+
+                val response = parseResponse(ByteReadChannel(builder.build())) ?: error("Expected a response")
+                try {
+                    assertThat(response.version.toString()).isEqualTo("HTTP/1.1")
+                    assertThat(response.status).isEqualTo(201)
+                    assertThat(response.statusText.toString()).isEqualTo("Created")
+                    assertThat(response.headers["content-type"].toString()).isEqualTo("text/plain")
+                    assertThat(response.headers.getAll("set-cookie").map { it.toString() }.toList())
+                        .containsExactly("a=1", "b=2")
+                } finally {
+                    response.release()
+                }
+            } finally {
+                builder.release()
+            }
+        }
+    }
+
+    @Test
+    fun requestResponseBuilderWritesLinesByteArraysAndByteBuffers(): Unit {
+        val builder = RequestResponseBuilder()
+        try {
+            builder.requestLine(HttpMethod.Put, "/resource/1", "HTTP/1.0")
+            builder.headerLine("Host", "localhost")
+            builder.line("X-Trace: abc")
+            builder.emptyLine()
+            builder.bytes("alpha".encodeToByteArray())
+            builder.bytes("0123456789".encodeToByteArray(), offset = 2, length = 4)
+            builder.bytes(ByteBuffer.wrap("omega".encodeToByteArray()))
+
+            val packet: Source = builder.build()
+            packet.use {
+                assertThat(it.readText()).isEqualTo(
+                    "PUT /resource/1 HTTP/1.0\r\n" +
+                        "Host: localhost\r\n" +
+                        "X-Trace: abc\r\n" +
+                        "\r\n" +
+                        "alpha2345omega"
+                )
+            }
+        } finally {
+            builder.release()
+        }
+    }
+
+    @Test
+    fun parsesStandaloneHeadersAndRejectsInvalidHeaderSyntax(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val headers = parseHeaders(
+                ByteReadChannel(
+                    "Host: example.org\n" +
+                        "Transfer-Encoding: identity, chunked\n" +
+                        "Connection: close\n" +
+                        "X-Whitespace: \t value with trimmed padding   \n" +
+                        "\n"
+                )
+            )
+            try {
+                assertThat(headers.size).isEqualTo(4)
+                assertThat(headers["host"].toString()).isEqualTo("example.org")
+                assertThat(headers["X-Whitespace"].toString()).isEqualTo("value with trimmed padding")
+                assertThat(expectHttpBody(HttpMethod.Post, -1, headers["Transfer-Encoding"], null, null)).isTrue()
+                assertThat(expectHttpBody(HttpMethod.Get, -1, null, ConnectionOptions.Close, null)).isFalse()
+                assertThat(expectHttpBody(HttpMethod.Post, -1, null, ConnectionOptions.Close, null)).isTrue()
+                assertThat(expectHttpBody(HttpMethod.Head, 5, null, null, null)).isTrue()
+                assertThat(expectHttpUpgrade(HttpMethod.Post, "websocket", ConnectionOptions.Upgrade)).isFalse()
+            } finally {
+                headers.release()
+            }
+
+            assertThatThrownBy {
+                runBlocking {
+                    parseHeaders(ByteReadChannel("Host: bad/path\r\n\r\n"))
+                }
+            }.isInstanceOf(ParserException::class.java)
+
+            assertThatThrownBy {
+                runBlocking {
+                    parseHeaders(ByteReadChannel(": empty\r\n\r\n"))
+                }
+            }.isInstanceOf(ParserException::class.java)
+        }
+    }
+
+    @Test
+    fun encodesDecodesChunkedBodiesAndParsesChunkedHttpBody(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val encodedOutput = ByteChannel(autoFlush = true)
+            encodeChunked(encodedOutput, ByteReadChannel("Wikipedia"))
+            encodedOutput.flushAndClose()
+            val encoded = encodedOutput.toByteArray().decodeToString()
+
+            assertThat(encoded).isEqualTo("9\r\nWikipedia\r\n0\r\n\r\n")
+
+            val decodedOutput = ByteChannel(autoFlush = true)
+            decodeChunked(ByteReadChannel("4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"), decodedOutput)
+            assertThat(decodedOutput.toByteArray().decodeToString()).isEqualTo("Wikipedia")
+
+            val parsedBody = ByteChannel(autoFlush = true)
+            parseHttpBody(
+                HttpProtocolVersion.HTTP_1_1,
+                contentLength = -1,
+                transferEncoding = "identity, chunked",
+                connectionOptions = ConnectionOptions.KeepAlive,
+                input = ByteReadChannel("5\r\nhello\r\n0\r\n\r\n"),
+                out = parsedBody
+            )
+            assertThat(parsedBody.toByteArray().decodeToString()).isEqualTo("hello")
+
+            assertThatThrownBy {
+                runBlocking {
+                    decodeChunked(ByteReadChannel("1\r\na\r\nnot-a-size\r\n"), ByteChannel(autoFlush = true))
+                }
+            }.isInstanceOf(NumberFormatException::class.java)
+        }
+    }
+
+    @Test
+    fun parsesMultipartEventsWithPreambleHeadersFilePartAndEpilogue(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val boundary = "NativeBoundary"
+            val body = listOf(
+                "POST /upload HTTP/1.1",
+                "Host: upload.example",
+                "Content-Type: multipart/form-data; boundary=$boundary",
+                "Connection: close",
+                "",
+                "preamble text",
+                "--$boundary",
+                "Content-Disposition: form-data; name=\"field\"",
+                "X-Part: one",
+                "",
+                "field value",
+                "--$boundary",
+                "Content-Disposition: form-data; name=\"file\"; filename=\"notes.txt\"",
+                "Content-Type: text/plain",
+                "Content-Length: 11",
+                "",
+                "hello file!",
+                "--$boundary--",
+                "epilogue text"
+            ).joinToString("\r\n")
+
+            val input = ByteReadChannel(body)
+            val request = parseRequest(input) ?: error("Expected multipart request")
+            try {
+                val events = parseMultipart(input, request.headers)
+
+                val preamble = events.receive() as MultipartEvent.Preamble
+                try {
+                    assertThat(preamble.body.readText()).isEqualTo("preamble text\r\n")
+                } finally {
+                    preamble.release()
+                }
+
+                val field = events.receive() as MultipartEvent.MultipartPart
+                val fieldHeaders = field.headers.await()
+                try {
+                    assertThat(fieldHeaders["Content-Disposition"].toString())
+                        .isEqualTo("form-data; name=\"field\"")
+                    assertThat(fieldHeaders["x-part"].toString()).isEqualTo("one")
+                    assertThat(field.body.readRemaining().readText()).isEqualTo("field value")
+                } finally {
+                    fieldHeaders.release()
+                    field.release()
+                }
+
+                val file = events.receive() as MultipartEvent.MultipartPart
+                val fileHeaders = file.headers.await()
+                try {
+                    val headers = CIOHeaders(fileHeaders)
+                    assertThat(headers.get("content-type")).isEqualTo("text/plain")
+                    assertThat(headers.get("content-length")).isEqualTo("11")
+                    assertThat(file.body.readRemaining().readText()).isEqualTo("hello file!")
+                } finally {
+                    fileHeaders.release()
+                    file.release()
+                }
+
+                val epilogue = events.receive() as MultipartEvent.Epilogue
+                try {
+                    assertThat(epilogue.body.readText()).isEqualTo("epilogue text")
+                } finally {
+                    epilogue.release()
+                }
+
+                assertThat(events.receiveCatching().isClosed).isTrue()
+            } finally {
+                request.release()
+            }
+        }
+    }
+
+    @Test
+    fun exposesParsedHeadersThroughIndexedAndOffsetAccessors(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val headers = parseHeaders(
+                ByteReadChannel(
+                    "Alpha: one\r\n" +
+                        "Beta: two\r\n" +
+                        "Alpha: three\r\n" +
+                        "\r\n"
+                )
+            )
+            try {
+                val indexedPairs: List<String> = (0 until headers.size)
+                    .map { "${headers.nameAt(it)}: ${headers.valueAt(it)}" }
+                val offsets: List<Int> = headers.offsets().toList()
+                val offsetPairs: List<String> = offsets
+                    .map { "${headers.nameAtOffset(it)}: ${headers.valueAtOffset(it)}" }
+
+                assertThat(offsets).hasSize(headers.size)
+                assertThat(indexedPairs).containsExactlyInAnyOrder("Alpha: one", "Beta: two", "Alpha: three")
+                assertThat(offsetPairs).containsExactlyElementsOf(indexedPairs)
+            } finally {
+                headers.release()
+            }
+        }
+    }
+
+    @Test
+    fun parsesBodyDelimitedByConnectionClose(): Unit = runBlocking {
+        withTimeout(10_000) {
+            val output = ByteChannel(autoFlush = true)
+            parseHttpBody(
+                HttpProtocolVersion.HTTP_1_1,
+                contentLength = -1,
+                transferEncoding = null,
+                connectionOptions = ConnectionOptions.Close,
+                input = ByteReadChannel("streamed until close"),
+                out = output
+            )
+            output.flushAndClose()
+
+            assertThat(output.toByteArray().decodeToString()).isEqualTo("streamed until close")
+        }
+    }
+
+    @Test
+    fun rejectsMalformedRequestsResponsesAndUnsupportedBodyEncodings(): Unit = runBlocking {
+        withTimeout(10_000) {
+            assertThat(parseRequest(ByteReadChannel("\r\n\r\n"))).isNull()
+            assertThat(parseResponse(ByteReadChannel(""))).isNull()
+
+            assertThatThrownBy {
+                runBlocking {
+                    parseRequest(ByteReadChannel("GET / HTTP/2.0\r\n\r\n"))
+                }
+            }.isInstanceOf(ParserException::class.java)
+                .hasMessageContaining("Unsupported HTTP version")
+
+            assertThatThrownBy {
+                runBlocking {
+                    parseResponse(ByteReadChannel("HTTP/1.1 99 TooLow\r\n\r\n"))
+                }
+            }.isInstanceOf(ParserException::class.java)
+                .hasMessageContaining("Status-code must be 3-digit")
+
+            assertThatThrownBy {
+                expectHttpBody(HttpMethod.Post, -1, "gzip", null, "text/plain")
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("Unsupported transfer encoding")
+
+            val noLengthOutput = ByteChannel(autoFlush = true)
+            parseHttpBody(
+                HttpProtocolVersion.HTTP_1_1,
+                contentLength = -1,
+                transferEncoding = null,
+                connectionOptions = ConnectionOptions.KeepAlive,
+                input = ByteReadChannel("body"),
+                out = noLengthOutput
+            )
+            assertThat(noLengthOutput.closedCause)
+                .hasMessageContaining("Failed to parse request body")
+        }
+    }
+}

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/user-code-filter.json
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "io.ktor.http.cio.**"
+    },
+    {
+      "includeClasses" : "io_ktor.ktor_http_cio_jvm.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #6521

This PR provides test fixes and new metadata for io.ktor:ktor-http-cio-jvm:3.4.1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 26403
- Cached input tokens: 168448
- Output tokens: 1931
- Metadata entries: 6
- Iterations: 1
- Library coverage percentage: 76.5
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 76.98

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e3ee8d33381cef5870bf665620bb7708e6867101`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- io.ktor:ktor-http-cio-jvm:3.2.0: 0/0 covered calls (100.00%)
- io.ktor:ktor-http-cio-jvm:3.4.1: 0/0 covered calls (100.00%)

#### Library coverage

**Instruction:**
- io.ktor:ktor-http-cio-jvm:3.2.0: 4891/6896 (70.93%)
- io.ktor:ktor-http-cio-jvm:3.4.1: 5382/7926 (67.90%)

**Line:**
- io.ktor:ktor-http-cio-jvm:3.2.0: 786/1021 (76.98%)
- io.ktor:ktor-http-cio-jvm:3.4.1: 791/1034 (76.50%)

**Method:**
- io.ktor:ktor-http-cio-jvm:3.2.0: 199/261 (76.25%)
- io.ktor:ktor-http-cio-jvm:3.4.1: 192/257 (74.71%)

**Comparison between existing test version and AI-Generated update**

```diff

```

### Local CI Verification

- Status: `success`
- Commands run: 20
- Fixup attempts: 0
