### PR TITLE
[GenAI] Mark io.ktor:ktor-http as not for Native Image

### DIFF
--- a/metadata/io.ktor/ktor-http/index.json
+++ b/metadata/io.ktor/ktor-http/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to io.ktor:ktor-http-jvm:3.4.2.",
+    "replacement": "io.ktor:ktor-http-jvm:3.4.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3720

This PR records `io.ktor:ktor-http` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains Kotlin Multiplatform metadata/linkdata and no JVM class files; Gradle module metadata redirects JVM variants to io.ktor:ktor-http-jvm:3.4.2.

Replacement guidance:
- io.ktor:ktor-http-jvm:3.4.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4bf453555641241c77837187cadf1f7714e5a3ab`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
