### PR TITLE
[GenAI] Mark io.ktor:ktor-http-cio as not for Native Image

### DIFF
--- a/metadata/io.ktor/ktor-http-cio/index.json
+++ b/metadata/io.ktor/ktor-http-cio/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.ktor:ktor-http-cio-jvm:3.4.2.",
+    "replacement": "io.ktor:ktor-http-cio-jvm:3.4.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3722

This PR records `io.ktor:ktor-http-cio` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects standard JVM variants to io.ktor:ktor-http-cio-jvm:3.4.2.

Replacement guidance:
- io.ktor:ktor-http-cio-jvm:3.4.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1863992b1238d26a8907ba0efb207d994f8a93cb`

### Local CI Verification

- Status: `success`
- Commands run: 73
- Fixup attempts: 1
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `ci.json`
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle`
