### PR TITLE
[GenAI] Mark io.ktor:ktor-websockets as not for Native Image

### DIFF
--- a/metadata/io.ktor/ktor-websockets/index.json
+++ b/metadata/io.ktor/ktor-websockets/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM .class files; Gradle module metadata redirects standard JVM variants to io.ktor:ktor-websockets-jvm:3.4.2.",
+    "replacement": "io.ktor:ktor-websockets-jvm:3.4.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3723

This PR records `io.ktor:ktor-websockets` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published root JAR contains Kotlin Multiplatform metadata/linkdata and no JVM .class files; Gradle module metadata redirects standard JVM variants to io.ktor:ktor-websockets-jvm:3.4.2.

Replacement guidance:
- io.ktor:ktor-websockets-jvm:3.4.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d6e8415a59ca08962c8f7267da6efed89cb8fc3e`

### Local CI Verification

- Status: `success`
- Commands run: 78
- Fixup attempts: 2
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `metadata/com.typesafe.akka/akka-serialization-jackson_3/index.json`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/.gitignore`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/build.gradle`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/gradle.properties`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/settings.gradle`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/src/test/scala/com_typesafe_akka/akka_serialization_jackson_3/Akka_serialization_jackson_3Test.scala`
  - `tests/src/com.typesafe.akka/akka-serialization-jackson_3/2.6.21/user-code-filter.json`
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle`
  - `tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java`
  - `tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/TckExtensionTests.java`
