### PR TITLE
[GenAI] Mark io.ktor:ktor-websocket-serialization as not for Native Image

### DIFF
--- a/metadata/io.ktor/ktor-websocket-serialization/index.json
+++ b/metadata/io.ktor/ktor-websocket-serialization/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "This Kotlin multiplatform metadata artifact contains no JVM .class files; JVM consumers resolve the dedicated ktor-websocket-serialization-jvm artifact.",
+    "replacement": "io.ktor:ktor-websocket-serialization-jvm:3.4.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3726

This PR records `io.ktor:ktor-websocket-serialization` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- This Kotlin multiplatform metadata artifact contains no JVM .class files; JVM consumers resolve the dedicated ktor-websocket-serialization-jvm artifact.

Replacement guidance:
- io.ktor:ktor-websocket-serialization-jvm:3.4.2

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e650f56656599d8b26de3e38543ea69f5c6072bf`

### Local CI Verification

- Status: `success`
- Commands run: 111
- Fixup attempts: 2
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `tests/src/org.postgresql/postgresql/42.7.3/src/test/java/postgresql/ArrayDecodingInnerAbstractObjectStringArrayDecoderTest.java`
  - `tests/src/org.postgresql/postgresql/42.7.3/src/test/java/postgresql/PGPooledConnectionInnerConnectionHandlerTest.java`
  - `tests/src/org.postgresql/postgresql/42.7.3/src/test/java/postgresql/PGXAConnectionTest.java`
  - `tests/src/org.postgresql/postgresql/42.7.3/src/test/java/postgresql/PgConnectionTest.java`
  - `tests/src/org.postgresql/postgresql/42.7.3/src/test/java/postgresql/PostgresqlDockerSupport.java`
  - `tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle`
