### PR TITLE
[GenAI] Mark org.clojure:tools.logging as not for Native Image

### DIFF
--- a/metadata/org.clojure/tools.logging/index.json
+++ b/metadata/org.clojure/tools.logging/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3619

This PR records `org.clojure:tools.logging` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `4bf453555641241c77837187cadf1f7714e5a3ab`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
